### PR TITLE
fix: include image-versions.yaml in build context

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -24,6 +24,7 @@ COPY --from=common /system_files/shared /files
 COPY --from=common /system_files/bluefin /files
 COPY system_files_overrides /overrides
 COPY build_scripts /build_scripts
+COPY image-versions.yaml /image-versions.yaml
 
 # ==============================================================================
 # Base stage (no DE) - Shared layer for all variants


### PR DESCRIPTION
Same as bluefin-lts Containerfile line 20. Without this, 10-base-packages.sh can't read the uupd version pin from image-versions.yaml.