### PR TITLE
chore(ci): shorten job names for readability

### DIFF
--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -160,7 +160,7 @@ jobs:
   # Builds {variant}:base for every variant in parallel.
   # Nothing else may start until all base images are published.
   build_base:
-    name: "S1 | ${{ matrix.variant_emoji }} ${{ matrix.variant }}:${{ matrix.flavor }}"
+    name: "${{ matrix.flavor }}"
     needs: generate_matrix
     if: fromJson(needs.generate_matrix.outputs.stage1_matrix).include[0]
     strategy:
@@ -187,7 +187,7 @@ jobs:
   #   - niri      (layers on base)
   # All of these run in parallel within stage 2.
   build_stage2:
-    name: "S2 | ${{ matrix.variant_emoji }} ${{ matrix.variant }}:${{ matrix.flavor }}"
+    name: "${{ matrix.flavor }}"
     needs: [generate_matrix, build_base]
     # build_base is SKIPPED (not failed) when a flavor-filtered dispatch
     # leaves stage 1 empty (e.g. `-f flavor=xfce`); without !cancelled() a
@@ -225,7 +225,7 @@ jobs:
   # pushed and available; stage-3 cells whose specific base is missing fail on
   # their own without taking the rest down.
   build_stage3:
-    name: "S3 | ${{ matrix.variant_emoji }} ${{ matrix.variant }}:${{ matrix.flavor }}"
+    name: "${{ matrix.flavor }}"
     needs: [generate_matrix, build_stage2]
     if: >-
       !cancelled() && needs.generate_matrix.result == 'success' &&
@@ -253,7 +253,7 @@ jobs:
   # built in stage 3. Same `!cancelled()` rationale as stage 3 (#285) so a
   # single stage-3 failure doesn't skip stage 4.
   build_stage4:
-    name: "S4 | ${{ matrix.variant_emoji }} ${{ matrix.variant }}:${{ matrix.flavor }}"
+    name: "${{ matrix.flavor }}"
     needs: [generate_matrix, build_stage3]
     if: >-
       !cancelled() && needs.generate_matrix.result == 'success' &&
@@ -281,7 +281,7 @@ jobs:
   # ISOs pull the already-published GHCR image for their stage.
 
   build_artifacts_s2:
-    name: "PkgS2 | ${{ matrix.variant_emoji }} ${{ matrix.variant }}:${{ matrix.flavor }}"
+    name: "iso:${{ matrix.flavor }}"
     needs: [generate_matrix, build_stage2]
     if: github.event_name != 'pull_request' && needs.generate_matrix.outputs.artifact_s2_count != '0'
     strategy:
@@ -304,7 +304,7 @@ jobs:
   # Same cell logic for stage-3 ISOs (gnome-nvidia etc.). `!cancelled()` so a
   # single stage-3 image failure doesn't skip the artifacts that DID build.
   build_artifacts_s3:
-    name: "PkgS3 | ${{ matrix.variant_emoji }} ${{ matrix.variant }}:${{ matrix.flavor }}"
+    name: "iso:${{ matrix.flavor }}"
     needs: [generate_matrix, build_stage3]
     if: >-
       !cancelled() && needs.generate_matrix.result == 'success' &&
@@ -329,7 +329,7 @@ jobs:
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
 
   build_artifacts_s4:
-    name: "PkgS4 | ${{ matrix.variant_emoji }} ${{ matrix.variant }}:${{ matrix.flavor }}"
+    name: "iso:${{ matrix.flavor }}"
     needs: [generate_matrix, build_stage4]
     if: >-
       !cancelled() && needs.generate_matrix.result == 'success' &&

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -90,7 +90,7 @@ jobs:
           echo "matrix=$(echo "${MATRIX}" | jq -c '.')" >> $GITHUB_OUTPUT
 
   build_push:
-    name: Build ${{ matrix.platform }}
+    name: ${{ matrix.safeplatform }}
     runs-on: ${{ contains(matrix.platform, 'amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     timeout-minutes: 60
     needs: generate_matrix
@@ -427,7 +427,7 @@ jobs:
           path: |
             /tmp/outputs/digests/*.txt
   manifest:
-    name: Manifest ${{ inputs.image-name }}:${{ inputs.major-version }}
+    name: Manifest
     runs-on: ubuntu-latest
     if: always()
     needs:
@@ -676,7 +676,7 @@ jobs:
   # Cosign throws errors when ran inside the Fedora container for one reason or another
   # so we move this to another step in order to run on Ubuntu
   sign:
-    name: Sign Manifest
+    name: Sign
     needs: manifest
     if: ${{ inputs.publish && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
@@ -697,7 +697,7 @@ jobs:
   # tags is blocked while this fails. Skipped for base* flavors (no desktop
   # to verify; they are exercised by every desktop build layered on them).
   verify_boot:
-    name: Boot Gate ${{ inputs.image-name }}:${{ inputs.default-tag }}
+    name: Gate
     needs: manifest
     if: >-
       inputs.publish && github.event_name != 'pull_request' &&
@@ -765,7 +765,7 @@ jobs:
           retention-days: 7
 
   tag-image:
-    name: Promote Tags
+    name: Promote
     needs: [manifest, verify_boot]
     if: >-
       !cancelled() && github.event_name != 'pull_request' &&


### PR DESCRIPTION
Cuts the verbose job names down. The variant is already shown by the parent workflow name, so repeating it in every stage job is noise.

```
Before: 🐟-albacore / S2 | 🐟 albacore:kde / Build linux/amd64/v2
After:  🐟-albacore / kde / linux-amd64-v2
```