### PR TITLE
feat: ship remora (local layering CLI) in all images

### DIFF
--- a/build_scripts/26-packages-post.sh
+++ b/build_scripts/26-packages-post.sh
@@ -39,6 +39,17 @@ rm "$DOWNLOADS_DIR/JetBrainsMono.tar.xz"
 mkdir -p /etc/flatpak/remotes.d
 install -m0644 "$DOWNLOADS_DIR/flathub.flatpakrepo" /etc/flatpak/remotes.d/flathub.flatpakrepo
 
+# remora — local layering CLI (github.com/tuna-os/remora). Static Go binary,
+# works on every base (dnf/zypper/pacman/apt). Version pinned for
+# reproducible image builds; renovate can bump it.
+REMORA_VERSION="v0.1.0"
+REMORA_ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+curl --retry 3 --fail -L \
+	"https://github.com/tuna-os/remora/releases/download/${REMORA_VERSION}/remora-linux-${REMORA_ARCH}" \
+	-o "$DOWNLOADS_DIR/remora"
+install -Dm0755 "$DOWNLOADS_DIR/remora" /usr/bin/remora
+rm "$DOWNLOADS_DIR/remora"
+
 # Generate initramfs image after installing Yellowfin branding because of Plymouth subpackage
 # Set TunaOS Plymouth theme before rebuilding initramfs so dracut picks it up
 if command -v plymouth-set-default-theme >/dev/null 2>&1; then


### PR DESCRIPTION
Installs the pinned static [remora](https://github.com/tuna-os/remora) `v0.1.0` binary to `/usr/bin` on every variant (amd64 + arm64, from GitHub releases, in `26-packages-post.sh` next to the other fetched assets).

remora is TunaOS's user-friendly local layering tool — the container-native answer to `rpm-ostree install`, working across the whole variant matrix (dnf/zypper/pacman/apt):

```bash
sudo remora init             # /etc/remora + build quadlet + timer (+ uupd hook if present)
sudo remora install htop     # layer packages, rebuild on newest base, bootc switch
sudo remora shims            # optional: 'dnf install' redirects here with an interactive offer
```

- Rebuilds ride uupd's schedule/gating when uupd is present (plain systemd drop-in, zero deps)
- Version pinned for reproducible builds; renovate can bump it
- Docs + blog post landing in tuna-os/docs alongside this

🤖 Generated with [Claude Code](https://claude.com/claude-code)