### PR TITLE
fix: guard cleanup rm commands, add tracker-extract preset

### DIFF
--- a/build_scripts/cleanup.sh
+++ b/build_scripts/cleanup.sh
@@ -106,10 +106,11 @@ ls /usr/local || ln -s /var/usrlocal /usr/local
 chmod 644 /usr/share/ublue-os/image-info.json
 
 # Clean up remaining /var artifacts to satisfy bootc lint
-rm -rf /var/lib/rhsm/*
-rm -rf /var/log/rhsm/*
-rm -rf /var/spool/plymouth/*
-rm -rf /var/roothome/buildinfo
+# Guard with existence checks — some paths don't exist on CentOS/AlmaLinux.
+[ -d /var/lib/rhsm ] && rm -rf /var/lib/rhsm/*
+[ -d /var/log/rhsm ] && rm -rf /var/log/rhsm/*
+[ -d /var/spool/plymouth ] && rm -rf /var/spool/plymouth/*
+[ -d /var/roothome/buildinfo ] && rm -rf /var/roothome/buildinfo
 
 # FIXME: use --fix option once https://github.com/containers/bootc/pull/1152 is merged
 # NOTE: --fatal-warnings suppressed for /var/lib/selinux deep module files which cannot

--- a/system_files/usr/lib/systemd/system-preset/50-tunaos.preset
+++ b/system_files/usr/lib/systemd/system-preset/50-tunaos.preset
@@ -1,0 +1,8 @@
+# TunaOS systemd presets — suppress benign warnings from services that
+# are present but intentionally not enabled in our images.
+#
+# tracker-extract-3.service: installed by tracker3 package but not
+# needed in our build environments. Without this preset, systemd emits
+# a warning on every bootc deployment.
+
+disable tracker-extract-3.service


### PR DESCRIPTION
Two small fixes from [IMPROVEMENT_PLAN.md](docs/IMPROVEMENT_PLAN.md) Phase 1:

### 1. Guard cleanup rm commands
`build_scripts/cleanup.sh`: Wrapped `/var/lib/rhsm`, `/var/log/rhsm`, `/var/spool/plymouth`, `/var/roothome/buildinfo` removals with `[ -d ... ] &&` existence checks. These paths don't exist on CentOS/AlmaLinux, causing 7 "No such file or directory" warnings in skipjack builds.

### 2. tracker-extract-3.service preset
Added `system_files/usr/lib/systemd/system-preset/50-tunaos.preset` to disable `tracker-extract-3.service`. This suppresses a benign-but-noisy warning on albacore where tracker3 is installed but not needed.