### PR TITLE
fix: skip sign-and-publish (key propagation broken)

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -224,18 +224,9 @@ jobs:
           echo "remote_image_digest=${REMOTE_IMAGE_DIGEST}" >> $GITHUB_OUTPUT
           echo "digest=${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
 
-      - name: Sign and publish
-        if: ${{ inputs.publish }}
-        uses: projectbluefin/actions/bootc-build/sign-and-publish@v1
-        env:
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-        with:
-          image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          digest: ${{ steps.push.outputs.remote_image_digest }}
-          signing-mode: key
-          signing-key: ${{ secrets.SIGNING_SECRET }}
-          generate-sbom: ${{ inputs.sbom }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      # TODO: reinstate sign-and-publish when key propagation through composite
+      # actions is resolved. The COSIGN_PRIVATE_KEY env var is masked but
+      # arrives empty at runtime in the composite action.
 
       - name: PR Testing Instructions
         if: github.event_name == 'pull_request'
@@ -571,17 +562,9 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Sign manifest
-        uses: projectbluefin/actions/bootc-build/sign-and-publish@v1
-        env:
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-        with:
-          image: ${{ needs.manifest.outputs.image }}
-          digest: ${{ needs.manifest.outputs.digest }}
-          signing-mode: key
-          signing-key: ${{ secrets.SIGNING_SECRET }}
-          generate-sbom: "false"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      # TODO: reinstate sign-and-publish for manifest when key propagation
+      # through composite actions is resolved. Same issue as per-arch signing.
+      - run: echo "Manifest signing skipped (TODO: sign-and-publish key propagation)"
   tag-image:
     name: Tag Image
     needs: manifest


### PR DESCRIPTION
Composite actions can't receive secrets via inputs.