### PR TITLE
fix: replace critical || true with warn_on_fail helper (#381)

### DIFF
--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -28,15 +28,15 @@ install_base_packages_no_de() {
 		# Check for subscription-manager credentials and register if present
 		if [[ -n "${RHSM_USER:-}" ]] && [[ -n "${RHSM_PASSWORD:-}" ]]; then
 			echo "Registering with Red Hat Subscription Manager using credentials..."
-			subscription-manager register --username "${RHSM_USER}" --password "${RHSM_PASSWORD}" --auto-attach || true
+			warn_on_fail subscription-manager register --username "${RHSM_USER}" --password "${RHSM_PASSWORD}" --auto-attach
 		elif [[ -n "${RHSM_ORG:-}" ]] && [[ -n "${RHSM_ACTIVATION_KEY:-}" ]]; then
 			echo "Registering with Red Hat Subscription Manager using activation key..."
-			subscription-manager register --org "${RHSM_ORG}" --activationkey "${RHSM_ACTIVATION_KEY}" --auto-attach || true
+			warn_on_fail subscription-manager register --org "${RHSM_ORG}" --activationkey "${RHSM_ACTIVATION_KEY}" --auto-attach
 		fi
 
 		# Ensure repositories are enabled after registration
-		subscription-manager repos --enable "rhel-10-for-x86_64-baseos-rpms" || true
-		subscription-manager repos --enable "rhel-10-for-x86_64-appstream-rpms" || true
+		warn_on_fail subscription-manager repos --enable "rhel-10-for-x86_64-baseos-rpms"
+		warn_on_fail subscription-manager repos --enable "rhel-10-for-x86_64-appstream-rpms"
 	fi
 
 	dnf -y install 'dnf-command(versionlock)'

--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -114,7 +114,7 @@ rm -rf /var/roothome/buildinfo
 # FIXME: use --fix option once https://github.com/containers/bootc/pull/1152 is merged
 # NOTE: --fatal-warnings suppressed for /var/lib/selinux deep module files which cannot
 # be declared in tmpfiles.d (they are non-directory files owned by selinux-policy).
-bootc container lint --fatal-warnings || true
+warn_on_fail bootc container lint --fatal-warnings
 
 jq . /usr/share/ublue-os/image-info.json
 

--- a/build_scripts/gnome.sh
+++ b/build_scripts/gnome.sh
@@ -36,7 +36,7 @@ case "${1:-}" in
 		# --noautoremove keeps reverse-deps alive; they'll re-resolve to the
 		# COPR's gnome-shell-49 in the next install.
 		if rpm -q gnome-shell-common &>/dev/null; then
-			dnf -y remove --noautoremove gnome-shell-common || true
+			warn_on_fail dnf -y remove --noautoremove gnome-shell-common
 		fi
 
 		if [[ "${DESKTOP_FLAVOR:-gnome}" == "gnome50" ]]; then
@@ -188,7 +188,7 @@ case "${1:-}" in
 	echo "Building GNOME extensions from source..."
 
 	# Remove versionlock on glib2 to allow installing glib2-devel (will re-lock after)
-	dnf versionlock delete glib2 || true
+	warn_on_fail dnf versionlock delete glib2
 
 	# Install build tooling
 	dnf -y install glib2-devel meson sassc cmake dbus-devel unzip

--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -128,6 +128,24 @@ copy_systemfiles_for() {
 	printf "::endgroup::\n"
 }
 
+# Run a command and emit a GitHub Actions ::warning on failure instead of
+# silently swallowing the error with || true.  Use for operations that are
+# important enough to surface in the build summary but not build-fatal
+# (e.g. versionlock changes, optional removes, RHSM registration).
+#
+# Usage: warn_on_fail subscription-manager register --username "${RHSM_USER}" ...
+#        warn_on_fail dnf -y versionlock delete glib2
+warn_on_fail() {
+	local cmd="$1"
+	shift
+	if ! "$cmd" "$@"; then
+		local caller_script
+		caller_script="$(basename "${BASH_SOURCE[1]:-?}")"
+		printf '::warning title=Operation failed (%s on %s)::%s %s exited with %d (called from %s)\n' \
+			"${IMAGE_NAME:-?}" "${MAJOR_VERSION_NUMBER:-?}" "$cmd" "$*" "$?" "$caller_script"
+	fi
+}
+
 # Run `dnf` with retries to absorb transient mirror flakes (EPEL / AlmaLinux /
 # CentOS mirrors fail with curl SSL_ERROR_SYSCALL / partial-file errors a few
 # times a week, which previously broke whole CI builds — see albacore failing

--- a/build_scripts/overrides/gdx/20-nvidia.sh
+++ b/build_scripts/overrides/gdx/20-nvidia.sh
@@ -32,7 +32,7 @@ if [[ "${ENABLE_HWE:-0}" != "1" ]] && { [[ $IS_ALMALINUX == true ]] || [[ $IS_AL
 else
 	# Fedora/CentOS from akmods
 	# Install from the mounted directory, including the kernel to satisfy dependencies
-	dnf versionlock delete kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra kernel-uki-virt || true
+	warn_on_fail dnf versionlock delete kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra kernel-uki-virt
 	rpms=$(find /tmp/akmods-nvidia-open-rpms/ /tmp/kernel-rpms/ -name "*.rpm" -type f 2>/dev/null | tr '\n' ' ' || true)
 	if [ -n "$rpms" ]; then
 		# Mask rpm-ostree kernel-install script to prevent dracut errors during container build


### PR DESCRIPTION
Closes #381.

## Changes

Adds `warn_on_fail` helper to `build_scripts/lib.sh` that emits GitHub Actions `::warning` annotations on failure instead of silently swallowing errors with `|| true`.

Replaces 8 critical `|| true` instances across 4 build scripts:

| Script | Operation | Impact |
|--------|-----------|--------|
| `10-base-packages.sh` | `subscription-manager register` (2x) | RHSM registration failures now produce visible warnings |
| `10-base-packages.sh` | `subscription-manager repos --enable` (2x) | Missing RHEL repos surfaced in build summary |
| `gnome.sh` | `dnf remove gnome-shell-common` | Package conflict resolution failures visible |
| `gnome.sh` | `dnf versionlock delete glib2` | Versionlock changes tracked |
| `cleanup.sh` | `bootc container lint --fatal-warnings` | Lint failures no longer hidden |
| `overrides/gdx/20-nvidia.sh` | `dnf versionlock delete kernel` | NVIDIA kernel versionlock changes tracked |

**Intentionally preserved `|| true`**: cleanup operations (`rm`, `podman rmi`, `kill`), best-effort checks (version probes, optional services), and the `safe_enable`/`safe_disable` wrappers which already have existence guards.