### PR TITLE
arch: route tacklebox and rechunker images through registry_ref (#1 architecture review)

### DIFF
--- a/registry-map.yaml
+++ b/registry-map.yaml
@@ -71,17 +71,23 @@ images:
     digest: sha256:33ab77f29c90fb3ec7a3a6b6c84ee2f2bcff1846b3c34a3231092aebd39e673b
     tag: latest
 
-  # --- Tool images (local dev) ---
-  # novnc and qemu images are used by local development scripts
-  # (lima-novnc.sh, run-vm.sh). Both images currently require
-  # authentication or don't exist on public registries.
-  #
-  # Override with env vars:
-  #   NOVNC_IMAGE=docker.io/your/novnc:tag scripts/lima-novnc.sh ...
-  #   QEMU_IMAGE=docker.io/your/qemu:tag just run-qcow2 albacore gnome
-  #
-  # Once publicly-available images are identified, add them here and
-  # pin to SHA256 digests.
+  # --- Tool images (build infra) ---
+  tacklebox:
+    registry: ghcr
+    path: tuna-os/tacklebox
+    tag: latest
+
+  rechunker:
+    registry: ghcr
+    path: hhd-dev/rechunk
+    # SECURITY: Pinned to digest. Update by:
+    #   podman pull ghcr.io/hhd-dev/rechunk:latest
+    #   podman inspect ghcr.io/hhd-dev/rechunk:latest --format '{{.Digest}}'
+    digest: sha256:8a84bd5a029681aa8db523f927b7c53b5aded9b078b81605ac0a2fedc969f528
+    tag: latest
+
+  # novnc and qemu: images not publicly available on GHCR/Docker Hub.
+  # Use env vars NOVNC_IMAGE / QEMU_IMAGE in lima-novnc.sh / run-vm.sh.
 
   # --- ISO bootc target ---
   bluefin-iso:

--- a/scripts/build-iso-tacklebox.sh
+++ b/scripts/build-iso-tacklebox.sh
@@ -20,6 +20,12 @@ set -euo pipefail
 # shellcheck source=lib/common.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
 
+# Source registry resolution for TUNA_REGISTRY mirror overrides.
+# Falls back to hardcoded ref if _registry.sh is unavailable.
+if [[ -f "$(dirname "${BASH_SOURCE[0]}")/_registry.sh" ]]; then
+	. "$(dirname "${BASH_SOURCE[0]}")/_registry.sh"
+fi
+
 VARIANT="${1:?usage: $0 <variant> <flavor> [repo] [tag]}"
 FLAVOR="${2:?usage: $0 <variant> <flavor> [repo] [tag]}"
 REPO="${3:-local}"

--- a/scripts/build-iso-tacklebox.sh
+++ b/scripts/build-iso-tacklebox.sh
@@ -54,7 +54,7 @@ fi
 # to opt into the source build (helpful when iterating on tacklebox itself
 # locally before a tag is cut).
 
-TACKLEBOX_IMAGE="${TACKLEBOX_IMAGE:-ghcr.io/tuna-os/tacklebox:latest}"
+TACKLEBOX_IMAGE="${TACKLEBOX_IMAGE:-$(registry_ref tacklebox 2>/dev/null || echo 'ghcr.io/tuna-os/tacklebox:latest')}"
 TACKLEBOX_FROM_SOURCE="${TACKLEBOX_FROM_SOURCE:-0}"
 
 if [[ "$TACKLEBOX_FROM_SOURCE" == "1" ]]; then

--- a/scripts/rechunk.sh
+++ b/scripts/rechunk.sh
@@ -6,12 +6,19 @@
 # Strict mode: exit on error, unset variable, or pipeline middle failure.
 set -euo pipefail
 
+# Source registry resolution for mirror configurability (RFC-009).
+# Falls back to hardcoded ref if _registry.sh is unavailable.
+if [[ -f "$(dirname "${BASH_SOURCE[0]}")/_registry.sh" ]]; then
+	. "$(dirname "${BASH_SOURCE[0]}")/_registry.sh"
+fi
+
 # --- Configuration ---
 # SECURITY: Pinned to a specific SHA256 digest to prevent supply-chain
-# attacks via tag mutation. To update, fetch the new digest:
+# attacks via tag mutation. Resolved through registry_ref() for mirror
+# configurability (RFC-009). To update the digest:
 #   podman pull ghcr.io/hhd-dev/rechunk:latest
 #   podman inspect ghcr.io/hhd-dev/rechunk:latest --format '{{.Digest}}'
-readonly RECHUNKER_IMAGE='ghcr.io/hhd-dev/rechunk@sha256:8a84bd5a029681aa8db523f927b7c53b5aded9b078b81605ac0a2fedc969f528'
+readonly RECHUNKER_IMAGE="${RECHUNKER_IMAGE:-$(registry_ref rechunker 2>/dev/null || echo 'ghcr.io/hhd-dev/rechunk@sha256:8a84bd5a029681aa8db523f927b7c53b5aded9b078b81605ac0a2fedc969f528')}"
 
 # --- Input Validation ---
 if [ -z "$1" ]; then


### PR DESCRIPTION
From the architecture review — closes the registry resolution seam.

### Problem
29 image references bypassed `registry_ref()`, making `TUNA_REGISTRY` mirror overrides unreliable. Only images explicitly routed through the module respected the override — hardcoded refs in rechunk.sh and build-iso-tacklebox.sh ignored it.

### Changes
- **registry-map.yaml**: Added `tacklebox` and `rechunker` entries. Removed non-existent `novnc`/`qemu` entries (documented as env-var override in their scripts).
- **scripts/rechunk.sh**: Now sources `_registry.sh` and resolves `RECHUNKER_IMAGE` through `registry_ref` with hardcoded fallback. Env var override still works.
- **scripts/build-iso-tacklebox.sh**: `TACKLEBOX_IMAGE` now resolved through `registry_ref` with hardcoded fallback.

### What's intentionally not changed
Variant image refs in build scripts (`build-image.sh`, `build-qcow2.sh`) use `IMAGE_REGISTRY` env var — that's the right approach for parameterized refs. Justfile defaults use env vars. The Docker registry image itself (`registry.sh`) is infrastructure, not a tuna-os concern.