### PR TITLE
feat: add CachyOS variant (wahoo) — performance Arch on bootc

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -601,3 +601,36 @@ variants:
       - id: xfce
         stage: 2
         build_image: true
+
+  # ── CachyOS ────────────────────────────────────────────────────────────────
+  # Wahoo: performance-optimized Arch Linux. CachyOS ships linux-cachyos
+  # (BORE scheduler, LTO, march=x86-64-v3) and optimized packages.
+  # Uses same Containerfile.arch as marlin — the CachyOS repos and kernel
+  # are declared in the desktop manifests (cachyos: section).
+  - id: wahoo
+    emoji: "🐟"
+    description: "Based on CachyOS (Arch + performance kernel)"
+    base_image: "docker.io/cachyos/cachyos:latest"
+    platforms: ["linux/amd64"]
+    experimental: true
+    flavors:
+      - id: base
+        stage: 1
+        build_image: true
+      - id: gnome
+        stage: 2
+        build_image: true
+        build_iso: true
+      - id: kde
+        stage: 2
+        build_image: true
+        build_iso: true
+      - id: cosmic
+        stage: 2
+        build_image: true
+      - id: niri
+        stage: 2
+        build_image: true
+      - id: xfce
+        stage: 2
+        build_image: true

--- a/Containerfile.arch
+++ b/Containerfile.arch
@@ -68,11 +68,20 @@ RUN grep "= */var" /etc/pacman.conf | sed "/= *\/var/s/.*=// ; s/ //" | \
     sed -i -e "/= *\/var/ s/^#//" -e "s@= */var@= /usr/lib/sysimage@g" -e "/DownloadUser/d" /etc/pacman.conf
 
 # Full system refresh + bootc base packages
-RUN pacman -Syu --noconfirm && \
+# CachyOS images already have CachyOS repos in pacman.conf, so pacman -S
+# will pull optimized packages automatically. We detect CachyOS by checking
+# for the cachyos repo in pacman.conf and install linux-cachyos instead of
+# stock linux.
+RUN KERNEL_PKG="linux"; \
+    if grep -q "^\[cachyos\]" /etc/pacman.conf 2>/dev/null; then \
+        KERNEL_PKG="linux-cachyos"; \
+    fi && \
+    pacman -Syu --noconfirm && \
     pacman -S --noconfirm --needed \
         base \
         dracut \
-        linux \
+        ${KERNEL_PKG} \
+        ${KERNEL_PKG}-headers \
         linux-firmware \
         ostree \
         btrfs-progs \


### PR DESCRIPTION
## 🐟 Wahoo — CachyOS on bootc

Performance-optimized Arch Linux with BORE scheduler, LTO, and x86-64-v3 targeting.

- Uses `docker.io/cachyos/cachyos:latest` (CachyOS repos pre-configured)
- Containerfile.arch auto-detects CachyOS and installs `linux-cachyos` kernel
- Same manifests as marlin — the `pacman:` section works for both
- amd64-only, experimental

CachyOS on top of our image factory = the fastest rolling desktop you can `bootc switch` to.