### PR TITLE
security: disable automerge for critical base image digest updates (#217)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,7 +39,9 @@
       "matchUpdateTypes": ["digest"]
     },
     {
-      "automerge": true,
+      // Base image digests are critical to system integrity — require
+      // human review rather than auto-merging (#217).
+      "automerge": false,
       "matchUpdateTypes": ["digest"],
       "matchDepNames": [
         // AlmaLinux base images


### PR DESCRIPTION
Closes #217.

## Problem
The Renovate configuration auto-merged digest updates for critical base images without human review:
- `quay.io/almalinuxorg/almalinux-bootc`
- `quay.io/centos-bootc/centos-bootc`
- `quay.io/centos-bootc/bootc-image-builder`
- `quay.io/fedora/fedora-bootc`
- `ghcr.io/projectbluefin/common`
- `ghcr.io/ublue-os/akmods-nvidia-open`
- `ghcr.io/tuna-os/akmods-nvidia-open`

## Fix
Changed `automerge: true` → `automerge: false` for the base image digest rule.

**Still auto-merged** (lower risk):
- Pin/pinDigest updates (version-locking)
- Dockerfile digest updates (tool images)