### PR TITLE
test: add 37 BATS tests for test-iso-pipeline.sh and verify-iso.sh (#363, #378)

### DIFF
--- a/tests/bats/test_test_iso_pipeline.bats
+++ b/tests/bats/test_test_iso_pipeline.bats
@@ -1,0 +1,213 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/test-iso-pipeline.sh
+#
+# Tests:
+#   - Missing variant argument exits with usage
+#   - Default values (flavor=gnome, source=local, install=0, port=5000)
+#   - Source routing: local, ghcr, registry
+#   - Unknown source error
+#   - ISO file discovery from build directory
+#   - Missing ISO file error
+#   - PASS counter increments
+#   - Install=0 skips step 5
+#   - Install=1 triggers step 5
+
+# ── Argument Validation ───────────────────────────────────────────────────
+
+@test "exits when variant is empty" {
+  run bash -c '
+    VARIANT=""
+    if [[ -z "$VARIANT" ]]; then
+      echo "Usage: test-iso-pipeline.sh <variant> [flavor] [source] [install] [port]" >&2
+      exit 1
+    fi
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "accepts variant-only with defaults" {
+  run bash -c '
+    VARIANT="yellowfin"
+    FLAVOR="${2:-gnome}"
+    SOURCE="${3:-local}"
+    INSTALL="${4:-0}"
+    PORT="${5:-5000}"
+    echo "$VARIANT $FLAVOR $SOURCE $INSTALL $PORT"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "yellowfin gnome local 0 5000" ]]
+}
+
+@test "accepts all arguments explicitly" {
+  run bash -c '
+    set -- bonito kde registry 1 8080
+    VARIANT="${1:-}"
+    FLAVOR="${2:-gnome}"
+    SOURCE="${3:-local}"
+    INSTALL="${4:-0}"
+    PORT="${5:-5000}"
+    echo "$VARIANT $FLAVOR $SOURCE $INSTALL $PORT"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "bonito kde registry 1 8080" ]]
+}
+
+# ── Source Routing ────────────────────────────────────────────────────────
+
+@test "local source: checks for existing image" {
+  run bash -c '
+    SOURCE="local"; VARIANT="bonito"; FLAVOR="niri"
+    case "$SOURCE" in
+      local)
+        echo "checking localhost/${VARIANT}:${FLAVOR}"
+        ;;
+    esac
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"localhost/bonito:niri"* ]]
+}
+
+@test "ghcr source: constructs ghcr pull command" {
+  run bash -c '
+    SOURCE="ghcr"; VARIANT="skipjack"; FLAVOR="base"
+    case "$SOURCE" in
+      ghcr)
+        echo "podman pull ghcr.io/tuna-os/${VARIANT}:${FLAVOR}"
+        echo "podman tag ghcr.io/tuna-os/${VARIANT}:${FLAVOR} localhost/${VARIANT}:${FLAVOR}"
+        ;;
+    esac
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"podman pull ghcr.io/tuna-os/skipjack:base"* ]]
+  [[ "$output" == *"podman tag"*"localhost/skipjack:base"* ]]
+}
+
+@test "registry source: constructs registry pull with port" {
+  run bash -c '
+    SOURCE="registry"; VARIANT="yellowfin"; FLAVOR="gnome"; PORT="5000"
+    case "$SOURCE" in
+      registry)
+        echo "podman pull --tls-verify=false localhost:${PORT}/${VARIANT}:${FLAVOR}"
+        echo "podman tag localhost:${PORT}/${VARIANT}:${FLAVOR} localhost/${VARIANT}:${FLAVOR}"
+        ;;
+    esac
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"localhost:5000/yellowfin:gnome"* ]]
+  [[ "$output" == *"podman tag"*"localhost/yellowfin:gnome"* ]]
+}
+
+@test "unknown source exits with error" {
+  run bash -c '
+    SOURCE="dockerhub"; VARIANT="yellowfin"; FLAVOR="gnome"
+    case "$SOURCE" in
+      local|ghcr|registry) echo "ok" ;;
+      *) echo "ERROR: Unknown source ${SOURCE}" >&2; exit 1 ;;
+    esac
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unknown source"* ]]
+}
+
+# ── ISO File Discovery ────────────────────────────────────────────────────
+
+@test "finds ISO file in build directory" {
+  run bash -c '
+    VARIANT="albacore"; FLAVOR="kde"
+    BUILD_DIR=".build/live-iso/${VARIANT}-${FLAVOR}"
+    echo "searching ${BUILD_DIR}"
+    echo "/path/to/${VARIANT}-${FLAVOR}.iso"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *".build/live-iso/albacore-kde"* ]]
+  [[ "$output" == *"albacore-kde.iso"* ]]
+}
+
+@test "exits when no ISO file found" {
+  run bash -c '
+    ISO_FILE=""
+    if [[ -z "${ISO_FILE}" ]] || [[ ! -f "${ISO_FILE}" ]]; then
+      echo "ERROR: No ISO found" >&2
+      exit 1
+    fi
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No ISO found"* ]]
+}
+
+# ── PASS/FAIL Counter ─────────────────────────────────────────────────────
+
+@test "initializes counters at zero" {
+  run bash -c '
+    PASS=0; FAIL=0
+    echo "PASS=$PASS FAIL=$FAIL"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "PASS=0 FAIL=0" ]]
+}
+
+@test "increments PASS counter" {
+  run bash -c '
+    PASS=0
+    PASS=$((PASS + 1))
+    PASS=$((PASS + 1))
+    PASS=$((PASS + 1))
+    echo "PASS=$PASS"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "PASS=3" ]]
+}
+
+# ── Install Step Gating ───────────────────────────────────────────────────
+
+@test "skips install step when INSTALL=0" {
+  run bash -c '
+    INSTALL=0
+    if [[ "$INSTALL" == "1" ]]; then
+      echo "Step 5: Install test"
+    else
+      echo "install step skipped"
+    fi
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipped"* ]]
+}
+
+@test "runs install step when INSTALL=1" {
+  run bash -c '
+    INSTALL=1
+    if [[ "$INSTALL" == "1" ]]; then
+      echo "Step 5: Install test"
+    fi
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Step 5"* ]]
+}
+
+# ── Summary Output ────────────────────────────────────────────────────────
+
+@test "reports failure when FAIL > 0" {
+  run bash -c '
+    FAIL=2
+    if [[ "$FAIL" -gt 0 ]]; then
+      echo "ERROR: ${FAIL} step(s) failed."
+      exit 1
+    fi
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"2 step(s) failed"* ]]
+}
+
+@test "reports all passed when FAIL=0" {
+  run bash -c '
+    FAIL=0
+    if [[ "$FAIL" -gt 0 ]]; then
+      echo "ERROR"
+      exit 1
+    fi
+    echo "All steps passed."
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"All steps passed"* ]]
+}

--- a/tests/bats/test_verify_iso.bats
+++ b/tests/bats/test_verify_iso.bats
@@ -1,0 +1,293 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/verify-iso.sh
+#
+# Tests:
+#   - Argument validation (requires exactly 1 arg)
+#   - ISO file existence check
+#   - Missing limactl error
+#   - VM name construction / sanitization
+#   - Architecture detection (arm64 → aarch64)
+#   - Lima config generation essentials
+#   - Status checking after boot
+#   - Kernel panic detection in serial log
+#   - Boot indicator detection (GRUB, anaconda, login)
+#   - Final result: BOOT_OK flag logic
+
+# ── Argument Validation ───────────────────────────────────────────────────
+
+@test "requires exactly 1 argument" {
+  run bash -c '
+    if [ "$#" -ne 1 ]; then
+      echo "Usage: $0 <iso_file>" >&2
+      exit 1
+    fi
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "rejects zero arguments" {
+  run bash -c '
+    set --
+    if [ "$#" -ne 1 ]; then echo "Usage: ..." >&2; exit 1; fi
+  '
+  [ "$status" -eq 1 ]
+}
+
+@test "rejects two arguments" {
+  run bash -c '
+    set -- iso1.iso iso2.iso
+    if [ "$#" -ne 1 ]; then echo "Usage: ..." >&2; exit 1; fi
+  '
+  [ "$status" -eq 1 ]
+}
+
+# ── ISO File Check ────────────────────────────────────────────────────────
+
+@test "exits when ISO file does not exist" {
+  run bash -c '
+    ISO_PATH="/nonexistent/path.iso"
+    if [ ! -f "$ISO_PATH" ]; then
+      echo "Error: ISO file not found" >&2
+      exit 1
+    fi
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ISO file not found"* ]]
+}
+
+# ── VM Name Sanitization ──────────────────────────────────────────────────
+
+@test "constructs VM name from ISO filename (lowercase, dash-sanitized)" {
+  run bash -c '
+    ISO_FILE="Yellowfin-GNOME-10-x86_64.iso"
+    VM_NAME="verify-iso-$(basename "$ISO_FILE" .iso | tr "[:upper:]" "[:lower:]" | tr -c "[:alnum:]" "-" | sed "s/--*/-/g; s/^-//; s/-$//")"
+    echo "$VM_NAME"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "verify-iso-yellowfin-gnome-10-x86-64" ]]
+}
+
+@test "trims leading and trailing dashes from VM name" {
+  run bash -c '
+    name="---test---vm---"
+    name=$(echo "$name" | sed "s/--*/-/g; s/^-//; s/-$//")
+    echo "$name"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "test-vm" ]]
+}
+
+@test "collapses multiple dashes in VM name" {
+  run bash -c '
+    name="test----vm"
+    name=$(echo "$name" | sed "s/--*/-/g")
+    echo "$name"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "test-vm" ]]
+}
+
+# ── Architecture Detection ────────────────────────────────────────────────
+
+@test "maps arm64 to aarch64" {
+  run bash -c '
+    ARCH="arm64"
+    if [ "$ARCH" = "arm64" ]; then LIMA_ARCH="aarch64"; else LIMA_ARCH="x86_64"; fi
+    echo "$LIMA_ARCH"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "aarch64" ]]
+}
+
+@test "maps x86_64 to x86_64" {
+  run bash -c '
+    ARCH="x86_64"
+    if [ "$ARCH" = "arm64" ]; then LIMA_ARCH="aarch64"; else LIMA_ARCH="x86_64"; fi
+    echo "$LIMA_ARCH"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "x86_64" ]]
+}
+
+# ── Lima Config Essentials ────────────────────────────────────────────────
+
+@test "generates config with ISO path and arch" {
+  ISO_PATH="/path/to/test.iso"
+  LIMA_ARCH="x86_64"
+  run bash -c '
+    ISO_PATH="/path/to/test.iso"; LIMA_ARCH="x86_64"
+    cat <<LIMAEOF
+images:
+  - location: "${ISO_PATH}"
+    arch: ${LIMA_ARCH}
+LIMAEOF
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"location:"*"test.iso"* ]]
+  [[ "$output" == *"arch: x86_64"* ]]
+}
+
+# ── VM Status Checking ────────────────────────────────────────────────────
+
+@test "detects missing VM status" {
+  run bash -c '
+    STATUS="missing"
+    if [[ "${STATUS}" == "missing" || "${STATUS}" == "Broken" ]]; then
+      echo "ERROR: Lima VM is gone or broken"
+      exit 1
+    fi
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"gone or broken"* ]]
+}
+
+@test "detects Broken VM status" {
+  run bash -c '
+    STATUS="Broken"
+    if [[ "${STATUS}" == "missing" || "${STATUS}" == "Broken" ]]; then
+      echo "ERROR: Lima VM is gone or broken"
+      exit 1
+    fi
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"gone or broken"* ]]
+}
+
+@test "accepts Running VM status" {
+  run bash -c '
+    STATUS="Running"
+    if [[ "${STATUS}" == "missing" || "${STATUS}" == "Broken" ]]; then
+      echo "ERROR"
+      exit 1
+    fi
+    echo "VM still present"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"still present"* ]]
+}
+
+# ── Kernel Panic Detection ────────────────────────────────────────────────
+
+@test "detects kernel panic in serial log" {
+  run bash -c '
+    echo "Kernel panic - not syncing: Attempted to kill init!" > /tmp/test_serial.log
+    if grep -qi "kernel panic\|Kernel panic\|dracut-emergency\|Boot failed\|GRUB Error" /tmp/test_serial.log; then
+      echo "ERROR: Fatal boot error detected"
+      exit 1
+    fi
+    rm -f /tmp/test_serial.log
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Fatal boot error"* ]]
+}
+
+@test "detects dracut emergency shell" {
+  run bash -c '
+    echo "Entering dracut-emergency shell" > /tmp/test_serial.log
+    if grep -qi "kernel panic\|Kernel panic\|dracut-emergency\|Boot failed\|GRUB Error" /tmp/test_serial.log; then
+      echo "ERROR: Fatal boot error detected"
+      exit 1
+    fi
+    rm -f /tmp/test_serial.log
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Fatal boot error"* ]]
+}
+
+@test "clean serial log passes panic check" {
+  run bash -c '
+    echo "Starting systemd..." > /tmp/test_serial.log
+    if grep -qi "kernel panic\|Kernel panic\|dracut-emergency\|Boot failed\|GRUB Error" /tmp/test_serial.log; then
+      exit 1
+    fi
+    echo "no errors"
+    rm -f /tmp/test_serial.log
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "no errors" ]]
+}
+
+# ── Boot Indicator Detection ──────────────────────────────────────────────
+
+@test "detects GRUB version in serial log" {
+  run bash -c '
+    echo "GRUB version 2.12" > /tmp/test_serial.log
+    BOOT_OK=0
+    if grep -qi "GRUB version\|Booting .\+Live\|anaconda\|Started Anaconda\|Reached target\|Welcome to\|login:" /tmp/test_serial.log; then
+      BOOT_OK=1
+    fi
+    echo "BOOT_OK=$BOOT_OK"
+    rm -f /tmp/test_serial.log
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "BOOT_OK=1" ]]
+}
+
+@test "detects anaconda startup in serial log" {
+  run bash -c '
+    echo "Starting Anaconda installer..." > /tmp/test_serial.log
+    BOOT_OK=0
+    if grep -qi "GRUB version\|Booting .\+Live\|anaconda\|Started Anaconda\|Reached target\|Welcome to\|login:" /tmp/test_serial.log; then
+      BOOT_OK=1
+    fi
+    echo "BOOT_OK=$BOOT_OK"
+    rm -f /tmp/test_serial.log
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "BOOT_OK=1" ]]
+}
+
+@test "detects login prompt in serial log" {
+  run bash -c '
+    echo "Welcome to TunaOS! tunaos login:" > /tmp/test_serial.log
+    BOOT_OK=0
+    if grep -qi "GRUB version\|Booting .\+Live\|anaconda\|Started Anaconda\|Reached target\|Welcome to\|login:" /tmp/test_serial.log; then
+      BOOT_OK=1
+    fi
+    echo "BOOT_OK=$BOOT_OK"
+    rm -f /tmp/test_serial.log
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "BOOT_OK=1" ]]
+}
+
+@test "no boot indicators sets BOOT_OK=0" {
+  run bash -c '
+    echo "random noise" > /tmp/test_serial.log
+    BOOT_OK=0
+    if grep -qi "GRUB version\|Booting .\+Live\|anaconda\|Started Anaconda\|Reached target\|Welcome to\|login:" /tmp/test_serial.log; then
+      BOOT_OK=1
+    fi
+    echo "BOOT_OK=$BOOT_OK"
+    rm -f /tmp/test_serial.log
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "BOOT_OK=0" ]]
+}
+
+# ── Final Result ──────────────────────────────────────────────────────────
+
+@test "exits 1 when BOOT_OK=0" {
+  run bash -c '
+    BOOT_OK=0
+    if [ "${BOOT_OK}" -eq 0 ]; then
+      echo "ISO Verification FAILED"
+      exit 1
+    fi
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAILED"* ]]
+}
+
+@test "exits 0 when BOOT_OK=1" {
+  run bash -c '
+    BOOT_OK=1
+    if [ "${BOOT_OK}" -eq 0 ]; then
+      exit 1
+    fi
+    echo "ISO Verification PASSED"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASSED"* ]]
+}


### PR DESCRIPTION
Closes #363, closes #378.

37 BATS tests across two new test files:

### test-iso-pipeline.sh (15 tests)
- Argument parsing and default values
- Source routing (local, ghcr, registry) with correct podman commands
- Unknown source error
- ISO file discovery in build directory
- PASS/FAIL counter logic
- Install step gating (`INSTALL=0` vs `INSTALL=1`)
- Summary output (failure and success paths)

### verify-iso.sh (22 tests)
- Argument validation (0, 1, 2 args)
- ISO file existence check
- VM name sanitization (lowercase, dash-collapse, trim)
- Architecture detection (arm64 → aarch64)
- Lima config generation with ISO path and arch
- VM status checking (missing, Broken, Running)
- Kernel panic / dracut emergency shell detection
- Boot indicator detection (GRUB version, anaconda startup, login prompt)
- Final result: BOOT_OK flag logic