### PR TITLE
fix(gate): resolve desktop-contract self-deadlock on graphical.target

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -72,6 +72,18 @@ sessions).
 - **No cell has passed yet.** All three finish-condition boxes above are
   unchecked. Next: dispatch a fresh `yellowfin:kde` (or niri/cosmic) run
   to verify the retry-pull fix.
+- **Bug #21 found (2026-07-17, PR #668):** `tunaos-desktop-contract.service`
+  asserted `is-active graphical.target` while being WantedBy that target —
+  targets gain implicit After= on their wants, so the check self-deadlocks;
+  the script exited silently under `set -e` and no marker ever reached
+  ttyS0. This broke every variant Gate on main AND explains why LUKS E2E's
+  installed-boot wait (which requires the contract marker from the *pulled
+  published image*) could never pass: no published image emits a marker.
+  Chain in flight: Build Yellowfin gnome (run 29614564619, branch
+  fix/desktop-contract-gate) proves the Gate; Build Yellowfin kde (run
+  29614735371, twin branch fix/desktop-contract-gate-kde — twin needed
+  because the concurrency group cancels same-ref dispatches) publishes a
+  marker-emitting :kde; then dispatch LUKS E2E yellowfin:kde.
 
 ## How to continue
 

--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -4,6 +4,19 @@ set -euo pipefail
 desktop="${1:?usage: verify-desktop-experience.sh <gnome|kde|niri|cosmic|xfce> [--runtime]}"
 mode="${2:-build}"
 
+# At runtime the E2E gate greps ttyS0 for a contract marker; a silent early
+# exit (e.g. a require_* failing under set -e) would leave the gate waiting
+# out its full timeout with no evidence. Guarantee a terminal FAIL marker on
+# any premature death; the normal paths below disarm this trap.
+marker_emitted=0
+emit_fail_on_early_exit() {
+	local rc=$?
+	if [[ "$mode" == --runtime && "$rc" -ne 0 && "$marker_emitted" -eq 0 ]]; then
+		echo "TUNAOS_DESKTOP_CONTRACT_FAIL desktop=${desktop} reason=early_exit rc=${rc}" | tee /dev/ttyS0 2>/dev/null || true
+	fi
+}
+trap emit_fail_on_early_exit EXIT
+
 require_command() { command -v "$1" >/dev/null || {
 	echo "missing required command: $1" >&2
 	exit 1
@@ -94,8 +107,13 @@ if [[ "$mode" == --runtime ]]; then
 	if ! compgen -G '/usr/share/tunaos/experience-contracts/remora' >/dev/null 2>&1; then
 		report_fail remora_contract_missing
 	fi
-	if ! systemctl is-active --quiet graphical.target 2>/dev/null; then
-		report_fail graphical_target_inactive
+	# NB: never check `is-active graphical.target` here. This service is
+	# WantedBy=graphical.target, and targets gain implicit After= on their
+	# wants — the target cannot become active until this script exits, so
+	# that check self-deadlocks into a guaranteed failure. Assert the boot
+	# *default* instead; liveness comes from the display-manager check below.
+	if [[ "$(systemctl get-default 2>/dev/null)" != graphical.target ]]; then
+		report_fail default_target_not_graphical
 	fi
 	# Check the display-manager.service alias (every DM registers it) and
 	# verify its Id resolves to a DM this desktop's contract allows — robust
@@ -116,6 +134,7 @@ if [[ "$mode" == --runtime ]]; then
 	if [[ "$ok" -eq 0 ]]; then
 		echo "TUNAOS_DESKTOP_CONTRACT_FAIL desktop=$desktop" | tee /dev/ttyS0 2>/dev/null || true
 	fi
+	marker_emitted=1
 else
 	# ── Static unit-graph validation (pattern from secureblue's
 	# validate_systemd_unit_files.sh) ── catches unit typos, missing

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -962,9 +962,15 @@ disk)
 			exit 1
 		fi
 		if grep -qE "TUNAOS_DESKTOP_CONTRACT_(OK|FAIL)" "$SERIAL_LOG" 2>/dev/null; then
-			echo "==> Desktop experience contract reached (serial)"
-			rc=0
-			harvest_install_checks || rc=1
+			if grep -q "TUNAOS_DESKTOP_CONTRACT_OK" "$SERIAL_LOG" 2>/dev/null; then
+				echo "==> Desktop experience contract passed (serial)"
+				rc=0
+				harvest_install_checks || rc=1
+			else
+				echo "ERROR: desktop experience contract FAILED:" >&2
+				grep "TUNAOS_DESKTOP_CONTRACT_FAIL" "$SERIAL_LOG" | tr -d '\r' >&2
+				rc=1
+			fi
 			break
 		fi
 		sleep 10
@@ -972,7 +978,7 @@ disk)
 	# Let the display manager finish drawing before capturing evidence.
 	sleep 30
 	screenshot "10-ready"
-	if [[ "$rc" -ne 0 ]]; then
+	if [[ "$rc" -eq 2 ]]; then
 		echo "ERROR: desktop experience contract marker was not emitted" >&2
 	fi
 	exit "$rc"

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -138,10 +138,22 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
 }
 
 @test "disk gate requires the desktop contract marker" {
-  # e9fe9e5: the gate deliberately accepts OK or FAIL — either proves the
-  # contract service ran (graphical.target reached, DM started).
+  # The gate wakes on either marker (both prove the contract service ran)
+  # but only OK passes; FAIL surfaces its reason lines and exits nonzero.
   run grep -F 'TUNAOS_DESKTOP_CONTRACT_(OK|FAIL)' "${REPO_ROOT}/scripts/iso-e2e.sh"
   [ "$status" -eq 0 ]
+  grep -qF 'desktop experience contract FAILED' "${REPO_ROOT}/scripts/iso-e2e.sh"
+}
+
+@test "runtime contract never asserts graphical.target is active" {
+  # The contract service is WantedBy=graphical.target; targets gain implicit
+  # After= on their wants, so is-active graphical.target inside the service
+  # self-deadlocks into a guaranteed failure. get-default is the safe assert.
+  run grep -F 'is-active --quiet graphical.target' \
+    "${REPO_ROOT}/build_scripts/checks/verify-desktop-experience.sh"
+  [ "$status" -ne 0 ]
+  grep -qF 'systemctl get-default' \
+    "${REPO_ROOT}/build_scripts/checks/verify-desktop-experience.sh"
 }
 
 @test "desktop installer makes graphical target the boot default" {


### PR DESCRIPTION
## Why every variant build went red

All 9 nightly variant builds failed their Gate jobs with `desktop experience contract marker was not emitted` after a full 900s wait — while the serial log shows the desktop actually up (GNOME initial-setup on screen) and `tunaos-desktop-contract.service` starting and then going silent.

Root cause: the runtime contract ran `systemctl is-active --quiet graphical.target` from a service that is itself `WantedBy=graphical.target`. Target units gain implicit `After=` ordering on their wants, so **graphical.target cannot become active until the contract service exits** — the check is a self-deadlock. Pre-#664 the script exited 1 silently under `set -e` (both `--quiet` checks print nothing), so no marker ever reached ttyS0 and the gate timed out. Post-#664 it would emit `FAIL reason=graphical_target_inactive` on every boot — and the gate treated any marker (OK *or* FAIL) as success, going green without verifying anything.

## Fix

- Runtime contract asserts `systemctl get-default` is `graphical.target` instead of `is-active`; actual liveness is already proven by the `display-manager.service` is-active check (`Requires=`/`After=` guarantees ordering).
- An EXIT trap guarantees a terminal `TUNAOS_DESKTOP_CONTRACT_FAIL reason=early_exit` marker if the script dies before the runtime checks, so the gate never again waits out 900s in silence.
- The disk gate now distinguishes OK from FAIL: FAIL prints the reason lines from serial and exits 1.

Evidence: run 29553663582 (`boot-gate-yellowfin-gnome-nvidia-hwe`): serial shows `Starting tunaos-desktop-contract.service` then zero output from the unit until the 900s powerdown; screenshot shows a healthy GNOME session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)