### PR TITLE
ci: add bonito-rawhide dispatch workflow

### DIFF
--- a/.github/workflows/build-bonito-rawhide.yml
+++ b/.github/workflows/build-bonito-rawhide.yml
@@ -1,0 +1,26 @@
+name: Build Bonito-Rawhide
+on:
+  workflow_dispatch:
+    inputs:
+      flavor:
+        description: 'Flavor (all, base, gnome, kde, niri, etc.)'
+        default: 'all'
+        type: string
+
+concurrency:
+  group: build-bonito-rawhide-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: 🐉-bonito-rawhide
+    uses: ./.github/workflows/build-variant.yml
+    with:
+      variant: 'bonito-rawhide'
+      flavor: ${{ inputs.flavor || 'all' }}
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}


### PR DESCRIPTION
bonito-rawhide variant already exists in build-config.yml and get-base-image.sh; this adds the workflow_dispatch trigger so it can be built in CI like every other variant.

**Checklist:**
- [x] Variant defined in build-config.yml
- [x] Base image mapped in get-base-image.sh
- [x] Uses same Containerfile as bonito (resolve-flavor.sh routes bonito-rawhide to Containerfile)
- [x] dispatch workflow created