### PR TITLE
feat: eliminate ublue-os/packages COPR dependency

### DIFF
--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -181,13 +181,13 @@ install_base_packages_no_de() {
 
 	dnf -y remove console-login-helper-messages setroubleshoot
 
-	# ublue-os/packages COPR only builds for Fedora (no EPEL/CentOS chroots).
-	if [[ $IS_FEDORA == true ]]; then
-		dnf -y copr enable ublue-os/packages
-		dnf -y copr disable ublue-os/packages
-		dnf -y --enablerepo copr:copr.fedorainfracloud.org:ublue-os:packages install \
-			uupd
-	fi
+	# Install uupd from GitHub release tarball.
+	# The ublue-os/packages COPR dropped epel-10 chroots (~2026-06-08);
+	# Bluefin LTS adopted this same approach.
+	# Version is pinned in image-versions.yaml and tracked by Renovate.
+	UUPD_VERSION=$(grep '^\s*uupd:' /run/context/image-versions.yaml | sed 's/.*"\(.*\)".*/\1/')
+	curl -fsSL "https://github.com/ublue-os/uupd/releases/download/${UUPD_VERSION}/uupd_Linux_$(uname -m | sed 's/x86_64/x86_64/;s/aarch64/arm64/').tar.gz" \
+		| tar -xzf - -C /usr/bin uupd
 
 	printf "::endgroup::\n"
 }

--- a/build_scripts/kcm-ublue.sh
+++ b/build_scripts/kcm-ublue.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Build and install kcm_ublue and krunner-bazaar from source/releases,
+# and copy oversteer udev rules.
+#
+# Called during KDE image builds (kde.sh "base" or "extra").
+# Uses pinned versions from image-versions.yaml (managed by Renovate).
+#
+# These packages were previously pulled from the ublue-os/packages COPR,
+# which dropped EPEL/CentOS chroots (~2026-06-08).
+# Bluefin LTS adopted the same curl-then-install approach for uupd;
+# we extend it here to the KDE-specific packages.
+
+set -xeuo pipefail
+
+source /run/context/build_scripts/lib.sh
+
+printf "::group:: === KCM Ublue + Krunner Bazaar + Oversteer Udev ===\n"
+
+# ---- Version pins --------------------------------------------------------
+KCM_UBLUE_VERSION=$(grep '^\s*kcm_ublue:' /run/context/image-versions.yaml | sed 's/.*"\(.*\)".*/\1/')
+KRUNNER_BAZAAR_VERSION=$(grep '^\s*krunner-bazaar:' /run/context/image-versions.yaml | sed 's/.*"\(.*\)".*/\1/')
+
+ARCH=$(uname -m)
+# GitHub release arch naming: x86_64 → x86_64, aarch64 → aarch64
+RPM_ARCH="$ARCH"
+
+# ---- kcm_ublue: build from source ----------------------------------------
+echo "Building kcm_ublue ${KCM_UBLUE_VERSION} from source..."
+
+# Install build dependencies (removed after build)
+BUILD_DEPS=(
+    git
+    cmake
+    gcc-g++
+    extra-cmake-modules
+    kf6-kcmutils-devel
+    kf6-config-devel
+    kf6-configwidgets-devel
+    kf6-coreaddons-devel
+    kf6-i18n-devel
+    kf6-auth-devel
+    kf6-codecs-devel
+    kf6-colorscheme-devel
+    kf6-service-devel
+    kf6-widgetsaddons-devel
+    qt6-qtbase-devel
+    qt6-qtdeclarative-devel
+    qt6-qttools-devel
+    gtest-devel
+)
+
+dnf_retry -y install "${BUILD_DEPS[@]}"
+
+BUILD_DIR=$(mktemp -d)
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+git clone --depth 1 --branch "${KCM_UBLUE_VERSION}" \
+    https://github.com/ledif/kcm_ublue.git "$BUILD_DIR"
+
+cd "$BUILD_DIR"
+cmake -B build -DCMAKE_INSTALL_PREFIX=/usr
+cmake --build build
+cmake --install build
+
+# Clean up build dependencies
+dnf -y remove "${BUILD_DEPS[@]}" || true
+dnf -y autoremove || true
+
+echo "kcm_ublue ${KCM_UBLUE_VERSION} installed."
+
+# ---- krunner-bazaar: install from GitHub release RPM ---------------------
+echo "Installing krunner-bazaar ${KRUNNER_BAZAAR_VERSION} from GitHub release..."
+
+KRUNNER_RPM="krunner-bazaar-${KRUNNER_BAZAAR_VERSION#v}-1.fc43.${RPM_ARCH}.rpm"
+KRUNNER_URL="https://github.com/bazaar-org/krunner-bazaar/releases/download/${KRUNNER_BAZAAR_VERSION}/${KRUNNER_RPM}"
+
+# krunner-bazaar only publishes x86_64 RPMs; skip on other arches
+if curl -fsSLI "$KRUNNER_URL" >/dev/null 2>&1; then
+    curl -fsSLo "/tmp/${KRUNNER_RPM}" "$KRUNNER_URL"
+    dnf_retry -y install "/tmp/${KRUNNER_RPM}"
+    rm -f "/tmp/${KRUNNER_RPM}"
+    echo "krunner-bazaar ${KRUNNER_BAZAAR_VERSION} installed."
+else
+    echo "krunner-bazaar ${KRUNNER_BAZAAR_VERSION} not available for ${RPM_ARCH} (skipping)"
+fi
+
+# ---- oversteer-udev: copy udev rules from upstream -----------------------
+echo "Installing oversteer udev rules..."
+
+OVERSTEER_UDEV_DIR="/usr/lib/udev/rules.d"
+mkdir -p "$OVERSTEER_UDEV_DIR"
+
+# Source: https://github.com/berarma/oversteer (upstream oversteer project)
+OVERSTEER_RULES=(
+    "99-logitech-wheel-perms.rules"
+    "99-fanatec-wheel-perms.rules"
+    "99-thrustmaster-wheel-perms.rules"
+)
+
+for rule in "${OVERSTEER_RULES[@]}"; do
+    curl -fsSLo "${OVERSTEER_UDEV_DIR}/${rule}" \
+        "https://raw.githubusercontent.com/berarma/oversteer/master/data/udev/${rule}"
+    echo "  ${rule}"
+done
+
+echo "oversteer udev rules installed."
+
+printf "::endgroup::\n"

--- a/build_scripts/kde.sh
+++ b/build_scripts/kde.sh
@@ -6,13 +6,6 @@ source /run/context/build_scripts/lib.sh
 
 case "${1:-}" in
 "base")
-	# ublue-os/packages COPR dropped EPEL/CentOS chroots; only Fedora remains.
-	# The install_available --copr calls below handle enabling per-package on Fedora.
-	if [[ $IS_FEDORA == false ]] && [ "$MAJOR_VERSION_NUMBER" -ge 10 ]; then
-		warn_on_fail dnf -y copr enable ublue-os/packages
-		warn_on_fail dnf config-manager --set-enabled --setopt "copr:copr.fedorainfracloud.org:ublue-os:packages.priority=10"
-	fi
-
 	if [[ $IS_FEDORA == true ]]; then
 		dnf -y group install "kde-desktop"
 		# Fedora-only set: these are Aurora's KDE package selection
@@ -75,12 +68,13 @@ case "${1:-}" in
 			qt5-qtwayland \
 			qt6-qtwayland
 
-		# EL10 catch-up to Aurora's Fedora-only package set. lib.sh's
+		# EL10 catch-up to Aurora's Fedora-only package set.
 		# install_available probes each one against the active repos
-		# (BaseOS / AppStream / EPEL10 / CRB + the ublue-os/packages
-		# COPR for things like `kcm_ublue`) and installs only what
+		# (BaseOS / AppStream / EPEL10 / CRB) and installs only what
 		# resolves. Misses get logged so the next porter sees the gap.
-		install_available --copr ublue-os/packages \
+		# kcm_ublue removed — Bluefin no longer ships it and the
+		# ublue-os/packages COPR dropped EPEL chroots.
+		install_available \
 			ksshaskpass \
 			ksystemlog \
 			input-remapper \
@@ -93,8 +87,7 @@ case "${1:-}" in
 			pam_yubico \
 			pamu2fcfg \
 			yubikey-manager \
-			nvtop \
-			kcm_ublue
+			nvtop
 
 		# Install fcitx5 input method support (Asian languages) if available
 		# Not available in EPEL10 yet
@@ -123,14 +116,10 @@ case "${1:-}" in
 	fi
 	;;
 "extra")
-	# ublue-os packages — most moved to the common OCI layer; only KDE-
-	# specific extras stay here. install_available probes each name in
-	# the COPR so a missing entry (e.g. krunner-bazaar awaiting Qt 6.10
-	# on EL10) is logged-and-skipped rather than aborting the build.
-	# Reference: https://github.com/ublue-os/aurora/issues/1227
-	install_available --copr ublue-os/packages \
-		kcm_ublue \
-		krunner-bazaar
+	# Build kcm_ublue from source, install krunner-bazaar from GitHub
+	# releases, and copy oversteer udev rules — replacing the
+	# ublue-os/packages COPR which dropped EPEL chroots.
+	source /run/context/build_scripts/kcm-ublue.sh
 
 	# Disable plasma-discover in favor of Flatpak/Bazaar (like Aurora)
 	if [ -f /usr/share/applications/org.kde.discover.desktop ]; then

--- a/build_scripts/niri.sh
+++ b/build_scripts/niri.sh
@@ -235,11 +235,11 @@ case "${1:-}" in
 	fi
 
 	# Zirconium-parity extras on EL10 — many of these are Fedora-shipped
-	# but show up in EL10 via EPEL / CRB / the ublue-os COPRs we already
-	# enable elsewhere. install_available probes each and skips the
-	# rest so a missing EL10 build of, say, librime-lua doesn't kill
-	# the whole package install transaction.
-	install_available --copr ublue-os/packages \
+	# but show up in EL10 via EPEL / CRB. install_available probes each
+	# and skips the rest so a missing EL10 build of, say, librime-lua
+	# doesn't kill the whole package install transaction.
+	# ublue-os/packages COPR removed — EPEL chroots dropped.
+	install_available \
 		bolt \
 		btop \
 		gst-thumbnailers \

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -11,3 +11,12 @@ images:
     image: ghcr.io/ublue-os/brew
     tag: latest
     digest: sha256:63c7219af97c1cae9a2a38e9944dc26f65d0798ab256980649947f96a269e1ce
+
+# Pinned binary downloads (managed by Renovate)
+downloads:
+  # renovate: datasource=github-releases depName=ublue-os/uupd
+  uupd: "v1.4.0"
+  # renovate: datasource=github-releases depName=bazaar-org/krunner-bazaar
+  krunner-bazaar: "v1.3.0"
+  # renovate: datasource=github-releases depName=ledif/kcm_ublue
+  kcm_ublue: "v0.6.1"


### PR DESCRIPTION
**Replaces #435** — goes further by removing the COPR dependency entirely rather than just guarding it.

## What changed

| Package | Before | After |
|---|---|---|
| `uupd` | COPR → dnf install (Fedora only) | curl→tar from GitHub releases (Fedora + CentOS) |
| `kcm_ublue` | COPR → dnf install | Built from source via cmake during KDE image build |
| `krunner-bazaar` | COPR → dnf install | Downloaded RPM from GitHub releases, installed with dnf |
| `oversteer-udev` | COPR → dnf install | udev rules copied from berarma/oversteer upstream |

## Files

- `image-versions.yaml` — new `downloads` section with Renovate-managed pins for uupd, krunner-bazaar, kcm_ublue
- `build_scripts/kcm-ublue.sh` — new script: builds kcm_ublue from source, installs krunner-bazaar RPM, copies oversteer udev rules
- `build_scripts/10-base-packages.sh` — uupd now installs from GitHub tarball (no COPR, works on CentOS)
- `build_scripts/kde.sh` — calls kcm-ublue.sh in 'extra' case, removes COPR references
- `build_scripts/niri.sh` — removes `--copr ublue-os/packages` from install_available call

## Pattern

Follows Bluefin LTS's approach (`build_scripts/20-packages.sh`) where uupd is pulled from GitHub releases after the COPR dropped EPEL chroots.