### PR TITLE
fix: attach ISOs to GitHub Releases, fix release branch targets (#284, #285)

### DIFF
--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -9,7 +9,7 @@ on:
     types:
       - completed
     branches:
-      - lts
+      - main
   workflow_dispatch:
     inputs:
       target:
@@ -21,6 +21,7 @@ on:
           - lts
           - dx
           - nvidia
+          - main
 
 jobs:
   generate-release:
@@ -34,7 +35,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: lts
+          ref: main
           fetch-depth: 0
 
       - name: Set up Python
@@ -97,7 +98,7 @@ jobs:
           gh release create "$TAG" \
             --title "$TITLE" \
             --notes-file changelog.md \
-            --target lts
+            --target main
 
       - name: Upload changelog artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6

--- a/.github/workflows/publish-isos.yml
+++ b/.github/workflows/publish-isos.yml
@@ -77,7 +77,7 @@ jobs:
     if: ${{ needs.generate-matrix.outputs.count != '0' }}
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: write
       packages: read
     strategy:
       fail-fast: false
@@ -136,3 +136,25 @@ jobs:
           path: "*.iso"
           if-no-files-found: error
           retention-days: 7
+
+      - name: Attach ISO to GitHub Release
+        if: ${{ inputs.skip_upload != true }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE=$(date +%Y%m%d)
+          TAG="${{ matrix.flavor }}-${DATE}"
+          ISO=$(find . -maxdepth 1 -name "${{ matrix.variant }}-${{ matrix.flavor }}-*.iso" | head -1)
+          if [[ -z "$ISO" ]]; then
+            echo "No ISO found to attach"
+            exit 0
+          fi
+          # Create or update the release
+          if ! gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" &>/dev/null; then
+            gh release create "$TAG" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "TunaOS ${{ matrix.flavor }} (${DATE})" \
+              --notes "Live ISO for ${{ matrix.variant }}:${{ matrix.flavor }}. Built from ghcr.io/tuna-os/${{ matrix.variant }}:${{ matrix.flavor }}."
+          fi
+          gh release upload "$TAG" --repo "${GITHUB_REPOSITORY}" "$ISO" --clobber
+          echo "==> Attached $(basename "$ISO") to release $TAG"


### PR DESCRIPTION
Closes #284, addresses #285.

## Problem
- GitHub Releases created by `generate-release.yml` had **zero assets** — changelog text only, no downloadable ISOs
- The release workflow referenced an `lts` branch that doesn't exist in the repo
- `publish-isos.yml` uploaded ISOs to Cloudflare R2 but never attached them to GitHub Releases

## Changes

### publish-isos.yml
- **New step**: After R2 upload, creates/updates a GitHub Release and attaches the ISO as a downloadable asset
- Tag format: `<flavor>-YYYYMMDD` (e.g., `gnome-20260611`)
- Permissions: `contents: read` → `contents: write` (required for release upload)

### generate-release.yml
- Branch references: `lts` → `main` (the `lts` branch doesn't exist)
- Added `main` to workflow_dispatch target options

### What this enables
After merge, the weekly `publish-isos.yml` cron (Sunday 22:00 UTC) will produce releases with downloadable ISOs for all flavors with `build_iso: true` in build-config.yml.