### PR TITLE
fix: bump scorecard pins — stale codeql-action SHA was causing impostor commit rejections

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -74,6 +74,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
**Problem:** The pinned commit for `github/codeql-action/upload-sarif` (`411bbbe5`) doesn't exist in the codeql-action repo. Scorecard flags it as an impostor commit, failing every run.

**Fix:**
- Pin codeql-action/upload-sarif to v4.36.2 (`8aad20d`) — actual upstream commit
- Bump scorecard-action from v2.4.1 → v2.4.3