### PR TITLE
fix: stop one flavor's failure blocking the whole variant lineup (#285)

### DIFF
--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -224,14 +224,24 @@ jobs:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
 
   # ── Stage 3: Desktop HWE and nvidia flavors ───────────────────────────────────
-  # Runs only after ALL stage-2 jobs pass. Includes:
+  # Layers on stage-2 images:
   #   - gnome-hwe, kde-hwe, niri-hwe   (layer on base-hwe)
   #   - gnome-nvidia, kde-nvidia, niri-nvidia   (layer on base-nvidia)
   # All run in parallel within stage 3.
+  #
+  # `!cancelled()` (rather than the default "all needs succeeded") so that ONE
+  # failed stage-2 flavor doesn't skip the entire stage-3 lineup (#285: a flaky
+  # yellowfin:kde build was blocking every -hwe / -nvidia image from shipping).
+  # fail-fast is already false, so the stage-2 images that *did* build are
+  # pushed and available; stage-3 cells whose specific base is missing fail on
+  # their own without taking the rest down.
   build_stage3:
     name: "S3 | ${{ matrix.variant_emoji }} ${{ matrix.variant }}:${{ matrix.flavor }}"
     needs: [generate_matrix, build_stage2]
-    if: github.event_name != 'pull_request' && fromJson(needs.generate_matrix.outputs.stage3_matrix).include[0]
+    if: >-
+      !cancelled() && needs.generate_matrix.result == 'success' &&
+      github.event_name != 'pull_request' &&
+      fromJson(needs.generate_matrix.outputs.stage3_matrix).include[0]
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate_matrix.outputs.stage3_matrix) }}
@@ -248,14 +258,18 @@ jobs:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
 
   # ── Stage 4: Combined nvidia+HWE flavors ──────────────────────────────────────
-  # Runs only after ALL stage-3 jobs pass. Includes:
+  # Layers on stage-3 images:
   #   - gnome-nvidia-hwe   (layers on gnome-hwe from stage 3)
-  # Must be a separate stage from stage 3 because gnome-nvidia-hwe depends on
-  # gnome-hwe, which is also built in stage 3.
+  # Separate from stage 3 because gnome-nvidia-hwe depends on gnome-hwe, itself
+  # built in stage 3. Same `!cancelled()` rationale as stage 3 (#285) so a
+  # single stage-3 failure doesn't skip stage 4.
   build_stage4:
     name: "S4 | ${{ matrix.variant_emoji }} ${{ matrix.variant }}:${{ matrix.flavor }}"
     needs: [generate_matrix, build_stage3]
-    if: github.event_name != 'pull_request' && fromJson(needs.generate_matrix.outputs.stage4_matrix).include[0]
+    if: >-
+      !cancelled() && needs.generate_matrix.result == 'success' &&
+      github.event_name != 'pull_request' &&
+      fromJson(needs.generate_matrix.outputs.stage4_matrix).include[0]
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate_matrix.outputs.stage4_matrix) }}

--- a/build_scripts/kcm-ublue.sh
+++ b/build_scripts/kcm-ublue.sh
@@ -49,24 +49,46 @@ BUILD_DEPS=(
     gtest-devel
 )
 
-dnf_retry -y install "${BUILD_DEPS[@]}"
+# kcm_ublue is built from source and needs the KF6 / Qt6 *-devel headers.
+# Those aren't in every EL repo set — AlmaLinux Kitten (yellowfin) ships the
+# KF6 runtime but not the -devel packages, so a hard `dnf install` failed the
+# WHOLE kde image (#285: every yellowfin:kde build errored on
+# `No match for argument: kf6-config-devel`, which in turn blocked the entire
+# stage-3 -hwe/-nvidia lineup). Probe first; if any build dep is missing, skip
+# the source build with a warning rather than failing the image. kcm_ublue is
+# a nice-to-have KDE control module, not essential to a working desktop.
+missing_deps=()
+for pkg in "${BUILD_DEPS[@]}"; do
+    if ! dnf repoquery --available --qf '%{name}\n' "$pkg" 2>/dev/null | grep -qx "$pkg"; then
+        missing_deps+=("$pkg")
+    fi
+done
 
-BUILD_DIR=$(mktemp -d)
-trap 'rm -rf "$BUILD_DIR"' EXIT
+if ((${#missing_deps[@]} > 0)); then
+    printf '::warning title=kcm_ublue skipped (%s)::build deps unavailable in the active repos: %s\n' \
+        "${IMAGE_NAME:-?}" "${missing_deps[*]}"
+    echo "Skipping kcm_ublue source build."
+else
+    dnf_retry -y install "${BUILD_DEPS[@]}"
 
-git clone --depth 1 --branch "${KCM_UBLUE_VERSION}" \
-    https://github.com/ledif/kcm_ublue.git "$BUILD_DIR"
+    BUILD_DIR=$(mktemp -d)
+    trap 'rm -rf "$BUILD_DIR"' EXIT
 
-cd "$BUILD_DIR"
-cmake -B build -DCMAKE_INSTALL_PREFIX=/usr
-cmake --build build
-cmake --install build
+    git clone --depth 1 --branch "${KCM_UBLUE_VERSION}" \
+        https://github.com/ledif/kcm_ublue.git "$BUILD_DIR"
 
-# Clean up build dependencies
-dnf -y remove "${BUILD_DEPS[@]}" || true
-dnf -y autoremove || true
+    cd "$BUILD_DIR"
+    cmake -B build -DCMAKE_INSTALL_PREFIX=/usr
+    cmake --build build
+    cmake --install build
+    cd - >/dev/null
 
-echo "kcm_ublue ${KCM_UBLUE_VERSION} installed."
+    # Clean up build dependencies
+    dnf -y remove "${BUILD_DEPS[@]}" || true
+    dnf -y autoremove || true
+
+    echo "kcm_ublue ${KCM_UBLUE_VERSION} installed."
+fi
 
 # ---- krunner-bazaar: install from GitHub release RPM ---------------------
 echo "Installing krunner-bazaar ${KRUNNER_BAZAAR_VERSION} from GitHub release..."


### PR DESCRIPTION
Closes #285.

## The problem
The README advertises KDE / COSMIC / Niri / HWE / NVIDIA variants, but only some ship. The strategist issue framed it as "only GNOME releases," but the real picture (from the actual GHCR tags) is that **stage-2 desktops mostly publish, while the entire stage-3/4 layered lineup (`-hwe` desktops, all `-nvidia`) never builds.**

## Root cause (from the 2026-06-13 yellowfin build)
1. **`yellowfin:kde` fails at build time.** `kcm-ublue.sh` builds `kcm_ublue` from source and hard-installs `kf6-*-devel` headers. AlmaLinux Kitten (yellowfin) ships the KF6 runtime but **not** the `-devel` packages → `No match for argument: kf6-config-devel …` aborts the whole KDE image. (AlmaLinux 10 / albacore *does* have them, which is why `kde` ships there but not on yellowfin.)
2. **The failure cascades.** `build_stage3` / `build_stage4` used the default `needs:` semantics (all dependencies must *succeed*). So one failed stage-2 cell **skips the entire next stage** — every `-hwe` and `-nvidia` desktop image — even though `gnome`/`gnome50`/`cosmic`/`niri` built and pushed fine.

## Fixes
- **`kcm-ublue.sh`** now probes the build deps with `dnf repoquery` and, if any are missing, **skips the source build with a `::warning`** instead of failing the image. `kcm_ublue` is a non-essential KDE control module; the desktop is complete without it. Variants that *do* have the headers still build it.
- **`build-variant.yml`** stage 3 & 4 now gate on `!cancelled() && needs.generate_matrix.result == 'success'` instead of all-needs-succeeded. With `fail-fast: false` (already set), every independently-buildable flavor publishes; a stage-N cell whose specific base image is missing fails on its own without taking the rest of the stage down.

## Result
Unblocks the KDE/HWE/NVIDIA images #285 reported as missing. Individual per-flavor failures (e.g. an occasional COSMIC hiccup) may still need their own fixes, but they no longer cascade into blocking the whole downstream lineup.

## Validation
The fix is in CI/build scripts — needs a real `Build <variant>` run to confirm the full lineup publishes (can't run the bootc build on the dev box). Lint clean: shellcheck, `shfmt -i 4`, yamllint, actionlint (no new findings vs. main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)