### PR TITLE
fix: revert scorecard to v2.4.1 — tag object SHA caused impostor rejection

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
**Root cause:** `gh api` returned the annotated tag object SHA for v2.4.3 (`99c09fe`), not the commit SHA. Scorecard's verification DB only whitelists commits, so it rejected it as impostor.

**Fix:** Revert scorecard-action to v2.4.1 (`f49aabe`) — which was never broken. The only actual problem was the stale codeql-action pin (already fixed to v4.36.2 / `8aad20d`).