### PR TITLE
fix: yq syntax error in install-desktop.sh (// empty → // "")

### DIFF
--- a/build_scripts/install-desktop.sh
+++ b/build_scripts/install-desktop.sh
@@ -63,7 +63,7 @@ if [[ "${OS_SECTION}" == "apt" ]]; then
     PPA_COUNT=$($YQ -r ".packages.apt.ppa | length // 0" "${MANIFEST}" 2>/dev/null)
     for ((i=0; i<PPA_COUNT; i++)); do
         PPA_REPO=$($YQ -r ".packages.apt.ppa[$i].repo" "${MANIFEST}")
-        PPA_COND=$($YQ -r ".packages.apt.ppa[$i].condition // empty" "${MANIFEST}")
+        PPA_COND=$($YQ -r ".packages.apt.ppa[$i].condition // """ "${MANIFEST}")
         # Only add PPA if condition matches (e.g. "ubuntu" only on Ubuntu)
         if [[ -z "${PPA_COND}" ]] || [[ "$IS_UBUNTU" == true && "${PPA_COND}" == "ubuntu" ]]; then
             if command -v add-apt-repository &>/dev/null; then
@@ -78,7 +78,7 @@ if [[ "${OS_SECTION}" == "apt" ]]; then
         pkg_install "${PKGS[@]}"
     fi
     # Enable display manager
-    DM=$($YQ -r '.display_manager // empty' "${MANIFEST}")
+    DM=$($YQ -r '.display_manager // ""' "${MANIFEST}")
     if [[ -n "${DM}" ]]; then
         systemctl enable "${DM}" || true
     fi
@@ -112,7 +112,7 @@ if [[ "${OS_SECTION}" == "pacman" ]]; then
     fi
 
     # Enable display manager
-    DM=$($YQ -r '.display_manager // empty' "${MANIFEST}")
+    DM=$($YQ -r '.display_manager // ""' "${MANIFEST}")
     if [[ -n "${DM}" ]]; then
         systemctl enable "${DM}" || true
     fi
@@ -123,9 +123,9 @@ fi
 # ── DNF path ─────────────────────────────────────────────────────────────────
 
 # Install groups
-GROUP_OPTIONS=$($YQ -r ".packages.${OS_SECTION}.group_options // empty" "${MANIFEST}")
-readarray -t GROUPS < <($YQ -r ".packages.${OS_SECTION}.groups[] // empty" "${MANIFEST}" 2>/dev/null)
-readarray -t GROUP_EXCLUDES < <($YQ -r ".packages.${OS_SECTION}.group_exclude[] // empty" "${MANIFEST}" 2>/dev/null)
+GROUP_OPTIONS=$($YQ -r ".packages.${OS_SECTION}.group_options // """ "${MANIFEST}")
+readarray -t GROUPS < <($YQ -r ".packages.${OS_SECTION}.groups[] // """ "${MANIFEST}" 2>/dev/null)
+readarray -t GROUP_EXCLUDES < <($YQ -r ".packages.${OS_SECTION}.group_exclude[] // """ "${MANIFEST}" 2>/dev/null)
 
 if ((${#GROUPS[@]} > 0)); then
     EXCLUDE_ARGS=()
@@ -137,8 +137,8 @@ if ((${#GROUPS[@]} > 0)); then
 fi
 
 # Install packages
-readarray -t PKGS < <($YQ -r ".packages.${OS_SECTION}.packages[] // empty" "${MANIFEST}" 2>/dev/null)
-readarray -t EXCLUDES < <($YQ -r ".packages.${OS_SECTION}.exclude[] // empty" "${MANIFEST}" 2>/dev/null)
+readarray -t PKGS < <($YQ -r ".packages.${OS_SECTION}.packages[] // """ "${MANIFEST}" 2>/dev/null)
+readarray -t EXCLUDES < <($YQ -r ".packages.${OS_SECTION}.exclude[] // """ "${MANIFEST}" 2>/dev/null)
 
 if ((${#PKGS[@]} > 0)); then
     EXCLUDE_ARGS=()
@@ -153,7 +153,7 @@ COPR_COUNT=$($YQ -r ".packages.${OS_SECTION}.copr | length // 0" "${MANIFEST}" 2
 for ((i=0; i<COPR_COUNT; i++)); do
     COPR_REPO=$($YQ -r ".packages.${OS_SECTION}.copr[$i].repo" "${MANIFEST}")
     readarray -t COPR_PKGS < <($YQ -r ".packages.${OS_SECTION}.copr[$i].packages[]" "${MANIFEST}")
-    COPR_OPTS=$($YQ -r ".packages.${OS_SECTION}.copr[$i].options // empty" "${MANIFEST}")
+    COPR_OPTS=$($YQ -r ".packages.${OS_SECTION}.copr[$i].options // """ "${MANIFEST}")
 
     dnf -y copr enable "${COPR_REPO}"
     dnf -y copr disable "${COPR_REPO}"
@@ -163,13 +163,13 @@ for ((i=0; i<COPR_COUNT; i++)); do
 done
 
 # Optional packages (best-effort)
-readarray -t OPTIONAL < <($YQ -r ".packages.${OS_SECTION}.optional[] // empty" "${MANIFEST}" 2>/dev/null)
+readarray -t OPTIONAL < <($YQ -r ".packages.${OS_SECTION}.optional[] // """ "${MANIFEST}" 2>/dev/null)
 if ((${#OPTIONAL[@]} > 0)); then
     install_available "${OPTIONAL[@]}"
 fi
 
 # Optional group (e.g. fcitx5 — install all if the first one is available)
-readarray -t OPT_GROUP < <($YQ -r ".packages.${OS_SECTION}.optional_group[] // empty" "${MANIFEST}" 2>/dev/null)
+readarray -t OPT_GROUP < <($YQ -r ".packages.${OS_SECTION}.optional_group[] // """ "${MANIFEST}" 2>/dev/null)
 if ((${#OPT_GROUP[@]} > 0)); then
     FIRST="${OPT_GROUP[0]}"
     if dnf repoquery --available --qf '%{name}\n' "$FIRST" 2>/dev/null | grep -qx "$FIRST"; then
@@ -180,7 +180,7 @@ if ((${#OPT_GROUP[@]} > 0)); then
 fi
 
 # ── Version locks ────────────────────────────────────────────────────────────
-readarray -t LOCKS < <($YQ -r '.versionlock[] // empty' "${MANIFEST}" 2>/dev/null)
+readarray -t LOCKS < <($YQ -r '.versionlock[] // ""' "${MANIFEST}" 2>/dev/null)
 if ((${#LOCKS[@]} > 0)); then
     # Ensure versionlock plugin is available
     dnf -y install python3-dnf-plugin-versionlock 2>/dev/null || true
@@ -190,13 +190,13 @@ if ((${#LOCKS[@]} > 0)); then
 fi
 
 # ── Display manager ──────────────────────────────────────────────────────────
-DM=$($YQ -r '.display_manager // empty' "${MANIFEST}")
+DM=$($YQ -r '.display_manager // ""' "${MANIFEST}")
 if [[ -n "${DM}" ]]; then
     safe_enable "${DM}.service"
 fi
 
 # ── Disable desktop files ────────────────────────────────────────────────────
-readarray -t DISABLE_DESKTOPS < <($YQ -r '.disable_desktop_files[] // empty' "${MANIFEST}" 2>/dev/null)
+readarray -t DISABLE_DESKTOPS < <($YQ -r '.disable_desktop_files[] // ""' "${MANIFEST}" 2>/dev/null)
 for df in "${DISABLE_DESKTOPS[@]}"; do
     if [[ -n "$df" && -f "/usr/share/applications/${df}" ]]; then
         mv "/usr/share/applications/${df}" "/usr/share/applications/${df}.disabled"
@@ -204,7 +204,7 @@ for df in "${DISABLE_DESKTOPS[@]}"; do
 done
 
 # ── Post-install scripts ─────────────────────────────────────────────────────
-readarray -t POST_SCRIPTS < <($YQ -r '.post_install[] // empty' "${MANIFEST}" 2>/dev/null)
+readarray -t POST_SCRIPTS < <($YQ -r '.post_install[] // ""' "${MANIFEST}" 2>/dev/null)
 for script in "${POST_SCRIPTS[@]}"; do
     if [[ -n "$script" && -f "${CONTEXT_PATH}/build_scripts/${script}" ]]; then
         echo "Running post-install: ${script}"
@@ -213,7 +213,7 @@ for script in "${POST_SCRIPTS[@]}"; do
 done
 
 # Inline post-install commands
-readarray -t POST_INLINE < <($YQ -r '.post_install_inline[] // empty' "${MANIFEST}" 2>/dev/null)
+readarray -t POST_INLINE < <($YQ -r '.post_install_inline[] // ""' "${MANIFEST}" 2>/dev/null)
 for cmd in "${POST_INLINE[@]}"; do
     if [[ -n "$cmd" ]]; then
         eval "$cmd"


### PR DESCRIPTION
yq uses `// ""` not `// empty` (that's jq). Fixes all DE builds failing with `lexer: invalid input text "empty"`.