### PR TITLE
[feat] Ubuntu 26.04 variant — PKG_MGR abstraction + grouper config (RFC 010 Phase 1)

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -440,3 +440,22 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
+
+  # ── Experimental ───────────────────────────────────────────────────────────
+  # RFC 010: Ubuntu 26.04 variant. GNOME-only, x86_64-only, manual dispatch only.
+  # Containerfile.ubuntu + apt build-script branches are pending (Phase 2).
+  - id: grouper
+    emoji: "🐟"
+    description: "Based on Ubuntu 26.04 Resolute Raccoon"
+    base_image: "ghcr.io/hanthor/ubuntu-26.04-desktop-bootc:latest"
+    # TODO: pin to digest before enabling builds (same concern as #462)
+    platforms: ["linux/amd64"]
+    experimental: true
+    flavors:
+      - id: base
+        stage: 1
+        build_image: true
+      - id: gnome
+        stage: 2
+        build_image: true
+        build_iso: true

--- a/.github/workflows/build-grouper.yml
+++ b/.github/workflows/build-grouper.yml
@@ -1,0 +1,21 @@
+name: Build Grouper [experimental]
+on:
+  workflow_dispatch:
+    inputs:
+      flavor:
+        description: 'Flavor (all, base, gnome, kde, niri, etc.)'
+        default: 'all'
+        type: string
+
+concurrency:
+  group: build-grouper-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: 🐟-grouper
+    uses: ./.github/workflows/build-variant.yml
+    with:
+      variant: 'grouper'
+      flavor: ${{ inputs.flavor || 'all' }}
+    secrets: inherit

--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -36,24 +36,41 @@ IS_RHEL=false
 IS_ALMALINUX=false
 IS_ALMALINUXKITTEN=false
 IS_CENTOS=false
+IS_UBUNTU=false
+IS_DEBIAN=false
 
 [[ "${BASE_IMAGE,,}" == *"fedora"* ]] && IS_FEDORA=true && IMAGE_NAME="bonito" && IMAGE_PRETTY_NAME="Bonito"
 [[ "${BASE_IMAGE,,}" == *"red hat"* || "${BASE_IMAGE,,}" == *"rhel"* || "${BASE_IMAGE,,}" == *"redhat"* ]] && IS_RHEL=true && IMAGE_NAME="redfin" && IMAGE_PRETTY_NAME="Redfin"
 [[ "${BASE_IMAGE,,}" == *"almalinux"* && "${BASE_IMAGE,,}" != *"-kitten"* ]] && IS_ALMALINUX=true && IMAGE_NAME="albacore" && IMAGE_PRETTY_NAME="Albacore"
 [[ "${BASE_IMAGE,,}" == *"-kitten"* ]] && IS_ALMALINUXKITTEN=true && IMAGE_NAME="yellowfin" && IMAGE_PRETTY_NAME="Yellowfin"
 [[ "${BASE_IMAGE,,}" == *"centos"* ]] && IS_CENTOS=true && IMAGE_NAME="skipjack" && IMAGE_PRETTY_NAME="Skipjack"
+[[ "${BASE_IMAGE,,}" == *"ubuntu"* ]] && IS_UBUNTU=true && IMAGE_NAME="grouper" && IMAGE_PRETTY_NAME="Grouper"
+[[ "${BASE_IMAGE,,}" == *"debian"* && "${BASE_IMAGE,,}" != *"ubuntu"* ]] && IS_DEBIAN=true && IMAGE_NAME="flounder" && IMAGE_PRETTY_NAME="Flounder"
+
+# Package manager dimension
+if [[ "$IS_UBUNTU" == true || "$IS_DEBIAN" == true ]]; then
+	PKG_MGR="apt"
+else
+	PKG_MGR="dnf"
+fi
 
 echo "FEDORA: $IS_FEDORA"
 echo "RHEL: $IS_RHEL"
 echo "ALMALINUX: $IS_ALMALINUX"
 echo "ALMALINUXKITTEN: $IS_ALMALINUXKITTEN"
 echo "CENTOS: $IS_CENTOS"
+echo "UBUNTU: $IS_UBUNTU"
+echo "DEBIAN: $IS_DEBIAN"
+echo "PKG_MGR: $PKG_MGR"
 
 export IS_FEDORA
 export IS_RHEL
 export IS_ALMALINUX
 export IS_ALMALINUXKITTEN
 export IS_CENTOS
+export IS_UBUNTU
+export IS_DEBIAN
+export PKG_MGR
 export IMAGE_NAME
 export IMAGE_PRETTY_NAME
 
@@ -74,6 +91,13 @@ detected_os() {
 	if [ "$IS_CENTOS" = true ]; then
 		echo "  CentOS"
 	fi
+	if [ "$IS_UBUNTU" = true ]; then
+		echo "  Ubuntu"
+	fi
+	if [ "$IS_DEBIAN" = true ]; then
+		echo "  Debian"
+	fi
+	echo "  Package manager: ${PKG_MGR}"
 }
 
 is_x86_64_v2() {
@@ -192,6 +216,52 @@ lint_image() {
 	printf '::warning title=bootc lint findings (%s)::lint reported failures (exit %d) — surfaced above, not build-fatal (set BOOTC_LINT_FATAL=1 to enforce)\n' \
 		"${IMAGE_NAME:-?}" "$rc"
 	return 0
+}
+
+# ---- Package manager abstraction (PKG_MGR) ----
+# These wrappers let build scripts call a single command regardless of
+# whether the base image is RPM-based (dnf) or deb-based (apt-get).
+# Scripts that still call dnf directly (e.g. install_from_copr) are
+# intentionally RPM-only and guarded by [[ $PKG_MGR == dnf ]] checks.
+
+# Install packages. On apt, skips recommended/suggested packages to keep
+# the image lean (mirrors --setopt=install_weak_deps=False on dnf).
+pkg_install() {
+	if [[ "$PKG_MGR" == "apt" ]]; then
+		apt-get update -qq
+		apt-get install -y --no-install-recommends "$@"
+	else
+		dnf_retry install -y --setopt=install_weak_deps=False "$@"
+	fi
+}
+
+# Remove packages. `apt-get purge` removes config files too (equivalent
+# to dnf's default `remove` behavior on EL/Fedora).
+pkg_remove() {
+	if [[ "$PKG_MGR" == "apt" ]]; then
+		apt-get purge -y "$@"
+	else
+		dnf_retry remove -y "$@"
+	fi
+}
+
+# Refresh package metadata.
+pkg_refresh() {
+	if [[ "$PKG_MGR" == "apt" ]]; then
+		apt-get update
+	else
+		dnf makecache
+	fi
+}
+
+# Clean package manager caches to minimize final image size.
+pkg_clean() {
+	if [[ "$PKG_MGR" == "apt" ]]; then
+		apt-get clean
+		rm -rf /var/lib/apt/lists/*
+	else
+		dnf clean all
+	fi
 }
 
 # Run `dnf` with retries to absorb transient mirror flakes (EPEL / AlmaLinux /

--- a/scripts/generate-workflows.py
+++ b/scripts/generate-workflows.py
@@ -37,12 +37,38 @@ jobs:
     secrets: inherit
 """
 
+    # Experimental variants: manual dispatch only — no cron schedule.
+    template_experimental = """name: Build {name_cap} [experimental]
+on:
+  workflow_dispatch:
+    inputs:
+      flavor:
+        description: 'Flavor (all, base, gnome, kde, niri, etc.)'
+        default: 'all'
+        type: string
+
+concurrency:
+  group: build-{name}-${{{{ github.ref }}}}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: {emoji}-{name}
+    uses: ./.github/workflows/build-variant.yml
+    with:
+      variant: '{name}'
+      flavor: ${{{{ inputs.flavor || 'all' }}}}
+    secrets: inherit
+"""
+
     for variant in config.get('variants', []):
         name = variant.get('id')
         emoji = variant.get('emoji', '❓')
         name_cap = name.capitalize()
-        
-        workflow_content = template.format(
+        experimental = variant.get('experimental', False)
+
+        tpl = template_experimental if experimental else template
+        workflow_content = tpl.format(
             name=name,
             name_cap=name_cap,
             emoji=emoji


### PR DESCRIPTION
## Summary

Phase 1 of [RFC 010](https://github.com/tuna-os/tunaOS/blob/main/rfcs/010-ubuntu-26.04-variant.md) — the foundation layer for building an Ubuntu 26.04 TunaOS variant `grouper` 🐟.

**Purely additive** — no behavior change for existing RPM-based builds.

## Changes

### `lib.sh` — PKG_MGR abstraction
- `IS_UBUNTU` / `IS_DEBIAN` OS detection flags
- `IMAGE_NAME=grouper` / `IMAGE_PRETTY_NAME=Grouper` for Ubuntu
- `IMAGE_NAME=flounder` for plain Debian (future-proofing)
- `PKG_MGR` dimension (`apt` vs `dnf`), auto-detected from `BASE_IMAGE`
- `pkg_install` / `pkg_remove` / `pkg_refresh` / `pkg_clean` wrappers
- `detected_os()` updated to print Ubuntu/Debian/PKG_MGR
- All new variables exported

### `build-config.yml` — grouper variant entry
- GNOME-only, x86_64-only, `experimental: true`
- `base` (stage 1) + `gnome` (stage 2, ISO) flavors
- TODO: pin base image to digest before enabling builds

### `generate-workflows.py` — experimental variant support
- Experimental variants (`experimental: true`) get `workflow_dispatch` only — no daily cron
- Regenerated `build-grouper.yml` (manual dispatch only)
- Existing workflows (yellowfin/albacore/skipjack/bonito) unchanged

## Verification

- [x] ShellCheck passes (`just fix`)
- [x] `python3 scripts/generate-workflows.py` regenerates 5 workflows cleanly
- [x] Only grouper is manual-dispatch; others retain cron
- [x] No RPM build scripts touched — `dnf_retry` path in `pkg_*` is identical

## Next phases

- Phase 2: `Containerfile.ubuntu` + base flavor
- Phase 3: GNOME flavor + ISO
- Phase 4: Matrix wiring (`experimental: true`)
- Phase 5: Docs + ROADMAP