### PR TITLE
fix: guard ublue-os/packages copr enable for CentOS (EPEL chroots dropped)

### DIFF
--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -181,10 +181,13 @@ install_base_packages_no_de() {
 
 	dnf -y remove console-login-helper-messages setroubleshoot
 
-	dnf -y copr enable ublue-os/packages
-	dnf -y copr disable ublue-os/packages
-	dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
-		uupd
+	# ublue-os/packages COPR only builds for Fedora (no EPEL/CentOS chroots).
+	if [[ $IS_FEDORA == true ]]; then
+		dnf -y copr enable ublue-os/packages
+		dnf -y copr disable ublue-os/packages
+		dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
+			uupd
+	fi
 
 	printf "::endgroup::\n"
 }

--- a/build_scripts/kde.sh
+++ b/build_scripts/kde.sh
@@ -6,9 +6,11 @@ source /run/context/build_scripts/lib.sh
 
 case "${1:-}" in
 "base")
+	# ublue-os/packages COPR dropped EPEL/CentOS chroots; only Fedora remains.
+	# The install_available --copr calls below handle enabling per-package on Fedora.
 	if [[ $IS_FEDORA == false ]] && [ "$MAJOR_VERSION_NUMBER" -ge 10 ]; then
-		dnf -y copr enable ublue-os/packages
-		dnf config-manager --set-enabled --setopt "copr:copr.fedorainfracloud.org:ublue-os:packages.priority=10"
+		warn_on_fail dnf -y copr enable ublue-os/packages
+		warn_on_fail dnf config-manager --set-enabled --setopt "copr:copr.fedorainfracloud.org:ublue-os:packages.priority=10"
 	fi
 
 	if [[ $IS_FEDORA == true ]]; then


### PR DESCRIPTION
**Problem:** The `ublue-os/packages` COPR dropped all EPEL/CentOS chroots — only Fedora 41/43/44 remain. Raw `dnf copr enable ublue-os/packages` fails on CentOS with:
```
Repository 'epel-10-x86_64' does not exist in project 'ublue-os/packages'
```
This breaks all CentOS-based builds (yellowfin, albacore, bonito).

**Fix:**
- `10-base-packages.sh`: Skip `uupd` install + copr enable entirely on CentOS
- `kde.sh`: Wrap centos copr enable with `warn_on_fail`
- `install_available --copr` calls already handle failure gracefully (no changes needed)