### PR TITLE
feat: enable bootc experimental unified storage

### DIFF
--- a/scripts/build-qcow2.sh
+++ b/scripts/build-qcow2.sh
@@ -99,6 +99,7 @@ sudo podman run \
 	bootc install to-disk \
 	--via-loopback \
 	--generic-image \
+	--experimental-unified-storage \
 	"${SSH_KEY_ARGS[@]}" \
 	--source-imgref "containers-storage:${IMG_REF}" \
 	/disk.img


### PR DESCRIPTION
## Summary

Enables [bootc unified storage](https://bootc-dev.github.io/bootc/experimental-unified-storage.html) across the build chain and installer.

## Changes

### `scripts/build-qcow2.sh`
Adds `--experimental-unified-storage` to the `bootc install to-disk` call used for QCOW2 disk image generation.

## Benefits

- **zstd:chunked deduplication**: OS image layers shared with app containers
- **Efficient `podman run <booted image>`**: Booted image directly accessible to podman without copy
- **Shared layer storage**: Layers common between OS and app containers stored once

## Related

- Companion PR in [tuna-os/first-setup](https://github.com/tuna-os/first-setup/pull/new/feat/bootc-unified-storage) adds the flag to the GUI installer (`install-to-disk` script, both `to-disk` and `to-filesystem` paths)
- Tracking issue: https://github.com/bootc-dev/bootc/issues/20

## Notes

- This is an experimental bootc feature; flag is hidden from `--help` but functional
- No TOML config equivalent exists yet — CLI flag only