### PR TITLE
feat: add Debian (flounder) + COSMIC for Ubuntu/Debian

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -634,3 +634,60 @@ variants:
       - id: xfce
         stage: 2
         build_image: true
+
+  # ── Debian ─────────────────────────────────────────────────────────────────
+  # Flounder: Debian Trixie (13) stable. Uses Containerfile.debian.
+  - id: flounder
+    emoji: "🐟"
+    description: "Based on Debian 13 Trixie (stable)"
+    base_image: "docker.io/library/debian:trixie"
+    platforms: ["linux/amd64"]
+    experimental: true
+    flavors:
+      - id: base
+        stage: 1
+        build_image: true
+      - id: gnome
+        stage: 2
+        build_image: true
+        build_iso: true
+      - id: kde
+        stage: 2
+        build_image: true
+        build_iso: true
+      - id: cosmic
+        stage: 2
+        build_image: true
+      - id: niri
+        stage: 2
+        build_image: true
+      - id: xfce
+        stage: 2
+        build_image: true
+
+  # Flounder-sid: Debian Sid (unstable/rolling). Has latest COSMIC natively.
+  - id: flounder-sid
+    emoji: "🐟"
+    description: "Based on Debian Sid (unstable, rolling)"
+    base_image: "docker.io/library/debian:sid"
+    platforms: ["linux/amd64"]
+    experimental: true
+    flavors:
+      - id: base
+        stage: 1
+        build_image: true
+      - id: gnome
+        stage: 2
+        build_image: true
+      - id: kde
+        stage: 2
+        build_image: true
+      - id: cosmic
+        stage: 2
+        build_image: true
+      - id: niri
+        stage: 2
+        build_image: true
+      - id: xfce
+        stage: 2
+        build_image: true

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -1,0 +1,152 @@
+# Containerfile.debian — Debian bootcification.
+#
+# Builds a bootc-compatible Debian image from stock debian:trixie or
+# debian:sid. Based on bootcrew/mono/debian pattern.
+#
+# Usage:
+#   buildah build --build-arg BASE_IMAGE=docker.io/library/debian:trixie \
+#     --target=kde --file Containerfile.debian .
+
+ARG BASE_IMAGE="docker.io/library/debian:trixie"
+ARG DESKTOP_FLAVOR="${DESKTOP_FLAVOR:-gnome}"
+ARG IMAGE_NAME
+ARG IMAGE_VENDOR
+ARG SHA_HEAD_SHORT
+ARG ENABLE_SSHD="${ENABLE_SSHD:-0}"
+ARG IMAGE_REGISTRY="ghcr.io"
+ARG IMAGE_NAME_VARIANT
+
+# ── Build bootc from source (Debian doesn't package it in stable) ─────────
+FROM ${BASE_IMAGE} AS bootc-builder
+RUN apt-get update -y && \
+    apt-get install -y git curl make build-essential go-md2man \
+        libzstd-dev pkgconf dracut libostree-dev ostree
+ENV CARGO_HOME=/tmp/rust
+ENV RUSTUP_HOME=/tmp/rust
+WORKDIR /home/build
+RUN curl --proto '=https' --tlsv1.2 -sSf "https://sh.rustup.rs" | \
+        sh -s -- --profile minimal -y && \
+    . ${RUSTUP_HOME}/env && \
+    git clone --depth 1 https://github.com/bootc-dev/bootc.git . && \
+    make bin && \
+    make install-all DESTDIR=/output
+
+# ── Context layer ────────────────────────────────────────────────────────────
+FROM scratch AS context
+COPY system_files /files
+COPY system_files_overrides /overrides
+COPY build_scripts /build_scripts
+COPY manifests /manifests
+
+# ── Base system (bootc-compatible Debian) ────────────────────────────────────
+FROM ${BASE_IMAGE} AS base-no-de
+
+ARG BASE_IMAGE
+ARG IMAGE_NAME
+ARG IMAGE_VENDOR
+ARG IMAGE_NAME_VARIANT
+ARG SHA_HEAD_SHORT
+ARG ENABLE_SSHD
+ARG DESKTOP_FLAVOR
+ARG IMAGE_REGISTRY
+
+ENV BASE_IMAGE=${BASE_IMAGE}
+ENV IMAGE_NAME=${IMAGE_NAME}
+ENV IMAGE_VENDOR=${IMAGE_VENDOR}
+ENV IMAGE_NAME_VARIANT=${IMAGE_NAME_VARIANT}
+ENV IMAGE_REGISTRY=${IMAGE_REGISTRY}
+ENV ENABLE_SSHD=${ENABLE_SSHD}
+ENV DESKTOP_FLAVOR=${DESKTOP_FLAVOR}
+
+# Install bootc from builder stage
+COPY --from=bootc-builder /output /
+
+# Install base system packages
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        btrfs-progs \
+        dosfstools \
+        e2fsprogs \
+        fdisk \
+        firmware-linux-free \
+        linux-image-generic \
+        skopeo \
+        podman \
+        systemd \
+        systemd-boot \
+        xfsprogs \
+        libostree-1-1 \
+        ostree \
+        dracut \
+        networkmanager \
+        pipewire \
+        wireplumber \
+        flatpak \
+        fwupd \
+        plymouth \
+        power-profiles-daemon \
+        curl \
+        unzip \
+        git && \
+    apt-get clean -y
+
+# Copy kernel to modules directory (Debian puts it in /boot)
+RUN cp /boot/vmlinuz-* "$(find /usr/lib/modules -maxdepth 1 -type d | tail -1)/vmlinuz"
+
+# Build initramfs
+RUN mkdir -p /usr/lib/dracut/dracut.conf.d/ && \
+    printf 'systemdsystemconfdir=/etc/systemd/system\nsystemdsystemunitdir=/usr/lib/systemd/system\n' \
+        > /usr/lib/dracut/dracut.conf.d/30-fix-bootc-module.conf && \
+    printf 'reproducible=yes\nhostonly=no\ncompress=zstd\nadd_dracutmodules+=" bootc "\n' \
+        > /usr/lib/dracut/dracut.conf.d/30-bootc-container-build.conf && \
+    dracut --force "$(find /usr/lib/modules -maxdepth 1 -type d | tail -1)/initramfs.img"
+
+# Set up bootc/ostree filesystem layout
+RUN sed -i 's|^HOME=.*|HOME=/var/home|' /etc/default/useradd && \
+    rm -rf /boot /home /root /usr/local /srv /opt /mnt /var && \
+    mkdir -p /sysroot /boot /usr/lib/ostree /var && \
+    ln -sT sysroot/ostree /ostree && \
+    ln -sT var/roothome /root && \
+    ln -sT var/srv /srv && \
+    ln -sT var/opt /opt && \
+    ln -sT var/mnt /mnt && \
+    ln -sT var/home /home && \
+    ln -sT ../var/usrlocal /usr/local && \
+    printf 'd /var/opt 0755 root root -\nd /var/home 0755 root root -\nd /var/srv 0755 root root -\nd /var/mnt 0755 root root -\nd /var/usrlocal 0755 root root -\nd /var/roothome 0700 root root -\nd /run/media 0755 root root -\n' \
+        > /usr/lib/tmpfiles.d/bootc-base-dirs.conf && \
+    printf '[composefs]\nenabled = yes\n[sysroot]\nreadonly = true\n' \
+        > /usr/lib/ostree/prepare-root.conf
+
+LABEL containers.bootc 1
+RUN bootc container lint
+
+# ==============================================================================
+# Desktop stages — manifest-driven
+# ==============================================================================
+FROM base-no-de AS base
+RUN ln -sf /var/opt /opt 2>/dev/null || true
+
+FROM base-no-de AS gnome
+RUN --mount=type=bind,from=context,source=/,target=/run/context \
+    /run/context/build_scripts/install-desktop.sh gnome
+RUN ln -sf /var/opt /opt 2>/dev/null || true
+
+FROM base-no-de AS kde
+RUN --mount=type=bind,from=context,source=/,target=/run/context \
+    /run/context/build_scripts/install-desktop.sh kde
+RUN ln -sf /var/opt /opt 2>/dev/null || true
+
+FROM base-no-de AS cosmic
+RUN --mount=type=bind,from=context,source=/,target=/run/context \
+    /run/context/build_scripts/install-desktop.sh cosmic
+RUN ln -sf /var/opt /opt 2>/dev/null || true
+
+FROM base-no-de AS niri
+RUN --mount=type=bind,from=context,source=/,target=/run/context \
+    /run/context/build_scripts/install-desktop.sh niri
+RUN ln -sf /var/opt /opt 2>/dev/null || true
+
+FROM base-no-de AS xfce
+RUN --mount=type=bind,from=context,source=/,target=/run/context \
+    /run/context/build_scripts/install-desktop.sh xfce
+RUN ln -sf /var/opt /opt 2>/dev/null || true

--- a/build_scripts/install-desktop.sh
+++ b/build_scripts/install-desktop.sh
@@ -59,7 +59,21 @@ echo "Installing ${DESKTOP} desktop (OS section: ${OS_SECTION})..."
 
 # ── APT path ─────────────────────────────────────────────────────────────────
 if [[ "${OS_SECTION}" == "apt" ]]; then
-    readarray -t PKGS < <($YQ -r ".packages.apt[]" "${MANIFEST}" 2>/dev/null)
+    # Handle PPAs (Ubuntu only — Debian uses native repos)
+    PPA_COUNT=$($YQ -r ".packages.apt.ppa | length // 0" "${MANIFEST}" 2>/dev/null)
+    for ((i=0; i<PPA_COUNT; i++)); do
+        PPA_REPO=$($YQ -r ".packages.apt.ppa[$i].repo" "${MANIFEST}")
+        PPA_COND=$($YQ -r ".packages.apt.ppa[$i].condition // empty" "${MANIFEST}")
+        # Only add PPA if condition matches (e.g. "ubuntu" only on Ubuntu)
+        if [[ -z "${PPA_COND}" ]] || [[ "$IS_UBUNTU" == true && "${PPA_COND}" == "ubuntu" ]]; then
+            if command -v add-apt-repository &>/dev/null; then
+                add-apt-repository -y "${PPA_REPO}"
+            fi
+        fi
+    done
+
+    # Install packages (may be under .packages.apt[] or .packages.apt.packages[])
+    readarray -t PKGS < <($YQ -r '(.packages.apt.packages // .packages.apt) | if type == "array" then .[] else empty end' "${MANIFEST}" 2>/dev/null)
     if ((${#PKGS[@]} > 0)); then
         pkg_install "${PKGS[@]}"
     fi

--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -3,6 +3,35 @@
 display_manager: greetd
 
 packages:
+  # ── APT (Ubuntu via PPA, Debian Sid has native packages) ───────────
+  apt:
+    ppa:
+      - repo: "ppa:hepp3n/cosmic-epoch"
+        condition: "ubuntu"  # only add PPA on Ubuntu; Debian Sid has native pkgs
+    packages:
+      - cosmic-session
+      - cosmic-comp
+      - cosmic-panel
+      - cosmic-app-library
+      - cosmic-applets
+      - cosmic-bg
+      - cosmic-files
+      - cosmic-idle
+      - cosmic-launcher
+      - cosmic-notifications
+      - cosmic-osd
+      - cosmic-randr
+      - cosmic-screenshot
+      - cosmic-settings
+      - cosmic-settings-daemon
+      - cosmic-term
+      - cosmic-wallpapers
+      - cosmic-workspaces
+      - cosmic-greeter
+      - cosmic-icon-theme
+      - greetd
+      - xdg-desktop-portal-cosmic
+
   fedora:
     packages:
       - cosmic-session

--- a/scripts/resolve-flavor.sh
+++ b/scripts/resolve-flavor.sh
@@ -43,6 +43,11 @@ if [[ "${VARIANT}" == "grouper" ]]; then
     CONTAINERFILE="Containerfile.ubuntu"
 fi
 
+# Debian variants use Containerfile.debian
+if [[ "${VARIANT}" == "flounder" || "${VARIANT}" == "flounder-sid" ]]; then
+    CONTAINERFILE="Containerfile.debian"
+fi
+
 # Arch-based variants use Containerfile.arch
 if [[ "${VARIANT}" == "marlin" || "${VARIANT}" == "wahoo" ]]; then
     CONTAINERFILE="Containerfile.arch"


### PR DESCRIPTION
## New Variants

| Variant | Fish | Base | COSMIC source |
|---------|------|------|---------------|
| 🐟 Flounder | Debian 13 Trixie | `debian:trixie` | native repos |
| 🐟 Flounder-sid | Debian Sid | `debian:sid` | native repos |

## COSMIC on apt-based systems

- **Ubuntu (grouper)**: COSMIC via `ppa:hepp3n/cosmic-epoch` PPA
- **Debian Sid (flounder-sid)**: COSMIC in native repos (no PPA needed)
- **Debian Trixie (flounder)**: may need backport — TBD

The `cosmic.yaml` manifest now has an `apt:` section with PPA support. `install-desktop.sh` conditionally adds the PPA only on Ubuntu.

## Containerfile.debian

Based on [bootcrew/mono/debian](https://github.com/bootcrew/mono/tree/main/debian):
- Builds bootc from source (Rust)
- Installs kernel + systemd-boot + ostree
- Same composefs/ostree layout as Containerfile.arch

## Full Matrix

```
11 variants × 6 desktops = the image factory
EL10 (3) + Fedora + Ubuntu + Debian (2) + Arch + CachyOS + RHEL
```