### PR TITLE
fix(grouper): install util-linux + fix apt kdeconnect package name

### DIFF
--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -31,6 +31,7 @@ install_base_packages_no_de() {
 			podman \
 			skopeo \
 			systemd-container \
+			util-linux \
 			flatpak \
 			distrobox \
 			fastfetch \

--- a/build_scripts/kde.sh
+++ b/build_scripts/kde.sh
@@ -16,7 +16,7 @@ case "${1:-}" in
 			konsole \
 			kate \
 			ark \
-			kde-connect \
+			kdeconnect \
 			xdg-desktop-portal-kde \
 			qt6-wayland
 
@@ -37,7 +37,7 @@ case "${1:-}" in
 			kate \
 			ark \
 			plasma-discover \
-			kde-connect \
+			kdeconnect \
 			xdg-desktop-portal-kde \
 			qt5-qtwayland \
 			qt6-qtwayland \
@@ -80,7 +80,7 @@ case "${1:-}" in
 			konsole \
 			kate \
 			ark \
-			kde-connect \
+			kdeconnect \
 			xdg-desktop-portal-kde \
 			qt5-qtwayland \
 			qt6-qtwayland


### PR DESCRIPTION
Two independent failures from today's grouper full-parity run:
- Boot Gate: `bootc install to-disk` needs sfdisk (util-linux), not installed on the apt base packages list.
- KDE build: Debian/Ubuntu's package is `kdeconnect`, not `kde-connect` (Fedora/EL naming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)