### PR TITLE
refactor: adopt projectbluefin/actions/setup-runner

### DIFF
--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -36,7 +36,14 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Build Environment
-        uses: ./.github/actions/setup-tunaos
+        uses: projectbluefin/actions/bootc-build/setup-runner@v1
+        with:
+          storage-backend: ""
+          update-podman: "false"
+          install-tools: '["just"]'
+
+      - name: Install yq
+        uses: mikefarah/yq@9b4e1b1b694a069c393f05e8c1d29c23e5a4a4e2 # v4.44.5
 
       - name: Validate Inputs
         env:

--- a/.github/workflows/daily-verify.yml
+++ b/.github/workflows/daily-verify.yml
@@ -75,7 +75,14 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup TunaOS Build Environment
-        uses: ./.github/actions/setup-tunaos
+        uses: projectbluefin/actions/bootc-build/setup-runner@v1
+        with:
+          storage-backend: ""
+          update-podman: "false"
+          install-tools: '["just"]'
+
+      - name: Install yq
+        uses: mikefarah/yq@9b4e1b1b694a069c393f05e8c1d29c23e5a4a4e2 # v4.44.5
 
       - name: Verify image
         id: run_verify

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -127,18 +127,15 @@ jobs:
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v4
         if: ${{ startsWith(inputs.flavor, 'base') }}
 
-      - name: Maximize build space (remove-software)
-        if: ${{ inputs.remove-unwanted-software && matrix.platform != 'arm64' }}
-        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
+      - name: Setup runner
+        uses: projectbluefin/actions/bootc-build/setup-runner@v1
         with:
-          remove-codeql: true
+          storage-backend: btrfs
+          update-podman: "true"
+          install-tools: '["just", "cosign"]'
 
-      - name: Mount BTRFS for podman storage
-        if: ${{ matrix.platform != 'linux/arm64' && inputs.cleanup_runner }}
-        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6 # main as of 2026-02-11
-
-      - name: Setup TunaOS Build Environment
-        uses: ./.github/actions/setup-tunaos
+      - name: Install yq
+        uses: mikefarah/yq@9b4e1b1b694a069c393f05e8c1d29c23e5a4a4e2 # v4.44.5
 
 
       - name: Cache DNF/RPM Packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,14 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup TunaOS Build Environment
-        uses: ./.github/actions/setup-tunaos
+        uses: projectbluefin/actions/bootc-build/setup-runner@v1
+        with:
+          storage-backend: ""
+          update-podman: "false"
+          install-tools: '["just"]'
+
+      - name: Install yq
+        uses: mikefarah/yq@9b4e1b1b694a069c393f05e8c1d29c23e5a4a4e2 # v4.44.5
 
       - name: Install test dependencies
         run: |


### PR DESCRIPTION
Replaces the custom setup-tunaos action and the 3-step runner setup (remove-software, container-storage, setup-tunaos) with `projectbluefin/actions/bootc-build/setup-runner@v1`.

- **reusable-build-image.yml**: Full setup — btrfs storage, updated podman, just + cosign
- **build-variant.yml** (generate_matrix): Minimal — just + yq only, no storage
- **test.yml**, **daily-verify.yml**: Minimal — just + yq only