### PR TITLE
security: fix hardcoded password, TLS test assertions, fake PAT token

### DIFF
--- a/tests/bats/test_registry.bats
+++ b/tests/bats/test_registry.bats
@@ -146,7 +146,6 @@ teardown() {
     echo "podman push --tls-verify=false --compression-format=zstd:chunked --compression-level=3 --force-compression localhost/${VARIANT}:${FLAVOR} ${HOST}:${PORT}/${VARIANT}:${FLAVOR}"
   '
   [ "$status" -eq 0 ]
-  [[ "$output" == *"--tls-verify=false"* ]]
   [[ "$output" == *"--compression-format=zstd:chunked"* ]]
   [[ "$output" == *"localhost/yellowfin:gnome"* ]]
   [[ "$output" == *"127.0.0.1:5000/yellowfin:gnome"* ]]
@@ -181,7 +180,7 @@ teardown() {
     echo "podman tag ${HOST}:${PORT}/${VARIANT}:${FLAVOR} localhost/${VARIANT}:${FLAVOR}"
   '
   [ "$status" -eq 0 ]
-  [[ "$output" == *"podman pull --tls-verify=false 127.0.0.1:5000/bonito:niri"* ]]
+  [[ "$output" == *"podman pull"*"127.0.0.1:5000/bonito:niri"* ]]
   [[ "$output" == *"podman tag 127.0.0.1:5000/bonito:niri localhost/bonito:niri"* ]]
 }
 


### PR DESCRIPTION
Closes #359, closes #329, closes #330.

## Changes

### Hardcoded password (#359)
- `live-iso/common/src/build.sh`: replaced `liveuser:live` with random password via `openssl rand -base64 12`
- Password stored in `/etc/liveiso-dev-pw` (mode 600), printed to build log
- Systemd oneshot reads from file, sets password with `chpasswd`, logs to journal (`journalctl -t liveiso-dev`)
- Only affects `ENABLE_SSHD=1` dev builds; production ISOs never reach this path

### TLS-verify test assertions (#329)
- Removed assertions that check for `--tls-verify=false` in registry BATS tests
- Tests now verify logical behavior (connecting to correct host:port) instead of locking in the insecure flag
- Prevents breakage when someone fixes the actual registry script to use TLS properly

### Fake PAT token (#330)
- `tests/test_fire_copilot_batch.py`: replaced `ghp_faketoken123` with `fake-gh-token-for-testing`
- The `ghp_` prefix matches GitHub PAT patterns and triggers secret scanners