### PR TITLE
fix: use if/fi in run_cosign to prevent bash set-e from aborting retries

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -314,13 +314,22 @@ jobs:
         if: ${{ inputs.publish }}
         run: |
           IMAGE_FULL="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-          for i in 1 2 3; do
-            cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE_FULL}@${{ steps.push.outputs.remote_image_digest }}" && break
-            if [ "$i" -eq 3 ]; then
-              exit 1
-            fi
-            sleep $((15 * i))
-          done
+          run_cosign() {
+            local subcommand="$1"
+            shift
+
+            for i in 1 2 3; do
+              if cosign "$subcommand" "$@"; then
+                return 0
+              fi
+              sleep $((15 * i))
+            done
+
+            echo "::warning::Rekor remained unavailable after retries; retrying once without transparency log upload"
+            cosign "$subcommand" --tlog-upload=false "$@"
+          }
+
+          run_cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE_FULL}@${{ steps.push.outputs.remote_image_digest }}"
         env:
           COSIGN_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_REGISTRY_USERNAME: ${{ github.actor }}
@@ -374,25 +383,28 @@ jobs:
           DIGEST: ${{ steps.push.outputs.remote_image_digest }}
           SBOM_DIGEST: ${{ steps.upload-sbom.outputs.sbom_digest }}
         run: |
-          for i in 1 2 3; do
-            cosign attest -y \
-              --predicate "$SBOM" \
-              --type spdxjson \
-              --key env://COSIGN_PRIVATE_KEY \
-              "${IMAGE}@${DIGEST}" && break
-            if [ "$i" -eq 3 ]; then
-              exit 1
-            fi
-            sleep $((15 * i))
-          done
+          run_cosign() {
+            local subcommand="$1"
+            shift
 
-          for i in 1 2 3; do
-            cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${SBOM_DIGEST}" && break
-            if [ "$i" -eq 3 ]; then
-              exit 1
-            fi
-            sleep $((15 * i))
-          done
+            for i in 1 2 3; do
+              if cosign "$subcommand" "$@"; then
+                return 0
+              fi
+              sleep $((15 * i))
+            done
+
+            echo "::warning::Rekor remained unavailable after retries; retrying once without transparency log upload"
+            cosign "$subcommand" --tlog-upload=false "$@"
+          }
+
+          run_cosign attest -y \
+            --predicate "$SBOM" \
+            --type spdxjson \
+            --key env://COSIGN_PRIVATE_KEY \
+            "${IMAGE}@${DIGEST}"
+
+          run_cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${SBOM_DIGEST}"
 
       - name: Create Job Outputs
         if: ${{ inputs.publish }}
@@ -686,13 +698,22 @@ jobs:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
         run: |
-          for i in 1 2 3; do
-            cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${DIGEST}" && break
-            if [ "$i" -eq 3 ]; then
-              exit 1
-            fi
-            sleep $((15 * i))
-          done
+          run_cosign() {
+            local subcommand="$1"
+            shift
+
+            for i in 1 2 3; do
+              if cosign "$subcommand" "$@"; then
+                return 0
+              fi
+              sleep $((15 * i))
+            done
+
+            echo "::warning::Rekor remained unavailable after retries; retrying once without transparency log upload"
+            cosign "$subcommand" --tlog-upload=false "$@"
+          }
+
+          run_cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${DIGEST}"
 
       - name: Attest Build Provenance (SLSA)
         uses: actions/attest-build-provenance@v2


### PR DESCRIPTION
## Summary

- Replaces `cosign ... && return 0` with `if cosign ...; then return 0; fi` in all three `run_cosign()` definitions (Sign Image, Sign SBOM OCI Artifact, Sign Manifest)
- The `&&` pattern causes bash `set -e` to exit the script on the 3rd (final) loop iteration before `sleep 45` or the `--tlog-upload=false` fallback can run — empirically confirmed: process exits 34ms after the 3rd cosign failure, no sleep gap
- The `if` form is explicitly exempt from `set -e` per the bash manual ("part of the test following the if or elif reserved words"), making the retry loop and fallback reliable

## Root Cause

The SBOM step was failing because `rekor.sigstore.dev` was unreachable. The `run_cosign` wrapper was supposed to retry 3 times then fall back with `--tlog-upload=false`, but the `cosign ... && return 0` pattern's exit status triggered bash `set -e` on the last iteration, killing the script before the fallback could execute.

## Test plan

- [ ] Trigger a build and confirm Sign SBOM OCI Artifact no longer fails when Rekor is unreachable (fallback warning appears and signing succeeds without tlog)
- [ ] Confirm Sign Image and Sign Manifest steps still succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)