### PR TITLE
refactor: extract _build to script, add resolve-image.sh

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -25,212 +25,30 @@ _ensure-deps:
         exit 1
     fi
 
-# Private build engine.
+# Private build engine — thin wrapper that exports env vars and calls the script.
 [private]
 _build target_tag_with_version target_tag container_file base_image_for_build target_platform use_cache enable_gdx enable_hwe desktop_flavor is_ci_build enable_sshd_build *args: _ensure-deps
     #!/usr/bin/env bash
     set -euxo pipefail
-
-    # Source registry abstraction for configurable mirror support (RFC-009)
-    source scripts/_registry.sh
-
-    # Get image digests from image-versions.yaml
-    common_image_sha=$({{ yq }} -r '.images[] | select(.name == "common") | .digest' image-versions.yaml)
-    common_image_ref="{{ common_image }}@${common_image_sha}"
-    brew_image_sha=$({{ yq }} -r '.images[] | select(.name == "brew") | .digest' image-versions.yaml)
-    brew_image_ref="{{ brew_image }}@${brew_image_sha}"
-
-    BUILD_ARGS=()
-    BUILD_ARGS+=("--build-arg" "IMAGE_NAME={{ target_tag }}")
-    BUILD_ARGS+=("--build-arg" "IMAGE_VENDOR={{ repo_organization }}")
-    BUILD_ARGS+=("--build-arg" "IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io}")
-    BUILD_ARGS+=("--build-arg" "BASE_IMAGE={{ base_image_for_build }}")
-    BUILD_ARGS+=("--build-arg" "COMMON_IMAGE_REF=${common_image_ref}")
-    BUILD_ARGS+=("--build-arg" "BREW_IMAGE_REF=${brew_image_ref}")
-    BUILD_ARGS+=("--build-arg" "ENABLE_HWE={{ enable_hwe }}")
-    BUILD_ARGS+=("--build-arg" "ENABLE_NVIDIA={{ enable_gdx }}")
-    BUILD_ARGS+=("--build-arg" "DESKTOP_FLAVOR={{ desktop_flavor }}")
-    BUILD_ARGS+=("--build-arg" "ENABLE_SSHD={{ enable_sshd_build }}")
-
-    # OVERLAY_TYPE is used by Containerfile.overlay to select HWE or nvidia script
-    if [[ -n "${OVERLAY_TYPE:-}" ]]; then
-        BUILD_ARGS+=("--build-arg" "OVERLAY_TYPE=${OVERLAY_TYPE}")
-    fi
-
-    AKMODS_ORG=$({{ yq }} -r ".variants[] | select(.id == \"{{ target_tag }}\") | .akmods // \"ublue-os\"" .github/build-config.yml)
-    # Resolve akmods registry via registry-map; falls back to ghcr.io/${AKMODS_ORG} if not mapped
-    AKMODS_REGISTRY_BASE="$(registry_ref akmods 2>/dev/null || echo "ghcr.io/${AKMODS_ORG}")"
-    BUILD_ARGS+=("--build-arg" "AKMODS_BASE=${AKMODS_REGISTRY_BASE}")
-
-    # RHSM credentials via BuildKit-style secret. The previous --build-arg
-    # approach baked them into `podman history --no-trunc` (and earlier into
-    # the image ENV); --mount=type=secret in the Containerfile exposes them
-    # only inside the one RUN that registers with subscription-manager and
-    # never persists them in any layer.
-    #
-    # Only materialise the secret file if at least one RHSM var is set —
-    # for non-RHEL builds (yellowfin/albacore/skipjack/bonito) this stays
-    # empty and no secret is passed.
-    RHSM_SECRET_FILE=""
-    if [[ -n "${RHSM_USER:-}${RHSM_PASSWORD:-}${RHSM_ORG:-}${RHSM_ACTIVATION_KEY:-}" ]]; then
-        RHSM_SECRET_FILE=$(mktemp)
-        # shellcheck disable=SC2064 # cleanup must run with the captured path
-        trap "rm -f '${RHSM_SECRET_FILE}'" EXIT
-        chmod 0600 "${RHSM_SECRET_FILE}"
-        {
-            printf 'export RHSM_USER=%q\n'           "${RHSM_USER:-}"
-            printf 'export RHSM_PASSWORD=%q\n'       "${RHSM_PASSWORD:-}"
-            printf 'export RHSM_ORG=%q\n'            "${RHSM_ORG:-}"
-            printf 'export RHSM_ACTIVATION_KEY=%q\n' "${RHSM_ACTIVATION_KEY:-}"
-        } > "${RHSM_SECRET_FILE}"
-        BUILD_ARGS+=("--secret" "id=rhsm,src=${RHSM_SECRET_FILE}")
-    fi
-
-    if [[ "{{ enable_hwe }}" -eq "1" ]] || [[ "{{ target_tag }}" == bonito* ]]; then
-        BUILD_ARGS+=("--build-arg" "AKMODS_VERSION=coreos-stable-{{ coreos_stable_version }}")
-        BUILD_ARGS+=("--build-arg" "AKMODS_NVIDIA_VERSION=coreos-stable-{{ coreos_stable_version }}")
-    else
-        BUILD_ARGS+=("--build-arg" "AKMODS_VERSION=centos-10")
-        BUILD_ARGS+=("--build-arg" "AKMODS_NVIDIA_VERSION=centos-10")
-    fi
-    BUILD_ARGS+=("--build-arg" "IMAGE_NAME_VARIANT={{ target_tag }}")
-
-    # Zirconium system files feed the niri desktop stages (all variants) and
-    # grouper (RFC 010). Pin the image ref via image-versions.yaml, same as
-    # common/brew — without this the Containerfile ARG default floats on
-    # :latest and builds aren't reproducible.
-    zirconium_image_sha=$({{ yq }} -r '.images[] | select(.name == "zirconium") | .digest' image-versions.yaml)
-    BUILD_ARGS+=("--build-arg" "ZIRCONIUM_IMAGE_REF=ghcr.io/zirconium-dev/zirconium@${zirconium_image_sha}")
-
-    # build_scripts/*.sh are injected into RUN steps via
-    # --mount=type=bind,from=context (not COPY), so their content never
-    # participates in buildah's layer-cache key — editing a script alone
-    # doesn't invalidate the layer that ran it. Hash the directory and pass
-    # it as a build-arg (consumed as an early ENV in the Containerfiles) so
-    # the cache correctly invalidates exactly when these scripts change,
-    # independent of SHA_HEAD_SHORT (which changes every commit and stays
-    # out of this position deliberately, to keep cross-commit caching for
-    # commits that don't touch build_scripts/ at all).
-    build_scripts_hash=$(find build_scripts -type f -name '*.sh' -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -c1-16)
-    BUILD_ARGS+=("--build-arg" "BUILD_SCRIPTS_HASH=${build_scripts_hash}")
-
-    if [[ -z "$(git status -s)" ]]; then
-        BUILD_ARGS+=("--build-arg" "SHA_HEAD_SHORT=$(git rev-parse --short HEAD)")
-    else
-        BUILD_ARGS+=("--build-arg" "SHA_HEAD_SHORT=dirty")
-    fi
-
-    if [[ "{{ use_cache }}" == "1" ]]; then
-        readarray -t CACHE_MOUNTS < <(./scripts/setup-build-cache.sh "{{ target_tag }}")
-        BUILD_ARGS+=("${CACHE_MOUNTS[@]}")
-    fi
-
-    DESKTOP_FLAVOR="{{ desktop_flavor }}"
-    PRE_CHUNK_TAG="{{ target_tag_with_version }}-pre-chunk"
-
-    echo "==> Building ${DESKTOP_FLAVOR} stage..."
-
-    # Use buildah in CI (for layer caching via actions/cache), podman locally
-    # (the local buildah wrapper tries to pull localhost/buildah-tool which fails).
-    BUILDER="podman"
-    PULL_FLAG="--pull=newer"
-    if [[ "{{ is_ci_build }}" == "1" ]] && command -v buildah &>/dev/null; then
-        BUILDER="buildah"
-        PULL_FLAG="--pull-always"
-    fi
-
-    # Pass 1: Build the target DE stage directly — no unused stages built
-    ${BUILDER} build \
-        --security-opt label=disable \
-        --dns=8.8.8.8 \
-        --platform "{{ target_platform }}" \
-        --target="${DESKTOP_FLAVOR}" \
-        "${BUILD_ARGS[@]}" \
-        --tag "${PRE_CHUNK_TAG}" \
-        {{ args }} \
-        ${PULL_FLAG} \
-        --file "{{ container_file }}" \
-        ${BUILDAH_CACHE_FLAGS:-} \
-        .
-
-    # PR/CI validation builds don't publish — the rechunk exists purely for
-    # client pull efficiency, so let callers skip passes 2-3 (~10 min).
-    if [[ "${SKIP_RECHUNK:-0}" == "1" ]]; then
-        echo "==> SKIP_RECHUNK=1 — tagging pre-chunk image as final (no chunkah/relabel)"
-        ${BUILDER} tag "${PRE_CHUNK_TAG}" "{{ target_tag_with_version }}"
-        exit 0
-    fi
-
-    echo "==> Running chunkah on ${PRE_CHUNK_TAG}..."
-
-    # Ensure the chunkah image is available. Try the published image first,
-    # then fall back to building from source if it's not pullable.
-    # quay.io/coreos/chunkah:latest is the canonical chunkah image.
-    # Override via CHUNKAH_IMAGE env var or registry-map.yaml registry_ref.
-    if [[ -z "${CHUNKAH_IMAGE:-}" ]]; then
-        CHUNKAH_IMAGE="quay.io/coreos/chunkah:latest"
-    fi
-    if ! podman image inspect "${CHUNKAH_IMAGE}" &>/dev/null; then
-        if ! podman pull "${CHUNKAH_IMAGE}" 2>/dev/null; then
-            echo "==> chunkah image not pullable, building from source..."
-            ./scripts/build-chunkah.sh
-            CHUNKAH_IMAGE="localhost/chunkah:latest"
-        fi
-    fi
-
-    # Use a clean temp dir to avoid SELinux relabeling issues with existing files in PWD
-    CHUNK_OUT=$(mktemp -d)
-    # Pass 2: Run chunkah externally against the built image
-    # --network host: chunkah needs no networking (reads from mounted image,
-    # writes to mounted output dir). Avoids podman userspace-network-NS
-    # (pasta) which fails inside nested VMs (KubeVirt) that lack user
-    # namespace pivot_root capability.
-    podman run --rm \
-        --security-opt label=disable \
-        --network host \
-        --entrypoint="" \
-        -v "${CHUNK_OUT}:/run/out:Z" \
-        --mount "type=image,source=${PRE_CHUNK_TAG},target=/chunkah" \
-        "${CHUNKAH_IMAGE}" \
-        sh -c 'chunkah build > /run/out/out.ociarchive'
-    mv "${CHUNK_OUT}/out.ociarchive" out.ociarchive
-    rm -rf "${CHUNK_OUT}"
-
-    echo "==> Applying labels from OCI archive..."
-
-    # Pass 3: Load archive into podman storage via podman load, then apply OCI labels.
-    # podman load guarantees the same graphRoot as the subsequent buildah build.
-    # skopeo copy is avoided here because CI uses ublue-os/container-storage-action
-    # which mounts a BTRFS graphRoot for podman; skopeo defaults to overlay and writes
-    # to a different path, causing buildah build to fall back to a remote registry pull.
-
-    # Prune ALL unused images from BTRFS storage before loading the rechunked archive.
-    # Targeted rmi of just pre-chunk + chain base isn't sufficient: multi-stage FROM
-    # images (e.g. akmods-nvidia-open) are also left in BTRFS and cause disk pressure
-    # that triggers a podman storage index bug ("image not known" after load).
-    # Containerfile.final only needs the rechunked archive (loaded next), so it's safe
-    # to remove everything else at this point.
-    podman system prune -af 2>/dev/null || true
-
-    RECHUNKED_REF="localhost/{{ target_tag_with_version }}-rechunked-$$"
-    LOADED_ID=$(TMPDIR=${TMPDIR:-/tmp} podman load --input out.ociarchive | awk '/Loaded image/{print $NF}')
-    rm -f out.ociarchive  # free disk immediately after load; don't hold archive while build runs
-    if [[ -z "${LOADED_ID}" ]]; then
-        echo "ERROR: podman load produced no image ID; the OCI archive may be corrupt or disk full" >&2
-        exit 1
-    fi
-    podman tag "${LOADED_ID}" "${RECHUNKED_REF}"
-
-    ${BUILDER} build \
-        --security-opt label=disable \
-        --dns=8.8.8.8 \
-        "${BUILD_ARGS[@]}" \
-        --build-arg "RECHUNKED_BASE=${RECHUNKED_REF}" \
-        --tag "{{ target_tag_with_version }}" \
-        --file "Containerfile.final" \
-        .
-
-    ${BUILDER} rmi "${RECHUNKED_REF}" 2>/dev/null || true
+    export IMAGE_TAG="{{ target_tag_with_version }}"
+    export VARIANT="{{ target_tag }}"
+    export CONTAINERFILE="{{ container_file }}"
+    export BASE_IMAGE="{{ base_image_for_build }}"
+    export PLATFORM="{{ target_platform }}"
+    export USE_CACHE="{{ use_cache }}"
+    export ENABLE_NVIDIA="{{ enable_gdx }}"
+    export ENABLE_HWE="{{ enable_hwe }}"
+    export DESKTOP_FLAVOR="{{ desktop_flavor }}"
+    export IS_CI="{{ is_ci_build }}"
+    export ENABLE_SSHD="{{ enable_sshd_build }}"
+    export IMAGE_REGISTRY="${IMAGE_REGISTRY:-ghcr.io}"
+    export REPO_ORGANIZATION="{{ repo_organization }}"
+    export COMMON_IMAGE="{{ common_image }}"
+    export BREW_IMAGE="{{ brew_image }}"
+    export COREOS_STABLE_VERSION="{{ coreos_stable_version }}"
+    export YQ="{{ yq }}"
+    # OVERLAY_TYPE inherited from parent shell (exported by build recipe)
+    ./scripts/build-image-inner.sh
 
 # Build a TunaOS variant
 build variant='albacore' flavor='gnome' target_platform='' is_ci="0" tag='latest' chain_base_image='' enable_sshd="0": _ensure-deps

--- a/scripts/build-image-inner.sh
+++ b/scripts/build-image-inner.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# build-image-inner.sh — The container image build engine.
+#
+# Replaces the Justfile _build recipe. Driven by environment variables
+# (not positional args) for readability and testability.
+#
+# Required env vars:
+#   IMAGE_TAG          — full tag (e.g. "yellowfin:gnome")
+#   VARIANT            — variant name (e.g. "yellowfin")
+#   CONTAINERFILE      — which Containerfile to use
+#   BASE_IMAGE         — the FROM image for the build
+#   PLATFORM           — target platform(s) (e.g. "linux/amd64")
+#   DESKTOP_FLAVOR     — the --target stage name
+#   ENABLE_HWE         — 0 or 1
+#   ENABLE_NVIDIA      — 0 or 1
+#   ENABLE_SSHD        — 0 or 1
+#
+# Optional env vars:
+#   OVERLAY_TYPE       — hwe or nvidia (for Containerfile.overlay)
+#   USE_CACHE          — 1 to enable local dnf cache mounts
+#   IS_CI              — 1 if running in CI
+#   SKIP_RECHUNK       — 1 to skip chunkah passes (PR builds)
+#   IMAGE_REGISTRY     — defaults to ghcr.io
+#   REPO_ORGANIZATION  — defaults to tuna-os
+#   CHUNKAH_IMAGE      — override chunkah image ref
+#   BUILDAH_CACHE_FLAGS — extra flags for buildah layer cache
+
+set -euxo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+IMAGE_REGISTRY="${IMAGE_REGISTRY:-ghcr.io}"
+REPO_ORGANIZATION="${REPO_ORGANIZATION:-tuna-os}"
+IS_CI="${IS_CI:-0}"
+USE_CACHE="${USE_CACHE:-0}"
+SKIP_RECHUNK="${SKIP_RECHUNK:-0}"
+ENABLE_SSHD="${ENABLE_SSHD:-0}"
+YQ="${YQ:-yq}"
+
+# ── Source shared helpers ─────────────────────────────────────────────────────
+source scripts/_registry.sh
+
+# ── Resolve image refs from image-versions.yaml ───────────────────────────────
+common_image="${COMMON_IMAGE:-ghcr.io/projectbluefin/common}"
+brew_image="${BREW_IMAGE:-ghcr.io/ublue-os/brew}"
+
+common_image_sha=$($YQ -r '.images[] | select(.name == "common") | .digest' image-versions.yaml)
+common_image_ref="${common_image}@${common_image_sha}"
+brew_image_sha=$($YQ -r '.images[] | select(.name == "brew") | .digest' image-versions.yaml)
+brew_image_ref="${brew_image}@${brew_image_sha}"
+zirconium_image_sha=$($YQ -r '.images[] | select(.name == "zirconium") | .digest' image-versions.yaml)
+
+# ── Build args ────────────────────────────────────────────────────────────────
+BUILD_ARGS=()
+BUILD_ARGS+=("--build-arg" "IMAGE_NAME=${VARIANT}")
+BUILD_ARGS+=("--build-arg" "IMAGE_VENDOR=${REPO_ORGANIZATION}")
+BUILD_ARGS+=("--build-arg" "IMAGE_REGISTRY=${IMAGE_REGISTRY}")
+BUILD_ARGS+=("--build-arg" "BASE_IMAGE=${BASE_IMAGE}")
+BUILD_ARGS+=("--build-arg" "COMMON_IMAGE_REF=${common_image_ref}")
+BUILD_ARGS+=("--build-arg" "BREW_IMAGE_REF=${brew_image_ref}")
+BUILD_ARGS+=("--build-arg" "ENABLE_HWE=${ENABLE_HWE}")
+BUILD_ARGS+=("--build-arg" "ENABLE_NVIDIA=${ENABLE_NVIDIA}")
+BUILD_ARGS+=("--build-arg" "DESKTOP_FLAVOR=${DESKTOP_FLAVOR}")
+BUILD_ARGS+=("--build-arg" "ENABLE_SSHD=${ENABLE_SSHD}")
+BUILD_ARGS+=("--build-arg" "IMAGE_NAME_VARIANT=${VARIANT}")
+BUILD_ARGS+=("--build-arg" "ZIRCONIUM_IMAGE_REF=ghcr.io/zirconium-dev/zirconium@${zirconium_image_sha}")
+
+# Overlay type for Containerfile.overlay
+if [[ -n "${OVERLAY_TYPE:-}" ]]; then
+    BUILD_ARGS+=("--build-arg" "OVERLAY_TYPE=${OVERLAY_TYPE}")
+fi
+
+# Akmods version selection
+AKMODS_ORG=$($YQ -r ".variants[] | select(.id == \"${VARIANT}\") | .akmods // \"ublue-os\"" .github/build-config.yml)
+AKMODS_REGISTRY_BASE="$(registry_ref akmods 2>/dev/null || echo "ghcr.io/${AKMODS_ORG}")"
+BUILD_ARGS+=("--build-arg" "AKMODS_BASE=${AKMODS_REGISTRY_BASE}")
+
+if [[ "${ENABLE_HWE}" == "1" ]] || [[ "${VARIANT}" == bonito* ]]; then
+    COREOS_STABLE="${COREOS_STABLE_VERSION:-41}"
+    BUILD_ARGS+=("--build-arg" "AKMODS_VERSION=coreos-stable-${COREOS_STABLE}")
+    BUILD_ARGS+=("--build-arg" "AKMODS_NVIDIA_VERSION=coreos-stable-${COREOS_STABLE}")
+else
+    BUILD_ARGS+=("--build-arg" "AKMODS_VERSION=centos-10")
+    BUILD_ARGS+=("--build-arg" "AKMODS_NVIDIA_VERSION=centos-10")
+fi
+
+# RHSM secret (RHEL only)
+RHSM_SECRET_FILE=""
+if [[ -n "${RHSM_USER:-}${RHSM_PASSWORD:-}${RHSM_ORG:-}${RHSM_ACTIVATION_KEY:-}" ]]; then
+    RHSM_SECRET_FILE=$(mktemp)
+    # shellcheck disable=SC2064 # intentional: capture path at definition time
+    trap "rm -f '${RHSM_SECRET_FILE}'" EXIT
+    chmod 0600 "${RHSM_SECRET_FILE}"
+    {
+        printf 'export RHSM_USER=%q\n'           "${RHSM_USER:-}"
+        printf 'export RHSM_PASSWORD=%q\n'       "${RHSM_PASSWORD:-}"
+        printf 'export RHSM_ORG=%q\n'            "${RHSM_ORG:-}"
+        printf 'export RHSM_ACTIVATION_KEY=%q\n' "${RHSM_ACTIVATION_KEY:-}"
+    } > "${RHSM_SECRET_FILE}"
+    BUILD_ARGS+=("--secret" "id=rhsm,src=${RHSM_SECRET_FILE}")
+fi
+
+# Build scripts hash for cache invalidation
+build_scripts_hash=$(find build_scripts -type f -name '*.sh' -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -c1-16)
+BUILD_ARGS+=("--build-arg" "BUILD_SCRIPTS_HASH=${build_scripts_hash}")
+
+# Git SHA
+if [[ -z "$(git status -s)" ]]; then
+    BUILD_ARGS+=("--build-arg" "SHA_HEAD_SHORT=$(git rev-parse --short HEAD)")
+else
+    BUILD_ARGS+=("--build-arg" "SHA_HEAD_SHORT=dirty")
+fi
+
+# Local cache mounts
+if [[ "${USE_CACHE}" == "1" ]]; then
+    readarray -t CACHE_MOUNTS < <(./scripts/setup-build-cache.sh "${VARIANT}")
+    BUILD_ARGS+=("${CACHE_MOUNTS[@]}")
+fi
+
+# ── Pass 1: Build image ──────────────────────────────────────────────────────
+PRE_CHUNK_TAG="${IMAGE_TAG}-pre-chunk"
+
+BUILDER="podman"
+PULL_FLAG="--pull=newer"
+if [[ "${IS_CI}" == "1" ]] && command -v buildah &>/dev/null; then
+    BUILDER="buildah"
+    PULL_FLAG="--pull-always"
+fi
+
+echo "==> Building ${DESKTOP_FLAVOR} stage..."
+
+${BUILDER} build \
+    --security-opt label=disable \
+    --dns=8.8.8.8 \
+    --platform "${PLATFORM}" \
+    --target="${DESKTOP_FLAVOR}" \
+    "${BUILD_ARGS[@]}" \
+    --tag "${PRE_CHUNK_TAG}" \
+    ${PULL_FLAG} \
+    --file "${CONTAINERFILE}" \
+    ${BUILDAH_CACHE_FLAGS:-} \
+    .
+
+# ── Skip rechunk for PR builds ───────────────────────────────────────────────
+if [[ "${SKIP_RECHUNK}" == "1" ]]; then
+    echo "==> SKIP_RECHUNK=1 — tagging pre-chunk image as final"
+    ${BUILDER} tag "${PRE_CHUNK_TAG}" "${IMAGE_TAG}"
+    exit 0
+fi
+
+# ── Pass 2: Rechunk ──────────────────────────────────────────────────────────
+echo "==> Running chunkah on ${PRE_CHUNK_TAG}..."
+
+if [[ -z "${CHUNKAH_IMAGE:-}" ]]; then
+    CHUNKAH_IMAGE="quay.io/coreos/chunkah:latest"
+fi
+if ! podman image inspect "${CHUNKAH_IMAGE}" &>/dev/null; then
+    if ! podman pull "${CHUNKAH_IMAGE}" 2>/dev/null; then
+        echo "==> chunkah image not pullable, building from source..."
+        ./scripts/build-chunkah.sh
+        CHUNKAH_IMAGE="localhost/chunkah:latest"
+    fi
+fi
+
+CHUNK_OUT=$(mktemp -d)
+podman run --rm \
+    --security-opt label=disable \
+    --network host \
+    --entrypoint="" \
+    -v "${CHUNK_OUT}:/run/out:Z" \
+    --mount "type=image,source=${PRE_CHUNK_TAG},target=/chunkah" \
+    "${CHUNKAH_IMAGE}" \
+    sh -c 'chunkah build > /run/out/out.ociarchive'
+mv "${CHUNK_OUT}/out.ociarchive" out.ociarchive
+rm -rf "${CHUNK_OUT}"
+
+# ── Pass 3: Relabel ──────────────────────────────────────────────────────────
+echo "==> Applying labels from OCI archive..."
+
+podman system prune -af 2>/dev/null || true
+
+RECHUNKED_REF="localhost/${IMAGE_TAG}-rechunked-$$"
+LOADED_ID=$(TMPDIR=${TMPDIR:-/tmp} podman load --input out.ociarchive | awk '/Loaded image/{print $NF}')
+rm -f out.ociarchive
+if [[ -z "${LOADED_ID}" ]]; then
+    echo "ERROR: podman load produced no image ID" >&2
+    exit 1
+fi
+podman tag "${LOADED_ID}" "${RECHUNKED_REF}"
+
+${BUILDER} build \
+    --security-opt label=disable \
+    --dns=8.8.8.8 \
+    "${BUILD_ARGS[@]}" \
+    --build-arg "RECHUNKED_BASE=${RECHUNKED_REF}" \
+    --tag "${IMAGE_TAG}" \
+    --file "Containerfile.final" \
+    .
+
+${BUILDER} rmi "${RECHUNKED_REF}" 2>/dev/null || true

--- a/scripts/resolve-image.sh
+++ b/scripts/resolve-image.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# resolve-image.sh — Single entry point for all image reference lookups.
+#
+# Consolidates three sources of image metadata:
+#   - .github/build-config.yml  (base_image per variant)
+#   - image-versions.yaml       (digest pins for common/brew/zirconium)
+#   - registry-map.yaml         (mirror overrides via _registry.sh)
+#
+# Usage:
+#   ./scripts/resolve-image.sh <variant> <role>
+#
+# Roles:
+#   base       — the OS base image for a variant (from build-config.yml)
+#   common     — projectbluefin/common with pinned digest
+#   brew       — ublue-os/brew with pinned digest
+#   zirconium  — zirconium-dev/zirconium with pinned digest
+#   akmods     — akmods-nvidia-open registry base (with mirror support)
+#
+# Output: fully-qualified image reference (image@sha256:... or image:tag)
+
+set -euo pipefail
+
+VARIANT="${1:?Usage: resolve-image.sh <variant> <role>}"
+ROLE="${2:?Usage: resolve-image.sh <variant> <role>}"
+YQ="${YQ:-yq}"
+
+# Source registry mirror support
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_registry.sh" 2>/dev/null || true
+
+case "${ROLE}" in
+    base)
+        # Base image from build-config.yml
+        $YQ -r ".variants[] | select(.id == \"${VARIANT}\") | .base_image" .github/build-config.yml
+        ;;
+    common)
+        IMAGE="${COMMON_IMAGE:-ghcr.io/projectbluefin/common}"
+        DIGEST=$($YQ -r '.images[] | select(.name == "common") | .digest' image-versions.yaml)
+        # Strip any :tag from IMAGE since digest takes precedence
+        echo "${IMAGE%%:*}@${DIGEST}"
+        ;;
+    brew)
+        IMAGE="${BREW_IMAGE:-ghcr.io/ublue-os/brew}"
+        DIGEST=$($YQ -r '.images[] | select(.name == "brew") | .digest' image-versions.yaml)
+        echo "${IMAGE%%:*}@${DIGEST}"
+        ;;
+    zirconium)
+        DIGEST=$($YQ -r '.images[] | select(.name == "zirconium") | .digest' image-versions.yaml)
+        echo "ghcr.io/zirconium-dev/zirconium@${DIGEST}"
+        ;;
+    akmods)
+        AKMODS_ORG=$($YQ -r ".variants[] | select(.id == \"${VARIANT}\") | .akmods // \"ublue-os\"" .github/build-config.yml)
+        registry_ref akmods 2>/dev/null || echo "ghcr.io/${AKMODS_ORG}"
+        ;;
+    *)
+        echo "ERROR: unknown role '${ROLE}'. Valid: base, common, brew, zirconium, akmods" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Architecture improvements from the review:

**`scripts/build-image-inner.sh`** — the 150-line `_build` Justfile monolith is now a standalone script:
- Env-var driven (not 11 positional args)
- Three clear phases: args → build → rechunk
- Debuggable without just/sudo (`export VARIANT=... && ./scripts/build-image-inner.sh`)
- Justfile `_build` is now a 25-line export wrapper

**`scripts/resolve-image.sh`** — consolidates 3 sources of image metadata:
- `build-config.yml` → base image per variant
- `image-versions.yaml` → digest pins
- `registry-map.yaml` → mirror overrides

Usage: `./scripts/resolve-image.sh yellowfin common` → `ghcr.io/projectbluefin/common@sha256:e5ab...`

build-config.yml templating deferred to a separate PR.