### PR TITLE
fix(manifests): fix rawhide package availability for bonito-rawhide

### DIFF
--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -103,7 +103,4 @@ packages:
 
 post_install_inline:
   - "glib-compile-schemas /usr/share/glib-2.0/schemas || true"
-  - |
-    if [ -f /etc/pam.d/greetd ]; then
-      sed --sandbox -i -e '/gnome_keyring.so/ s/-auth/auth/ ; /gnome_keyring.so/ s/-session/session/' /etc/pam.d/greetd
-    fi
+  - "if [ -f /etc/pam.d/greetd ]; then sed --sandbox -i -e '/gnome_keyring.so/ s/-auth/auth/ ; /gnome_keyring.so/ s/-session/session/' /etc/pam.d/greetd; fi"

--- a/manifests/desktops/kde.yaml
+++ b/manifests/desktops/kde.yaml
@@ -30,7 +30,7 @@ packages:
       - kate
       - ark
       - plasma-discover
-      - kdeconnect
+      - kde-connect
       - xdg-desktop-portal-kde
       - qt5-qtwayland
       - qt6-qtwayland
@@ -85,7 +85,7 @@ packages:
       - PackageKit-command-not-found
     # Best-effort packages — installed if available in repos, skipped otherwise
     optional:
-      - kdeconnect
+      - kde-connect
       - ksshaskpass
       - ksystemlog
       - input-remapper

--- a/manifests/desktops/niri.yaml
+++ b/manifests/desktops/niri.yaml
@@ -30,7 +30,6 @@ packages:
       - xdg-user-dirs
       - pipewire
       - wireplumber
-      - polkit-gnome
       - NetworkManager-tui
       - brightnessctl
       - playerctl
@@ -41,6 +40,8 @@ packages:
       - nautilus
       - adw-gtk3-theme
       - papirus-icon-theme
+    optional:
+      - polkit-gnome
 
   el10:
     copr:
@@ -101,7 +102,4 @@ versionlock:
 
 post_install_inline:
   - "glib-compile-schemas /usr/share/glib-2.0/schemas || true"
-  - |
-    if [ -f /etc/pam.d/greetd ]; then
-      sed --sandbox -i -e '/gnome_keyring.so/ s/-auth/auth/ ; /gnome_keyring.so/ s/-session/session/' /etc/pam.d/greetd
-    fi
+  - "if [ -f /etc/pam.d/greetd ]; then sed --sandbox -i -e '/gnome_keyring.so/ s/-auth/auth/ ; /gnome_keyring.so/ s/-session/session/' /etc/pam.d/greetd; fi"

--- a/manifests/desktops/xfce.yaml
+++ b/manifests/desktops/xfce.yaml
@@ -7,7 +7,6 @@ packages:
     groups:
       - xfce-desktop
     packages:
-      - xfce4-wayland
       - gdm
       - xdg-desktop-portal-gtk
       - xdg-user-dirs-gtk
@@ -15,6 +14,8 @@ packages:
       - mousepad
       - ristretto
       - xfce4-terminal
+    optional:
+      - xfce4-wayland
 
   el10:
     groups:


### PR DESCRIPTION
## Problem
bonito-rawhide non-gnome desktop flavors fail with missing packages:
- KDE: package `kdeconnect` not found — renamed to `kde-connect` in Fedora
- Niri: `polkit-gnome` retired from Fedora (orphaned 6+ weeks)
- XFCE: `xfce4-wayland` not in Fedora repos (awaiting COPR release)
- Cosmic/Niri: multi-line `post_install_inline` if-blocks broken by readarray splitting

## Fixes
1. KDE: `kdeconnect` → `kde-connect` (correct Fedora package name)
2. Niri: move `polkit-gnome` to optional (best-effort)
3. XFCE: move `xfce4-wayland` to optional (matches EL10 convention)
4. Cosmic/Niri: flatten multi-line post_install_inline if-blocks to single lines

## Testing
- [x] CI passes (lint / shellcheck)
- [ ] bonito-rawhide KDE build succeeds
- [ ] bonito-rawhide Niri build succeeds (polkit-gnome skipped gracefully)
- [ ] bonito-rawhide XFCE build succeeds (xfce4-wayland skipped gracefully)
- [ ] bonito-rawhide Cosmic build succeeds (post_install_inline eval fixed)