### PR TITLE
refactor(kde): merge extra into base — one install pass

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -36,9 +36,7 @@ fi
 # Ensure unzip is available for font installation in 26-packages-post.sh
 dnf_retry -y install unzip
 
-if [[ "${DESKTOP_FLAVOR}" == "kde" ]]; then
-	/run/context/build_scripts/kde.sh extra
-elif [[ "${DESKTOP_FLAVOR}" == "niri" ]]; then
+if [[ "${DESKTOP_FLAVOR}" == "niri" ]]; then
 	/run/context/build_scripts/niri.sh extra
 else
 	echo "Skipping DE-specific extra packages (DESKTOP_FLAVOR='${DESKTOP_FLAVOR}')"

--- a/build_scripts/kde.sh
+++ b/build_scripts/kde.sh
@@ -131,11 +131,11 @@ case "${1:-}" in
 		dnf versionlock add plasma-desktop
 		dnf versionlock add "qt6-*"
 	fi
-	;;
-"extra")
-	# Build kcm_ublue from source, install krunner-bazaar from GitHub
-	# releases, and copy oversteer udev rules — replacing the
-	# ublue-os/packages COPR which dropped EPEL chroots.
+
+	# ── KDE extras (kcm_ublue, Bazaar, oversteer) ────────────────────────
+	# Previously in a separate "extra" case called from 20-packages.sh
+	# (before KDE was installed, so KF6 devel deps were missing). Now runs
+	# after the DE group install so build deps are satisfiable.
 	source /run/context/build_scripts/kcm-ublue.sh
 
 	# Disable plasma-discover in favor of Flatpak/Bazaar (like Aurora)


### PR DESCRIPTION
Moves kcm_ublue, krunner-bazaar, Bazaar setup, oversteer, and Discover disabling from the `extra` case (which ran before KDE was installed and always skipped due to missing deps) into the `base` case (runs after KDE group install).

No more `kde.sh extra` — everything in one shot.