### PR TITLE
chore: bump tacklebox pin (kernel selection + single-context fixes)

### DIFF
--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -28,4 +28,4 @@ downloads:
   # renovate: datasource=github-releases depName=ledif/kcm_ublue
   kcm_ublue: "v0.6.1"
   # renovate: datasource=git-refs depName=tuna-os/tacklebox
-  tacklebox: "75c837b39d9dcb360509c49d2e0306621dced904"
+  tacklebox: "e3625d5155b77ffedbd110eacbaa8c551c2bd24b"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -181,7 +181,7 @@ tunaos_run_tacklebox() {
 		# Pin the source SHA so CI doesn't silently track a moving HEAD.
 		local sha cache bin
 		sha="${TACKLEBOX_SHA:-$(grep '^\s*tacklebox:' image-versions.yaml 2>/dev/null | sed 's/.*"\(.*\)".*/\1/')}"
-		sha="${sha:-75c837b39d9dcb360509c49d2e0306621dced904}"
+		sha="${sha:-e3625d5155b7c96da44b706d0dad57cb1e6cd870}"
 		cache="${TACKLEBOX_CACHE:-/var/cache/tunaos/tacklebox}"
 		bin="${cache}/tacklebox"
 


### PR DESCRIPTION
Brings in tuna-os/tacklebox#87. Directly fixes today's skipjack:gnome ISO failure (debug-kernel-without-initramfs picked by the old extract script). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)