### PR TITLE
fix: drop krunner-bazaar pending Qt 6.10 availability in EL10

### DIFF
--- a/.github/prompts/aurora-port.md
+++ b/.github/prompts/aurora-port.md
@@ -36,30 +36,43 @@ Always run `just fix && just check` after making changes to validate the build c
 
 ## Porting Rules
 
-1. **Packages**: Aurora targets Fedora only. TunaOS KDE targets both Fedora (bonito) and EL10
-   (yellowfin/albacore/skipjack). Port Fedora packages into the `IS_FEDORA == true` block in
-   `build_scripts/kde.sh`. For packages that also exist in EL10 repos or the `ublue-os/packages`
-   COPR, also add them to the EL10 block.
+> **Goal: incorporate as much as possible from upstream.**
+> At the end of this file is an **EL10 Package Availability Check** section with
+> definitive results from a live AlmaLinux Kitten 10 + EPEL 10 + CRB container query.
+> Use those results — do not guess.
+
+1. **Packages — use the availability report**:
+
+   Aurora targets Fedora only. TunaOS KDE targets both Fedora (`bonito`) and EL10
+   (`yellowfin`/`albacore`/`skipjack`). For every package in the diff, check the
+   `## EL10 Package Availability Check` section at the bottom of this file:
+
+   | Result | Action |
+   |---|---|
+   | ✅ Available in EL10 | Add to **both** the `IS_FEDORA == true` block **and** the `else` (EL10) block in `build_scripts/kde.sh` |
+   | ❌ Not available in EL10 | Add **only** inside `if [[ $IS_FEDORA == true ]]; then` — a tracking issue has already been opened |
+
+   Active EL10 repos in TunaOS: base AlmaLinux/CentOS Stream 10, EPEL 10, CRB,
+   `ublue-os/packages` COPR, `tuna-os/github-copr` COPR (see `build_scripts/lib.sh`).
 
 2. **COPR packages**: Aurora uses `ublue-os/packages`, `ublue-os/staging`, `ledif/kairpods`,
-   `lizardbyte/beta`. TunaOS already has `ublue-os/packages` for EL10. Add Fedora-only COPRs
+   `lizardbyte/beta`. TunaOS has `ublue-os/packages` for EL10. Add Fedora-only COPRs
    inside the `IS_FEDORA == true` block only.
 
-3. **Config files**: Mirror aurora's `system_files/shared/` → TunaOS's `system_files/`,
-   and any KDE-specific overrides → `system_files_overrides/kde/`.
+3. **Config files**: Mirror aurora's `system_files/shared/` → TunaOS `system_files/`,
+   and KDE-specific overrides → `system_files_overrides/kde/`.
 
-4. **Version-specific packages**: Aurora has `case "$FEDORA_MAJOR_VERSION"` blocks. TunaOS
+4. **Version-specific packages**: Aurora uses `case "$FEDORA_MAJOR_VERSION"` blocks. TunaOS
    uses `$MAJOR_VERSION_NUMBER` from `lib.sh`. Replicate conditionals using that variable.
 
-5. **DX flavor**: Aurora's `dx` variant maps to TunaOS's `kde` flavor with DX additions — check
-   `system_files_overrides/kde/` for the right place.
+5. **DX flavor**: Aurora's `dx` variant maps to TunaOS's `kde` flavor with DX additions —
+   check `system_files_overrides/kde/` for the right place.
 
-6. **Do NOT port**: aurora/fedora branding, `plasma-lookandfeel-fedora` removal (TunaOS may
-   have its own), signing keys, CI/CD files, Renovate config, documentation,
-   `plasma-welcome-fedora` removal (check if TunaOS needs this), or `image.toml`.
+6. **Do NOT port**: aurora/fedora branding, signing keys, CI/CD files, Renovate config,
+   documentation, `image.toml`, or `os-release` changes.
 
-7. **If nothing to port**: Still commit a file `.github/upstream-notes/aurora-{SHORT_SHA}.md`
-   documenting why the commit was reviewed and skipped.
+7. **If nothing to port**: Still commit `.github/upstream-notes/aurora-{SHORT_SHA}.md`
+   explaining why the commit was skipped.
 
 ## Output
 

--- a/.github/prompts/zirconium-port.md
+++ b/.github/prompts/zirconium-port.md
@@ -34,23 +34,34 @@ Always run `just fix && just check` after making changes to validate the build c
 
 ## Porting Rules
 
-1. **Packages**: Only port packages that exist in Fedora repos or the active COPRs already configured
-   in `niri.sh` (e.g., `yalter/niri-git`, `avengemedia/dms-git`, `zirconium/packages`).
-   If a package is Fedora-only and not available on EL10, add it only in the `IS_FEDORA == true` block.
+> **Goal: incorporate as much as possible from upstream.**
+> At the end of this file is an **EL10 Package Availability Check** section with
+> definitive results from a live AlmaLinux Kitten 10 + EPEL 10 + CRB container query.
+> Use those results — do not guess.
 
-2. **Config files**: Drop config files into `system_files_overrides/niri/` mirroring the path structure
+1. **Packages — use the availability report**:
+
+   For every package in the diff, check the `## EL10 Package Availability Check`
+   section at the bottom of this file and apply the following rules:
+
+   | Result | Action |
+   |---|---|
+   | ✅ Available in EL10 | Add to **both** the `IS_FEDORA == true` block **and** the `else` (EL10) block |
+   | ❌ Not available in EL10 | Add **only** inside `if [[ $IS_FEDORA == true ]]; then` — a tracking issue has already been opened |
+
+   Active EL10 repos in TunaOS: base AlmaLinux/CentOS Stream 10, EPEL 10, CRB,
+   `ublue-os/packages` COPR, `tuna-os/github-copr` COPR (see `build_scripts/lib.sh`).
+
+2. **Config files**: Drop config files into `system_files_overrides/niri/` mirroring the path
    from `mkosi.extra/`. Create subdirectories as needed.
 
 3. **Post-install scripts**: Add equivalent logic to the `"post"` case in `build_scripts/niri.sh`.
 
-4. **EL10 variants**: TunaOS targets both Fedora (bonito) and EL10 (yellowfin/albacore/skipjack).
-   If the change only makes sense for Fedora, wrap it in `if [[ $IS_FEDORA == true ]]; then`.
+4. **Do NOT port**: branding changes, hostname changes, zirconium-specific signing keys/policies,
+   `os-release` changes, CI/CD files, Renovate config, or documentation.
 
-5. **Do NOT port**: branding changes, hostname changes, zirconium-specific signing keys/policies,
-   changes to `os-release`, CI/CD files, Renovate config, or documentation.
-
-6. **If nothing to port**: Still commit a file `.github/upstream-notes/zirconium-{SHORT_SHA}.md`
-   documenting why the commit was reviewed and skipped.
+5. **If nothing to port**: Still commit `.github/upstream-notes/zirconium-{SHORT_SHA}.md`
+   explaining why the commit was skipped.
 
 ## Output
 

--- a/.github/scripts/check-el10-packages.py
+++ b/.github/scripts/check-el10-packages.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Check EL10 package availability for packages mentioned in the upstream diff.
+
+Spins up an AlmaLinux Kitten 10 container, enables EPEL 10 + CRB +
+ublue-os/packages COPR + tuna-os/github-copr, then queries dnf for every
+package candidate found in the diff's added lines.
+
+Results are appended to GEMINI_TASK.md so the AI knows exactly which packages
+can go in both blocks vs. the IS_FEDORA-only block.
+
+For packages that are NOT available in EL10, a GitHub issue is opened as a
+tracking item (deduplicated — skips if an open issue already exists).
+
+Environment variables:
+  GH_TOKEN      - GitHub token for issue creation
+  REPO          - owner/repo
+  SHORT_SHA     - 8-char upstream commit SHA (for issue context)
+  URL           - upstream commit URL (for issue context)
+  UPSTREAM_REPO - e.g. zirconium-dev/zirconium (for issue title/label)
+  FLAVOR        - niri / gnome / kde (for issue label)
+"""
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+GH_TOKEN = os.environ.get("GH_TOKEN", "")
+REPO = os.environ.get("REPO", "")
+SHORT_SHA = os.environ.get("SHORT_SHA", "unknown")
+URL = os.environ.get("URL", "")
+UPSTREAM_REPO = os.environ.get("UPSTREAM_REPO", "upstream")
+FLAVOR = os.environ.get("FLAVOR", "unknown")
+
+TASK_FILE = pathlib.Path("GEMINI_TASK.md")
+
+# ── Extract package candidates from +lines in the diff ───────────────────────
+
+content = TASK_FILE.read_text()
+
+# Grab everything between "## Diff" and the next "## " heading
+diff_text = re.search(r"## Diff\n(.*?)(?=\n## |\Z)", content, re.DOTALL)
+diff_lines = diff_text.group(1).splitlines() if diff_text else []
+
+PKG_RE = re.compile(r'\b([a-z][a-z0-9._+\-]{2,60})\b')
+
+# Words that are definitely not package names
+NOISE = {
+    "the", "and", "for", "not", "are", "was", "has", "that", "this", "with",
+    "from", "true", "false", "then", "else", "elif", "done", "esac", "exit",
+    "echo", "sudo", "bash", "fish", "dnf", "rpm", "yum", "git", "apt", "var",
+    "usr", "etc", "lib", "bin", "sbin", "tmp", "run", "dev", "sys", "proc",
+    "boot", "root", "null", "set", "get", "put", "use", "new", "add", "all",
+    "any", "can", "may", "let", "top", "end", "now", "type", "name", "path",
+    "file", "line", "list", "item", "call", "read", "make", "copy", "move",
+    "link", "test", "info", "base", "core", "main", "pass", "fail", "work",
+    "help", "just", "only", "also", "very", "more", "most", "some", "each",
+    "both", "even", "into", "over", "when", "than", "like", "after", "before",
+    "while", "local", "export", "source", "return", "function", "install",
+    "remove", "update", "enable", "disable", "start", "stop", "check", "build",
+    "clean", "version", "package", "packages", "true", "false", "null", "yes",
+    "copr", "repo", "enabled", "disabled", "quiet", "verbose", "args", "opts",
+    "diff", "hash", "head", "tail", "grep", "sort", "uniq", "awk", "sed",
+    "cat", "tee", "cut", "wc", "find", "xargs", "curl", "wget", "tar", "zip",
+}
+
+candidates = set()
+for line in diff_lines:
+    if not line.startswith("+"):
+        continue
+    stripped = line[1:].strip()
+    if stripped.startswith("#"):
+        continue
+    # Skip lines that look like paths, URLs, or assignments
+    if any(c in stripped for c in ["/", "http", "$", "=", "{"]):
+        continue
+    for m in PKG_RE.finditer(stripped):
+        word = m.group(1)
+        if word not in NOISE and not word.startswith("-") and len(word) >= 3:
+            candidates.add(word)
+
+if not candidates:
+    print("No package candidates found in diff — skipping EL10 check")
+    sys.exit(0)
+
+pkg_list = sorted(candidates)
+print(f"Checking {len(pkg_list)} package candidates in EL10+EPEL+CRB+COPRs:")
+print("  " + ", ".join(pkg_list))
+
+# ── Run check inside AlmaLinux Kitten 10 container ───────────────────────────
+
+setup = " && ".join([
+    "dnf install -y dnf-plugins-core epel-release --quiet --nogpgcheck 2>/dev/null",
+    "crb enable --quiet 2>/dev/null || true",
+    "dnf copr enable -y ublue-os/packages --quiet 2>/dev/null || true",
+    "dnf copr enable -y tuna-os/github-copr --quiet 2>/dev/null || true",
+    "dnf makecache --quiet 2>/dev/null || true",
+])
+query = "dnf repoquery --available --quiet " + " ".join(pkg_list) + " 2>/dev/null"
+
+try:
+    result = subprocess.run(
+        ["docker", "run", "--rm", "almalinux:kitten", "bash", "-c",
+         f"{setup} && {query}"],
+        capture_output=True, text=True, timeout=300,
+    )
+except subprocess.TimeoutExpired:
+    print("WARNING: Container check timed out — skipping availability report")
+    sys.exit(0)
+except FileNotFoundError:
+    print("WARNING: Docker not available — skipping availability report")
+    sys.exit(0)
+
+# ── Parse results — repoquery outputs name-version.arch lines ────────────────
+
+found_names = set()
+for line in result.stdout.splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    # Strip epoch:version-release.arch suffix: keep base name
+    base = re.sub(r'[:-]\d.*$', '', line)
+    base = re.sub(r'\.\w+$', '', base)  # strip .arch
+    if base:
+        found_names.add(base)
+
+available, unavailable = [], []
+for pkg in pkg_list:
+    # Match if the package name is found exactly or as a prefix in found names
+    if pkg in found_names or any(f == pkg or f.startswith(pkg + "-") for f in found_names):
+        available.append(pkg)
+    else:
+        unavailable.append(pkg)
+
+print(f"EL10 available ({len(available)}): {', '.join(available) or 'none'}")
+print(f"EL10 unavailable ({len(unavailable)}): {', '.join(unavailable) or 'none'}")
+
+# ── Append availability report to GEMINI_TASK.md ─────────────────────────────
+
+lines = [
+    "",
+    "---",
+    "",
+    "## EL10 Package Availability Check",
+    "",
+    "Packages from the diff were queried against **AlmaLinux Kitten 10 + EPEL 10 + CRB + "
+    "`ublue-os/packages` + `tuna-os/github-copr`**.",
+    "",
+    "**Port as much as possible.** Use this report to place packages correctly:",
+    "",
+]
+if available:
+    lines += [
+        "### ✅ Available in EL10 — add to BOTH Fedora and EL10 blocks",
+        "",
+    ] + [f"- `{p}`" for p in available] + [""]
+if unavailable:
+    lines += [
+        "### ❌ Not available in EL10 — add to `IS_FEDORA == true` block only",
+        "",
+    ] + [f"- `{p}`" for p in unavailable] + [""]
+
+TASK_FILE.write_text(content + "\n".join(lines))
+
+# ── Open tracking issues for EL10-unavailable packages (deduplicated) ────────
+
+if not unavailable or not GH_TOKEN or not REPO:
+    sys.exit(0)
+
+# Ensure the label exists
+subprocess.run(
+    ["gh", "label", "create", "el10-gap",
+     "--repo", REPO,
+     "--description", "Package not available in EL10+EPEL — needs packaging or alternative",
+     "--color", "E11D48"],
+    capture_output=True,
+    env={**os.environ, "GH_TOKEN": GH_TOKEN},
+)
+
+for pkg in unavailable:
+    # Check for existing open issue to avoid duplicates
+    existing = subprocess.run(
+        ["gh", "issue", "list",
+         "--repo", REPO,
+         "--label", "el10-gap",
+         "--state", "open",
+         "--search", f"el10-gap {pkg}",
+         "--json", "number",
+         "--jq", "length"],
+        capture_output=True, text=True,
+        env={**os.environ, "GH_TOKEN": GH_TOKEN},
+    ).stdout.strip()
+
+    if existing != "0":
+        print(f"  Issue already open for {pkg} — skipping")
+        continue
+
+    body = (
+        f"## EL10 Packaging Gap: `{pkg}`\n\n"
+        f"`{pkg}` is present in the upstream [`{UPSTREAM_REPO}`]"
+        f"(https://github.com/{UPSTREAM_REPO}) at commit "
+        f"[`{SHORT_SHA}`]({URL}) but is **not available** in "
+        f"EL10 + EPEL 10 + CRB + `ublue-os/packages`.\n\n"
+        f"### Impact\n\n"
+        f"The `{FLAVOR}` flavor on EL10 variants (yellowfin / albacore / skipjack) "
+        f"cannot include this package. It is currently added to the "
+        f"`IS_FEDORA == true` block only.\n\n"
+        f"### Options\n\n"
+        f"- [ ] Package it in `tuna-os/github-copr`\n"
+        f"- [ ] Find an EL10-compatible alternative\n"
+        f"- [ ] Accept the Fedora-only status and document it\n"
+    )
+
+    result = subprocess.run(
+        ["gh", "issue", "create",
+         "--repo", REPO,
+         "--title", f"📦 [el10-gap] `{pkg}` not available in EL10 (from {UPSTREAM_REPO}@{SHORT_SHA})",
+         "--label", f"el10-gap,upstream-{FLAVOR}",
+         "--body", body],
+        capture_output=True, text=True,
+        env={**os.environ, "GH_TOKEN": GH_TOKEN},
+    )
+    if result.returncode == 0:
+        issue_url = result.stdout.strip()
+        print(f"  Opened issue for {pkg}: {issue_url}")
+    else:
+        print(f"  Failed to open issue for {pkg}: {result.stderr.strip()}")

--- a/.github/workflows/watch-aurora.yml
+++ b/.github/workflows/watch-aurora.yml
@@ -137,6 +137,16 @@ jobs:
           mkdir -p .github/upstream-notes
           python3 .github/scripts/write-gemini-task.py
 
+      - name: Check EL10 package availability
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHORT_SHA: ${{ matrix.short_sha }}
+          URL: ${{ matrix.url }}
+          UPSTREAM_REPO: ublue-os/aurora
+          FLAVOR: kde
+        run: python3 .github/scripts/check-el10-packages.py
+
       - name: Run Gemini to port the change
         id: gemini
         continue-on-error: true

--- a/.github/workflows/watch-bluefin-lts.yml
+++ b/.github/workflows/watch-bluefin-lts.yml
@@ -137,6 +137,16 @@ jobs:
           mkdir -p .github/upstream-notes
           python3 .github/scripts/write-gemini-task.py
 
+      - name: Check EL10 package availability
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHORT_SHA: ${{ matrix.short_sha }}
+          URL: ${{ matrix.url }}
+          UPSTREAM_REPO: ublue-os/bluefin-lts
+          FLAVOR: gnome
+        run: python3 .github/scripts/check-el10-packages.py
+
       - name: Run Gemini to port the change
         id: gemini
         continue-on-error: true

--- a/.github/workflows/watch-zirconium.yml
+++ b/.github/workflows/watch-zirconium.yml
@@ -137,6 +137,16 @@ jobs:
           mkdir -p .github/upstream-notes
           python3 .github/scripts/write-gemini-task.py
 
+      - name: Check EL10 package availability
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHORT_SHA: ${{ matrix.short_sha }}
+          URL: ${{ matrix.url }}
+          UPSTREAM_REPO: zirconium-dev/zirconium
+          FLAVOR: niri
+        run: python3 .github/scripts/check-el10-packages.py
+
       - name: Run Gemini to port the change
         id: gemini
         continue-on-error: true

--- a/build_scripts/kde.sh
+++ b/build_scripts/kde.sh
@@ -88,8 +88,8 @@ case "${1:-}" in
 	dnf -y copr enable ublue-os/packages
 	dnf -y copr disable ublue-os/packages
 	dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
-		kcm_ublue \
-		krunner-bazaar
+		kcm_ublue
+	# krunner-bazaar 1.3.0 requires Qt 6.10 which is not yet in EL10; re-add when COPR is fixed
 
 	# Disable plasma-discover in favor of Flatpak/Bazaar (like Aurora)
 	if [ -f /usr/share/applications/org.kde.discover.desktop ]; then

--- a/system_files/usr/share/plymouth/themes/tunaos/tunaos.script
+++ b/system_files/usr/share/plymouth/themes/tunaos/tunaos.script
@@ -8,6 +8,15 @@ FRAME_COUNT = 72;
 FRAME_RATE  = 2;  # advance one frame every N refresh ticks (Plymouth ticks at ~20fps)
                   # FRAME_RATE=2 → ~10fps playback to match the original GIF speed
 
+TEXT_COLOR_R = 1;
+TEXT_COLOR_G = 1;
+TEXT_COLOR_B = 1;
+MUTED_COLOR_R = 0.72;
+MUTED_COLOR_G = 0.8;
+MUTED_COLOR_B = 0.9;
+PROMPT_GAP = 28;
+ENTRY_GAP = 10;
+
 fun ZeroPad(n) {
     if (n < 10)   return "000" + n;
     if (n < 100)  return "00"  + n;
@@ -29,6 +38,118 @@ fish_sprite.SetImage(fish_images[1]);
 
 current_frame = 1;
 tick = 0;
+status = "normal";
+prompt_sprite = NULL;
+entry_sprite = NULL;
+prompt_image = NULL;
+entry_image = NULL;
+prompt_text = "";
+prompt_value = "";
+password_bullets = 0;
+fish_x = Window.GetWidth()  / 2 - fish_images[1].GetWidth()  / 2;
+fish_y = Window.GetHeight() / 2 - fish_images[1].GetHeight() / 2;
+
+fun RepeatText(text, count) {
+    local output;
+    output = "";
+
+    for (i = 0; i < count; i++) {
+        output += text;
+    }
+
+    return output;
+}
+
+fun SetSpriteImage(sprite, image) {
+    if (!sprite) {
+        sprite = Sprite();
+    }
+
+    sprite.SetImage(image);
+    sprite.SetZ(10);
+    return sprite;
+}
+
+fun HidePromptOverlay() {
+    if (prompt_sprite) {
+        prompt_sprite.SetOpacity(0);
+    }
+
+    if (entry_sprite) {
+        entry_sprite.SetOpacity(0);
+    }
+}
+
+fun PositionPromptOverlay() {
+    local center_x;
+    local prompt_y;
+    local entry_y;
+
+    if (!prompt_image || !entry_image) {
+        return;
+    }
+
+    center_x = Window.GetWidth() / 2;
+    prompt_y = fish_y + fish_images[current_frame].GetHeight() + PROMPT_GAP;
+    entry_y = prompt_y + prompt_image.GetHeight() + ENTRY_GAP;
+
+    prompt_sprite.SetX(center_x - prompt_image.GetWidth() / 2);
+    prompt_sprite.SetY(prompt_y);
+    prompt_sprite.SetOpacity(1);
+
+    entry_sprite.SetX(center_x - entry_image.GetWidth() / 2);
+    entry_sprite.SetY(entry_y);
+    entry_sprite.SetOpacity(1);
+}
+
+fun ShowPromptOverlay(prompt_text, entry_text, entry_r, entry_g, entry_b) {
+    prompt_image = Image.Text(prompt_text, TEXT_COLOR_R, TEXT_COLOR_G, TEXT_COLOR_B);
+    entry_image = Image.Text(entry_text, entry_r, entry_g, entry_b);
+
+    prompt_sprite = SetSpriteImage(prompt_sprite, prompt_image);
+    entry_sprite = SetSpriteImage(entry_sprite, entry_image);
+    PositionPromptOverlay();
+}
+
+fun display_normal_callback() {
+    status = "normal";
+    prompt_text = "";
+    prompt_value = "";
+    password_bullets = 0;
+    HidePromptOverlay();
+}
+
+fun display_password_callback(prompt, bullets) {
+    local bullet_text;
+
+    status = "password";
+    prompt_text = prompt;
+    password_bullets = bullets;
+
+    bullet_text = RepeatText("*", bullets);
+
+    if (bullet_text == "") {
+        bullet_text = "Enter disk password";
+    }
+
+    prompt_value = bullet_text;
+    ShowPromptOverlay(prompt_text, prompt_value, MUTED_COLOR_R, MUTED_COLOR_G, MUTED_COLOR_B);
+}
+
+fun display_question_callback(prompt, entry_text) {
+    local value_text;
+
+    status = "question";
+    prompt_text = prompt;
+    value_text = entry_text;
+
+    if (value_text == "") {
+        value_text = "_";
+    }
+
+    prompt_value = value_text;
+    ShowPromptOverlay(prompt_text, prompt_value, MUTED_COLOR_R, MUTED_COLOR_G, MUTED_COLOR_B);
+}
 
 fun refresh_callback() {
     tick = tick + 1;
@@ -36,6 +157,20 @@ fun refresh_callback() {
         current_frame = (current_frame % FRAME_COUNT) + 1;
         fish_sprite.SetImage(fish_images[current_frame]);
     }
+
+    fish_x = Window.GetWidth()  / 2 - fish_images[current_frame].GetWidth()  / 2;
+    fish_y = Window.GetHeight() / 2 - fish_images[current_frame].GetHeight() / 2;
+    fish_sprite.SetX(fish_x);
+    fish_sprite.SetY(fish_y);
+
+    if (status == "password") {
+        PositionPromptOverlay();
+    } else if (status == "question") {
+        PositionPromptOverlay();
+    }
 }
 
 Plymouth.SetRefreshFunction(refresh_callback);
+Plymouth.SetDisplayNormalFunction(display_normal_callback);
+Plymouth.SetDisplayPasswordFunction(display_password_callback);
+Plymouth.SetDisplayQuestionFunction(display_question_callback);


### PR DESCRIPTION
## Summary
- Removes `krunner-bazaar` from the KDE extra install step — v1.3.0 in the `ublue-os/packages` COPR now requires `libQt6Core.so.6(Qt_6.10)` which is not yet available in EL10, causing all KDE builds to fail
- Adds EL10 package availability check step to watch-aurora, watch-bluefin-lts, and watch-zirconium workflows
- Updates aurora-port and zirconium-port prompts with clearer porting rules and availability table
- Adds Plymouth password/question prompt overlay so disk-encryption prompts render correctly at boot

## Test plan
- [ ] KDE builds (albacore:kde, bonito:kde, etc.) should pass without the broken COPR package
- [ ] Re-add `krunner-bazaar` once the COPR package is rebuilt against Qt 6.8 or EL10 ships Qt 6.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)