### PR TITLE
fix(ci): declare watch-upstream secrets to fix startup_failure

### DIFF
--- a/.github/workflows/watch-upstream.yml
+++ b/.github/workflows/watch-upstream.yml
@@ -55,6 +55,13 @@ name: Watch upstream (reusable)
         required: false
         default: '7'
         type: string
+    secrets:
+      GEMINI_API_KEY:
+        description: 'API key for the Gemini CLI port step'
+        required: false
+      COPILOT_PAT:
+        description: 'PAT used to fire the Copilot batch agent (degrades cleanly if absent)'
+        required: false
 
 jobs:
   scan:


### PR DESCRIPTION
## Problem

The three upstream-sync workflows — `watch-aurora`, `watch-bluefin-lts`, `watch-zirconium` — have all hit `startup_failure` since 2026-06-15 and never start.

## Root cause

Commit c18610b ("replace secrets:inherit with explicit least-privilege secrets") changed the callers to pass `GEMINI_API_KEY` and `COPILOT_PAT` explicitly, but the reusable `watch-upstream.yml` never declared them under `on.workflow_call.secrets`. `secrets: inherit` tolerated undeclared secrets; explicit passing does not, so GitHub rejects the workflow before it starts.

## Fix

Declare both secrets (`required: false`, so the Copilot batch still degrades cleanly when `COPILOT_PAT` is absent) in the reusable workflow. One block repairs all three callers.

Not redundant — each caller watches a distinct upstream/flavor (kde / gnome / niri), so they were fixed rather than removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)