### PR TITLE
docs: rewrite architecture docs for manifest-driven build system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,29 +1,46 @@
 # Agent Guidelines for TunaOS
 
-> The authoritative agent guide lives at [`docs/AGENT_GUIDE.md`](docs/AGENT_GUIDE.md). Read that file for complete instructions on setup, building, pre-commit workflow, architecture, and troubleshooting.
+> The authoritative agent guide lives at [`docs/AGENT_GUIDE.md`](docs/AGENT_GUIDE.md). Read that file for complete architecture, setup, and troubleshooting.
 
 ## Quick Reference
 
 ```bash
 just fix && just check   # format + validate (mandatory before every commit)
-just lint && just test   # the same shellcheck/bats/pytest CI runs
-just yellowfin base      # build a single variant (fastest test)
-just verify-disk x.qcow2 # QEMU boot gate, identical to CI's publish gate
+just test                # bats + pytest (same as CI)
+just build yellowfin gnome  # build a single flavor
 just --list              # show all available commands
 ```
 
-Build pipeline, publish gating, and CI failure triage: [`docs/PIPELINE.md`](docs/PIPELINE.md).
+## Architecture (July 2026)
 
-## Agent skills
+The build system is **manifest-driven**:
+
+```
+manifests/desktops/*.yaml  →  install-desktop.sh  →  image
+```
+
+Key scripts:
+- `scripts/resolve-flavor.sh` — flavor → build params (tested: 18 bats cases)
+- `scripts/resolve-image.sh` — consolidated image ref lookups
+- `scripts/build-image-inner.sh` — the build engine (env-var driven)
+- `build_scripts/install-desktop.sh` — generic DE installer
+- `build_scripts/lib.sh` — shared library (OS detection, pkg abstraction)
+
+Containerfiles:
+- `Containerfile` — main (base + all DE stages)
+- `Containerfile.overlay` — HWE/nvidia parameterized layer
+- `Containerfile.ubuntu` — Ubuntu/Debian bootcification
+
+Build pipeline: [`docs/PIPELINE.md`](docs/PIPELINE.md)
+
+## Adding a Desktop
+
+Write `manifests/desktops/<name>.yaml`. No shell script needed. See existing manifests for the format.
+
+## Agent Skills
 
 ### Issue tracker
-
-GitHub Issues for `tuna-os/tunaos`, operated via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+GitHub Issues for `tuna-os/tunaos`, operated via `gh` CLI.
 
 ### Triage labels
-
-Defaults — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
-
-### Domain docs
-
-Single-context — `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,87 +1,100 @@
 # Contributing to TunaOS
 
-Thank you for contributing to TunaOS — bootc-based desktop OS images on Enterprise Linux.
+Thank you for contributing to TunaOS — an image factory that produces bootc-based desktop OS images.
 
 ## Quick Start
 
 ```bash
-# Install prerequisites (Homebrew recommended for consistency with CI)
-brew install just podman shellcheck shfmt
-
-# Clone and set up
-git clone https://github.com/tuna-os/tunaOS.git
-cd tunaOS
+brew install just podman shellcheck shfmt yq
+git clone https://github.com/tuna-os/tunaOS.git && cd tunaOS
 just fix && just check
 ```
 
-## Pre-Commit Workflow (mandatory)
-
-Always run before every commit:
+## Pre-Commit (mandatory)
 
 ```bash
-just fix     # Format shell scripts and Justfile
-just check   # shellcheck, yamllint, jq, actionlint
-git diff     # Review your changes
+just fix     # format shell scripts and Justfile
+just check   # shellcheck, yamllint, actionlint
 ```
-
-Commits must be signed with DCO: `git commit -s`
 
 ## Building Images
 
 ```bash
-# Build a single variant (fastest test — ~25-35 min with warm cache)
-just yellowfin base
-
-# Build the full flavor chain
-just yellowfin base && just yellowfin dx && just yellowfin nvidia
-
-# Build other variants
-just albacore base
-just skipjack base
-just bonito base
+just build yellowfin gnome           # single flavor (~25 min warm cache)
+just build yellowfin kde linux/amd64 # specific platform
+just build yellowfin all             # all flavors
 ```
 
-**First build:** ~45-60 minutes (cold cache). **Never cancel builds early.**
+## Adding a Desktop Environment
 
-## When to Build
+No shell scripting required. Write a YAML manifest:
 
-| Change type | Build required? |
-|---|---|
-| `Containerfile*`, `build_scripts/*`, `system_files*` | **Yes — always** |
-| `scripts/*` | Sometimes (if testing ISO/VM) |
-| Docs, CI workflows, README | No |
+```bash
+# 1. Create the manifest
+cat > manifests/desktops/budgie.yaml <<EOF
+display_manager: gdm
+packages:
+  fedora:
+    packages: [budgie-desktop, budgie-extras, gdm]
+  el10:
+    packages: [budgie-desktop, gdm]
+    optional: [budgie-extras]
+  apt:
+    - budgie-desktop
+    - gdm3
+versionlock: [glib2]
+EOF
 
-## Pull Request Process
-
-1. Fork the repository and create a feature branch
-2. Run `just fix && just check` before pushing
-3. Ensure your commits are signed (`git commit -s`)
-4. Open a PR against the `main` branch
-5. CI runs builds and image diffs automatically
-6. Address feedback from maintainers
+# 2. Add stage to Containerfile (copy from existing DE pattern)
+# 3. Add flavor to .github/build-config.yml
+# 4. That's it — install-desktop.sh handles the rest
+```
 
 ## Architecture
 
-See [`docs/AGENT_GUIDE.md`](docs/AGENT_GUIDE.md) for a detailed architecture overview:
-- Variants and flavors
-- Build pipeline stages
-- CI/CD matrix configuration
-- Key files and environment variables
+The build system is **manifest-driven**:
+
+```
+manifests/desktops/*.yaml  →  install-desktop.sh  →  image
+```
+
+Key scripts:
+- `scripts/resolve-flavor.sh` — routes flavor to Containerfile + build params
+- `scripts/resolve-image.sh` — resolves image refs from 3 config sources
+- `scripts/build-image-inner.sh` — the build engine (env-var driven)
+- `build_scripts/install-desktop.sh` — generic DE installer (reads YAML)
+- `build_scripts/lib.sh` — shared helpers (OS detection, pkg abstraction)
+
+Full architecture: [`docs/AGENT_GUIDE.md`](docs/AGENT_GUIDE.md)
+
+## Pull Request Process
+
+1. Fork and create a feature branch
+2. Run `just fix && just check`
+3. Open PR against `main`
+4. CI validates (lint, unit tests, image build on PR)
+5. Merge queue handles the rest (automerge for passing PRs)
+
+## Testing
+
+```bash
+just test          # all tests (bats + pytest)
+just test-bats     # shell script tests
+just verify-disk image.qcow2  # QEMU boot verification
+```
 
 ## Documentation
 
-- [Agent Guide](docs/AGENT_GUIDE.md) — complete reference for contributors
-- [Build Pipeline](docs/build-pipeline.md) — CI/CD overview
-- [Improvement Plan](docs/IMPROVEMENT_PLAN.md) — roadmap and progress
-- [Testing Guide](docs/TESTING.md) — ISO e2e test harness
-- [Developer Docs](https://tunaos.org/docs/dev/introduction) — build and contribution guide
+- [Vision](VISION.md) — project philosophy
+- [Agent Guide](docs/AGENT_GUIDE.md) — architecture reference
+- [Pipeline](docs/PIPELINE.md) — CI/CD details
+- [Testing](docs/TESTING.md) — test harness
 
 ## Community
 
 - [GitHub Issues](https://github.com/tuna-os/tunaOS/issues)
-- [Matrix Chat: #tunaos:reilly.asia](https://matrix.to/#/%23tunaos:reilly.asia)
-- [Universal Blue Discord](https://discord.gg/WEu6BdFEtp)
+- [Matrix: #tunaos:reilly.asia](https://matrix.to/#/%23tunaos:reilly.asia)
 
 ## License
 
-TunaOS is licensed under [Apache 2.0](LICENSE).
+[Apache 2.0](LICENSE)

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -1,233 +1,155 @@
 # TunaOS Agent Guide
 
-Authoritative reference for AI agents working on the TunaOS repository. All other agent-specific files (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.github/copilot-instructions.md`) point here.
+Authoritative reference for AI agents and contributors working on the TunaOS repository.
 
 ---
 
 ## What This Project Is
 
-TunaOS is a **bootc-based OS image builder** — it produces bootable OCI container images that serve as complete, immutable desktop Linux operating systems deployable via bootc/rpm-ostree. This is not traditional software; the build output is a container image, not a binary.
+TunaOS is an **image factory** — it produces bootable OCI container images that serve as complete, immutable desktop Linux operating systems. The output is `base OS × desktop × kernel × drivers = image`, assembled by a build matrix and delivered via bootc.
+
+See [`VISION.md`](../VISION.md) for the project philosophy.
 
 ---
 
-## Variants and Flavors
+## Architecture (post-refactor July 2026)
 
-### Variants (base OS)
+### The Manifest System
 
-| Variant | Base | Status |
-|---|---|---|
-| `yellowfin` | AlmaLinux Kitten 10 | Stable |
-| `albacore` | AlmaLinux 10 | Stable |
-| `skipjack` | CentOS Stream 10 | Beta |
-| `bonito` | Fedora 44 | In progress |
-| `grouper` | Ubuntu 26.04 (bootcified, `Containerfile.ubuntu`) | Experimental, amd64-only |
+Desktop environments are defined as **YAML manifests** in `manifests/desktops/`:
 
-### Flavors (layered via 4-stage DAG; see `.github/build-config.yml` for full matrix)
+```
+manifests/desktops/
+├── gnome.yaml   — packages, COPRs, version locks, post-install hooks
+├── kde.yaml
+├── cosmic.yaml
+├── niri.yaml
+├── xfce.yaml
+├── kde-arch.yaml    — Arch/CachyOS variant (pacman)
+└── kde-debian.yaml  — Debian variant (apt)
+```
 
-| Layer | Flavors | Contents |
-|---|---|---|
-| Stage 1 — base | `base` | Minimal OS (all variants) |
-| Stage 2 — HWE/nvidia base + desktops | `base-hwe`, `base-nvidia`, `gnome`, `gnome50`, `cosmic`, `kde`, `niri`, `xfce` | DE packages; HWE coreos kernel; nvidia NVIDIA base |
-| Stage 3 — HWE/nvidia desktops | `<de>-hwe`, `<de>-nvidia` (e.g. `gnome-hwe`, `kde-nvidia`) | DE layered on HWE/nvidia base |
-| Stage 4 — combined | `gnome-nvidia-hwe` | GNOME + nvidia + HWE (layers on `gnome-hwe`) |
+The generic installer `build_scripts/install-desktop.sh` reads a manifest and installs the desktop. One script, all desktops, all OS families.
 
-Flavor availability varies per variant — consult `.github/build-config.yml`.
-- `bonito` has fewer HWE/nvidia combos (no `gnome50`, fewer non-GNOME HWE layers).
-- HWE flavors ship the `coreos/fedora` kernel + `ublue-os/akmods-nvidia-open`.
-- `xfce` on EL10 is the **hanthor/xfce-wayland** port (xfwl4 compositor) from
-  repo.tunaos.org — EL10 x86_64 only, hence its platform restrictions.
-  bonito/grouper ship stock X11 XFCE. See `docs/PIPELINE.md`.
-- `grouper` builds only `gnome`, `kde`, `niri`, `xfce` (apt branches in
-  `build_scripts/*.sh`; `cosmic.sh` has no apt branch).
+### Key Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/resolve-flavor.sh` | Routes flavor → Containerfile, target, parent, flags |
+| `scripts/resolve-image.sh` | Resolves image refs (base, common, brew, akmods) |
+| `scripts/build-image-inner.sh` | The build engine (env-var driven, replaces old Justfile monolith) |
+| `build_scripts/install-desktop.sh` | Generic manifest-driven DE installer |
+| `build_scripts/lib.sh` | Shared library (OS detection, pkg abstraction, retry logic) |
+| `build_scripts/gnome-extensions.sh` | GNOME extension compilation (separate cache layer) |
+
+### Containerfiles
+
+| File | Purpose |
+|------|---------|
+| `Containerfile` | Main build — base stage + all DE stages |
+| `Containerfile.overlay` | HWE/nvidia layer (parameterized by `OVERLAY_TYPE`) |
+| `Containerfile.ubuntu` | Ubuntu/Debian bootcification |
+| `Containerfile.final` | Rechunk relabeling (pass 3) |
+
+### Flavor Resolution
+
+All flavors route through `scripts/resolve-flavor.sh`:
+
+```bash
+$ ./scripts/resolve-flavor.sh yellowfin gnome-hwe
+CONTAINERFILE="Containerfile.overlay"
+DESKTOP_FLAVOR="desktop"
+ENABLE_HWE="1"
+ENABLE_NVIDIA="0"
+OVERLAY_TYPE="hwe"
+PARENT_FLAVOR="gnome"
+```
+
+### Build Stages (CI DAG)
+
+```
+Stage 1: base
+Stage 2: gnome, kde, niri, cosmic, xfce, base-hwe, base-nvidia  (parallel)
+Stage 3: gnome-hwe, kde-hwe, gnome-nvidia, kde-nvidia, etc.     (parallel)
+Stage 4: gnome-nvidia-hwe                                        (depends on stage 3)
+```
+
+Defined in `.github/build-config.yml`. The workflow is `build-variant.yml` → `reusable-build-image.yml`.
+
+---
+
+## Variants
+
+| Variant | Fish | Base | Pkg Mgr | Status |
+|---------|------|------|---------|--------|
+| `yellowfin` | 🐠 | AlmaLinux Kitten 10 | dnf | Stable |
+| `albacore` | 🐟 | AlmaLinux 10 | dnf | Stable |
+| `skipjack` | 🍣 | CentOS Stream 10 | dnf | Beta |
+| `bonito` | 🎣 | Fedora 44 | dnf | In progress |
+| `grouper` | 🐟 | Ubuntu 26.04 | apt | Experimental |
+| `redfin` | 🔒 | RHEL 10 | dnf | Local-only |
+| `marlin` | 🐟 | Arch Linux | pacman | Planned |
+| `wahoo` | 🐟 | CachyOS | pacman | Planned |
+| `flounder` | 🐟 | Debian Trixie | apt | Planned |
 
 ---
 
 ## Setup
 
-Install `just` via Homebrew for consistency with CI:
-
 ```bash
-# Install Homebrew if not already installed
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-brew install just
+brew install just podman shellcheck shfmt yq
+git clone https://github.com/tuna-os/tunaOS.git && cd tunaOS
+just fix && just check   # validate everything
+just --list              # see all commands
 ```
 
-**NEVER** extract tools directly into the repository root — always use `/tmp` to avoid overwriting project files.
-
-Other requirements:
-- `podman` — required for container builds
-- `shellcheck` — required for linting (`sudo apt-get install -y shellcheck`)
-- Root privileges — required for ISO/VM image generation
-
----
-
-## Commands
+## Building
 
 ```bash
-# Format and validate — run before every commit (mandatory)
-just fix        # Format shell scripts and Justfile
-just check      # shellcheck, yamllint, jq, actionlint
+just build yellowfin gnome     # single flavor (~25 min warm cache)
+just build yellowfin all       # all flavors for a variant
+just build yellowfin kde linux/amd64  # specific platform
+```
 
-# Build a single variant + flavor (fastest test)
-just yellowfin base
+## Pre-Commit (mandatory)
 
-# Build a chain (each depends on previous stage)
-just yellowfin base && just yellowfin gnome && just yellowfin gnome-nvidia
+```bash
+just fix && just check
+```
 
-# Build shortcuts (all default to base flavor)
-just yellowfin [flavor]
-just albacore [flavor]
-just skipjack [flavor]
-just bonito [flavor]
+## Testing
 
-# Batch builds
-just build-all           # All stable variants, all flavors
-just build-all-base      # Base flavor only for all variants
-
-# ISO / VM generation (requires root, adds 20-30 min)
-sudo just iso <variant> <flavor> <local|ghcr>
-sudo just iso-tacklebox <variant> <flavor> <local|ghcr> <tag>
-sudo just qcow2 <variant> <flavor> <local|ghcr>
-
-# Verification (the same gates CI enforces before publishing)
-just lint                          # shellcheck + yamllint, mirrors lint.yml
-just test                          # bats + pytest, mirrors test.yml
-just verify-disk <image.qcow2>     # QEMU boot gate for a disk image
-./scripts/iso-e2e.sh <file.iso>    # QEMU boot gate for a live ISO
-
-# Cleanup
-just clean               # Remove build artifacts and images (preserves .rpm-cache)
-just clean-cache         # Remove DNF/RPM cache only
-just --list              # Show all available commands
+```bash
+just test          # bats + pytest
+just test-bats     # shell script tests only
+just verify-disk image.qcow2   # QEMU boot gate
 ```
 
 ---
 
-## Pre-Commit Workflow (mandatory)
+## Adding a New Desktop
 
-1. `just fix` — format code
-2. `just check` — validate syntax
-3. `git diff` — review changes
-4. Commit only after both pass
+1. Create `manifests/desktops/<name>.yaml` with package lists per OS family
+2. Add a stage in `Containerfile` (copy the pattern from existing DE stages)
+3. Add the flavor to `.github/build-config.yml` for each variant
 
-`shellcheck` SC1091 is excluded (sourced file path detection).
+No new shell script needed. `install-desktop.sh` handles it.
 
----
+## Adding a New Variant
 
-## When to Build Images
-
-| Change type | Build required? |
-|---|---|
-| `Containerfile*`, `build_scripts/*`, `system_files*` | **Yes — always** |
-| `scripts/*` | Sometimes (if testing ISO/VM) |
-| Docs, CI workflows, README | No |
+1. Find/build a bootc-compatible base image
+2. Add detection to `build_scripts/lib.sh` (IS_* flag, PKG_MGR)
+3. Add the variant to `.github/build-config.yml`
+4. Add pacman/apt/dnf sections to each desktop manifest
+5. (Optional) Create a `Containerfile.<variant>` if bootcification is needed
 
 ---
 
-## Build Timing
+## Key Config Files
 
-- **First build (cold cache):** ~45-60 minutes
-- **Subsequent builds (warm cache):** ~25-35 minutes
-- **NEVER cancel a build early** — CI timeout is 60 minutes; local builds should allow 90 minutes.
-- RPM cache lives in `.rpm-cache/` (shared across all variants; preserved by `just clean`).
-
----
-
-## Architecture
-
-### Build Pipeline
-
-1. Pull base image from Quay.io
-2. Multi-stage `Containerfile`: `context` stage → `base-no-de` → `gnome`/`kde`/`niri`
-3. Build scripts run in numbered order (`00-workarounds.sh` → … → `90-image-info.sh`)
-4. `build_scripts/lib.sh` provides shared functions and OS detection via `/etc/os-release`
-5. `system_files_overrides/` applies variant/flavor-specific file overlays
-6. CI rechunks layers via `chunkah` for optimized distribution
-
-### CI/CD
-
-Full reference (workflow map, gating model, triage cheat-sheet): **[`docs/PIPELINE.md`](PIPELINE.md)**.
-
-- **Central matrix config:** `.github/build-config.yml` — single source of truth; adding a variant only requires updating this file
-- **Orchestrator:** `.github/workflows/build-variant.yml` — DAG with 4 stages + per-stage artifact (ISO) builds; needs-based stage ordering
-- **Reusable image job:** `.github/workflows/reusable-build-image.yml` — multi-platform (amd64, amd64v2, arm64), SBOMs, and **publish gating**: manifests push as `:<flavor>-testing`, a QEMU boot gate must pass before the bare `:<flavor>` + date tags are promoted
-- **Reusable ISO job:** `.github/workflows/reusable-build-artifacts.yml` — build ISO → boot gate → only then publish to R2/Releases
-- **Trigger wrappers:** per-variant workflows (`build-yellowfin.yml`, etc.) call `build-variant.yml`
-- CI timeout: **60 minutes maximum** per build; boot gates add ~15–25 min after manifest
-
-### Key Files
-
-| File/Dir | Purpose |
-|---|---|
-| `Justfile` | All build commands and task automation |
-| `Containerfile` | Main multi-stage build definition (base, gnome, kde, niri, cosmic) |
-| `Containerfile.nvidia` | NVIDIA flavor definition (NVIDIA drivers + CUDA + gnome/kde/niri/cosmic DE stages) |
-| `Containerfile.hwe` | HWE layer definition (coreos kernel, akmods + gnome/kde/niri/cosmic DE stages) |
-| `Containerfile.final` | Labels-only stage — applies OCI annotations to rechunked base image |
-| `build_scripts/lib.sh` | Shared functions; OS detection logic |
-| `build_scripts/overrides/` | Variant-specific script overrides |
-| `system_files/` | Files copied into every image (`etc/`, `usr/`) |
-| `system_files_overrides/` | Variant/flavor-specific file overlays |
-| `scripts/get-base-image.sh` | Maps variant names to base container image URIs |
-| `image-versions.yaml` | Pinned base image digests |
-| `.github/build-config.yml` | Central CI matrix config |
-| `renovate.json5` | Automated dependency update config |
-
-### Environment Variables
-
-Overridable at build time:
-
-| Variable | Default |
-|---|---|
-| `GITHUB_REPOSITORY_OWNER` | `tuna-os` |
-| `DEFAULT_TAG` | `latest` |
-| `PLATFORM` | auto-detected from arch |
-| `BASE_IMAGE` | `quay.io/almalinuxorg/almalinux-bootc` |
-| `BASE_IMAGE_TAG` | `10` |
-
----
-
-## External Package Sources (COPRs)
-
-The CentOS Stream 10 (skipjack) and AlmaLinux Kitten 10 (yellowfin) GNOME builds rely on custom COPR packages defined in **[github.com/tuna-os/github-copr](https://github.com/tuna-os/github-copr)**:
-
-- `gnome49-el10-compat` — compatibility shim for GNOME 49 on CentOS/AlmaLinux 10
-- `gnome50-el10-compat` — compatibility shim for GNOME 50 on CentOS/AlmaLinux 10
-
-When debugging RPM conflicts or missing packages in skipjack/yellowfin GNOME builds, **check the spec files in that repository first**.
-
----
-
-## Shell Script Conventions
-
-- All build scripts use `set -euo pipefail`
-- Quote all variables
-- Follow patterns in `build_scripts/lib.sh` for OS detection
-- GNOME Shell extensions are Git submodules — conditionally initialized for non-GNOME builds
-
----
-
-## Troubleshooting
-
-### Build failures
-- Check network connectivity (base image pull from Quay.io)
-- Verify disk space (20GB+ required)
-- Check parent image exists (base must exist before stage 2; stage 2 before stage 3)
-- RPM conflicts in skipjack/yellowfin GNOME builds → check [github.com/tuna-os/github-copr](https://github.com/tuna-os/github-copr)
-- Transient EPEL/RPM fetch failures → `dnf_retry` in `lib.sh` auto-retries up to 4 attempts with exponential backoff and metadata clear; check `.build-logs/` for retry traces
-
-### Common pitfalls
-- **NEVER cancel builds early**
-- **NEVER extract tools into the repo root**
-- **NEVER skip `just fix` + `just check` before committing**
-- **NEVER commit build artifacts** (`.build/`, `.rpm-cache/` are gitignored)
-- **New `build_scripts/*.sh` must be executable** (`chmod +x`) — the container
-  runtime exits 126 launching a mode-644 script, and shellcheck/bats won't
-  catch it
-- **CI's shellcheck is 0.9.0** (Ubuntu apt), stricter on some patterns than
-  local 0.11 — e.g. it flags `A && B || true` as SC2015. Reproduce with
-  `podman run koalaman/shellcheck:v0.9.0`
-- **QEMU screendumps need `-vga virtio`** — the default VGA framebuffer is
-  black under UEFI GOP, which reads as a boot-gate failure
-- **Never install `tuna-os.repo` on Fedora** (bonito) — its $releasever
-  baseurl 404s and `skip_if_unavailable=False` breaks every later dnf call
+| File | What it controls |
+|------|-----------------|
+| `.github/build-config.yml` | The build matrix (variants × flavors × platforms × stages) |
+| `image-versions.yaml` | Pinned image digests + download versions |
+| `registry-map.yaml` | Registry mirror overrides |
+| `renovate.json` | Automated dependency updates (automerge all) |

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1,174 +1,137 @@
 # TunaOS Build Pipeline Reference
 
-Authoritative map of how images and ISOs get built, verified, and published.
-Written for both humans and AI agents (Hive: guide, architect, sec-check,
-quality, ci-maintainer, strategist). If you are changing CI, read this first;
-if you change the pipeline's shape, update this file in the same PR.
-
-Related: [`AGENT_GUIDE.md`](AGENT_GUIDE.md) (dev workflow),
-[`TESTING.md`](TESTING.md) (test harness details),
-[`../CONTEXT.md`](../CONTEXT.md) (domain glossary),
-[`../.github/build-config.yml`](../.github/build-config.yml) (the matrix).
+How images and ISOs get built, verified, and published. If you change CI, read this first; if you change the pipeline's shape, update this file.
 
 ---
 
-## The product matrix
+## The Build Matrix
 
-`variant × desktop [× hardware flavor]`, defined entirely in
-`.github/build-config.yml`. Every variant builds **gnome, kde, niri, xfce**
-(cosmic on RPM variants only; grouper has no cosmic — `cosmic.sh` has no apt
-branch).
+`variant × desktop × hardware_layer`, defined in `.github/build-config.yml`.
 
-| Variant | Base | Desktops | HWE/NVIDIA | Arch |
-|---|---|---|---|---|
-| yellowfin | AlmaLinux Kitten 10 | gnome, gnome50, cosmic, kde, niri, xfce | yes | amd64, amd64/v2, arm64 (xfce: x86_64 only) |
-| albacore | AlmaLinux 10 | gnome, gnome50, cosmic, kde, niri, xfce | yes | amd64, amd64/v2, arm64 (xfce/gnome50: x86_64 only) |
-| skipjack | CentOS Stream 10 | gnome, gnome50, cosmic, kde, niri, xfce | gnome/cosmic families | amd64, arm64 (xfce: amd64 only) |
+| Variant | Base | Desktops | HWE/NVIDIA | Platforms |
+|---------|------|----------|------------|-----------|
+| yellowfin | AlmaLinux Kitten 10 | gnome, gnome50, cosmic, kde, niri, xfce | yes | amd64, amd64/v2, arm64 |
+| albacore | AlmaLinux 10 | gnome, gnome50, cosmic, kde, niri, xfce | yes | amd64, amd64/v2, arm64 |
+| skipjack | CentOS Stream 10 | gnome, gnome50, cosmic, kde, niri | gnome/cosmic families | amd64, arm64 |
 | bonito | Fedora 44 | gnome, cosmic, kde, niri, xfce | nvidia only | amd64, arm64 |
-| grouper (experimental) | Ubuntu 26.04 | gnome, kde, niri, xfce | none | amd64 only |
-
-**XFCE is special**: on EL10 it is the [hanthor/xfce-wayland](https://github.com/hanthor/xfce-wayland)
-port — the `xfwl4` Rust/Smithay compositor plus Wayland-adapted XFCE
-components — installed via the `xfce4-wayland` meta package. Specs live in
-[tuna-os/github-copr](https://github.com/tuna-os/github-copr) under
-`src/xfce-wayland/`, served from `repo.tunaos.org` (**EL10 x86_64 only**;
-that constraint drives the platform restrictions above). bonito ships stock
-Fedora XFCE (X11) until a Fedora chroot exists; grouper ships the Ubuntu X11
-stack (no debs). Session entry is `startxfce4 --wayland`; xfwl4 requires
-`xfwm4` installed (themes).
-
-> **Status**: the EL10 xfce/xfce-hwe/xfce-nvidia entries are **commented out
-> in build-config** — repo.tunaos.org does not serve the stack yet (most
-> component specs and the build-order tier are missing). Tracking:
-> [tuna-os/github-copr#65](https://github.com/tuna-os/github-copr/issues/65).
-> bonito and grouper xfce build today.
+| grouper | Ubuntu 26.04 | gnome, kde, niri, xfce | none | amd64 |
 
 ---
 
-## Image flow: build → testing tag → boot gate → promote
-
-Implemented in `reusable-build-image.yml`. **The bare `:<flavor>` tag is only
-ever written by the promote job, after the boot gate.**
+## Build Stages (DAG)
 
 ```
-build_push (per arch)         pushes  :<flavor>-<arch>          (plumbing)
-  └─ chunkah rechunk, telemetry, rechunk-metadata check, SBOM
-manifest                      pushes  :<flavor>-testing         (multi-arch)
-verify_boot  [amd64]          bootc install → qcow2 → QEMU boot
-  │                           (skipped for base* flavors — no desktop)
-tag-image "Promote Tags"      copies  -testing → :<flavor>, :<flavor>-YYYYMMDD,
-                                      :<flavor>-<arch>[-YYYYMMDD]
-                              only if boot gate passed AND all platforms built
+Stage 1:  base
+             │
+Stage 2:  ┌──┼──────────────────────────────────────┐
+          │  base-hwe  base-nvidia                   │
+          │  gnome  gnome50  kde  niri  cosmic  xfce │  (all parallel)
+          └──┬───────────────────────────────────────┘
+             │
+Stage 3:  gnome-hwe, kde-hwe, niri-hwe, cosmic-hwe     (layer on DE image)
+          gnome-nvidia, kde-nvidia, niri-nvidia, cosmic-nvidia
+             │
+Stage 4:  gnome-nvidia-hwe                              (layer on gnome-hwe)
 ```
 
-Consequences agents must respect:
+**Key insight**: HWE/nvidia layers are applied ON TOP of DE images (not the other way around). `gnome-hwe` = `yellowfin:gnome` + HWE kernel. The DE is never duplicated.
 
-- **Consumers pull bare tags** (`ghcr.io/tuna-os/<variant>:<flavor>`) — these
-  are always boot-verified. A red boot gate leaves users on the last good
-  image; it does not break them.
-- **CI stage chaining pulls `-testing`** (`Justfile`, `PARENT_FLAVOR` logic):
-  stage-3 `gnome-hwe` builds on this run's `gnome`, not last week's.
-- On PRs nothing is pushed; the same QEMU boot check runs against the locally
-  built image (amd64 leg only).
-- If you see a `-testing` tag newer than the bare tag, the boot gate is
-  failing — check the `boot-gate-*` artifact (serial.log + screenshots) on
-  the failing run before touching anything else.
+---
 
-## ISO flow
+## Workflow Files
 
-Two paths, both boot-gated **before** any upload:
+| File | Role |
+|------|------|
+| `build-yellowfin.yml` / `build-albacore.yml` / etc. | Top-level per-variant entry points (trigger: schedule + manual) |
+| `build-variant.yml` | Unified orchestrator — generates matrix, runs 4-stage DAG |
+| `reusable-build-image.yml` | Per-platform build + push + sign + boot-gate |
+| `reusable-build-artifacts.yml` | ISO/QCOW2 generation |
 
-1. **Per-flavor ISOs** — `reusable-build-artifacts.yml` (called from the
-   per-stage `PkgS2/S3/S4` jobs in `build-variant.yml` and from
-   `publish-isos.yml`): tacklebox builds the ISO from GHCR → workflow
-   artifact (always, for debugging) → `scripts/iso-e2e.sh` boot gate →
-   only on success: R2 `live-isos/<variant>-<flavor>[-latest].iso` and
-   (publish-isos only) GitHub Release attach.
-2. **Grouped dedup ISOs** — `publish-iso-groups.yml` builds one ISO per
-   `iso_groups:` entry (flagship / community / nvidia) via
-   `just iso-group`; inline boot gate before the R2 upload.
+---
 
-## Boot verification mechanics (`scripts/iso-e2e.sh`)
+## How a Build Works
 
-One harness, three relevant modes:
+1. **Matrix generation** — `build-variant.yml` reads `build-config.yml`, emits per-stage matrices
+2. **Stage 1** — builds `base` (Containerfile `base-no-de` target)
+3. **Stage 2** — builds DE images via `install-desktop.sh <de>` (reads YAML manifests)
+4. **Stage 3-4** — layers HWE/nvidia via `Containerfile.overlay`
+5. **Rechunk** — chunkah produces ostree-optimized layers for delta updates
+6. **Boot gate** — QEMU verifies the image boots (PR builds only)
+7. **Publish** — multi-arch manifest pushed to GHCR, signed with cosign
 
-| Mode | Use | Pass condition |
-|---|---|---|
-| default (`ready`) | live ISOs | `TUNAOS_LIVE_READY` on serial **or** screenshot-sanity fallback |
-| `--disk` | qcow2/raw images (GHCR boot gate, PR gate, `just verify-disk`) | graphical/multi-user marker on serial **or** screenshot-sanity fallback |
-| `--kickstart` | unattended `bootc install to-disk` + reboot check | install completes and installed disk boots |
+---
 
-Two hardware facts shape this design — do not "simplify" them away:
+## Flavor Resolution
 
-- **Serial is unreliable**: EL10 bootc kernels ship `CONFIG_SERIAL_8250=m`,
-  so markers often never reach the serial console (`research.md`).
-- **Default VGA screendumps are black under UEFI GOP**: every QEMU
-  invocation must carry `-vga virtio` or screenshots are useless
-  (`STATUS_2026-07-02.md`).
-
-The fallback: a screendump whose grayscale stddev > 0.02 counts as a rendered
-screen; blank/absent screenshots fail. It can be fooled by a rendered-but-hung
-splash — if you need a stronger signal, extend the harness (VLM check in
-`scripts/desktop-verify.py` is wired but advisory), don't weaken the gate.
-
-## Workflow map
-
-| Workflow | Trigger | Role | Gate? |
-|---|---|---|---|
-| `build-<variant>.yml` ×5 | nightly cron + dispatch (`flavor` input) | thin caller of build-variant | — |
-| `build-flavor.yml` | dispatch | one flavor across all variants | — |
-| `build-variant.yml` | workflow_call | staged DAG: S1 base → S2 desktops/base-hwe/nvidia → S3 `<de>-hwe/-nvidia` → S4 combos; per-stage artifact jobs | via callees |
-| `reusable-build-image.yml` | workflow_call | build/rechunk/push/manifest/**boot-gate/promote** one image | **yes** |
-| `reusable-build-artifacts.yml` | workflow_call | build/**boot-gate**/publish one ISO | **yes** |
-| `publish-isos.yml` | Sun 22:00 + dispatch | per-flavor ISOs → R2 + Releases | **yes** |
-| `publish-iso-groups.yml` | Sun 23:00 + dispatch | grouped dedup ISOs → R2 | **yes** |
-| `test.yml` / `lint.yml` | PR + push main | bats+pytest / shellcheck,yamllint,actionlint,justfmt | blocks PRs |
-| `daily-verify.yml` | daily 04:00 | skopeo label/config sanity of published images; files issues | advisory |
-| `iso-e2e.yml` | Mon 06:00 + PR-on-harness-changes | smoke of *published* ISOs | advisory |
-| `weekly-desktop-screenshots.yml` | Mon 02:00 | desktop capture per variant×DE → R2 + **commits to `docs/images/desktops/`** | advisory |
-| `installer-screenshots.yml` | Mon 05:00 | GUI-installer walkthrough capture → **commits to `docs/images/installer/`**, then boot-verifies the installed disk | advisory |
-| `weekly-boot-report.yml` / `weekly-qcow2-screenshots.yml` | weekly | aggregate report issue / login-screen shots | advisory |
-
-## Tooling for agents (run these before/instead of pushing to find out)
+`scripts/resolve-flavor.sh` maps any flavor to its build parameters:
 
 ```bash
-just lint                      # same shellcheck/yamllint CI's lint.yml runs
-just test                      # bats + pytest, same as test.yml
-just build <variant> <flavor>  # real image build (rootful podman, 25-60 min)
-just qcow2 <variant> <flavor>  # disk image from a local/ghcr image
-just verify-disk <file.qcow2>  # the exact boot gate CI uses (QEMU, no Lima)
-./scripts/iso-e2e.sh <iso>     # the exact ISO gate CI uses
-just iso <variant> <flavor> ghcr <tag>   # tacklebox live ISO (root)
-bash scripts/run-walkthrough.sh <iso> out/   # installer screenshots
+$ ./scripts/resolve-flavor.sh yellowfin gnome-nvidia
+CONTAINERFILE="Containerfile.overlay"
+DESKTOP_FLAVOR="desktop"
+ENABLE_HWE="0"
+ENABLE_NVIDIA="1"
+OVERLAY_TYPE="nvidia"
+PARENT_FLAVOR="gnome"
 ```
 
-Matrix sanity check after editing `build-config.yml`:
+---
+
+## The Manifest Installer
+
+DE packages are installed by `build_scripts/install-desktop.sh`, which reads `manifests/desktops/<de>.yaml`:
+
+```yaml
+# manifests/desktops/kde.yaml
+display_manager: sddm
+packages:
+  fedora:
+    groups: [kde-desktop]
+    packages: [sddm, dolphin, konsole, ...]
+  el10:
+    groups: ["KDE Plasma Workspaces", ...]
+    optional: [kdeconnect, nvtop, ...]
+  apt:
+    - kde-plasma-desktop
+    - sddm
+versionlock: [plasma-desktop, "qt6-*"]
+```
+
+Supports: dnf (Fedora/EL10), apt (Ubuntu/Debian), pacman (Arch/CachyOS).
+
+---
+
+## Image Refs and Pinning
+
+Three sources of image metadata, consolidated via `scripts/resolve-image.sh`:
+
+| Source | Contains |
+|--------|----------|
+| `.github/build-config.yml` | `base_image` per variant |
+| `image-versions.yaml` | Digest pins for common/brew/zirconium + download versions |
+| `registry-map.yaml` | Mirror overrides |
+
+Usage: `./scripts/resolve-image.sh yellowfin common` → full `image@sha256:...` ref.
+
+---
+
+## Local Development
 
 ```bash
-yq -o=json '.' .github/build-config.yml | jq '.variants[] | {id, flavors: [.flavors[].id]}'
-bats tests/bats/test_build_iso_group.bats   # group-selection expectations
+just build yellowfin gnome             # build locally
+just qcow2 yellowfin gnome             # generate VM disk
+just verify-disk ./yellowfin-gnome.qcow2  # QEMU boot check
+just iso yellowfin gnome               # build ISO via tacklebox
 ```
 
-## Failure triage cheat-sheet
+---
 
-| Symptom | Likely cause | Where to look |
-|---|---|---|
-| RUN step exits **126** in Containerfile | script not executable (`git ls-files -s build_scripts/`) | `chmod +x`, commit the mode bit |
-| Single-flavor dispatch builds nothing | a stage's `needs` skipped and the job `if:` lacks `!cancelled()` | `build-variant.yml` stage conditions |
-| shellcheck green locally, red in CI | CI Ubuntu ships shellcheck **0.9.0**; 0.11 suppresses some findings (e.g. SC2015 with `|| true`) | reproduce: `podman run koalaman/shellcheck:v0.9.0` |
-| boot gate red, image "looks fine" | black screendump (missing `-vga virtio`), or genuinely no DM | `boot-gate-*`/`e2e-*` artifacts: serial.log + PNGs |
-| xfce build fails resolving packages | repo.tunaos.org is EL10 x86_64 only; check chroot/arch | `build_scripts/xfce.sh`, github-copr repo |
-| bonito dnf fails after repo add | tuna-os.repo 404s on Fedora ($releasever=44) with `skip_if_unavailable=False` | never install that repo file on Fedora |
-| ISO picks wrong kernel on CentOS | `+debug` kernel sorts first, has no initramfs | dracut workaround, see STATUS_2026-07-02.md |
-| tacklebox container fails `podman unshare` | runs as root; unshare is rootless-only | `TACKLEBOX_FROM_SOURCE=1` |
+## Renovate (Automated Updates)
 
-## Publishing surfaces
+All dependency updates automerge via `renovate.json`:
+- Image digest pins (image-versions.yaml)
+- GitHub Actions SHA pins
+- Git submodules
+- Download versions (uupd, kcm_ublue, tacklebox)
 
-- **GHCR** `ghcr.io/tuna-os/<variant>` — tags: `<flavor>` (verified),
-  `<flavor>-testing` (unverified stream), `<flavor>-YYYYMMDD`,
-  `<flavor>-<arch>[-YYYYMMDD]`.
-- **R2** (`download.tunaos.org`): `live-isos/*.iso` (+ `-latest` aliases),
-  `screenshots/<variant>-<flavor>-latest.png`, `screenshots/boot/…`.
-- **Repo commits**: `docs/images/desktops/` and `docs/images/installer/`
-  are bot-updated weekly (`[skip ci]` commits by github-actions[bot]).
-- **GitHub Releases**: `<flavor>-YYYYMMDD` tags with ISO assets.
+No human review required — CI is the gate.


### PR DESCRIPTION
Complete doc rewrite reflecting the July 2026 refactor session:

- **AGENT_GUIDE.md** — full rewrite with manifest system, key scripts table, variant matrix (including planned Arch/CachyOS/Debian), how to add desktops/variants
- **PIPELINE.md** — rewrite with DAG visualization, manifest installer explanation, flavor resolution, image pinning
- **CONTRIBUTING.md** — simplified to show adding a DE is just writing a YAML file
- **AGENTS.md** — updated quick reference

Removes ~400 lines of outdated content (references to old per-DE scripts, wrong stage descriptions, missing variants).