### PR TITLE
fix(iso-group): specify disk size in recipe to resolve missing size error

### DIFF
--- a/scripts/build-iso-group.sh
+++ b/scripts/build-iso-group.sh
@@ -171,6 +171,7 @@ jq -n \
 	--argjson offline "$OFFLINE_PAYLOADS_JSON" \
 	'{
 		media_name: $media_name,
+		size: "35G",
 		shared_store: { dedup: true, compression: "release" },
 		bootable_environments: $envs,
 		offline_payloads: $offline


### PR DESCRIPTION
Specifies a 35G disk size in the recipe to resolve the tacklebox build failure due to missing size definition.