### PR TITLE
fix(tacklebox): use realpath for paths inside podman namespaces

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -227,8 +227,8 @@ tunaos_run_tacklebox() {
 			"$tacklebox_image")
 	fi
 
-	"${tb[@]}" build "$recipe_file" \
-		--iso "$iso_out" \
-		--output-base "$out_dir" \
+	"${tb[@]}" build "$(realpath "$recipe_file")" \
+		--iso "$(realpath "$iso_out")" \
+		--output-base "$(realpath "$out_dir")" \
 		--yes
 }


### PR DESCRIPTION
Ensures absolute paths are passed to tacklebox build inside the container, resolving file/recipe loading errors in container namespaces.