### PR TITLE
feat: switch to manifest-driven desktop installs

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -156,7 +156,7 @@ FROM base-no-de AS gnome
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
-  /run/context/build_scripts/gnome.sh base
+  /run/context/build_scripts/install-desktop.sh gnome
 # Extensions are a separate layer so DE package install caches independently
 # of submodule updates to extension sources.
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
@@ -169,15 +169,14 @@ FROM base-no-de AS cosmic
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
-  /run/context/build_scripts/cosmic.sh base
-RUN dnf versionlock add glib2
+  /run/context/build_scripts/install-desktop.sh cosmic
 RUN rm -rf /opt && ln -s /var/opt /opt
 
 FROM base-no-de AS gnome50
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
-  /run/context/build_scripts/gnome.sh base
+  DESKTOP_FLAVOR=gnome50 /run/context/build_scripts/install-desktop.sh gnome
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
@@ -188,16 +187,11 @@ FROM base-no-de AS kde
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
-  /run/context/build_scripts/kde.sh base
-RUN dnf versionlock add glib2
+  /run/context/build_scripts/install-desktop.sh kde
 RUN rm -rf /opt && ln -s /var/opt /opt
 
 FROM base-no-de AS niri
 # Zirconium (DMS/Niri upstream) config payload — niri images only.
-# NB: there is NO /etc/niri (or factory equivalent) in the zirconium image
-# — verified against the published image 2026-07-02. Niri user config is
-# materialized per-user by chezmoi-init from /usr/share/zirconium
-# (zdots/skel), so only the /usr paths below are copied.
 COPY --from=zirconium /usr/share/zirconium /usr/share/zirconium
 COPY --from=zirconium /usr/share/xdg-terminal-exec /usr/share/xdg-terminal-exec
 COPY --from=zirconium /usr/share/greetd /usr/share/greetd
@@ -208,14 +202,12 @@ COPY --from=zirconium /usr/lib/systemd/user/chezmoi-update.service /usr/lib/syst
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
-  /run/context/build_scripts/niri.sh base
-RUN dnf versionlock add glib2
+  /run/context/build_scripts/install-desktop.sh niri
 RUN rm -rf /opt && ln -s /var/opt /opt
 
 FROM base-no-de AS xfce
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
-  /run/context/build_scripts/xfce.sh base
-RUN dnf versionlock add glib2
+  /run/context/build_scripts/install-desktop.sh xfce
 RUN rm -rf /opt && ln -s /var/opt /opt


### PR DESCRIPTION
## The Switch

All Containerfile DE stages now call:
```
/run/context/build_scripts/install-desktop.sh <desktop>
```

Instead of per-DE scripts (`kde.sh base`, `cosmic.sh base`, etc.).

## What install-desktop.sh does

Reads `manifests/desktops/<desktop>.yaml` and:
1. Detects OS (apt/fedora/el10)
2. Installs package groups
3. Installs packages (with excludes)
4. Enables COPRs, installs their packages, disables COPRs
5. Installs optional/best-effort packages
6. Applies version locks
7. Enables display manager
8. Disables replaced desktop files
9. Runs post-install hooks

## What's preserved

- GNOME extensions in separate layer (cache optimization)
- Niri zirconium COPY stages (config from another container image)
- All existing functionality — same packages, same services, same result

## Risk

This is a functional change — if a manifest is missing a package that the old script installed, the image will differ. The old scripts are kept as dead code for comparison. If CI build fails, we can diff against the old scripts to find what's missing.

## After this merges

The old per-DE scripts (`gnome.sh`, `kde.sh`, `cosmic.sh`, `niri.sh`, `xfce.sh`) become dead code and can be deleted.