### PR TITLE
docs: point ISO downloads at tunaos.org/download

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,9 @@ Image tags are constructed as `<desktop>[-hardware]`:
 
 ### Use a pre-built ISO
 
-ISOs are published every two weeks for `gnome` and `gnome-hwe` flavors of Yellowfin and Albacore:
+Grab a live ISO for any variant and flavor from the download page:
 
-| Variant | GNOME | GNOME (HWE) |
-|---------|-------|-------------|
-| **Albacore** | [albacore-gnome-latest.iso](https://download.tunaos.org/live-isos/albacore-gnome-latest.iso) | [albacore-gnome-hwe-latest.iso](https://download.tunaos.org/live-isos/albacore-gnome-hwe-latest.iso) |
-| **Yellowfin** | [yellowfin-gnome-latest.iso](https://download.tunaos.org/live-isos/yellowfin-gnome-latest.iso) | [yellowfin-gnome-hwe-latest.iso](https://download.tunaos.org/live-isos/yellowfin-gnome-hwe-latest.iso) |
+**[📦 tunaos.org/download](https://tunaos.org/download)**
 
 ### Build your own ISO or VM image
 


### PR DESCRIPTION
Replaces the stale hardcoded latest-ISO table (two variants, one flavor) with a link to [tunaos.org/download](https://tunaos.org/download), which is generated from the real publish matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)