### PR TITLE
perf: late SHA_HEAD_SHORT so the layer cache can actually hit across commits

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -45,7 +45,6 @@ ARG ENABLE_SSHD
 ARG DESKTOP_FLAVOR
 ARG IMAGE_NAME
 ARG IMAGE_VENDOR
-ARG SHA_HEAD_SHORT
 ARG IMAGE_REGISTRY="ghcr.io"
 
 # RHSM credentials are NOT declared as ARG here — they're passed via
@@ -58,7 +57,6 @@ ENV BASE_IMAGE=${BASE_IMAGE}
 ENV IMAGE_NAME=${IMAGE_NAME}
 ENV IMAGE_VENDOR=${IMAGE_VENDOR}
 ENV IMAGE_REGISTRY=${IMAGE_REGISTRY}
-ENV SHA_HEAD_SHORT=${SHA_HEAD_SHORT}
 ENV ENABLE_HWE=${ENABLE_HWE}
 ENV ENABLE_NVIDIA=${ENABLE_NVIDIA}
 ENV ENABLE_SSHD=${ENABLE_SSHD}
@@ -106,6 +104,12 @@ RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=bind,from=context,source=/,target=/run/context \
    /run/context/build_scripts/40-services.sh
 
+# SHA_HEAD_SHORT changes on every commit. Declared HERE (not at the top of
+# the stage) so only the layers from this point down rebuild per commit —
+# with it in the early ENV block, the layer cache could never hit across
+# commits and the expensive dnf layers above rebuilt every time.
+ARG SHA_HEAD_SHORT
+ENV SHA_HEAD_SHORT=${SHA_HEAD_SHORT}
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -51,14 +51,12 @@ ARG ENABLE_NVIDIA
 ARG DESKTOP_FLAVOR
 ARG IMAGE_NAME
 ARG IMAGE_VENDOR
-ARG SHA_HEAD_SHORT
 ARG IMAGE_REGISTRY="ghcr.io"
 
 ENV BASE_IMAGE=${BASE_IMAGE} \
     IMAGE_NAME=${IMAGE_NAME} \
     IMAGE_VENDOR=${IMAGE_VENDOR} \
     IMAGE_REGISTRY=${IMAGE_REGISTRY} \
-    SHA_HEAD_SHORT=${SHA_HEAD_SHORT} \
     ENABLE_HWE=${ENABLE_HWE} \
     ENABLE_NVIDIA=${ENABLE_NVIDIA} \
     DESKTOP_FLAVOR=${DESKTOP_FLAVOR} \
@@ -146,6 +144,11 @@ RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   flatpak remote-add --if-not-exists --system flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
+# SHA_HEAD_SHORT changes on every commit — declared here (not in the early
+# ENV block) so per-commit values only rebuild from this layer down and the
+# expensive apt layers above stay cache-hittable. See Containerfile.
+ARG SHA_HEAD_SHORT
+ENV SHA_HEAD_SHORT=${SHA_HEAD_SHORT}
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \


### PR DESCRIPTION
Follow-up to #580 with measurement: warm-cache build times were flat vs cold because the early `ENV SHA_HEAD_SHORT` busts every dnf layer on every commit. Moving the declaration to its single consumer (90-image-info) makes the cache effective across commits. BUILD_ID in the shipped image is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)