### PR TITLE
fix(build): initialize IS_OPENSUSE and IS_GENTOO defaults in lib.sh

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -493,7 +493,7 @@ boot-gate variant flavor='gnome' tag='':
 # pairs, or a variant alone to gate its default desktop set.
 # Usage:
 #   just boot-gate-matrix yellowfin:gnome yellowfin:kde albacore:gnome
-#   just boot-gate-matrix yellowfin              # gnome kde cosmic niri xfce
+# just boot-gate-matrix yellowfin              # gnome kde cosmic niri xfce
 boot-gate-matrix +targets='yellowfin':
     ./scripts/boot-gate-matrix.sh {{ targets }}
 

--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -51,6 +51,8 @@ else
 	IS_DEBIAN=false
 	IS_ARCH=false
 	IS_CACHYOS=false
+	IS_OPENSUSE=false
+	IS_GENTOO=false
 
 	[[ "${BASE_IMAGE,,}" == *"fedora"* ]] && IS_FEDORA=true && IMAGE_NAME="bonito" && IMAGE_PRETTY_NAME="Bonito"
 	[[ "${BASE_IMAGE,,}" == *"red hat"* || "${BASE_IMAGE,,}" == *"rhel"* || "${BASE_IMAGE,,}" == *"redhat"* ]] && IS_RHEL=true && IMAGE_NAME="redfin" && IMAGE_PRETTY_NAME="Redfin"


### PR DESCRIPTION
## Problem
bonito-rawhide base build fails with:
```
/run/context/build_scripts/lib.sh: line 72: IS_OPENSUSE: unbound variable
```

## Root Cause
`IS_OPENSUSE` and `IS_GENTOO` are set conditionally by BASE_IMAGE pattern matching (for sailfin/guppy) but were never initialized to `false` in the defaults block. When `set -u` is active, referencing them in the package-manager selection block causes 'unbound variable' failures for any variant that doesn't match opensuse/gentoo (including bonito-rawhide).

## Fix
Add `IS_OPENSUSE=false` and `IS_GENTOO=false` to the OS detection flag defaults.

## Testing
- [x] CI passes (lint / shellcheck)
- [ ] bonito-rawhide base build succeeds after merge
- [x] Other variants unaffected (no behavior change — the flags were already false by default, just not declared)