### PR TITLE
feat: Arch Linux, CachyOS, and Debian variant foundations

### DIFF
--- a/build_scripts/install-desktop.sh
+++ b/build_scripts/install-desktop.sh
@@ -33,10 +33,18 @@ printf "::group:: === install-desktop: %s ===\n" "${DESKTOP}"
 OS_SECTION=""
 if [[ "$PKG_MGR" == "apt" ]]; then
     OS_SECTION="apt"
+elif [[ "$PKG_MGR" == "pacman" ]]; then
+    OS_SECTION="pacman"
 elif [[ "$IS_FEDORA" == true ]]; then
     OS_SECTION="fedora"
 else
     OS_SECTION="el10"
+fi
+
+# Check for CachyOS-specific section (Arch derivative with extra repos)
+if [[ "${OS_SECTION}" == "pacman" ]] && [[ -f /etc/cachyos-release ]]; then
+    # If the manifest has a cachyos section, merge its repos/packages
+    CACHYOS_SECTION="cachyos"
 fi
 
 echo "Installing ${DESKTOP} desktop (OS section: ${OS_SECTION})..."
@@ -47,6 +55,40 @@ if [[ "${OS_SECTION}" == "apt" ]]; then
     if ((${#PKGS[@]} > 0)); then
         pkg_install "${PKGS[@]}"
     fi
+    # Enable display manager
+    DM=$($YQ -r '.display_manager // empty' "${MANIFEST}")
+    if [[ -n "${DM}" ]]; then
+        systemctl enable "${DM}" || true
+    fi
+    printf "::endgroup::\n"
+    exit 0
+fi
+
+# ── Pacman path (Arch Linux / CachyOS) ───────────────────────────────────────
+if [[ "${OS_SECTION}" == "pacman" ]]; then
+    # Install CachyOS repos if applicable
+    if [[ -n "${CACHYOS_SECTION:-}" ]]; then
+        REPO_COUNT=$($YQ -r ".packages.${CACHYOS_SECTION}.repos | length // 0" "${MANIFEST}" 2>/dev/null)
+        for ((i=0; i<REPO_COUNT; i++)); do
+            REPO_NAME=$($YQ -r ".packages.${CACHYOS_SECTION}.repos[$i].name" "${MANIFEST}")
+            REPO_URL=$($YQ -r ".packages.${CACHYOS_SECTION}.repos[$i].url" "${MANIFEST}")
+            if ! grep -q "\\[${REPO_NAME}\\]" /etc/pacman.conf; then
+                printf '\n[%s]\nServer = %s\n' "${REPO_NAME}" "${REPO_URL}" >> /etc/pacman.conf
+            fi
+        done
+        pacman -Sy --noconfirm
+        # Install CachyOS-specific packages
+        readarray -t CACHY_PKGS < <($YQ -r ".packages.${CACHYOS_SECTION}.packages[]" "${MANIFEST}" 2>/dev/null)
+        if ((${#CACHY_PKGS[@]} > 0)); then
+            pacman -S --noconfirm --needed "${CACHY_PKGS[@]}"
+        fi
+    fi
+
+    readarray -t PKGS < <($YQ -r ".packages.pacman[]" "${MANIFEST}" 2>/dev/null)
+    if ((${#PKGS[@]} > 0)); then
+        pacman -S --noconfirm --needed "${PKGS[@]}"
+    fi
+
     # Enable display manager
     DM=$($YQ -r '.display_manager // empty' "${MANIFEST}")
     if [[ -n "${DM}" ]]; then

--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -49,6 +49,8 @@ else
 	IS_CENTOS=false
 	IS_UBUNTU=false
 	IS_DEBIAN=false
+	IS_ARCH=false
+	IS_CACHYOS=false
 
 	[[ "${BASE_IMAGE,,}" == *"fedora"* ]] && IS_FEDORA=true && IMAGE_NAME="bonito" && IMAGE_PRETTY_NAME="Bonito"
 	[[ "${BASE_IMAGE,,}" == *"red hat"* || "${BASE_IMAGE,,}" == *"rhel"* || "${BASE_IMAGE,,}" == *"redhat"* ]] && IS_RHEL=true && IMAGE_NAME="redfin" && IMAGE_PRETTY_NAME="Redfin"
@@ -57,10 +59,14 @@ else
 	[[ "${BASE_IMAGE,,}" == *"centos"* ]] && IS_CENTOS=true && IMAGE_NAME="skipjack" && IMAGE_PRETTY_NAME="Skipjack"
 	[[ "${BASE_IMAGE,,}" == *"ubuntu"* ]] && IS_UBUNTU=true && IMAGE_NAME="grouper" && IMAGE_PRETTY_NAME="Grouper"
 	[[ "${BASE_IMAGE,,}" == *"debian"* && "${BASE_IMAGE,,}" != *"ubuntu"* ]] && IS_DEBIAN=true && IMAGE_NAME="flounder" && IMAGE_PRETTY_NAME="Flounder"
+	[[ "${BASE_IMAGE,,}" == *"archlinux"* || "${BASE_IMAGE,,}" == *"arch-bootc"* ]] && IS_ARCH=true && IMAGE_NAME="marlin" && IMAGE_PRETTY_NAME="Marlin"
+	[[ "${BASE_IMAGE,,}" == *"cachyos"* ]] && IS_CACHYOS=true && IS_ARCH=true && IMAGE_NAME="wahoo" && IMAGE_PRETTY_NAME="Wahoo"
 
 	# Package manager dimension
 	if [[ "$IS_UBUNTU" == true || "$IS_DEBIAN" == true ]]; then
 		PKG_MGR="apt"
+	elif [[ "$IS_ARCH" == true ]]; then
+		PKG_MGR="pacman"
 	else
 		PKG_MGR="dnf"
 	fi
@@ -76,6 +82,8 @@ else
 		IS_CENTOS=${IS_CENTOS}
 		IS_UBUNTU=${IS_UBUNTU}
 		IS_DEBIAN=${IS_DEBIAN}
+		IS_ARCH=${IS_ARCH}
+		IS_CACHYOS=${IS_CACHYOS}
 		PKG_MGR="${PKG_MGR}"
 		IMAGE_NAME="${IMAGE_NAME:-}"
 		IMAGE_PRETTY_NAME="${IMAGE_PRETTY_NAME:-}"
@@ -100,6 +108,8 @@ export IS_ALMALINUXKITTEN
 export IS_CENTOS
 export IS_UBUNTU
 export IS_DEBIAN
+export IS_ARCH
+export IS_CACHYOS
 export PKG_MGR
 export IMAGE_NAME
 export IMAGE_PRETTY_NAME
@@ -264,6 +274,8 @@ pkg_install() {
 			dpkg --configure -a --force-depends || true
 			apt-get install -y -f --no-install-recommends
 		}
+	elif [[ "$PKG_MGR" == "pacman" ]]; then
+		pacman -S --noconfirm --needed "$@"
 	else
 		dnf_retry install -y --setopt=install_weak_deps=False "$@"
 	fi
@@ -274,6 +286,8 @@ pkg_install() {
 pkg_remove() {
 	if [[ "$PKG_MGR" == "apt" ]]; then
 		apt-get purge -y "$@"
+	elif [[ "$PKG_MGR" == "pacman" ]]; then
+		pacman -Rns --noconfirm "$@" 2>/dev/null || true
 	else
 		dnf_retry remove -y "$@"
 	fi
@@ -294,6 +308,8 @@ pkg_clean() {
 		apt-get clean
 		rm -rf /var/lib/apt/lists/*
 		mkdir -p /var/lib/apt/lists/partial
+	elif [[ "$PKG_MGR" == "pacman" ]]; then
+		pacman -Scc --noconfirm 2>/dev/null || true
 	else
 		dnf clean all
 	fi

--- a/manifests/desktops/kde-arch.yaml
+++ b/manifests/desktops/kde-arch.yaml
@@ -1,0 +1,58 @@
+# KDE Plasma Desktop Manifest — Arch Linux / CachyOS
+# Pacman package names differ from RPM/apt names.
+
+display_manager: sddm
+
+packages:
+  pacman:
+    - plasma-desktop
+    - sddm
+    - dolphin
+    - konsole
+    - kate
+    - ark
+    - kdeconnect
+    - xdg-desktop-portal-kde
+    - qt6-wayland
+    - qt5-wayland
+    - ksshaskpass
+    - ksystemlog
+    - input-remapper
+    - libratbag
+    - solaar
+    - pam-u2f
+    - yubikey-manager
+    - nvtop
+    - networkmanager
+    - pipewire
+    - wireplumber
+    - xdg-user-dirs
+    - flatpak
+    - wl-clipboard
+    - power-profiles-daemon
+    - fwupd
+    - plymouth
+
+  # CachyOS adds its own repos on top of Arch — same pacman packages
+  # but with performance-optimized builds (BORE scheduler, LTO, march=v3)
+  cachyos:
+    repos:
+      - name: cachyos
+        url: "https://mirror.cachyos.org/repo/$arch/cachyos"
+      - name: cachyos-extra
+        url: "https://mirror.cachyos.org/repo/$arch/cachyos-extra"
+    packages:
+      - linux-cachyos
+      - linux-cachyos-headers
+      - cachyos-settings
+      - cachyos-keyring
+      - cachyos-mirrorlist
+
+versionlock: []
+
+disable_desktop_files:
+  - org.kde.discover.desktop
+  - org.kde.discover.urlhandler.desktop
+
+post_install:
+  - kcm-ublue.sh

--- a/manifests/desktops/kde-debian.yaml
+++ b/manifests/desktops/kde-debian.yaml
@@ -1,0 +1,29 @@
+# KDE Plasma Desktop Manifest — Debian
+# Uses the same apt path as Ubuntu but with Debian-specific package names.
+
+display_manager: sddm
+
+packages:
+  apt:
+    - kde-plasma-desktop
+    - sddm
+    - dolphin
+    - konsole
+    - kate
+    - ark
+    - kdeconnect
+    - xdg-desktop-portal-kde
+    - qt6-wayland
+    - plasma-workspace-wayland
+    - network-manager
+    - pipewire
+    - wireplumber
+    - flatpak
+    - fwupd
+    - plymouth
+    - power-profiles-daemon
+
+versionlock: []
+
+disable_desktop_files:
+  - org.kde.discover.desktop


### PR DESCRIPTION
## New Variants

| Variant | Fish name | Base | Package Manager |
|---------|-----------|------|-----------------|
| 🐟 **Marlin** | Arch Linux | archlinux/archlinux (bootcified) | pacman |
| 🐟 **Wahoo** | CachyOS | Arch + CachyOS repos (BORE, LTO, march=v3) | pacman |
| 🐟 **Flounder** | Debian 13 Trixie | debian:trixie (bootcified) | apt |

## What's Added

- **lib.sh**: `IS_ARCH`, `IS_CACHYOS` detection, `PKG_MGR=pacman` path
- **lib.sh**: `pkg_install`/`pkg_remove`/`pkg_clean` handle pacman
- **install-desktop.sh**: full pacman path with CachyOS custom repo support
- **kde-arch.yaml**: KDE manifest with pacman package names + CachyOS extras
- **kde-debian.yaml**: KDE manifest for Debian (apt path)

## The Matrix Grows

```
         │ gnome │ kde  │ niri │ cosmic │ xfce │
─────────┼───────┼──────┼──────┼────────┼──────┤
EL10     │  ✅   │  ✅  │  ✅  │   ✅   │  ✅  │  (yellowfin, albacore, skipjack)
Fedora   │  ✅   │  ✅  │  ✅  │   ✅   │  ✅  │  (bonito)
Ubuntu   │  ✅   │  ✅  │  ✅  │   -    │  ✅  │  (grouper)
Debian   │  -    │  🆕  │  -   │   -    │  -   │  (flounder) — manifests ready
Arch     │  -    │  🆕  │  -   │   -    │  -   │  (marlin) — manifests ready
CachyOS  │  -    │  🆕  │  -   │   -    │  -   │  (wahoo) — manifests ready
```

## Next Steps

1. Source or build bootc base images for Arch and Debian
2. Add variant entries to `build-config.yml`
3. Write remaining desktop manifests (gnome-arch, niri-arch, etc.)
4. The install-desktop.sh + manifest system handles the rest