### PR TITLE
feat: complete desktop manifests (gnome, niri, xfce)

### DIFF
--- a/manifests/desktops/gnome.yaml
+++ b/manifests/desktops/gnome.yaml
@@ -1,0 +1,172 @@
+# GNOME Desktop Manifest
+
+display_manager: gdm
+
+packages:
+  apt:
+    - ubuntu-desktop-minimal
+    - gnome-shell-extension-manager
+    - gnome-browser-connector
+    - gnome-disk-utility
+    - gnome-system-monitor
+    - gnome-user-docs
+    - nautilus
+    - yelp
+    - plymouth-theme-spinner
+    - xdg-desktop-portal-gnome
+    - xdg-desktop-portal-gtk
+    - xdg-user-dirs-gtk
+
+  fedora:
+    packages:
+      - ModemManager
+      - NetworkManager-adsl
+      - NetworkManager-openconnect-gnome
+      - NetworkManager-openvpn-gnome
+      - NetworkManager-ppp
+      - NetworkManager-ssh-gnome
+      - NetworkManager-vpnc-gnome
+      - NetworkManager-wwan
+      - avahi
+      - dconf
+      - fprintd-pam
+      - gdm
+      - glib-networking
+      - gnome-backgrounds
+      - gnome-bluetooth
+      - gnome-browser-connector
+      - gnome-classic-session
+      - gnome-color-manager
+      - gnome-control-center
+      - gnome-disk-utility
+      - gnome-initial-setup
+      - gnome-remote-desktop
+      - gnome-session-wayland-session
+      - gnome-settings-daemon
+      - gnome-shell
+      - gnome-system-monitor
+      - gnome-user-docs
+      - gnome-user-share
+      - gvfs-afc
+      - gvfs-afp
+      - gvfs-archive
+      - gvfs-fuse
+      - gvfs-goa
+      - gvfs-gphoto2
+      - gvfs-mtp
+      - gvfs-smb
+      - librsvg2
+      - libsane-hpaio
+      - mesa-dri-drivers
+      - mesa-libEGL
+      - mesa-vulkan-drivers
+      - nautilus
+      - polkit
+      - ptyxis
+      - xdg-desktop-portal-gnome
+      - xdg-desktop-portal-gtk
+      - xdg-user-dirs-gtk
+      - yelp
+      - desktop-backgrounds-gnome
+      - pinentry-gnome3
+      - qadwaitadecorations-qt5
+      - evince-thumbnailer
+      - evince-previewer
+      - totem-video-thumbnailer
+    exclude:
+      - PackageKit
+      - PackageKit-command-not-found
+      - gnome-software
+      - gnome-software-fedora-langpacks
+
+  el10:
+    # COPR repos for GNOME 49/50 backport — the distro ships GNOME 48
+    # These bring modern GNOME to Enterprise Linux without waiting 3 years
+    copr:
+      - repo: jreilly1821/c10s-gnome-49
+        condition: "gnome"  # only for gnome flavor (not gnome50)
+        pre_install:
+          - "dnf -y upgrade glib2 fontconfig gobject-introspection gjs"
+          - "dnf_retry -y install --allowerasing gnome49-el10-compat"
+        packages: []
+      - repo: jreilly1821/c10s-gnome-50-fresh
+        condition: "gnome50"
+        extra_repos:
+          - jreilly1821/c10s-gnome-50
+        pre_install:
+          - "dnf -y upgrade glib2 fontconfig"
+          - "dnf_retry -y install --allowerasing gnome50-el10-compat"
+        packages: []
+
+    # Remove conflicting packages before COPR install
+    pre_install:
+      - "warn_on_fail dnf_retry -y remove --noautoremove gnome-shell-common"
+
+    groups:
+      - "Common NetworkManager submodules"
+      - "Core"
+      - "Fonts"
+      - "Guest Desktop Agents"
+      - "Hardware Support"
+      - "Printing Client"
+      - "Standard"
+      - "Workstation product core"
+    group_options: "--nobest --allowerasing"
+    group_exclude:
+      - PackageKit
+      - PackageKit-command-not-found
+
+    packages:
+      - gdm
+      - glib2
+      - gnome-bluetooth
+      - gnome-color-manager
+      - gnome-control-center
+      - gnome-initial-setup
+      - gnome-remote-desktop
+      - gnome-session-wayland-session
+      - gnome-settings-daemon
+      - gnome-shell
+      - gnome-user-docs
+      - gvfs-fuse
+      - gvfs-goa
+      - gvfs-gphoto2
+      - gvfs-mtp
+      - gvfs-smb
+      - libsane-hpaio
+      - nautilus
+      - dbus-daemon
+      - orca
+      - ptyxis
+      - sane-backends-drivers-scanners
+      - xdg-desktop-portal-gnome
+      - xdg-user-dirs-gtk
+      - yelp-tools
+      - gnome-disk-utility
+      - NetworkManager-adsl
+    exclude:
+      - gnome-software
+      - gnome-extensions-app
+      - PackageKit
+      - PackageKit-command-not-found
+      - gnome-software-fedora-langpacks
+
+versionlock:
+  - glib2
+  - fontconfig
+  - gdm
+  - gnome-shell
+  - mutter
+  - gnome-session-wayland-session
+  - gnome-settings-daemon
+  - gnome-control-center
+  - gsettings-desktop-schemas
+  - gtk4
+  - libadwaita
+  - pango
+  - xdg-desktop-portal
+  - xdg-desktop-portal-gnome
+
+# Extensions are built in a separate layer (gnome-extensions.sh)
+post_install:
+  - gnome-extensions.sh

--- a/manifests/desktops/niri.yaml
+++ b/manifests/desktops/niri.yaml
@@ -1,0 +1,99 @@
+# Niri (Tiling Wayland Compositor) + DMS Desktop Manifest
+
+display_manager: greetd
+
+packages:
+  fedora:
+    copr:
+      - repo: yalter/niri-git
+        packages:
+          - niri
+      - repo: avengemedia/danklinux
+        packages:
+          - quickshell-git
+      - repo: avengemedia/dms-git
+        packages:
+          - dms
+          - dms-cli
+          - dms-greeter
+    packages:
+      - greetd
+      - greetd-selinux
+      - swaylock
+      - SwayNotificationCenter
+      - waybar
+      - fuzzel
+      - swayidle
+      - wl-clipboard
+      - xdg-desktop-portal-gnome
+      - xdg-desktop-portal-gtk
+      - xdg-user-dirs
+      - pipewire
+      - wireplumber
+      - polkit-gnome
+      - NetworkManager-tui
+      - brightnessctl
+      - playerctl
+      - blueman
+      - pavucontrol
+      - gnome-keyring
+      - gnome-keyring-pam
+      - nautilus
+      - adw-gtk3-theme
+      - papirus-icon-theme
+
+  el10:
+    copr:
+      - repo: zirconium/packages
+        packages:
+          - greetd
+          - greetd-selinux
+      - repo: yalter/niri-git
+        packages:
+          - niri
+      - repo: yselkowitz/wlroots-epel
+        packages: []  # just enable for deps
+      - repo: ligenix/enterprise-cosmic
+        packages: []  # just enable for deps
+      - repo: avengemedia/danklinux
+        packages:
+          - quickshell-git
+      - repo: avengemedia/dms-git
+        packages:
+          - dms
+          - dms-cli
+          - dms-greeter
+    packages:
+      - swaylock
+      - SwayNotificationCenter
+      - waybar
+      - fuzzel
+      - swayidle
+      - wl-clipboard
+      - xdg-desktop-portal-gnome
+      - xdg-desktop-portal-gtk
+      - xdg-user-dirs
+      - pipewire
+      - wireplumber
+      - polkit-gnome
+      - NetworkManager-tui
+      - nautilus
+      - adw-gtk3-theme
+      - papirus-icon-theme
+    optional:
+      - brightnessctl
+      - playerctl
+      - blueman
+      - pavucontrol
+      - gnome-keyring
+      - gnome-keyring-pam
+
+versionlock:
+  - glib2
+
+post_install_inline:
+  - "glib-compile-schemas /usr/share/glib-2.0/schemas || true"
+  - |
+    if [ -f /etc/pam.d/greetd ]; then
+      sed --sandbox -i -e '/gnome_keyring.so/ s/-auth/auth/ ; /gnome_keyring.so/ s/-session/session/' /etc/pam.d/greetd
+    fi

--- a/manifests/desktops/xfce.yaml
+++ b/manifests/desktops/xfce.yaml
@@ -1,0 +1,42 @@
+# XFCE 4.20 Desktop Manifest (Wayland — xfwl4 compositor)
+
+display_manager: gdm
+
+packages:
+  fedora:
+    groups:
+      - xfce-desktop
+    packages:
+      - xfce4-wayland
+      - gdm
+      - xdg-desktop-portal-gtk
+      - xdg-user-dirs-gtk
+      - thunar
+      - mousepad
+      - ristretto
+      - xfce4-terminal
+
+  el10:
+    groups:
+      - xfce-desktop
+    packages:
+      - gdm
+      - xdg-desktop-portal-gtk
+      - xdg-user-dirs-gtk
+      - thunar
+      - mousepad
+      - ristretto
+      - xfce4-terminal
+    optional:
+      - xfce4-wayland
+
+  apt:
+    - xfce4
+    - xfce4-goodies
+    - gdm3
+    - xdg-desktop-portal-gtk
+    - thunar
+    - mousepad
+
+versionlock:
+  - glib2


### PR DESCRIPTION
Adds the remaining 3 desktop manifests, completing the set:

| Desktop | Manifest | Lines | COPRs declared |
|---------|----------|-------|----------------|
| KDE | ✅ (PR #599) | 129 | — |
| COSMIC | ✅ (PR #599) | 80 | yselkowitz/cosmic-epel |
| **GNOME** | ✅ new | 172 | jreilly1821/c10s-gnome-{49,50} |
| **Niri** | ✅ new | 99 | yalter/niri-git, avengemedia/dms-git, etc. |
| **XFCE** | ✅ new | 42 | — |

COPRs are declared as data — the generic installer handles the enable→install→disable lifecycle. No per-DE bash required.