### PR TITLE
ci: add ShellCheck/YAML/JSON lint, scorecard concurrency, workflow drift check

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,6 +17,13 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+# Prevent overlapping scorecard runs on the same ref — the OSSF API has
+# per-repo rate limits and concurrent runs can trigger alternating
+# success/failure (#377).
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   analysis:
     name: Scorecard analysis

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,13 @@ on:
       - 'scripts/**'
       - 'tests/**'
       - 'build_scripts/**'
+      - 'live-iso/**'
+      - 'iso_files/**'
+      - 'system_files/**'
+      - 'system_files_overrides/**'
       - '.github/scripts/**'
       - '.github/changelogs.py'
+      - '.github/workflows/**'
       - 'Justfile'
   push:
     branches: [main]
@@ -16,6 +21,62 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: Lint (ShellCheck + YAML + JSON)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install lint tools
+        run: |
+          sudo apt-get update && sudo apt-get install -y shellcheck yamllint jq
+
+      - name: ShellCheck
+        run: |
+          find . \
+            -not -path './system_files/usr/share/gnome-shell/extensions/*' \
+            -not -path './packages-repo/*' \
+            -not -path './.build/*' \
+            -iname "*.sh" -type f \
+            -exec shellcheck --exclude=SC1091 "{}" ";"
+
+      - name: YAML lint
+        run: |
+          find . \
+            -not -path './system_files/usr/share/gnome-shell/extensions/*' \
+            -not -path './packages-repo/*' \
+            -not -path './.build/*' \
+            -type f -name "*.yaml" | while read -r file; do
+            yamllint -c ./.yamllint.yml "$file" || { exit 1; }
+          done
+          find . \
+            -not -path './system_files/usr/share/gnome-shell/extensions/*' \
+            -not -path './packages-repo/*' \
+            -not -path './.build/*' \
+            -type f -name "*.yml" | while read -r file; do
+            yamllint "$file" || { exit 1; }
+          done
+
+      - name: JSON validate
+        run: |
+          find . \
+            -not -path './system_files/usr/share/gnome-shell/extensions/*' \
+            -not -path './packages-repo/*' \
+            -not -path './.build/*' \
+            -type f -name "*.json" | while read -r file; do
+            jq . "$file" > /dev/null || { exit 1; }
+          done
+
+      - name: Check generated files are up to date
+        run: |
+          pip3 install pyyaml --break-system-packages 2>/dev/null || pip3 install pyyaml --user
+          just generate-workflows
+          if ! git diff --exit-code -- .github/build-config.yml .github/workflows/build-*.yml; then
+            echo "::error::Generated files are out of date. Run 'just generate-workflows' and commit."
+            exit 1
+          fi
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #365, closes #377, closes #311.

## Changes

### Lint job in test.yml (#365)
- New `lint` job runs shellcheck, yamllint, and jq validation on every PR
- Mirrors what `just check` does locally, enforced in CI
- Expanded path triggers to cover `live-iso/**`, `iso_files/**`, `system_files/**`, `.github/workflows/**`

### Scorecard concurrency (#377)
- Added `concurrency` group to prevent overlapping scorecard runs on the same ref
- The alternating success/failure pattern on main is likely caused by concurrent runs hitting OSSF API rate limits

### Generated workflow drift check (#311)
- CI now regenerates workflows and fails if output differs from committed files
- Catches the classic anti-pattern of generated files drifting from their config