### PR TITLE
feat: VISION.md + declarative desktop manifests (image factory foundation)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -32,6 +32,7 @@ COPY --from=common /system_files/shared /files
 COPY --from=common /system_files/bluefin /files
 COPY system_files_overrides /overrides
 COPY build_scripts /build_scripts
+COPY manifests /manifests
 COPY image-versions.yaml /image-versions.yaml
 
 # ==============================================================================

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,77 @@
+# Vision
+
+## Erase the Mystique of the Linux Distribution
+
+A Linux distribution shouldn't be a monolithic artifact hand-tuned by a single vendor. It should be a **composition of choices** — base OS, desktop environment, kernel, drivers — assembled by a build matrix and delivered as an immutable image.
+
+TunaOS exists to demonstrate this: there is no "TunaOS distro." There is a **build factory** that takes:
+
+```
+base OS  ×  desktop  ×  kernel  ×  drivers  =  image
+```
+
+Every cell in that matrix is a valid, shippable, bootable system. Users traverse the matrix at runtime with `bootc switch`. The factory stamps them all out — same pipeline, same Containerfile, same tooling.
+
+## Principles
+
+1. **The image IS the distribution.** There is no installer that assembles packages at install time. The image is pre-composed, tested, and shipped whole. What you pull is what you run.
+
+2. **Composition over customization.** Adding a new desktop, kernel, or driver variant should be a config change — not a fork, not a new repo, not new scripts. One matrix, many outputs.
+
+3. **Bootc is the delivery mechanism.** Atomic updates, rollback, switching between images — these aren't features we build, they're features we inherit from the container-native Linux stack.
+
+4. **Enterprise Linux on the desktop.** The base layer is RHEL-compatible (AlmaLinux, CentOS Stream). You get the stability and ecosystem of Enterprise Linux with the desktop experience of Fedora or Arch.
+
+5. **Declarative over imperative.** The build system should read a manifest and produce an image. Not: "run these 15 shell scripts in this order and hope the COPR repos are up." The manifest is the single source of truth for what goes into each image.
+
+## The Build Factory
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      build-config.yml                        │
+│  variant: yellowfin (AlmaLinux Kitten 10)                   │
+│  desktops: [gnome, gnome50, kde, niri, cosmic, xfce]        │
+│  kernels: [standard, hwe]                                   │
+│  drivers: [none, nvidia]                                    │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    Containerfile (parameterized)             │
+│  FROM $base → base packages → DE stage → overlay            │
+│  One file. Every combination. Same pipeline.                │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│              ghcr.io/tuna-os/yellowfin:gnome-hwe            │
+│              ghcr.io/tuna-os/yellowfin:kde-nvidia           │
+│              ghcr.io/tuna-os/albacore:niri                  │
+│              ghcr.io/tuna-os/bonito:cosmic                  │
+│              ... (every cell in the matrix)                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Where We're Going
+
+The end state is a build system where:
+
+- **Adding a new desktop** = one YAML entry (package list + display manager + a few config files)
+- **Adding a new base OS** = one YAML entry (image ref + package manager + repo setup)
+- **Adding a new kernel/driver layer** = one YAML entry (overlay script + akmods ref)
+- **No per-variant shell scripts.** The factory reads the manifest and knows what to do.
+
+The current build scripts (`gnome.sh`, `kde.sh`, `cosmic.sh`, etc.) are stepping stones. They encode the knowledge of "what packages make a GNOME desktop on EL10 vs Fedora vs Ubuntu." The goal is to extract that knowledge into declarative manifests and have a single generic installer that reads them.
+
+## Non-Goals
+
+- We are NOT building a package manager, repo, or installer from scratch.
+- We are NOT forking the desktops or kernels — we consume upstream.
+- We are NOT competing with Fedora/Ubuntu/Arch — we compose their work into a matrix they don't ship.
+
+## Inspiration
+
+- [Universal Blue](https://universal-blue.org/) — proved bootc-based desktop images work at scale
+- [Project Bluefin](https://projectbluefin.io) — showed that "opinionated defaults + bootc" is a valid product
+- [NixOS](https://nixos.org/) — declarative system configuration (we want the DX without the Nix complexity)
+- [Talos Linux](https://www.talos.dev/) — a "Linux distribution" that's just a manifest + an image factory

--- a/build_scripts/install-desktop.sh
+++ b/build_scripts/install-desktop.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# install-desktop.sh — Generic desktop installer driven by YAML manifests.
+#
+# Reads a desktop manifest from manifests/desktops/<desktop>.yaml and
+# installs packages, enables services, applies version locks, and runs
+# post-install hooks. Replaces per-DE shell scripts (kde.sh, cosmic.sh, etc.)
+# with a single data-driven installer.
+#
+# Usage:
+#   /run/context/build_scripts/install-desktop.sh <desktop>
+#
+# Requires yq (mikefarah/yq) available at YQ env var or in PATH.
+
+set -xeuo pipefail
+
+DESKTOP="${1:?Usage: install-desktop.sh <desktop>}"
+CONTEXT_PATH="/run/context"
+MANIFEST="${CONTEXT_PATH}/manifests/desktops/${DESKTOP}.yaml"
+
+if [[ ! -f "${MANIFEST}" ]]; then
+    echo "ERROR: No manifest found at ${MANIFEST}" >&2
+    echo "Available desktops:"
+    ls "${CONTEXT_PATH}/manifests/desktops/"*.yaml 2>/dev/null | sed 's|.*/||;s|\.yaml||'
+    exit 1
+fi
+
+source "${CONTEXT_PATH}/build_scripts/lib.sh"
+
+YQ="${YQ:-yq}"
+printf "::group:: === install-desktop: %s ===\n" "${DESKTOP}"
+
+# ── Determine OS section to use ──────────────────────────────────────────────
+OS_SECTION=""
+if [[ "$PKG_MGR" == "apt" ]]; then
+    OS_SECTION="apt"
+elif [[ "$IS_FEDORA" == true ]]; then
+    OS_SECTION="fedora"
+else
+    OS_SECTION="el10"
+fi
+
+echo "Installing ${DESKTOP} desktop (OS section: ${OS_SECTION})..."
+
+# ── APT path ─────────────────────────────────────────────────────────────────
+if [[ "${OS_SECTION}" == "apt" ]]; then
+    readarray -t PKGS < <($YQ -r ".packages.apt[]" "${MANIFEST}" 2>/dev/null)
+    if ((${#PKGS[@]} > 0)); then
+        pkg_install "${PKGS[@]}"
+    fi
+    # Enable display manager
+    DM=$($YQ -r '.display_manager // empty' "${MANIFEST}")
+    if [[ -n "${DM}" ]]; then
+        systemctl enable "${DM}" || true
+    fi
+    printf "::endgroup::\n"
+    exit 0
+fi
+
+# ── DNF path ─────────────────────────────────────────────────────────────────
+
+# Install groups
+GROUP_OPTIONS=$($YQ -r ".packages.${OS_SECTION}.group_options // empty" "${MANIFEST}")
+readarray -t GROUPS < <($YQ -r ".packages.${OS_SECTION}.groups[] // empty" "${MANIFEST}" 2>/dev/null)
+readarray -t GROUP_EXCLUDES < <($YQ -r ".packages.${OS_SECTION}.group_exclude[] // empty" "${MANIFEST}" 2>/dev/null)
+
+if ((${#GROUPS[@]} > 0)); then
+    EXCLUDE_ARGS=()
+    for exc in "${GROUP_EXCLUDES[@]}"; do
+        [[ -n "$exc" ]] && EXCLUDE_ARGS+=("-x" "$exc")
+    done
+    # shellcheck disable=SC2086 # GROUP_OPTIONS may be empty or contain flags
+    dnf group install -y ${GROUP_OPTIONS} "${EXCLUDE_ARGS[@]}" "${GROUPS[@]}"
+fi
+
+# Install packages
+readarray -t PKGS < <($YQ -r ".packages.${OS_SECTION}.packages[] // empty" "${MANIFEST}" 2>/dev/null)
+readarray -t EXCLUDES < <($YQ -r ".packages.${OS_SECTION}.exclude[] // empty" "${MANIFEST}" 2>/dev/null)
+
+if ((${#PKGS[@]} > 0)); then
+    EXCLUDE_ARGS=()
+    for exc in "${EXCLUDES[@]}"; do
+        [[ -n "$exc" ]] && EXCLUDE_ARGS+=("-x" "$exc")
+    done
+    dnf_retry -y install "${EXCLUDE_ARGS[@]}" "${PKGS[@]}"
+fi
+
+# COPR packages (EL10 primarily)
+COPR_COUNT=$($YQ -r ".packages.${OS_SECTION}.copr | length // 0" "${MANIFEST}" 2>/dev/null)
+for ((i=0; i<COPR_COUNT; i++)); do
+    COPR_REPO=$($YQ -r ".packages.${OS_SECTION}.copr[$i].repo" "${MANIFEST}")
+    readarray -t COPR_PKGS < <($YQ -r ".packages.${OS_SECTION}.copr[$i].packages[]" "${MANIFEST}")
+    COPR_OPTS=$($YQ -r ".packages.${OS_SECTION}.copr[$i].options // empty" "${MANIFEST}")
+
+    dnf -y copr enable "${COPR_REPO}"
+    dnf -y copr disable "${COPR_REPO}"
+    REPO_ID="copr:copr.fedorainfracloud.org:$(echo "${COPR_REPO}" | tr '/' ':')"
+    # shellcheck disable=SC2086
+    dnf -y --enablerepo="${REPO_ID}" install ${COPR_OPTS} "${COPR_PKGS[@]}" || true
+done
+
+# Optional packages (best-effort)
+readarray -t OPTIONAL < <($YQ -r ".packages.${OS_SECTION}.optional[] // empty" "${MANIFEST}" 2>/dev/null)
+if ((${#OPTIONAL[@]} > 0)); then
+    install_available "${OPTIONAL[@]}"
+fi
+
+# Optional group (e.g. fcitx5 — install all if the first one is available)
+readarray -t OPT_GROUP < <($YQ -r ".packages.${OS_SECTION}.optional_group[] // empty" "${MANIFEST}" 2>/dev/null)
+if ((${#OPT_GROUP[@]} > 0)); then
+    FIRST="${OPT_GROUP[0]}"
+    if dnf repoquery --available --qf '%{name}\n' "$FIRST" 2>/dev/null | grep -qx "$FIRST"; then
+        dnf_retry -y install "${OPT_GROUP[@]}"
+    else
+        echo "Skipping optional group (${FIRST} not available in repos)"
+    fi
+fi
+
+# ── Version locks ────────────────────────────────────────────────────────────
+readarray -t LOCKS < <($YQ -r '.versionlock[] // empty' "${MANIFEST}" 2>/dev/null)
+if ((${#LOCKS[@]} > 0)); then
+    # Ensure versionlock plugin is available
+    dnf -y install python3-dnf-plugin-versionlock 2>/dev/null || true
+    for lock in "${LOCKS[@]}"; do
+        [[ -n "$lock" ]] && dnf versionlock add "$lock" 2>/dev/null || true
+    done
+fi
+
+# ── Display manager ──────────────────────────────────────────────────────────
+DM=$($YQ -r '.display_manager // empty' "${MANIFEST}")
+if [[ -n "${DM}" ]]; then
+    safe_enable "${DM}.service"
+fi
+
+# ── Disable desktop files ────────────────────────────────────────────────────
+readarray -t DISABLE_DESKTOPS < <($YQ -r '.disable_desktop_files[] // empty' "${MANIFEST}" 2>/dev/null)
+for df in "${DISABLE_DESKTOPS[@]}"; do
+    if [[ -n "$df" && -f "/usr/share/applications/${df}" ]]; then
+        mv "/usr/share/applications/${df}" "/usr/share/applications/${df}.disabled"
+    fi
+done
+
+# ── Post-install scripts ─────────────────────────────────────────────────────
+readarray -t POST_SCRIPTS < <($YQ -r '.post_install[] // empty' "${MANIFEST}" 2>/dev/null)
+for script in "${POST_SCRIPTS[@]}"; do
+    if [[ -n "$script" && -f "${CONTEXT_PATH}/build_scripts/${script}" ]]; then
+        echo "Running post-install: ${script}"
+        source "${CONTEXT_PATH}/build_scripts/${script}"
+    fi
+done
+
+# Inline post-install commands
+readarray -t POST_INLINE < <($YQ -r '.post_install_inline[] // empty' "${MANIFEST}" 2>/dev/null)
+for cmd in "${POST_INLINE[@]}"; do
+    if [[ -n "$cmd" ]]; then
+        eval "$cmd"
+    fi
+done
+
+printf "::endgroup::\n"

--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -1,0 +1,80 @@
+# COSMIC Desktop Manifest
+
+display_manager: greetd
+
+packages:
+  fedora:
+    packages:
+      - cosmic-session
+      - cosmic-comp
+      - cosmic-panel
+      - cosmic-app-library
+      - cosmic-applets
+      - cosmic-bg
+      - cosmic-files
+      - cosmic-idle
+      - cosmic-launcher
+      - cosmic-notifications
+      - cosmic-osd
+      - cosmic-randr
+      - cosmic-screenshot
+      - cosmic-settings
+      - cosmic-settings-daemon
+      - cosmic-term
+      - cosmic-wallpapers
+      - cosmic-workspaces
+      - cosmic-greeter
+      - cosmic-icon-theme
+      - greetd
+      - xdg-desktop-portal-cosmic
+      - pop-icon-theme
+
+  el10:
+    copr:
+      - repo: yselkowitz/cosmic-epel
+        packages:
+          - cosmic-comp
+          - cosmic-panel
+          - cosmic-app-library
+          - cosmic-applets
+          - cosmic-bg
+          - cosmic-files
+          - cosmic-idle
+          - cosmic-launcher
+          - cosmic-notifications
+          - cosmic-osd
+          - cosmic-randr
+          - cosmic-screenshot
+          - cosmic-settings
+          - cosmic-settings-daemon
+          - cosmic-term
+          - cosmic-wallpapers
+          - cosmic-workspaces
+          - cosmic-icon-theme
+          - xdg-desktop-portal-cosmic
+          - adw-gtk3-theme
+      - repo: yselkowitz/cosmic-epel
+        packages:
+          - cosmic-session
+          - greetd
+          - cosmic-greeter
+        options: "--nobest --allowerasing"
+    packages:
+      - flatpak
+      - pipewire
+      - wireplumber
+      - wl-clipboard
+      - xdg-user-dirs
+      - zram-generator
+    optional:
+      - brightnessctl
+      - playerctl
+      - gnome-keyring
+      - gnome-keyring-pam
+
+post_install_inline:
+  - "glib-compile-schemas /usr/share/glib-2.0/schemas || true"
+  - |
+    if [ -f /etc/pam.d/greetd ]; then
+      sed --sandbox -i -e '/gnome_keyring.so/ s/-auth/auth/ ; /gnome_keyring.so/ s/-session/session/' /etc/pam.d/greetd
+    fi

--- a/manifests/desktops/kde.yaml
+++ b/manifests/desktops/kde.yaml
@@ -1,0 +1,129 @@
+# KDE Plasma Desktop Manifest
+# Declares what goes into a KDE image — packages, services, config.
+# The generic installer (install-desktop.sh) reads this and applies it.
+
+display_manager: sddm
+
+# Packages to install, keyed by package manager / OS family.
+# The installer picks the right section based on detected OS.
+packages:
+  # ── APT (Ubuntu/Debian) ────────────────────────────────────────────
+  apt:
+    - kde-plasma-desktop
+    - sddm
+    - dolphin
+    - konsole
+    - kate
+    - ark
+    - kdeconnect
+    - xdg-desktop-portal-kde
+    - qt6-wayland
+
+  # ── DNF: Fedora ────────────────────────────────────────────────────
+  fedora:
+    groups:
+      - kde-desktop
+    packages:
+      - sddm
+      - dolphin
+      - konsole
+      - kate
+      - ark
+      - plasma-discover
+      - kdeconnect
+      - xdg-desktop-portal-kde
+      - qt5-qtwayland
+      - qt6-qtwayland
+      - ksshaskpass
+      - ksystemlog
+      - input-remapper
+      - evtest
+      - tesseract
+      - libratbag-ratbagd
+      - solaar-udev
+      - openrgb-udev-rules
+      - pam-u2f
+      - pam_yubico
+      - pamu2fcfg
+      - yubikey-manager
+      - nvtop
+    exclude:
+      - PackageKit
+      - PackageKit-command-not-found
+
+  # ── DNF: EL10 (AlmaLinux, CentOS Stream, RHEL) ────────────────────
+  el10:
+    groups:
+      - "KDE Plasma Workspaces"
+      - "Common NetworkManager submodules"
+      - "Core"
+      - "Fonts"
+      - "Guest Desktop Agents"
+      - "Hardware Support"
+      - "Printing Client"
+      - "Standard"
+    group_options: "--nobest"
+    group_exclude:
+      - plasma-discover
+      - plasma-discover-notifier
+      - plasma-nm-vpnc
+      - pinentry-qt
+      - plasma-workspace-wayland
+      - plasma-workspace-geolocation
+      - plasma-drkonqi
+    packages:
+      - sddm
+      - dolphin
+      - konsole
+      - kate
+      - ark
+      - xdg-desktop-portal-kde
+      - qt5-qtwayland
+      - qt6-qtwayland
+    exclude:
+      - PackageKit
+      - PackageKit-command-not-found
+    # Best-effort packages — installed if available in repos, skipped otherwise
+    optional:
+      - kdeconnect
+      - ksshaskpass
+      - ksystemlog
+      - input-remapper
+      - evtest
+      - tesseract
+      - libratbag-ratbagd
+      - solaar-udev
+      - openrgb-udev-rules
+      - pam-u2f
+      - pam_yubico
+      - pamu2fcfg
+      - yubikey-manager
+      - nvtop
+    # fcitx5 input method support (Asian languages) — only if available
+    optional_group:
+      - fcitx5
+      - fcitx5-chewing
+      - fcitx5-chinese-addons
+      - fcitx5-gtk
+      - fcitx5-hangul
+      - fcitx5-m17n
+      - fcitx5-mozc
+      - fcitx5-qt
+      - fcitx5-sayura
+      - fcitx5-unikey
+      - kcm-fcitx5
+
+# Version locks — prevent partial upgrades causing black screens
+# Ref: https://github.com/ublue-os/aurora/issues/1227
+versionlock:
+  - plasma-desktop
+  - "qt6-*"
+
+# Desktop files to disable (replaced by Bazaar/Flatpak)
+disable_desktop_files:
+  - org.kde.discover.desktop
+  - org.kde.discover.urlhandler.desktop
+
+# Post-install scripts to source (relative to build_scripts/)
+post_install:
+  - kcm-ublue.sh


### PR DESCRIPTION
## The Vision

> A Linux distribution shouldn't be a monolithic artifact hand-tuned by a single vendor. It should be a **composition of choices** — base OS, desktop, kernel, drivers — assembled by a build matrix and delivered as an immutable image.

See `VISION.md` for the full philosophy.

## What This PR Adds

### 1. `VISION.md`
Project philosophy — why TunaOS exists, what "erase the mystique" means, principles, non-goals.

### 2. Declarative Desktop Manifests (`manifests/desktops/*.yaml`)
Each desktop is declared as YAML:
- Package lists per OS family (apt, fedora, el10)
- Groups, COPRs, optional packages
- Version locks, display manager, post-install hooks

```yaml
# manifests/desktops/kde.yaml
display_manager: sddm
packages:
  fedora:
    groups: [kde-desktop]
    packages: [sddm, dolphin, konsole, ...]
  el10:
    groups: ["KDE Plasma Workspaces", ...]
    optional: [kdeconnect, nvtop, ...]
versionlock: [plasma-desktop, "qt6-*"]
```

### 3. `build_scripts/install-desktop.sh` — Generic Manifest Installer
One 159-line script that reads any manifest and installs the desktop. Replaces the per-DE pattern of `kde.sh`, `cosmic.sh`, etc.

### Migration Path
The existing DE scripts continue to work unchanged. Once we validate the manifest installer produces identical images, we swap the Containerfile RUN calls. No big-bang rewrite.