### PR TITLE
feat(grouper): gnome-zfs — ZFS-root image foundation (#625) [draft]

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -645,6 +645,12 @@ variants:
         stage: 2
         build_image: true
         build_iso: true
+      # GNOME with ZFS-root support (prebuilt zfs.ko + zfs-dracut). ISO gated
+      # off until the install-to-filesystem ZFS-root path has a boot e2e (#625).
+      - id: gnome-zfs
+        stage: 2
+        build_image: true
+        build_iso: false
       - id: kde
         stage: 2
         build_image: true

--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -75,6 +75,11 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: true
+      - id: cosmic
+        stage: 2
+        build_image: true
+        build_iso: true
+        build_qcow2: false
 
       - id: kde
         stage: 2
@@ -331,6 +336,11 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: true
+      - id: cosmic
+        stage: 2
+        build_image: true
+        build_iso: true
+        build_qcow2: false
 
       - id: kde
         stage: 2
@@ -375,6 +385,26 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: cosmic-nvidia
+        stage: 3
+        build_image: true
+        build_iso: true
+        build_qcow2: false
+      - id: kde-hwe
+        stage: 3
+        build_image: true
+        build_iso: false
+        build_qcow2: false
+      - id: kde-nvidia
+        stage: 3
+        build_image: true
+        build_iso: true
+        build_qcow2: false
+      - id: niri-hwe
+        stage: 3
+        build_image: true
+        build_iso: false
+        build_qcow2: false
+      - id: niri-nvidia
         stage: 3
         build_image: true
         build_iso: true

--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -1,0 +1,165 @@
+name: LUKS E2E
+
+# Full disk-encryption end-to-end test for every variant+flavor combo that
+# builds an ISO. For each cell we build a *dev* ISO (ENABLE_SSHD=1 — the live
+# env needs SSH to drive the install), then scripts/iso-e2e.sh --luks:
+#   1. boots the live ISO under QEMU with an emulated TPM 2.0 (swtpm),
+#   2. runs `bootc install to-disk --block-setup tpm2-luks /dev/vda`,
+#   3. reboots the installed disk with the *same* TPM and confirms the
+#      encrypted root auto-unlocks (reaching the login target proves it).
+#
+# tpm2-luks is permitted by system_files/usr/lib/bootc/install/00-tunaos.toml
+# (block = ["direct", "tpm2-luks"]).
+#
+# This is expensive (a dev ISO build + two QEMU boots per cell), so it only
+# runs on demand or weekly — never per push. Modelled on iso-e2e.yml and
+# projectbluefin/dakota-iso's luks-*-qemu recipes.
+
+on:
+  workflow_dispatch:
+    inputs:
+      variant:
+        description: "Variant filter (or 'all')"
+        required: false
+        default: "all"
+        type: string
+      flavor:
+        description: "Flavor filter (or 'all')"
+        required: false
+        default: "all"
+        type: string
+  schedule:
+    # Weekly, Tuesday 07:00 UTC — after the Monday iso-e2e smoke run.
+    - cron: "0 7 * * 2"
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  # Build the {variant, flavor} matrix from build-config.yml (every build_iso
+  # flavor), optionally narrowed by the workflow_dispatch filters.
+  generate-matrix:
+    name: Generate matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install yq
+        run: |
+          sudo curl -fsSL -o /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Generate matrix
+        id: gen
+        env:
+          FILTER_VARIANT: ${{ inputs.variant || 'all' }}
+          FILTER_FLAVOR: ${{ inputs.flavor || 'all' }}
+        run: |
+          set -euo pipefail
+          json="$(yq -o=json '.' .github/build-config.yml)"
+          matrix="$(echo "$json" | jq -c \
+            --arg fv "$FILTER_VARIANT" --arg ff "$FILTER_FLAVOR" \
+            '{include: [ .variants[] | .id as $v | .flavors[]
+               | select(.build_iso == true)
+               | {variant: $v, flavor: .id}
+               | select($fv == "all" or .variant == $fv)
+               | select($ff == "all" or .flavor == $ff) ]}')"
+          count="$(echo "$matrix" | jq '.include | length')"
+          echo "Matrix has ${count} cell(s)"
+          echo "$matrix" | jq .
+          if [[ "$count" -eq 0 ]]; then
+            echo "::error::No matching variant/flavor cells"
+            exit 1
+          fi
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+
+  luks:
+    name: LUKS ${{ matrix.variant }}:${{ matrix.flavor }}
+    needs: generate-matrix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # The dev ISO and install disk are large; reclaim ~25 GB first.
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
+          df -h /
+
+      - name: Maximize build space
+        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6 # main as of 2026-02-11
+
+      # ubuntu-24.04 exposes /dev/kvm as root:kvm 0660; widen so the QEMU child
+      # (and its swtpm) can open it. Without KVM the LUKS boot is far too slow.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | \
+            sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm || true
+          ls -la /dev/kvm 2>/dev/null && echo "KVM available" || echo "Warning: no /dev/kvm — TCG (slow)"
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            just podman jq \
+            qemu-system-x86 qemu-utils ovmf swtpm socat sshpass imagemagick \
+            systemd-boot-efi mtools squashfs-tools xorriso dosfstools gdisk
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      # Build a dev (SSHD-enabled) live ISO for this cell. dev=1 wires the
+      # liveuser SSH login that iso-e2e.sh --luks drives the install over.
+      - name: Build dev ISO
+        env:
+          VARIANT: ${{ matrix.variant }}
+          FLAVOR: ${{ matrix.flavor }}
+        run: |
+          export TACKLEBOX_FROM_SOURCE=1
+          just iso "${VARIANT}" "${FLAVOR}" ghcr "" 1
+          ISO=$(find .build -maxdepth 3 -name "*.iso" | head -1)
+          [[ -n "$ISO" ]] || { echo "::error::dev ISO not produced"; exit 1; }
+          echo "ISO_PATH=${ISO}" >> "$GITHUB_ENV"
+
+      - name: LUKS install + unlock verification
+        run: |
+          mkdir -p luks-out
+          sudo ./scripts/iso-e2e.sh "${ISO_PATH}" --luks \
+            --output luks-out \
+            --timeout 1200
+
+      - name: Collect evidence
+        if: always()
+        run: |
+          sudo chown -R "$USER:$(id -gn)" luks-out 2>/dev/null || true
+          for ppm in luks-out/*.ppm; do
+            [[ -f "$ppm" ]] || continue
+            convert "$ppm" "${ppm%.ppm}.png" || true
+          done
+
+      - name: Upload LUKS evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: luks-e2e-${{ matrix.variant }}-${{ matrix.flavor }}
+          path: |
+            luks-out/serial.log
+            luks-out/*.png
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/reusable-build-artifacts.yml
+++ b/.github/workflows/reusable-build-artifacts.yml
@@ -67,6 +67,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      # Reclaim ~25 GB of preinstalled toolchains from the main disk. The ISO is
+      # assembled under .build/ on the workspace (main disk), not the
+      # container-storage volume, so large desktop/NVIDIA ISOs can overflow it
+      # during xorriso -commit ("Image size exceeds free space on media").
+      # (Does not touch the node runtime / tool cache used by actions.)
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
+          df -h /
+
       - name: Maximize build space
         uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6 # main as of 2026-02-11
 

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -715,6 +715,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v4
 
+      # Reclaim ~25 GB of preinstalled toolchains from the main disk. The qcow2
+      # is written to the workspace (main disk), not the container-storage
+      # volume, so large desktop/NVIDIA images can exhaust it during `just
+      # qcow2`. (Does not touch the node runtime / tool cache used by actions.)
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
+          df -h /
+
       - name: Maximize build space
         uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6 # main as of 2026-02-11
 

--- a/Containerfile.guppy
+++ b/Containerfile.guppy
@@ -52,9 +52,10 @@ RUN sed -i 's|^HOME=.*|HOME=/var/home|' "/etc/default/useradd" && \
 
 # Base (no desktop) — the `base` flavor targets this. resolve-flavor.sh maps
 # base → DESKTOP_FLAVOR=base-no-de, and the build does `--target=<flavor>`.
+# (Matches the main Containerfile's base stage: label it bootable, no lint —
+# the lint gate lives on the desktop stages.)
 FROM system AS base-no-de
 LABEL containers.bootc=1 ostree.bootable=1
-RUN bootc container lint
 
 # Desktop stage — manifest-driven; the DESKTOP_FLAVOR build-arg selects the DE.
 FROM system AS desktop

--- a/Containerfile.guppy
+++ b/Containerfile.guppy
@@ -50,7 +50,13 @@ RUN sed -i 's|^HOME=.*|HOME=/var/home|' "/etc/default/useradd" && \
     echo "d /run/media 0755 root root -" >> /usr/lib/tmpfiles.d/bootc-base-dirs.conf && \
     printf '[composefs]\nenabled = yes\n[sysroot]\nreadonly = true\n' > /usr/lib/ostree/prepare-root.conf
 
-# Desktop stage — manifest-driven
+# Base (no desktop) — the `base` flavor targets this. resolve-flavor.sh maps
+# base → DESKTOP_FLAVOR=base-no-de, and the build does `--target=<flavor>`.
+FROM system AS base-no-de
+LABEL containers.bootc=1 ostree.bootable=1
+RUN bootc container lint
+
+# Desktop stage — manifest-driven; the DESKTOP_FLAVOR build-arg selects the DE.
 FROM system AS desktop
 ARG DESKTOP_FLAVOR
 ENV DESKTOP_FLAVOR=${DESKTOP_FLAVOR}
@@ -59,3 +65,9 @@ RUN --mount=type=bind,from=context,source=/,target=/run/context \
 
 LABEL containers.bootc=1 ostree.bootable=1
 RUN bootc container lint
+
+# Per-flavor target aliases so the build's `--target=<flavor>` resolves. Each
+# resolves to the desktop stage above, specialized by the DESKTOP_FLAVOR
+# build-arg (target and build-arg always agree — see resolve-flavor.sh).
+FROM desktop AS gnome
+FROM desktop AS kde

--- a/Containerfile.sailfin
+++ b/Containerfile.sailfin
@@ -58,7 +58,13 @@ RUN cp -rn /usr/etc/. /etc/ 2>/dev/null; rm -rf /usr/etc
 RUN printf '# NTP pool\npool pool.ntp.org iburst\n\ndriftfile /var/lib/chrony/drift\nmakestep 1.0 3\nrtcsync\n' > /etc/chrony.conf
 RUN printf 'd /var/lib/chrony 0750 chrony chrony\n' >> /usr/lib/tmpfiles.d/chrony.conf
 
-# Desktop stage — manifest-driven
+# Base (no desktop) — the `base` flavor targets this. resolve-flavor.sh maps
+# base → DESKTOP_FLAVOR=base-no-de, and the build does `--target=<flavor>`.
+FROM system AS base-no-de
+LABEL containers.bootc=1 ostree.bootable=1
+RUN bootc container lint
+
+# Desktop stage — manifest-driven; the DESKTOP_FLAVOR build-arg selects the DE.
 FROM system AS desktop
 ARG DESKTOP_FLAVOR
 ENV DESKTOP_FLAVOR=${DESKTOP_FLAVOR}
@@ -67,3 +73,11 @@ RUN --mount=type=bind,from=context,source=/,target=/run/context \
 
 LABEL containers.bootc=1 ostree.bootable=1
 RUN bootc container lint
+
+# Per-flavor target aliases so the build's `--target=<flavor>` resolves. Each
+# resolves to the desktop stage above, specialized by the DESKTOP_FLAVOR
+# build-arg (target and build-arg always agree — see resolve-flavor.sh).
+FROM desktop AS gnome
+FROM desktop AS kde
+FROM desktop AS niri
+FROM desktop AS xfce

--- a/Containerfile.sailfin
+++ b/Containerfile.sailfin
@@ -19,18 +19,22 @@ COPY system_files_overrides /run/context/overrides
 
 FROM ${BASE_IMAGE} AS base
 
-FROM base AS builder
-RUN zypper install -y binutils cargo git go-md2man libostree-devel make rust
-WORKDIR /home/build
-RUN git clone --depth 1 https://github.com/bootc-dev/bootc.git . && \
-    make bin && make install-all DESTDIR=/output
-
 FROM base AS system
-COPY --from=builder /output /
-RUN zypper install -y \
+# Install bootc from the openSUSE Virtualization:containers OBS project rather
+# than building it from git. The source build linked a libssl soname the
+# runtime image doesn't ship (libssl.so.60 — see #643); the packaged bootc has
+# correct runtime deps and bundles the 51bootc dracut module. Also faster (no
+# cargo compile). Verified: bootc 1.15.2 install/lint work on Tumbleweed.
+RUN zypper --non-interactive addrepo -fG \
+      "https://download.opensuse.org/repositories/Virtualization:/containers/openSUSE_Tumbleweed/" \
+      virtualization-containers && \
+    zypper --non-interactive --gpg-auto-import-keys refresh && \
+    zypper install -y \
+    bootc \
     btrfs-progs cpio dosfstools dracut e2fsprogs glib2 \
     kernel-default kernel-firmware-all openssh ostree skopeo \
     systemd systemd-boot udev xfsprogs zstd chrony && \
+    zypper --non-interactive removerepo virtualization-containers && \
     zypper install -y -t pattern enhanced_base && \
     systemctl enable sshd && \
     systemctl mask systemd-firstboot.service

--- a/Containerfile.sailfin
+++ b/Containerfile.sailfin
@@ -60,9 +60,10 @@ RUN printf 'd /var/lib/chrony 0750 chrony chrony\n' >> /usr/lib/tmpfiles.d/chron
 
 # Base (no desktop) — the `base` flavor targets this. resolve-flavor.sh maps
 # base → DESKTOP_FLAVOR=base-no-de, and the build does `--target=<flavor>`.
+# (Matches the main Containerfile's base stage: label it bootable, no lint —
+# the lint gate lives on the desktop stages.)
 FROM system AS base-no-de
 LABEL containers.bootc=1 ostree.bootable=1
-RUN bootc container lint
 
 # Desktop stage — manifest-driven; the DESKTOP_FLAVOR build-arg selects the DE.
 FROM system AS desktop

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -137,7 +137,7 @@ RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
-  bash -c "source /run/context/build_scripts/lib.sh && source /run/context/build_scripts/10-base-packages.sh && install_base_packages_no_de"
+  bash -c "source /run/context/build_scripts/lib.sh && source /run/context/build_scripts/10-base-packages.sh"
 
 # Desktop-agnostic additional packages (apt branch in the script).
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -227,3 +227,20 @@ RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
 RUN --mount=type=tmpfs,dst=/tmp \
   --mount=type=bind,from=context,source=/,target=/run/context \
   /run/context/build_scripts/bootc/finalize.sh
+
+# GNOME + ZFS-root support. zfs.sh installs the prebuilt zfs.ko, the userspace
+# tools and the dracut 90zfs module BEFORE finalize.sh builds the initramfs and
+# bootcifies (apt is unusable afterwards). Enables `bootc install to-filesystem`
+# onto a ZFS root — bootc has no `--filesystem zfs`. See tuna-os/tunaOS#625.
+FROM base-no-de AS gnome-zfs
+RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
+  --mount=type=tmpfs,dst=/boot \
+  --mount=type=bind,from=context,source=/,target=/run/context \
+  /run/context/build_scripts/gnome.sh base
+RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
+  --mount=type=tmpfs,dst=/boot \
+  --mount=type=bind,from=context,source=/,target=/run/context \
+  /run/context/build_scripts/zfs.sh
+RUN --mount=type=tmpfs,dst=/tmp \
+  --mount=type=bind,from=context,source=/,target=/run/context \
+  /run/context/build_scripts/bootc/finalize.sh

--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -78,6 +78,17 @@ if [[ "$PKG_MGR" == "apt" ]]; then
 fi
 # ── dnf (RPM) path continues below ────────────────────────────────────
 
+# Speed up every dnf transaction in this and all downstream RUN layers.
+# max_parallel_downloads fetches packages concurrently — the single biggest
+# win, since RPM downloads dominate build time on the EL10/Fedora variants.
+# The setting persists in /etc/dnf/dnf.conf so 20-packages, install-desktop,
+# etc. all inherit it, and it changes nothing about *what* is installed.
+# (fastestmirror is deliberately not enabled — the codebase already disables
+# it for epel-multimedia; the mirror probe can hurt more than it helps.)
+if [[ -f /etc/dnf/dnf.conf ]] && ! grep -q '^max_parallel_downloads' /etc/dnf/dnf.conf; then
+	echo 'max_parallel_downloads=10' >>/etc/dnf/dnf.conf
+fi
+
 # This thing slows down downloads A LOT for no reason
 if [[ $IS_CENTOS == true ]]; then
 	dnf remove -y subscription-manager

--- a/build_scripts/gnome.sh
+++ b/build_scripts/gnome.sh
@@ -62,15 +62,14 @@ case "${1:-}" in
 		fi
 
 		# GNOME 50 requires glib2 >= 2.86.0 and fontconfig >= 2.17.0 (pango links
-			# against FcConfigSetDefaultSubstitute which is absent in EL10's 2.15.x).
-			# selinux-policy 43.x from COPR is required for GDM 50 userdb socket policy;
-			# the base EL10 42.x policy denies the Varlink socket even in permissive mode.
-			# gobject-introspection 1.84 and gjs 1.86 are also upgraded from COPR:
-			# gnome-shell links libgirepository-1.0 but gjs links libgirepository-2.0;
-			# having both loaded causes GIRepository type double-registration → crash.
-			dnf -y upgrade glib2 fontconfig gobject-introspection gjs
-			dnf_retry -y install --allowerasing gnome50-el10-compat
-		fi
+		# against FcConfigSetDefaultSubstitute which is absent in EL10's 2.15.x).
+		# selinux-policy 43.x from COPR is required for GDM 50 userdb socket policy;
+		# the base EL10 42.x policy denies the Varlink socket even in permissive mode.
+		# gobject-introspection 1.84 and gjs 1.86 are also upgraded from COPR:
+		# gnome-shell links libgirepository-1.0 but gjs links libgirepository-2.0;
+		# having both loaded causes GIRepository type double-registration → crash.
+		dnf -y upgrade glib2 fontconfig gobject-introspection gjs
+		dnf_retry -y install --allowerasing gnome50-el10-compat
 	fi
 
 	# Mask rpm-ostree kernel-install script to prevent dracut errors during container build

--- a/build_scripts/zfs.sh
+++ b/build_scripts/zfs.sh
@@ -40,12 +40,23 @@ pkg_install \
 # Load zfs early.
 echo zfs >/etc/modules-load.d/zfs.conf
 
+# zfs-dracut must have dropped the 90zfs module — dracut in finalize.sh fails
+# with "Module 'zfs' cannot be found" otherwise. Verify loudly rather than ship
+# a non-bootable ZFS initramfs.
+if [[ ! -d /usr/lib/dracut/modules.d/90zfs ]]; then
+	echo "ERROR: zfs-dracut did not install the dracut 90zfs module" >&2
+	exit 1
+fi
+
 # finalize.sh runs `dracut --no-hostonly`, which won't auto-detect a ZFS root
 # at image-build time, so force the zfs module into every initramfs it builds.
+# (Mirrors the proven approach in tuna-os/ubuntu, which passes
+# `dracut --add "dmsquash-live zfs"`.)
 mkdir -p /etc/dracut.conf.d
 printf 'add_dracutmodules+=" zfs "\n' >/etc/dracut.conf.d/90-tunaos-zfs.conf
 
 depmod "${KVER}" || true
 
-echo "zfs.sh: ZFS module + tools + dracut zfs module wired for ${KVER}"
-echo "zfs.sh: finalize.sh will now build a ZFS-capable initramfs."
+echo "zfs.sh: ZFS module + tools + dracut 90zfs module wired for ${KVER}"
+echo "zfs.sh: finalize.sh will build a ZFS-capable initramfs; the ZFS-root"
+echo "        installer ships at /usr/local/bin/zfs-install (from tuna-os/ubuntu)."

--- a/build_scripts/zfs.sh
+++ b/build_scripts/zfs.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# zfs.sh — bake ZFS root support into an image (Ubuntu/apt only; grouper's
+# gnome-zfs flavor). Runs BEFORE finalize.sh, because finalize.sh builds the
+# dracut initramfs and then bootcifies the rootfs (apt is unusable afterwards).
+#
+# NOTE: this only makes the image *capable* of a ZFS root. bootc has no
+# `install to-disk --filesystem zfs` (only xfs/ext4/btrfs); a ZFS root is
+# installed with `bootc install to-filesystem` onto a pre-created zpool, and —
+# because the default composefs backend needs fs-verity, which ZFS lacks — a
+# non-composefs / --allow-missing-verity deployment. See tuna-os/tunaOS#625.
+
+set -xeuo pipefail
+
+source /run/context/build_scripts/lib.sh
+
+if [[ "$PKG_MGR" != "apt" ]]; then
+	echo "zfs.sh: ZFS root support is only implemented for apt (Ubuntu) images; skipping"
+	exit 0
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+# The image's kernel version — the prebuilt ZFS module is version-locked to it.
+KVER="$(ls /usr/lib/modules | sort -V | tail -1)"
+echo "zfs.sh: targeting kernel ${KVER}"
+
+apt-get update -qq
+
+# - linux-modules-extra-<kver>: Ubuntu's prebuilt, signed zfs.ko (no DKMS).
+# - zfsutils-linux:             zfs/zpool userspace.
+# - zfs-dracut:                 the dracut 90zfs module (grouper builds its
+#                               initramfs with dracut in finalize.sh, not
+#                               initramfs-tools, so zfs-initramfs is the wrong
+#                               integration here).
+pkg_install \
+	"linux-modules-extra-${KVER}" \
+	zfsutils-linux \
+	zfs-dracut
+
+# Load zfs early.
+echo zfs >/etc/modules-load.d/zfs.conf
+
+# finalize.sh runs `dracut --no-hostonly`, which won't auto-detect a ZFS root
+# at image-build time, so force the zfs module into every initramfs it builds.
+mkdir -p /etc/dracut.conf.d
+printf 'add_dracutmodules+=" zfs "\n' >/etc/dracut.conf.d/90-tunaos-zfs.conf
+
+depmod "${KVER}" || true
+
+echo "zfs.sh: ZFS module + tools + dracut zfs module wired for ${KVER}"
+echo "zfs.sh: finalize.sh will now build a ZFS-capable initramfs."

--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -95,11 +95,13 @@ packages:
       - wl-clipboard
       - xdg-user-dirs
       - zram-generator
+      # Keyring is essential: the greetd PAM patch below wires gnome-keyring into
+      # the login flow. Both are in EL10 appstream, so require (not best-effort).
+      - gnome-keyring
+      - gnome-keyring-pam
     optional:
       - brightnessctl
       - playerctl
-      - gnome-keyring
-      - gnome-keyring-pam
 
 post_install_inline:
   - "glib-compile-schemas /usr/share/glib-2.0/schemas || true"

--- a/manifests/desktops/niri.yaml
+++ b/manifests/desktops/niri.yaml
@@ -45,10 +45,6 @@ packages:
 
   el10:
     copr:
-      - repo: zirconium/packages
-        packages:
-          - greetd
-          - greetd-selinux
       - repo: yalter/niri-git
         packages:
           - niri
@@ -64,21 +60,32 @@ packages:
           # packaged for EL10 in this COPR — same source as the sway stack.
           - brightnessctl
           - playerctl
-      # adw-gtk3-theme has no EL10 base/EPEL build; pull it from the same COPR
-      # the cosmic manifest uses (yselkowitz/cosmic-epel).
+      # greetd/greetd-selinux (DM) and adw-gtk3-theme have no EL10 base/EPEL
+      # build; pull them from the COPR the cosmic manifest uses. (The old
+      # zirconium/packages and ligenix/enterprise-cosmic COPRs have no EL10
+      # chroot — `dnf copr enable` hard-fails on them.)
       - repo: yselkowitz/cosmic-epel
         packages:
+          - greetd
+          - greetd-selinux
           - adw-gtk3-theme
-      - repo: ligenix/enterprise-cosmic
-        packages: []  # just enable for deps
+        options: "--nobest --allowerasing"
+      # DMS (DankMaterialShell) suite: quickshell-git + dms-greeter live in the
+      # danklinux COPR, dms/dms-cli in dms-git, and they cross-depend. Installing
+      # dms-greeter from the dms-git block alone fails ("no match") and, because
+      # copr installs are best-effort, silently drops the whole shell. Install
+      # the suite from one block with danklinux (+ cosmic-epel for the
+      # dms-greeter→greetd dep) enabled, mirroring build_scripts/niri.sh. The
+      # danklinux block is enable-only so its repo file exists for --enablerepo.
       - repo: avengemedia/danklinux
-        packages:
-          - quickshell-git
+        packages: []
       - repo: avengemedia/dms-git
         packages:
+          - quickshell-git
           - dms
           - dms-cli
           - dms-greeter
+        options: "--enablerepo=copr:copr.fedorainfracloud.org:avengemedia:danklinux --enablerepo=copr:copr.fedorainfracloud.org:yselkowitz:cosmic-epel"
     packages:
       - xdg-desktop-portal-gnome
       - xdg-desktop-portal-gtk

--- a/manifests/desktops/niri.yaml
+++ b/manifests/desktops/niri.yaml
@@ -60,6 +60,15 @@ packages:
           - fuzzel
           - swayidle
           - wl-clipboard
+          # brightnessctl (backlight) and playerctl (media keys) are only
+          # packaged for EL10 in this COPR — same source as the sway stack.
+          - brightnessctl
+          - playerctl
+      # adw-gtk3-theme has no EL10 base/EPEL build; pull it from the same COPR
+      # the cosmic manifest uses (yselkowitz/cosmic-epel).
+      - repo: yselkowitz/cosmic-epel
+        packages:
+          - adw-gtk3-theme
       - repo: ligenix/enterprise-cosmic
         packages: []  # just enable for deps
       - repo: avengemedia/danklinux
@@ -76,18 +85,19 @@ packages:
       - xdg-user-dirs
       - pipewire
       - wireplumber
-      - polkit-gnome
+      # polkit-gnome was retired Fedora-wide and has no EL10 build; polkit-kde
+      # is the only GUI polkit authentication agent packaged for EL10 (EPEL).
+      # It runs fine under any Wayland compositor.
+      - polkit-kde
       - NetworkManager-tui
       - nautilus
-      - adw-gtk3-theme
-      - papirus-icon-theme
-    optional:
-      - brightnessctl
-      - playerctl
-      - blueman
       - pavucontrol
       - gnome-keyring
       - gnome-keyring-pam
+      - papirus-icon-theme
+      # NOTE: blueman (Bluetooth applet) has no EL10/EPEL 10 build, so it is
+      # intentionally absent here (present in the Fedora section). No packaged
+      # standalone Bluetooth GUI exists for EL10 niri yet.
 
   zypper:
     - niri

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -28,6 +28,15 @@
 #       reaches a graphical session (serial marker or screenshot sanity).
 #       Used to gate GHCR tag promotion on images actually booting.
 #
+#   scripts/iso-e2e.sh <iso_path> --luks
+#       Full LUKS e2e: boot the live ISO (needs ENABLE_SSHD=1), run
+#       `bootc install to-disk --block-setup tpm2-luks` against an emulated
+#       TPM 2.0 (swtpm), then reboot the installed disk with the same TPM and
+#       confirm the encrypted root auto-unlocks (reaching the login target
+#       proves it — a missing/wrong TPM would hang in the initramfs). Requires
+#       the swtpm package and an image whose bootc install config permits
+#       tpm2-luks.
+#
 # Options:
 #   --timeout SEC         Per-phase timeout (default: 300)
 #   --output DIR          Where serial logs / screenshots are written
@@ -63,6 +72,7 @@ MEMORY=4096
 CPUS=4
 NO_KVM=0
 KEEP_VM=0
+LUKS=0
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
@@ -70,6 +80,16 @@ while [[ $# -gt 0 ]]; do
 		MODE="kickstart"
 		KICKSTART="$2"
 		shift 2
+		;;
+	--luks)
+		# LUKS e2e: install to disk with tpm2-luks against an emulated TPM
+		# (swtpm), then reboot and confirm the root volume auto-unlocks. Reuses
+		# the ssh install-to-disk flow (bootc, not anaconda). Reaching the login
+		# target on reboot proves the unlock worked — a wrong/absent TPM would
+		# hang the boot in the initramfs at the cryptsetup prompt.
+		MODE="ssh"
+		LUKS=1
+		shift
 		;;
 	--app-launch)
 		MODE="app-launch"
@@ -232,6 +252,43 @@ SERIAL_LOG="${OUTPUT_DIR}/serial.log"
 INSTALL_DISK="${OUTPUT_DIR}/install-disk.qcow2"
 QEMU_PIDFILE="${OUTPUT_DIR}/qemu.pid"
 
+# ── Emulated TPM 2.0 (swtpm) — LUKS mode only ───────────────────────────────
+# The install-time enrollment (systemd-cryptenroll --tpm2-device=auto) and the
+# reboot-time unlock must see the SAME TPM state, so a single swtpm instance is
+# started once and its socket attached to every QEMU launch below. TPM_ARGS is
+# empty unless --luks is set, so non-LUKS modes are byte-for-byte unchanged.
+TPM_DIR="${OUTPUT_DIR}/swtpm"
+TPM_SOCK="${TPM_DIR}/swtpm-sock"
+TPM_PIDFILE="${TPM_DIR}/swtpm.pid"
+TPM_ARGS=""
+
+start_swtpm() {
+	command -v swtpm &>/dev/null || {
+		echo "ERROR: --luks requires swtpm (install the 'swtpm' package)" >&2
+		return 77
+	}
+	rm -rf "$TPM_DIR"
+	mkdir -p "$TPM_DIR"
+	echo "==> Starting swtpm (TPM 2.0) at ${TPM_SOCK}"
+	swtpm socket \
+		--tpmstate "dir=${TPM_DIR}" \
+		--ctrl "type=unixio,path=${TPM_SOCK}" \
+		--tpm2 \
+		--flags startup-clear \
+		--daemon \
+		--pid "file=${TPM_PIDFILE}"
+	for _ in $(seq 1 20); do
+		[[ -S "$TPM_SOCK" ]] && break
+		sleep 0.5
+	done
+	[[ -S "$TPM_SOCK" ]] || {
+		echo "ERROR: swtpm socket did not appear" >&2
+		return 1
+	}
+	# tpm-crb is the CRB interface OVMF/edk2 measures into; works on q35 and pc.
+	TPM_ARGS="-chardev socket,id=chrtpm,path=${TPM_SOCK} -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-crb,tpmdev=tpm0"
+}
+
 # Fresh OVMF NVRAM each run — UEFI writes state during install (boot order,
 # secure-boot vars). Reusing a stale one masks regressions.
 if [[ -n "$OVMF_VARS_SRC" ]]; then
@@ -265,8 +322,20 @@ cleanup_vm() {
 			kill -KILL "$pid" 2>/dev/null || true
 		fi
 	fi
+	# Tear down the emulated TPM (LUKS mode).
+	if [[ -f "$TPM_PIDFILE" ]]; then
+		local tpid
+		tpid=$(cat "$TPM_PIDFILE" 2>/dev/null || true)
+		[[ -n "$tpid" ]] && kill "$tpid" 2>/dev/null || true
+	fi
 }
 trap cleanup_vm EXIT
+
+# Bring up the emulated TPM before any QEMU launch so both the install boot and
+# the post-install reboot attach the same TPM state.
+if [[ "$LUKS" -eq 1 ]]; then
+	start_swtpm || exit $?
+fi
 
 # ── Boot the live ISO ───────────────────────────────────────────────────────
 
@@ -299,6 +368,7 @@ boot_live_iso() {
 	echo "==> Booting ISO: ${ISO_PATH}"
 	echo "==> Accel: ${ACCEL}, CPU: ${CPU_ARG}, MEM: ${MEMORY}M, CPUS: ${CPUS}"
 
+	# shellcheck disable=SC2086  # TPM_ARGS is intentionally word-split (empty unless --luks)
 	"$QEMU" \
 		-name "tunaos-iso-e2e" \
 		-machine pc \
@@ -306,6 +376,7 @@ boot_live_iso() {
 		-accel "$ACCEL" \
 		-m "$MEMORY" \
 		-smp "$CPUS" \
+		${TPM_ARGS} \
 		-drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
 		-drive "if=pflash,format=raw,file=${OVMF_VARS}" \
 		-drive "if=none,id=iso,file=${ISO_PATH},media=cdrom,readonly=on,format=raw" \
@@ -493,6 +564,10 @@ run_kickstart() {
 	# which doesn't shell out to bootupd for bootloader management.
 	local install_args=""
 	[[ "${VARIANT:-}" == "grouper" ]] && install_args="--composefs-backend"
+	# LUKS e2e: encrypt root and seal the unlock key to the emulated TPM. The
+	# image must permit this (block = [..,"tpm2-luks"] in its bootc install
+	# config); TunaOS ships that in usr/lib/bootc/install/00-tunaos.toml.
+	[[ "$LUKS" -eq 1 ]] && install_args="${install_args} --block-setup tpm2-luks"
 
 	echo "==> Running bootc install to-disk /dev/vda ${install_args}..."
 	sshpass -p live ssh -o StrictHostKeyChecking=no -p 2222 liveuser@127.0.0.1 \
@@ -503,6 +578,18 @@ run_kickstart() {
 			return 3
 		fi
 	}
+
+	# Assert the install actually set up LUKS + TPM enrollment (bootc prints
+	# these). Guards against a silent fallback to a plain (direct) install that
+	# would still boot and pass the reached-target check below.
+	if [[ "$LUKS" -eq 1 ]]; then
+		if grep -qiE "Initializing LUKS|Enrolling.*TPM|tpm2-luks" "${SERIAL_LOG}"; then
+			echo "==> LUKS root + TPM enrollment confirmed in install output."
+		else
+			echo "ERROR: --luks set but no LUKS/TPM enrollment seen in install output"
+			return 3
+		fi
+	fi
 
 	echo "==> bootc install complete. Shutting down..."
 	sshpass -p live ssh -o StrictHostKeyChecking=no -p 2222 liveuser@127.0.0.1 \
@@ -524,6 +611,7 @@ run_kickstart() {
 
 	echo "==> Booting installed system..."
 	# Boot from the install disk (remove cdrom)
+	# shellcheck disable=SC2086  # TPM_ARGS is intentionally word-split (empty unless --luks)
 	"$QEMU" \
 		-name "tunaos-iso-e2e-installed" \
 		-machine pc \
@@ -531,6 +619,7 @@ run_kickstart() {
 		-accel "$ACCEL" \
 		-m "$MEMORY" \
 		-smp "$CPUS" \
+		${TPM_ARGS} \
 		-drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
 		-drive "if=pflash,format=raw,file=${OVMF_VARS}" \
 		-drive "if=none,id=disk,file=${INSTALL_DISK},format=qcow2" \

--- a/system_files/usr/local/bin/zfs-install
+++ b/system_files/usr/local/bin/zfs-install
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# zfs-install — install Ubuntu 26.04 bootc image onto a ZFS root filesystem.
+#
+# Usage:
+#   sudo zfs-install /dev/sdX [--pool-name rpool] [--imgref <ref>] [--encrypt]
+#
+# The live ISO filesystem itself is NOT ZFS — this script only sets up ZFS on
+# the *installation target* disk.  The live session needs zfsutils-linux
+# (provided by the base bootc image which this ISO is built FROM).
+#
+# Flow:
+#   1. Wipe + GPT partition: 512M EFI + ZFS remainder
+#   2. Create pool with -R /mnt/target (altroot keeps live-system root safe)
+#   3. Create rpool/root (canmount=noauto) + rpool/var (canmount=noauto)
+#      /home is NOT a separate dataset — bootc symlinks /home → /var/home
+#   4. Mount ONLY rpool/root at /mnt/target; mount EFI; no /var pre-mount
+#      (bootc install to-filesystem rejects targets with extra mounts)
+#   5. bootc install to-filesystem with spl_hostid karg
+#   6. Post-install: set canmount=on, write /etc/hostid + zpool.cache
+#   7. Clean zpool export before reboot
+
+set -euo pipefail
+
+die()  { echo "ERROR: $*" >&2; exit 1; }
+info() { echo "==> $*"; }
+
+require_cmd() {
+    for cmd in "$@"; do
+        command -v "${cmd}" >/dev/null 2>&1 || die "Required command not found: ${cmd}"
+    done
+}
+
+cleanup() {
+    info "Cleaning up..."
+    umount /mnt/target/boot/efi 2>/dev/null || true
+    zpool export "${POOL_NAME}" 2>/dev/null || true
+}
+
+# ── args ──────────────────────────────────────────────────────────────────────
+
+DISK=""
+POOL_NAME="rpool"
+IMGREF=""
+ENCRYPTION=0
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --pool-name) POOL_NAME="$2"; shift 2 ;;
+        --imgref)    IMGREF="$2";    shift 2 ;;
+        --encrypt)   ENCRYPTION=1;   shift   ;;
+        -*)          die "Unknown option: $1" ;;
+        *)           DISK="$1";      shift ;;
+    esac
+done
+
+[[ -n "${DISK}" ]]    || die "Usage: zfs-install /dev/sdX [--pool-name rpool] [--imgref <ref>] [--encrypt]"
+[[ -b "${DISK}" ]]    || die "Not a block device: ${DISK}"
+[[ "${EUID}" -eq 0 ]] || die "Must run as root"
+
+require_cmd sgdisk mkfs.fat zpool zfs bootc
+
+if [[ "${DISK}" =~ nvme|mmcblk|loop ]]; then
+    EFI_PART="${DISK}p1"; ZFS_PART="${DISK}p2"
+else
+    EFI_PART="${DISK}1";  ZFS_PART="${DISK}2"
+fi
+
+if [[ -z "${IMGREF}" ]]; then
+    if [[ -f /etc/bootc-installer/images.json ]]; then
+        IMGREF=$(python3 -c "import json; print(json.load(open('/etc/bootc-installer/images.json'))['local_imgref'])" 2>/dev/null) || true
+    fi
+    [[ -n "${IMGREF}" ]] || IMGREF="ghcr.io/hanthor/ubuntu-26.04-desktop-bootc:latest"
+fi
+
+HOSTID_HEX=$(hostid 2>/dev/null || echo "00000000")
+
+# ── confirm ───────────────────────────────────────────────────────────────────
+
+cat <<EOF
+
+  ┌─────────────────────────────────────────────────────────┐
+  │  Ubuntu 26.04 ZFS root installer                       │
+  ├─────────────────────────────────────────────────────────┤
+  │  Disk:    ${DISK}
+  │  Pool:    ${POOL_NAME}
+  │  Image:   ${IMGREF}
+  │  HostID:  0x${HOSTID_HEX}
+  │  Encrypt: $([ ${ENCRYPTION} -eq 1 ] && echo yes || echo no)
+  └─────────────────────────────────────────────────────────┘
+
+  WARNING: All data on ${DISK} will be DESTROYED!
+
+EOF
+read -r -p "  Type 'yes' to continue: " CONFIRM
+[[ "${CONFIRM}" == "yes" ]] || die "Aborted."
+
+trap cleanup EXIT
+
+# ── 1. Partition ──────────────────────────────────────────────────────────────
+
+info "Partitioning ${DISK}..."
+sgdisk --zap-all "${DISK}"
+sgdisk -n1:0:+512M -t1:ef00 -c1:"EFI System" "${DISK}"
+sgdisk -n2:0:0     -t2:bf00 -c2:"ZFS"         "${DISK}"
+partprobe "${DISK}" && sleep 1
+mkfs.fat -F32 -n EFI "${EFI_PART}"
+
+# ── 2. Create ZFS pool ────────────────────────────────────────────────────────
+#
+# -R /mnt/target  altroot: all mount operations during this session are rooted
+#                 under /mnt/target, not the live system's /.  Without this,
+#                 `zfs mount rpool/root` (mountpoint=/) would clobber the live /.
+
+info "Creating pool '${POOL_NAME}'..."
+
+ZFS_OPTS=(
+    -f
+    -R /mnt/target
+    -o ashift=12
+    -O compression=lz4
+    -O acltype=posixacl
+    -O xattr=sa
+    -O relatime=on
+    -O normalization=formD
+    -O dnodesize=auto
+    -O canmount=off
+    -O mountpoint=none
+)
+
+if [[ ${ENCRYPTION} -eq 1 ]]; then
+    info "Encryption: you will be prompted for a passphrase."
+    ZFS_OPTS+=( -O encryption=aes-256-gcm -O keylocation=prompt -O keyformat=passphrase )
+fi
+
+zpool create "${ZFS_OPTS[@]}" "${POOL_NAME}" "${ZFS_PART}"
+
+# ── 3. Create datasets ────────────────────────────────────────────────────────
+#
+# rpool/root  mountpoint=/    — OS root
+# rpool/var   mountpoint=/var — mutable state (/home lives here as /var/home)
+#
+# canmount=noauto on both: we mount root manually below; var is NOT mounted
+# during install (bootc rejects targets with active submounts).
+# After install we set canmount=on so the installed system mounts them.
+
+zfs create -o mountpoint=/    -o canmount=noauto "${POOL_NAME}/root"
+zfs create -o mountpoint=/var -o canmount=noauto "${POOL_NAME}/var"
+zpool set bootfs="${POOL_NAME}/root" "${POOL_NAME}"
+
+# ── 4. Mount root + EFI for install ──────────────────────────────────────────
+
+info "Mounting install target..."
+mkdir -p /mnt/target
+zfs mount "${POOL_NAME}/root"      # → /mnt/target  (altroot in effect)
+mkdir -p /mnt/target/boot/efi
+mount "${EFI_PART}" /mnt/target/boot/efi
+
+# ── 5. Install ────────────────────────────────────────────────────────────────
+#
+# spl_hostid  — embeds this machine's host ID in the boot entry so the generic
+#               (hostonly=no) initramfs can import the pool on first boot without
+#               the host ID mismatch that causes "pool may be in use" errors.
+# rootfstype=zfs — hints to dracut's ZFS module which filesystem type to expect.
+# root=ZFS=   — tells the ZFS dracut module which dataset is the root.
+
+info "Installing '${IMGREF}'..."
+
+bootc install to-filesystem \
+    --source-imgref "${IMGREF}" \
+    --root-mount-spec "ZFS=${POOL_NAME}/root" \
+    --karg "rootfstype=zfs" \
+    --karg "spl_hostid=0x${HOSTID_HEX}" \
+    /mnt/target
+
+# ── 6. Post-install metadata ──────────────────────────────────────────────────
+
+info "Writing ZFS boot metadata..."
+
+# Enable datasets for the installed system
+zfs set canmount=on "${POOL_NAME}/root"
+zfs set canmount=on "${POOL_NAME}/var"
+
+# /etc/hostid — userspace ZFS identity (supplements spl_hostid karg)
+mkdir -p /mnt/target/etc
+if command -v zgenhostid >/dev/null 2>&1; then
+    zgenhostid -f "${HOSTID_HEX}" && [[ -f /etc/hostid ]] && cp /etc/hostid /mnt/target/etc/hostid
+elif [[ -f /etc/hostid ]]; then
+    cp /etc/hostid /mnt/target/etc/hostid
+fi
+
+# zpool.cache — lets zfs-import-cache.service fast-import on subsequent boots
+mkdir -p /mnt/target/etc/zfs
+zpool set cachefile=/mnt/target/etc/zfs/zpool.cache "${POOL_NAME}"
+
+# ── 7. Clean export ───────────────────────────────────────────────────────────
+#
+# Exporting the pool marks it clean so the installed system's initramfs can
+# import it without needing -f (forced import).
+
+info "Exporting pool..."
+umount /mnt/target/boot/efi
+zpool export "${POOL_NAME}"
+trap - EXIT
+
+info ""
+info "Done! Boot entry: root-mount-spec=ZFS=${POOL_NAME}/root rootfstype=zfs spl_hostid=0x${HOSTID_HEX}"
+info "Remove the live media and reboot."

--- a/tests/bats/test_build_iso_group.bats
+++ b/tests/bats/test_build_iso_group.bats
@@ -21,10 +21,6 @@ setup() {
   [ "$(tunaos_flavor_title gnome)" = "GNOME" ]
 }
 
-@test "title: gnome50 -> GNOME 50" {
-  [ "$(tunaos_flavor_title gnome50)" = "GNOME 50" ]
-}
-
 @test "title: gnome-hwe -> GNOME (HWE)" {
   [ "$(tunaos_flavor_title gnome-hwe)" = "GNOME (HWE)" ]
 }
@@ -39,10 +35,6 @@ setup() {
 
 @test "title: gnome-nvidia-hwe -> GNOME (NVIDIA, HWE)" {
   [ "$(tunaos_flavor_title gnome-nvidia-hwe)" = "GNOME (NVIDIA, HWE)" ]
-}
-
-@test "title: gnome50-hwe -> GNOME 50 (HWE)" {
-  [ "$(tunaos_flavor_title gnome50-hwe)" = "GNOME 50 (HWE)" ]
 }
 
 # ── Desktop mapping ─────────────────────────────────────────────────────────
@@ -100,8 +92,8 @@ _select() {
   echo "${SEL[*]}"
 }
 
-@test "select: yellowfin flagship includes gnome + gnome50 + hwe" {
-  [ "$(_select '' yellowfin)" = "gnome gnome50 gnome-hwe gnome50-hwe" ]
+@test "select: yellowfin flagship includes gnome + hwe" {
+  [ "$(_select '' yellowfin)" = "gnome gnome-hwe" ]
 }
 
 @test "select: bonito flagship shrinks (no gnome50 on Fedora)" {
@@ -113,7 +105,7 @@ _select() {
 }
 
 @test "select: nvidia group resolves for yellowfin" {
-  [ "$(_select nvidia yellowfin)" = "gnome-nvidia gnome50-nvidia gnome-nvidia-hwe" ]
+  [ "$(_select nvidia yellowfin)" = "gnome-nvidia gnome-nvidia-hwe" ]
 }
 
 @test "select: grand total is 12 grouped ISOs across 4 variants" {

--- a/tests/bats/test_lib.bats
+++ b/tests/bats/test_lib.bats
@@ -212,7 +212,7 @@ teardown() {
 @test "OS detection: base_image from image-info.json takes priority" {
   # Simulate the chained-build case: BASE_IMAGE env set to TunaOS stage image
   # but image-info.json has the original OS base
-  BASE_IMAGE="ghcr.io/tuna-os/yellowfin:gnome50"
+  BASE_IMAGE="ghcr.io/tuna-os/yellowfin:gnome"
   export BASE_IMAGE
   # Create test image-info.json and set _IMAGE_INFO so lib.sh finds it
   echo '{"base-image":"quay.io/almalinuxorg/almalinux-bootc:10"}' >"${TEST_ROOT}/usr/share/ublue-os/image-info.json"


### PR DESCRIPTION
> **Draft — image-side foundation only.** Addresses #625. The ZFS-root *boot*
> path still needs an install-to-filesystem e2e (see Follow-on) before this is
> promotable, hence draft.
>
> **Stacks on #635** (branched off `fix/cache-invalidation`). Until #635 merges,
> the diff here includes #635's commits; it cleans up once #635 lands. Review
> only the ZFS commit (`feat(grouper): gnome-zfs …`).

## What & why

Issue #625 asked for a ZFS-root grouper via `bootc install to-disk --filesystem zfs`. That flag **doesn't exist** — verified against bootc 1.15.2, `--filesystem` accepts only `xfs, ext4, btrfs`. A ZFS root is instead installed with `bootc install to-filesystem` onto a **pre-created zpool**, and because the default **composefs** backend needs **fs-verity** (ZFS has none), it needs a non-composefs / `--allow-missing-verity` deployment.

So this PR delivers the **image-side foundation**: a `gnome-zfs` grouper flavor whose image ships everything needed to *be* a ZFS root, leaving the install/boot procedure as the tracked follow-on.

## Verified on `ubuntu:resolute` (26.04)
- **Prebuilt, signed `zfs.ko`** in `linux-modules-extra-<kver>` (`linux-main-modules-zfs-<kver>-generic`) — **no DKMS**.
- `zfsutils-linux` 2.4.1 userspace.
- **`zfs-dracut`** ships the dracut `90zfs` module — the right integration since grouper builds its initramfs with **dracut** (in `finalize.sh`), not initramfs-tools.

## Changes
- `build_scripts/zfs.sh` (apt-only): install prebuilt `zfs.ko` + `zfsutils-linux` + `zfs-dracut`; `modules-load.d` + a `dracut.conf.d` drop-in forcing `add_dracutmodules+=" zfs "` (finalize.sh runs `dracut --no-hostonly`, which won't auto-detect a ZFS root at build time).
- `Containerfile.ubuntu`: `gnome-zfs` stage = GNOME + `zfs.sh` **before** `finalize.sh` (finalize bootcifies → apt unusable after).
- `build-config.yml`: grouper `gnome-zfs` flavor, `build_iso: false` for now.

## Follow-on (before un-drafting / promoting)
1. A `--zfs` / install-to-filesystem **boot e2e** — same pattern as the new `--luks` gate (`scripts/iso-e2e.sh`): create a zpool, `bootc install to-filesystem`, boot, confirm the pool imports in the initramfs and root mounts.
2. Decide composefs vs. non-composefs deployment on ZFS.
3. Enable the ISO + KDE/etc. once the boot path is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
