### PR TITLE
feat: drop dmsquash-live hacks — tacklebox tbox-live carries the live boot path

### DIFF
--- a/Containerfile.arch
+++ b/Containerfile.arch
@@ -9,9 +9,6 @@
 
 ARG BASE_IMAGE="docker.io/archlinux/archlinux:latest"
 
-FROM registry.fedoraproject.org/fedora:44 AS fedora-dracut
-RUN dnf install -y dracut-live
-
 ARG DESKTOP_FLAVOR="${DESKTOP_FLAVOR:-gnome}"
 ARG IMAGE_NAME
 ARG IMAGE_VENDOR
@@ -120,15 +117,13 @@ RUN KERNEL_PKG="linux"; \
         yq && \
     pacman -Scc --noconfirm
 
-# Arch's dracut does not package the dmsquash-live module. Copy Fedora's
-# dracut modules.d on top of Arch's (merge, don't replace — preserves bootc).
-COPY --from=fedora-dracut /usr/lib/dracut/modules.d /usr/lib/dracut/modules.d
-
-# Build initramfs (include dmsquash-live so tacklebox doesn't need to rebuild)
+# Build initramfs. Live-boot modules are NOT needed here: tacklebox
+# injects its own embedded tbox-live/tbox-root dracut modules at ISO
+# build time using this image's stock dracut (tuna-os/tacklebox#90).
 RUN mkdir -p /usr/lib/dracut/dracut.conf.d/ && \
     printf 'systemdsystemconfdir=/etc/systemd/system\nsystemdsystemunitdir=/usr/lib/systemd/system\n' \
         > /usr/lib/dracut/dracut.conf.d/30-fix-bootc-module.conf && \
-    printf 'reproducible=yes\nhostonly=no\ncompress=zstd\nadd_dracutmodules+=" bootc dmsquash-live "\n' \
+    printf 'reproducible=yes\nhostonly=no\ncompress=zstd\nadd_dracutmodules+=" bootc "\n' \
         > /usr/lib/dracut/dracut.conf.d/30-bootc-container-build.conf && \
     dracut --force "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v '\.img' | tail -1)/initramfs.img"
 

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -9,9 +9,6 @@
 
 ARG BASE_IMAGE="docker.io/library/debian:trixie"
 
-FROM registry.fedoraproject.org/fedora:44 AS fedora-dracut
-RUN dnf install -y dracut-live
-
 ARG DESKTOP_FLAVOR="${DESKTOP_FLAVOR:-gnome}"
 ARG IMAGE_NAME
 ARG IMAGE_VENDOR
@@ -118,16 +115,13 @@ RUN apt-get update -y && \
 # Copy kernel to modules directory (Debian puts it in /boot)
 RUN cp /boot/vmlinuz-* "$(find /usr/lib/modules -maxdepth 1 -type d | tail -1)/vmlinuz"
 
-# Debian's dracut does not package the dmsquash-live module (nor its
-# dependencies img-lib, initqueue, etc). Copy Fedora's dracut modules.d
-# on top of Debian's (merge, don't replace — preserves bootc module).
-COPY --from=fedora-dracut /usr/lib/dracut/modules.d /usr/lib/dracut/modules.d
-
-# Build initramfs (include dmsquash-live so tacklebox doesn't need to rebuild)
+# Build initramfs. Live-boot modules are NOT needed here: tacklebox
+# injects its own embedded tbox-live/tbox-root dracut modules at ISO
+# build time using this image's stock dracut (tuna-os/tacklebox#90).
 RUN mkdir -p /usr/lib/dracut/dracut.conf.d/ && \
     printf 'systemdsystemconfdir=/etc/systemd/system\nsystemdsystemunitdir=/usr/lib/systemd/system\n' \
         > /usr/lib/dracut/dracut.conf.d/30-fix-bootc-module.conf && \
-    printf 'reproducible=yes\nhostonly=no\ncompress=zstd\nadd_dracutmodules+=" bootc dmsquash-live "\n' \
+    printf 'reproducible=yes\nhostonly=no\ncompress=zstd\nadd_dracutmodules+=" bootc "\n' \
         > /usr/lib/dracut/dracut.conf.d/30-bootc-container-build.conf && \
     KVER=$(basename "$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d | tail -1)") && \
     dracut --force "/usr/lib/modules/${KVER}/initramfs.img" "${KVER}"

--- a/Containerfile.gentoo
+++ b/Containerfile.gentoo
@@ -3,9 +3,6 @@
 
 ARG BASE_IMAGE
 
-FROM registry.fedoraproject.org/fedora:44 AS fedora-dracut
-RUN dnf install -y dracut-live
-
 ARG IMAGE_NAME
 ARG IMAGE_VENDOR
 ARG SHA_HEAD_SHORT
@@ -58,9 +55,8 @@ RUN emerge --verbose \
         app-arch/cpio btrfs-progs dev-vcs/git dosfstools \
         linux-firmware rust skopeo sys-kernel/gentoo-kernel-bin systemd
 
-# Copy dmsquash-live module (and its img-lib dependency) from Fedora since Gentoo's dracut does not package them
-COPY --from=fedora-dracut /usr/lib/dracut/modules.d/70dmsquash-live /usr/lib/dracut/modules.d/90dmsquash-live
-COPY --from=fedora-dracut /usr/lib/dracut/modules.d/70img-lib /usr/lib/dracut/modules.d/90img-lib
+# No live-boot dracut modules needed: tacklebox injects its embedded
+# tbox-live/tbox-root modules at ISO build time (tuna-os/tacklebox#90).
 
 FROM base AS builder
 RUN emerge --verbose dev-util/ostree && \

--- a/Justfile
+++ b/Justfile
@@ -163,7 +163,7 @@ lifecycle-test variant='albacore' flavor='gnome':
 corral-build variant='redfin' +flavors='all':
     ./scripts/corral-build.sh "{{ variant }}" {{ flavors }}
 
-# Build a TunaOS live ISO via tacklebox (no Anaconda, dmsquash-live + sd-boot)
+# Build a TunaOS live ISO via tacklebox (no Anaconda, tbox-live + sd-boot)
 # Build a live ISO via tacklebox (replaces deprecated bootc-image-builder approach)
 iso variant='skipjack' flavor='gnome' repo='local' tag='' dev='0':
     #!/usr/bin/env bash

--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -143,7 +143,6 @@ if [[ $IS_FEDORA == true ]]; then
 		plymouth \
 		plymouth-system-theme \
 		plymouth-plugin-script \
-		dracut-live \
 		xdg-desktop-portal \
 		systemd-oomd-defaults \
 		unzip
@@ -220,7 +219,6 @@ else
 		plymouth \
 		plymouth-system-theme \
 		plymouth-plugin-script \
-		dracut-live \
 		libcamera-v4l2 \
 		libcamera-gstreamer \
 		libcamera-tools \

--- a/build_scripts/26-packages-post.sh
+++ b/build_scripts/26-packages-post.sh
@@ -59,8 +59,10 @@ fi
 # Disable system sleep/suspend to prevent VMs from suspending during walkthroughs
 systemctl mask suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target || true
 
-# Add resume and dmsquash-live modules so that hibernation and live boot works
-echo "add_dracutmodules+=\" resume dmsquash-live \"" >/etc/dracut.conf.d/resume.conf 2>/dev/null || true
+# Add the resume module so hibernation works. Live boot needs nothing
+# here: tacklebox injects its embedded tbox-live/tbox-root dracut
+# modules at ISO build time (tuna-os/tacklebox#90).
+echo "add_dracutmodules+=\" resume \"" >/etc/dracut.conf.d/resume.conf 2>/dev/null || true
 # Omit optional modules that aren't available in container builds
 echo "omit_dracutmodules+=\" pcsc bluetooth pcmcia syslog \"" >/etc/dracut.conf.d/omit-optional.conf 2>/dev/null || true
 

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -26,7 +26,7 @@ downloads:
   # renovate: datasource=github-releases depName=ledif/kcm_ublue
   kcm_ublue: "v0.6.1"
   # renovate: datasource=git-refs depName=tuna-os/tacklebox
-  tacklebox: "59089ec0f6e23518a7a372130fb30b1a4a70e52b"
+  tacklebox: "d6f4f257283436240f8946621068354196e9418c"
 
   # Bootc toolchain built from source (see toolchain/) and published to
   # ghcr.io/tuna-os/bootc-toolchain-<base> as OCI artifacts via ORAS.

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -26,7 +26,7 @@ downloads:
   # renovate: datasource=github-releases depName=ledif/kcm_ublue
   kcm_ublue: "v0.6.1"
   # renovate: datasource=git-refs depName=tuna-os/tacklebox
-  tacklebox: "d6f4f257283436240f8946621068354196e9418c"
+  tacklebox: "86da45b29a8d7ade640ef669ac18100659347903"
 
   # Bootc toolchain built from source (see toolchain/) and published to
   # ghcr.io/tuna-os/bootc-toolchain-<base> as OCI artifacts via ORAS.

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -26,7 +26,7 @@ downloads:
   # renovate: datasource=github-releases depName=ledif/kcm_ublue
   kcm_ublue: "v0.6.1"
   # renovate: datasource=git-refs depName=tuna-os/tacklebox
-  tacklebox: "3b4598273efb2f71d17515947e442f0e6b26a6c5"
+  tacklebox: "59089ec0f6e23518a7a372130fb30b1a4a70e52b"
 
   # Bootc toolchain built from source (see toolchain/) and published to
   # ghcr.io/tuna-os/bootc-toolchain-<base> as OCI artifacts via ORAS.


### PR DESCRIPTION
Depends on tuna-os/tacklebox#91 (pinned by SHA in `image-versions.yaml`, so this branch's CI can already exercise it before that PR merges).

tacklebox now ships its own distro-neutral dracut modules (`tbox-live` + `tbox-root`) and injects them at ISO build time using each image's **stock** dracut — closing tuna-os/tacklebox#90. That makes every dmsquash-live workaround in this repo dead weight:

- **Containerfile.{debian,arch,gentoo}**: remove the `fedora-dracut` build stage and the `COPY` of Fedora's `modules.d` (the part that broke on Fedora 44's 90→70 module rename); drop `dmsquash-live` from the image-build dracut config (the `bootc` module stays)
- **build_scripts/10-base-packages.sh**: stop installing `dracut-live` on Fedora variants too — no tunaOS image needs it anymore
- **build_scripts/26-packages-post.sh**: `resume.conf` keeps only the `resume` module
- **image-versions.yaml**: tacklebox pinned to `59089ec` (tbox-live + the new delta dedup layout). Re-pin to the main SHA after tacklebox#91 lands if that branch gets squash-merged.

Effects: Flounder (Debian) and Guppy (Gentoo) ISO builds stop depending on Fedora packaging internals; images get slightly smaller (no foreign modules.d, no dracut-live); the first ISO build per image update pays a ~2–3 min cached initramfs rebuild, after which the image-ID-keyed cache absorbs it.

For future multi-image ISOs, tacklebox also gained `shared_store.dedup_layout: "delta"` — shared base squashfs + per-env deltas, so single-image updates re-diff one env instead of rebuilding the whole store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)