### PR TITLE
fix: readarray + set -e in install-desktop.sh

### DIFF
--- a/build_scripts/install-desktop.sh
+++ b/build_scripts/install-desktop.sh
@@ -73,7 +73,7 @@ if [[ "${OS_SECTION}" == "apt" ]]; then
     done
 
     # Install packages (may be under .packages.apt[] or .packages.apt.packages[])
-    readarray -t PKGS < <($YQ -r '(.packages.apt.packages // .packages.apt)[]' "${MANIFEST}" 2>/dev/null)
+    readarray -t PKGS < <($YQ -r '(.packages.apt.packages // .packages.apt)[]' "${MANIFEST}" 2>/dev/null || true)
     if ((${#PKGS[@]} > 0)); then
         pkg_install "${PKGS[@]}"
     fi
@@ -100,13 +100,13 @@ if [[ "${OS_SECTION}" == "pacman" ]]; then
         done
         pacman -Sy --noconfirm
         # Install CachyOS-specific packages
-        readarray -t CACHY_PKGS < <($YQ -r ".packages.${CACHYOS_SECTION}.packages[]" "${MANIFEST}" 2>/dev/null)
+        readarray -t CACHY_PKGS < <($YQ -r ".packages.${CACHYOS_SECTION}.packages[]" "${MANIFEST}" 2>/dev/null || true)
         if ((${#CACHY_PKGS[@]} > 0)); then
             pacman -S --noconfirm --needed "${CACHY_PKGS[@]}"
         fi
     fi
 
-    readarray -t PKGS < <($YQ -r ".packages.pacman[]" "${MANIFEST}" 2>/dev/null)
+    readarray -t PKGS < <($YQ -r ".packages.pacman[]" "${MANIFEST}" 2>/dev/null || true)
     if ((${#PKGS[@]} > 0)); then
         pacman -S --noconfirm --needed "${PKGS[@]}"
     fi
@@ -124,8 +124,8 @@ fi
 
 # Install groups
 GROUP_OPTIONS=$($YQ -r ".packages.${OS_SECTION}.group_options" "${MANIFEST}")
-readarray -t GROUPS < <($YQ -r ".packages.${OS_SECTION}.groups[]" "${MANIFEST}" 2>/dev/null)
-readarray -t GROUP_EXCLUDES < <($YQ -r ".packages.${OS_SECTION}.group_exclude[]" "${MANIFEST}" 2>/dev/null)
+readarray -t GROUPS < <($YQ -r ".packages.${OS_SECTION}.groups[]" "${MANIFEST}" 2>/dev/null || true)
+readarray -t GROUP_EXCLUDES < <($YQ -r ".packages.${OS_SECTION}.group_exclude[]" "${MANIFEST}" 2>/dev/null || true)
 
 if ((${#GROUPS[@]} > 0)); then
     EXCLUDE_ARGS=()
@@ -137,8 +137,8 @@ if ((${#GROUPS[@]} > 0)); then
 fi
 
 # Install packages
-readarray -t PKGS < <($YQ -r ".packages.${OS_SECTION}.packages[]" "${MANIFEST}" 2>/dev/null)
-readarray -t EXCLUDES < <($YQ -r ".packages.${OS_SECTION}.exclude[]" "${MANIFEST}" 2>/dev/null)
+readarray -t PKGS < <($YQ -r ".packages.${OS_SECTION}.packages[]" "${MANIFEST}" 2>/dev/null || true)
+readarray -t EXCLUDES < <($YQ -r ".packages.${OS_SECTION}.exclude[]" "${MANIFEST}" 2>/dev/null || true)
 
 if ((${#PKGS[@]} > 0)); then
     EXCLUDE_ARGS=()
@@ -152,7 +152,7 @@ fi
 COPR_COUNT=$($YQ -r ".packages.${OS_SECTION}.copr | length // 0" "${MANIFEST}" 2>/dev/null)
 for ((i=0; i<COPR_COUNT; i++)); do
     COPR_REPO=$($YQ -r ".packages.${OS_SECTION}.copr[$i].repo" "${MANIFEST}")
-    readarray -t COPR_PKGS < <($YQ -r ".packages.${OS_SECTION}.copr[$i].packages[]" "${MANIFEST}")
+    readarray -t COPR_PKGS < <($YQ -r ".packages.${OS_SECTION}.copr[$i].packages[]" "${MANIFEST}" 2>/dev/null || true)
     COPR_OPTS=$($YQ -r ".packages.${OS_SECTION}.copr[$i].options" "${MANIFEST}")
 
     dnf -y copr enable "${COPR_REPO}"
@@ -163,13 +163,13 @@ for ((i=0; i<COPR_COUNT; i++)); do
 done
 
 # Optional packages (best-effort)
-readarray -t OPTIONAL < <($YQ -r ".packages.${OS_SECTION}.optional[]" "${MANIFEST}" 2>/dev/null)
+readarray -t OPTIONAL < <($YQ -r ".packages.${OS_SECTION}.optional[]" "${MANIFEST}" 2>/dev/null || true)
 if ((${#OPTIONAL[@]} > 0)); then
     install_available "${OPTIONAL[@]}"
 fi
 
 # Optional group (e.g. fcitx5 — install all if the first one is available)
-readarray -t OPT_GROUP < <($YQ -r ".packages.${OS_SECTION}.optional_group[]" "${MANIFEST}" 2>/dev/null)
+readarray -t OPT_GROUP < <($YQ -r ".packages.${OS_SECTION}.optional_group[]" "${MANIFEST}" 2>/dev/null || true)
 if ((${#OPT_GROUP[@]} > 0)); then
     FIRST="${OPT_GROUP[0]}"
     if dnf repoquery --available --qf '%{name}\n' "$FIRST" 2>/dev/null | grep -qx "$FIRST"; then
@@ -180,7 +180,7 @@ if ((${#OPT_GROUP[@]} > 0)); then
 fi
 
 # ── Version locks ────────────────────────────────────────────────────────────
-readarray -t LOCKS < <($YQ -r '.versionlock[]' "${MANIFEST}" 2>/dev/null)
+readarray -t LOCKS < <($YQ -r '.versionlock[]' "${MANIFEST}" 2>/dev/null || true)
 if ((${#LOCKS[@]} > 0)); then
     # Ensure versionlock plugin is available
     dnf -y install python3-dnf-plugin-versionlock 2>/dev/null || true
@@ -196,7 +196,7 @@ if [[ -n "${DM}" ]]; then
 fi
 
 # ── Disable desktop files ────────────────────────────────────────────────────
-readarray -t DISABLE_DESKTOPS < <($YQ -r '.disable_desktop_files[]' "${MANIFEST}" 2>/dev/null)
+readarray -t DISABLE_DESKTOPS < <($YQ -r '.disable_desktop_files[]' "${MANIFEST}" 2>/dev/null || true)
 for df in "${DISABLE_DESKTOPS[@]}"; do
     if [[ -n "$df" && -f "/usr/share/applications/${df}" ]]; then
         mv "/usr/share/applications/${df}" "/usr/share/applications/${df}.disabled"
@@ -204,7 +204,7 @@ for df in "${DISABLE_DESKTOPS[@]}"; do
 done
 
 # ── Post-install scripts ─────────────────────────────────────────────────────
-readarray -t POST_SCRIPTS < <($YQ -r '.post_install[]' "${MANIFEST}" 2>/dev/null)
+readarray -t POST_SCRIPTS < <($YQ -r '.post_install[]' "${MANIFEST}" 2>/dev/null || true)
 for script in "${POST_SCRIPTS[@]}"; do
     if [[ -n "$script" && -f "${CONTEXT_PATH}/build_scripts/${script}" ]]; then
         echo "Running post-install: ${script}"
@@ -213,7 +213,7 @@ for script in "${POST_SCRIPTS[@]}"; do
 done
 
 # Inline post-install commands
-readarray -t POST_INLINE < <($YQ -r '.post_install_inline[]' "${MANIFEST}" 2>/dev/null)
+readarray -t POST_INLINE < <($YQ -r '.post_install_inline[]' "${MANIFEST}" 2>/dev/null || true)
 for cmd in "${POST_INLINE[@]}"; do
     if [[ -n "$cmd" ]]; then
         eval "$cmd"


### PR DESCRIPTION
Fixes all desktop builds failing when a manifest key is missing. `|| true` inside process substitutions prevents `set -e` from killing the script.