### PR TITLE
fix: relabel /var/home on deployed systems

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -237,6 +237,8 @@ jobs:
           for i in $(seq "${MAX_RETRIES}"); do
             sudo podman push --digestfile=/tmp/digestfile \
               --compression-format=zstd:chunked \
+              --compression-level=3 \
+              --force-compression \
               "${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${SAFE_PLATFORM}" \
               && break || sleep $((5 * i));
           done
@@ -312,7 +314,13 @@ jobs:
         if: ${{ inputs.publish }}
         run: |
           IMAGE_FULL="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${IMAGE_FULL}@${{ steps.push.outputs.remote_image_digest }}
+          for i in 1 2 3; do
+            cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE_FULL}@${{ steps.push.outputs.remote_image_digest }}" && break
+            if [ "$i" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((15 * i))
+          done
         env:
           COSIGN_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_REGISTRY_USERNAME: ${{ github.actor }}
@@ -366,12 +374,25 @@ jobs:
           DIGEST: ${{ steps.push.outputs.remote_image_digest }}
           SBOM_DIGEST: ${{ steps.upload-sbom.outputs.sbom_digest }}
         run: |
-          cosign attest -y \
-            --predicate "$SBOM" \
-            --type spdxjson \
-            --key env://COSIGN_PRIVATE_KEY \
-            "${IMAGE}@${DIGEST}"
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${SBOM_DIGEST}"
+          for i in 1 2 3; do
+            cosign attest -y \
+              --predicate "$SBOM" \
+              --type spdxjson \
+              --key env://COSIGN_PRIVATE_KEY \
+              "${IMAGE}@${DIGEST}" && break
+            if [ "$i" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((15 * i))
+          done
+
+          for i in 1 2 3; do
+            cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${SBOM_DIGEST}" && break
+            if [ "$i" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((15 * i))
+          done
 
       - name: Create Job Outputs
         if: ${{ inputs.publish }}
@@ -624,7 +645,11 @@ jobs:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
         run: |
           while IFS= read -r tag; do
-            podman manifest push --all=false --digestfile=/tmp/digestfile --compression-format=zstd:chunked $MANIFEST $IMAGE_REGISTRY/$IMAGE_NAME:$tag
+            podman manifest push --all=false --digestfile=/tmp/digestfile \
+              --compression-format=zstd:chunked \
+              --compression-level=3 \
+              --force-compression \
+              "$MANIFEST" "$IMAGE_REGISTRY/$IMAGE_NAME:$tag"
           done <<< "$TAGS"
 
           DIGEST=$(cat /tmp/digestfile)
@@ -661,7 +686,13 @@ jobs:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
         run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${DIGEST}"
+          for i in 1 2 3; do
+            cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${DIGEST}" && break
+            if [ "$i" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((15 * i))
+          done
 
       - name: Attest Build Provenance (SLSA)
         uses: actions/attest-build-provenance@v2

--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -34,6 +34,7 @@ sed -i 's/#HandleLidSwitchDocked=.*/HandleLidSwitchDocked=suspend-then-hibernate
 sed -i 's/#HandleLidSwitchExternalPower=.*/HandleLidSwitchExternalPower=suspend-then-hibernate/g' /usr/lib/systemd/logind.conf
 sed -i 's/#SleepOperation=.*/SleepOperation=suspend-then-hibernate/g' /usr/lib/systemd/logind.conf
 safe_enable brew-setup.service
+safe_enable tunaos-var-home-restorecon.service
 if [[ "${DESKTOP_FLAVOR}" == "kde" ]]; then
 	safe_disable gdm.service
 	safe_enable sddm.service

--- a/scripts/registry.sh
+++ b/scripts/registry.sh
@@ -49,6 +49,9 @@ push)
 		exit 1
 	fi
 	podman push --tls-verify=false \
+		--compression-format=zstd:chunked \
+		--compression-level=3 \
+		--force-compression \
 		"localhost/${VARIANT}:${FLAVOR}" \
 		"${HOST}:${PORT}/${VARIANT}:${FLAVOR}"
 	;;

--- a/system_files/usr/lib/systemd/system/tunaos-var-home-restorecon.service
+++ b/system_files/usr/lib/systemd/system/tunaos-var-home-restorecon.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Relabel /var/home before graphical login
+DefaultDependencies=no
+ConditionSecurity=selinux
+ConditionPathIsDirectory=/var/home
+ConditionPathExists=!/var/lib/tunaos/var-home-relabeled
+After=local-fs.target
+Before=display-manager.service gdm.service
+Wants=local-fs.target
+
+[Service]
+Type=oneshot
+StateDirectory=tunaos
+ExecStart=/usr/sbin/restorecon -RF /var/home
+ExecStart=/usr/bin/touch /var/lib/tunaos/var-home-relabeled
+
+[Install]
+WantedBy=graphical.target

--- a/system_files/usr/lib/tmpfiles.d/tunaos-var-compat.conf
+++ b/system_files/usr/lib/tmpfiles.d/tunaos-var-compat.conf
@@ -1,6 +1,8 @@
 # Declare /var paths created by package scriptlets that lack tmpfiles.d entries.
 # Required for bootc container lint (var-tmpfiles check) to pass on EL10 stable
 # where authselect and selinux-policy-targeted create these dirs without declarations.
+# Ensure /var/home exists on deployed systems before first-login user creation.
+d /var/home 0755 root root - -
 d /var/lib/authselect/backups 0755 root root - -
 d /var/lib/selinux/targeted/active 0755 root root - -
 d /var/lib/selinux/targeted/active/modules 0755 root root - -


### PR DESCRIPTION
## Summary
- relabel `/var/home` on deployed systems before GDM so reused bootc installs don't rely on compose-time RPM scriptlets
- force `zstd:chunked` pushes with compression level 3 for podman push paths
- retry flaky cosign/Rekor signing steps in CI

## Testing
- local `just build yellowfin gnome`
- GitHub `Just Fix`
