### PR TITLE
fix(flounder): KDE actually installs — trixie package name + honest apt fallback

### DIFF
--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -276,7 +276,11 @@ pkg_install() {
 		apt-get update -qq
 		apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" "$@" || {
 			dpkg --configure -a --force-depends || true
-			apt-get install -y -f --no-install-recommends
+			# Retry WITH the package list: a bare `apt-get -f install`
+			# succeeds without installing anything, silently swallowing
+			# real failures (e.g. a nonexistent package name shipped a
+			# desktop-less flounder:kde while the build stayed green).
+			apt-get install -y -f --no-install-recommends "$@"
 		}
 	elif [[ "$PKG_MGR" == "pacman" ]]; then
 		pacman -S --noconfirm --needed "$@"

--- a/manifests/desktops/kde-debian.yaml
+++ b/manifests/desktops/kde-debian.yaml
@@ -14,7 +14,6 @@ packages:
     - kdeconnect
     - xdg-desktop-portal-kde
     - qt6-wayland
-    - plasma-workspace-wayland
     - network-manager
     - pipewire
     - wireplumber


### PR DESCRIPTION
Follow-up to #653 for the last red job on Flounder (`iso:kde`).

`flounder:kde` images have been shipping with **zero KDE** while building green: `plasma-workspace-wayland` has no installation candidate in trixie (Plasma 6 ships the wayland session inside `plasma-workspace`), the apt transaction failed on it, and `pkg_install`'s fallback — a bare `apt-get -f install` with no package list — swallowed the failure. That's why the KDE ISO customize kept detecting gnome (no session files) and dying on the missing glib tool.

- `kde-debian.yaml`: drop `plasma-workspace-wayland`
- `lib.sh` `pkg_install`: the fallback retries **with** `"$@"`, so real apt failures fail the build (same silent-green disease as the yq bug in #653, now closed at the second layer)

Validation: Build Flounder (flavor=kde) dispatch on this branch — image must contain plasma/sddm, and `iso:kde` must pass customize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)