### PR TITLE
docs(adr): browser ISO builder feasibility + configurator prototype

### DIFF
--- a/docs/adr/0002-browser-iso-builder.md
+++ b/docs/adr/0002-browser-iso-builder.md
@@ -1,115 +1,108 @@
-# ADR 0002: Browser-based ISO builder — feasibility and staged architecture
+# ADR 0002: In-browser ISO builder from existing GHCR bootc images
 
 - Status: proposed
 - Date: 2026-07-17
 - Issue: [#667](https://github.com/tuna-os/tunaOS/issues/667)
-- Prototype: `prototype/iso-builder/index.html` (static configurator, no backend)
+- Prototype: `prototype/iso-builder/` (static page + stateless CORS shim;
+  pull chain — token → index → manifest → config — working)
 
 ## Context
 
-TunaOS intentionally publishes a small ISO catalogue (grouped dedup ISOs,
-issue #455) and wants everything else self-service. The target experience:
-**the browser takes a bootc image and makes an ISO** — pick any
-variant × flavor on a web page and leave with bootable media, without
-TunaOS operating build servers.
+TunaOS publishes a small ISO catalogue and wants every other
+variant × flavor to be self-service **without maintaining anything new**:
+the bootc images already exist on ghcr.io, and the user should be able to
+take one and leave with bootable media from a web page — no terminal, no
+app install, no extra published artifacts, no build servers.
 
-## Feasibility findings (verified 2026-07-17)
+## Constraints (verified 2026-07-17)
 
-**GHCR cannot feed a browser.** Tested directly: `ghcr.io/token` and
-`/v2/.../manifests/...` return 200 to non-browser clients but send **no
-`Access-Control-Allow-Origin` header**, and the `Authorization` header
-fails preflight. Browsers therefore cannot pull image layers from GHCR,
-full stop. Any in-browser pipeline must be fed from a CORS-enabled origin.
+- **ghcr.io sends no `Access-Control-Allow-Origin` headers** on its token,
+  manifest, or blob endpoints (tested directly). Browser JS cannot read
+  its responses — this is structural and applies to every registry
+  endpoint the builder needs. No client-side technique bypasses CORS.
+- Real payload (yellowfin:gnome amd64): **65 layers, 3.5 GB compressed,
+  all `tar+zstd`** (sailfin:kde: 65 layers, 1.8 GB). Unpacked roots run
+  6–8 GB.
+- Nothing in ISO authoring fundamentally needs root: squashfs/erofs
+  creation, ESP (FAT) assembly, and ISO9660/El Torito wrapping are all
+  userspace file authoring — portable to WASM in principle.
 
-**R2 is that origin.** Cloudflare R2 supports per-bucket CORS rules and
-has **zero egress fees** — serving multi-GB layer sets to browsers costs
-storage only, which is compatible with the R2 cost-reduction work. CI can
-mirror what the builder needs with `rclone`/`oras` in the existing publish
-workflows.
+## Decision
 
-**The hard parts of full in-browser assembly are payload and authoring,
-not privilege.** Everything tacklebox does can in principle be userspace
-file authoring (no loop devices needed): but squashfs/erofs creation and
-ISO9660/El Torito + ESP authoring have no maintained WASM ports today, and
-streaming 3–8 GB through browser memory needs the File System Access API
-and careful chunking. Real, but a project — not a blocker in principle.
+**Build the ISO entirely in the browser, sourced directly from the
+existing ghcr.io images.** The only server-side piece is a **stateless
+CORS shim** (`prototype/iso-builder/worker/cors-shim.js`, ~60 lines of
+Cloudflare Worker): a read-only relay for the three GHCR endpoints,
+restricted to `tuna-os/*` images, that adds the CORS headers GHCR
+refuses to send. It stores nothing, has no build pipeline, and never
+needs updating when images change. Blob responses are content-addressed,
+so the Worker lets Cloudflare's edge cache absorb repeat pulls (free
+egress) and shield ghcr.io.
 
-## Decision: three stages toward the browser builder
+Explicitly rejected alternatives:
 
-### Stage A — ship now (the "oras hack")
+- **Publishing anything extra** (shell/net-install ISOs, R2-mirrored OCI
+  layouts, ORAS-wrapped ISOs): every one of them is a second artifact
+  stream to build, gate, store, and keep in sync with GHCR — the exact
+  maintenance this ADR exists to avoid.
+- **Hosted build service**: servers to run, abuse to police, egress or
+  compute to pay for.
+- **Local CLI / fork-and-dispatch as the *primary* path**: requires a
+  terminal or a GitHub account; both stay documented as fallbacks for
+  air-gapped or exotic cases, nothing more.
 
-Store prebuilt ISOs as plain R2 objects (today's `live-isos/` layout — an
-ORAS artifact adds indirection with no browser benefit since R2 is already
-HTTP+CORS) and let the page hand out the link. This is the current
-pipeline; it is blocked only by the publish gate being red and the
-download host misconfiguration (issue #543 — `download.tunaos.org`
-currently 404s on every path).
+## In-browser pipeline
 
-### Stage B — the MVP browser builder: one shell ISO + in-browser recipe injection
+| Stage | Mechanism | Status |
+|---|---|---|
+| 1. Pull | token → index → platform manifest → config → layer blobs, via the shim; digest-verify with WebCrypto | **Working** (prototype demo; verified against real images) |
+| 2. Unpack | streaming zstd (WASM, e.g. a compiled libzstd — small, well-trodden) + tar walker; overlay whiteout handling | next |
+| 3. Live root | author erofs (preferred: `mkfs.erofs` is a clean userspace C codebase to compile to WASM) or squashfs from the merged tree | the main lift |
+| 4. Boot bits | extract kernel + initramfs from `/usr/lib/modules/<ver>/`, systemd-boot from the image's own payload; write fisherman `recipe.json` pointing back at the source image by digest | straightforward once 2 exists |
+| 5. Media | FAT ESP image + ISO9660/El Torito wrapper (JS/WASM writer) | bounded, well-specified formats |
+| 6. Deliver | stream to disk via File System Access API (`showSaveFilePicker`) — memory stays at chunk scale, not ISO scale | standard |
 
-The live ISO's installer is **fisherman driving `recipe.json`** — the
-image to install is *data inside the ISO*, not baked structure. So:
+Browser floor: a File System Access-capable browser (Chromium today,
+Firefox behind a flag) and disk headroom ~2× the ISO. Firefox/Safari
+fallback: classic download of a streamed Blob, capped by memory — detect
+and warn.
 
-1. CI publishes **one generic live/net-install ISO per arch** to R2
-   (CORS on).
-2. The browser fetches it, patches `recipe.json` to point at the chosen
-   `ghcr.io/tuna-os/<variant>:<flavor>` (installer pulls it over the
-   network at install time — the exact `bootcDirect` network-pull path the
-   LUKS E2E exercises), and streams the result to disk via the File
-   System Access API.
-3. Patching one file inside an ISO9660 image is small, bounded work
-   (rewrite one file's extents + path table, or reserve a fixed-size
-   padded config region to make it a pure in-place overwrite) — JS/WASM
-   scale, not squashfs scale.
-
-**Every variant × flavor becomes buildable in-browser with a single
-published shell ISO** (~1–2 GB fetch), which also collapses the published
-catalogue further. This is the recommended MVP.
-
-### Stage C — full offline assembly in the browser
-
-Mirror per-flavor OCI layouts to R2; in-browser: pull layers, author the
-dedup squashfs store and the hybrid ISO in WASM (`squashfs-tools-ng` or an
-erofs writer compiled to WASM; a minimal ISO9660/ESP writer). Produces
-fully *offline* installer ISOs client-side. Target state; start after
-Stage B proves the streaming/download UX.
-
-Interim fallbacks for combinations Stage B can't serve (e.g. air-gapped
-installs) stay as today: local `build-iso-group.sh` / tacklebox, or
-fork-and-dispatch on the user's own GitHub fork (free runners, their
-provenance). The prototype page presents both.
+The recipe embedded in the ISO uses the same fisherman `bootcDirect`
+contract the LUKS E2E exercises, with the image pinned by digest at build
+time in the browser — what you clicked is what installs.
 
 ## Threat model notes
 
-- No tokens or secrets in the page; GHCR stays out of the browser path
-  entirely (CORS makes this structural, not just policy).
-- The R2 mirror is read-only, versioned by digest, and only ever contains
-  artifacts CI signed/gated — the browser verifies digests before
-  patching (sha256 in JS/WebCrypto is cheap).
-- Recipe injection only interpolates values from the embedded
-  variant/flavor allowlist — never free text — so a shared "builder link"
-  cannot point a victim's installer at a hostile image.
-- Client-built ISOs are the user's provenance; the page says so, and the
-  shell ISO's own signature still covers everything except the recipe.
+- The shim is GET/HEAD-only, org-allowlisted (`tuna-os/*`), and forwards
+  only `Authorization`/`Accept` — it cannot be used as a general relay,
+  and it never sees credentials (public images, anonymous tokens).
+- The page verifies every blob against its manifest digest before use
+  (WebCrypto sha256), so a compromised shim or cache can corrupt but not
+  substitute content unnoticed.
+- Generated recipes only interpolate allowlisted variant/flavor values
+  and digests the page resolved itself — a crafted "builder link" cannot
+  aim the installer at a foreign image.
+- Client-built ISOs are the user's provenance; cosign signatures on the
+  *image* still verify at install time, which is the trust anchor that
+  matters.
 
 ## Resource estimates
 
-- Stage A: already-built pipeline + a CORS rule + fixing #543.
-- Stage B: shell-ISO recipe surface in tacklebox (padded config region
-  recommended), ~2–4 weeks of a browser ISO-patcher (JS + WebCrypto +
-  File System Access), CI job to publish the shell ISO. R2 delta: one ISO
-  per arch.
-- Stage C: WASM ports of squashfs/ISO authoring + OCI-layout mirror job;
-  months, not weeks. R2 delta: per-flavor layer storage (dedup helps —
-  layers are shared across flavors).
+- Shim: one Worker, free tier scale; edge cache does the heavy lifting.
+- User side per build: 1.8–3.5 GB download, minutes of WASM decompress/
+  author time, ~2× ISO disk headroom.
+- Engineering: stage 2 ≈ days (zstd WASM builds exist; tar is trivial);
+  stages 3+5 are the real work — an erofs writer and a minimal
+  ISO9660+ESP writer in WASM/JS; weeks-to-months, incrementally
+  shippable (each stage demos on its own).
 
-## MVP scope (Stage B)
+## MVP scope
 
-- [ ] tacklebox: reserve a padded, fixed-offset `recipe.json` region in
-      the shell ISO so browser patching is a pure in-place overwrite.
-- [ ] CI: publish `tunaos-shell-<arch>-latest.iso` to R2; enable bucket
-      CORS for `tunaos.org` origins.
-- [ ] Web: extend the prototype configurator with the fetch → patch →
-      save pipeline and digest verification.
-- [ ] E2E: boot a browser-patched ISO in the existing `iso-e2e.sh` disk
-      gate to prove parity with CI-built ISOs.
+- [x] Configurator page + working stage-1 pull chain (prototype).
+- [x] Stateless CORS shim (`worker/cors-shim.js`), ready to deploy.
+- [ ] Deploy shim at `ghcr-shim.tunaos.org`; wire digest verification.
+- [ ] Stage 2: WASM zstd + tar walk — demo: extract and display the
+      kernel version from any variant:flavor in-browser.
+- [ ] Stage 3–5: erofs + ESP + ISO writers; boot the result in the
+      existing `iso-e2e.sh` disk gate to prove parity with CI ISOs.
+- Out of scope: any new published artifact; any stateful service.

--- a/docs/adr/0002-browser-iso-builder.md
+++ b/docs/adr/0002-browser-iso-builder.md
@@ -1,0 +1,115 @@
+# ADR 0002: Browser-based ISO builder — feasibility and staged architecture
+
+- Status: proposed
+- Date: 2026-07-17
+- Issue: [#667](https://github.com/tuna-os/tunaOS/issues/667)
+- Prototype: `prototype/iso-builder/index.html` (static configurator, no backend)
+
+## Context
+
+TunaOS intentionally publishes a small ISO catalogue (grouped dedup ISOs,
+issue #455) and wants everything else self-service. The target experience:
+**the browser takes a bootc image and makes an ISO** — pick any
+variant × flavor on a web page and leave with bootable media, without
+TunaOS operating build servers.
+
+## Feasibility findings (verified 2026-07-17)
+
+**GHCR cannot feed a browser.** Tested directly: `ghcr.io/token` and
+`/v2/.../manifests/...` return 200 to non-browser clients but send **no
+`Access-Control-Allow-Origin` header**, and the `Authorization` header
+fails preflight. Browsers therefore cannot pull image layers from GHCR,
+full stop. Any in-browser pipeline must be fed from a CORS-enabled origin.
+
+**R2 is that origin.** Cloudflare R2 supports per-bucket CORS rules and
+has **zero egress fees** — serving multi-GB layer sets to browsers costs
+storage only, which is compatible with the R2 cost-reduction work. CI can
+mirror what the builder needs with `rclone`/`oras` in the existing publish
+workflows.
+
+**The hard parts of full in-browser assembly are payload and authoring,
+not privilege.** Everything tacklebox does can in principle be userspace
+file authoring (no loop devices needed): but squashfs/erofs creation and
+ISO9660/El Torito + ESP authoring have no maintained WASM ports today, and
+streaming 3–8 GB through browser memory needs the File System Access API
+and careful chunking. Real, but a project — not a blocker in principle.
+
+## Decision: three stages toward the browser builder
+
+### Stage A — ship now (the "oras hack")
+
+Store prebuilt ISOs as plain R2 objects (today's `live-isos/` layout — an
+ORAS artifact adds indirection with no browser benefit since R2 is already
+HTTP+CORS) and let the page hand out the link. This is the current
+pipeline; it is blocked only by the publish gate being red and the
+download host misconfiguration (issue #543 — `download.tunaos.org`
+currently 404s on every path).
+
+### Stage B — the MVP browser builder: one shell ISO + in-browser recipe injection
+
+The live ISO's installer is **fisherman driving `recipe.json`** — the
+image to install is *data inside the ISO*, not baked structure. So:
+
+1. CI publishes **one generic live/net-install ISO per arch** to R2
+   (CORS on).
+2. The browser fetches it, patches `recipe.json` to point at the chosen
+   `ghcr.io/tuna-os/<variant>:<flavor>` (installer pulls it over the
+   network at install time — the exact `bootcDirect` network-pull path the
+   LUKS E2E exercises), and streams the result to disk via the File
+   System Access API.
+3. Patching one file inside an ISO9660 image is small, bounded work
+   (rewrite one file's extents + path table, or reserve a fixed-size
+   padded config region to make it a pure in-place overwrite) — JS/WASM
+   scale, not squashfs scale.
+
+**Every variant × flavor becomes buildable in-browser with a single
+published shell ISO** (~1–2 GB fetch), which also collapses the published
+catalogue further. This is the recommended MVP.
+
+### Stage C — full offline assembly in the browser
+
+Mirror per-flavor OCI layouts to R2; in-browser: pull layers, author the
+dedup squashfs store and the hybrid ISO in WASM (`squashfs-tools-ng` or an
+erofs writer compiled to WASM; a minimal ISO9660/ESP writer). Produces
+fully *offline* installer ISOs client-side. Target state; start after
+Stage B proves the streaming/download UX.
+
+Interim fallbacks for combinations Stage B can't serve (e.g. air-gapped
+installs) stay as today: local `build-iso-group.sh` / tacklebox, or
+fork-and-dispatch on the user's own GitHub fork (free runners, their
+provenance). The prototype page presents both.
+
+## Threat model notes
+
+- No tokens or secrets in the page; GHCR stays out of the browser path
+  entirely (CORS makes this structural, not just policy).
+- The R2 mirror is read-only, versioned by digest, and only ever contains
+  artifacts CI signed/gated — the browser verifies digests before
+  patching (sha256 in JS/WebCrypto is cheap).
+- Recipe injection only interpolates values from the embedded
+  variant/flavor allowlist — never free text — so a shared "builder link"
+  cannot point a victim's installer at a hostile image.
+- Client-built ISOs are the user's provenance; the page says so, and the
+  shell ISO's own signature still covers everything except the recipe.
+
+## Resource estimates
+
+- Stage A: already-built pipeline + a CORS rule + fixing #543.
+- Stage B: shell-ISO recipe surface in tacklebox (padded config region
+  recommended), ~2–4 weeks of a browser ISO-patcher (JS + WebCrypto +
+  File System Access), CI job to publish the shell ISO. R2 delta: one ISO
+  per arch.
+- Stage C: WASM ports of squashfs/ISO authoring + OCI-layout mirror job;
+  months, not weeks. R2 delta: per-flavor layer storage (dedup helps —
+  layers are shared across flavors).
+
+## MVP scope (Stage B)
+
+- [ ] tacklebox: reserve a padded, fixed-offset `recipe.json` region in
+      the shell ISO so browser patching is a pure in-place overwrite.
+- [ ] CI: publish `tunaos-shell-<arch>-latest.iso` to R2; enable bucket
+      CORS for `tunaos.org` origins.
+- [ ] Web: extend the prototype configurator with the fetch → patch →
+      save pipeline and digest verification.
+- [ ] E2E: boot a browser-patched ISO in the existing `iso-e2e.sh` disk
+      gate to prove parity with CI-built ISOs.

--- a/prototype/iso-builder/index.html
+++ b/prototype/iso-builder/index.html
@@ -1,0 +1,346 @@
+<title>TunaOS ISO Builder</title>
+<style>
+  :root {
+    --bg: #f1f5f6;
+    --panel: #ffffff;
+    --panel-2: #e9eff1;
+    --line: #c9d6db;
+    --text: #182833;
+    --muted: #5c7280;
+    --accent: #d6472f;
+    --accent-ink: #ffffff;
+    --ok: #1e7d5f;
+    --ok-bg: #1e7d5f1a;
+    --warn: #8a6414;
+    --warn-bg: #d9a03f26;
+    --code-bg: #0d1720;
+    --code-text: #d9e6ec;
+    --code-muted: #7e96a3;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1720;
+      --panel: #13212c;
+      --panel-2: #182a37;
+      --line: #24384a;
+      --text: #d9e6ec;
+      --muted: #7e96a3;
+      --accent: #f0563c;
+      --accent-ink: #14100f;
+      --ok: #46a886;
+      --ok-bg: #46a8861f;
+      --warn: #d9a03f;
+      --warn-bg: #d9a03f1f;
+      --code-bg: #0a121a;
+      --code-text: #d9e6ec;
+      --code-muted: #7e96a3;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #0d1720; --panel: #13212c; --panel-2: #182a37; --line: #24384a;
+    --text: #d9e6ec; --muted: #7e96a3; --accent: #f0563c; --accent-ink: #14100f;
+    --ok: #46a886; --ok-bg: #46a8861f; --warn: #d9a03f; --warn-bg: #d9a03f1f;
+    --code-bg: #0a121a; --code-text: #d9e6ec; --code-muted: #7e96a3;
+  }
+  :root[data-theme="light"] {
+    --bg: #f1f5f6; --panel: #ffffff; --panel-2: #e9eff1; --line: #c9d6db;
+    --text: #182833; --muted: #5c7280; --accent: #d6472f; --accent-ink: #ffffff;
+    --ok: #1e7d5f; --ok-bg: #1e7d5f1a; --warn: #8a6414; --warn-bg: #d9a03f26;
+    --code-bg: #0d1720; --code-text: #d9e6ec; --code-muted: #7e96a3;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font: 15px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  code, pre, .mono { font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace; }
+
+  header {
+    display: flex; align-items: baseline; gap: 1rem; flex-wrap: wrap;
+    padding: 1.4rem 1.6rem 1.1rem;
+    border-bottom: 1px solid var(--line);
+  }
+  header h1 { margin: 0; font-size: 1.15rem; font-weight: 650; letter-spacing: .01em; }
+  header h1 .mono { color: var(--accent); font-weight: 600; }
+  header p { margin: 0; color: var(--muted); font-size: .85rem; }
+
+  .wrap {
+    display: grid; grid-template-columns: minmax(260px, 340px) 1fr; gap: 1.2rem;
+    padding: 1.2rem 1.6rem 2.5rem; max-width: 1120px; margin: 0 auto;
+  }
+  @media (max-width: 760px) { .wrap { grid-template-columns: 1fr; } }
+
+  .label {
+    font-size: .68rem; font-weight: 650; letter-spacing: .1em; text-transform: uppercase;
+    color: var(--muted); margin: 0 0 .5rem;
+  }
+
+  .variants { display: flex; flex-direction: column; gap: .35rem; }
+  .variant {
+    display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: .6rem;
+    width: 100%; text-align: left;
+    padding: .5rem .7rem; border: 1px solid var(--line); border-radius: 6px;
+    background: var(--panel); color: var(--text); cursor: pointer; font: inherit;
+  }
+  .variant:hover { border-color: var(--muted); }
+  .variant[aria-pressed="true"] { border-color: var(--accent); box-shadow: inset 2px 0 0 var(--accent); }
+  .variant:focus-visible, .chip:focus-visible, .tab:focus-visible, .copy:focus-visible {
+    outline: 2px solid var(--accent); outline-offset: 2px;
+  }
+  .variant .name { font-weight: 600; }
+  .variant .base { display: block; color: var(--muted); font-size: .72rem; }
+  .variant .count { color: var(--muted); font-size: .75rem; font-variant-numeric: tabular-nums; }
+
+  .chips { display: flex; flex-wrap: wrap; gap: .4rem; margin-top: .4rem; }
+  .chip {
+    padding: .28rem .65rem; border: 1px solid var(--line); border-radius: 999px;
+    background: var(--panel); color: var(--text); cursor: pointer; font: inherit; font-size: .82rem;
+  }
+  .chip:hover { border-color: var(--muted); }
+  .chip[aria-pressed="true"] { background: var(--accent); border-color: var(--accent); color: var(--accent-ink); font-weight: 600; }
+
+  .result { border: 1px solid var(--line); border-radius: 8px; background: var(--panel); padding: 1.1rem 1.2rem; align-self: start; }
+  .placeholder { color: var(--muted); }
+
+  .pill {
+    display: inline-flex; align-items: center; gap: .4rem;
+    font-size: .74rem; font-weight: 650; letter-spacing: .04em;
+    padding: .22rem .6rem; border-radius: 999px;
+  }
+  .pill.ok { color: var(--ok); background: var(--ok-bg); }
+  .pill.warn { color: var(--warn); background: var(--warn-bg); }
+  .pill::before { content: ""; width: .5em; height: .5em; border-radius: 50%; background: currentColor; }
+
+  .result h2 { margin: .7rem 0 .2rem; font-size: 1.05rem; }
+  .result h2 .mono { font-size: .95em; }
+  .result .sub { color: var(--muted); margin: 0 0 .9rem; font-size: .88rem; max-width: 60ch; }
+
+  .dl {
+    display: inline-block; margin: .2rem 0 .6rem;
+    background: var(--accent); color: var(--accent-ink);
+    padding: .5rem .9rem; border-radius: 6px; font-weight: 650; text-decoration: none;
+  }
+  .dl:hover { filter: brightness(1.07); }
+  .finePrint { color: var(--muted); font-size: .78rem; max-width: 62ch; }
+
+  .tabs { display: flex; gap: .2rem; border-bottom: 1px solid var(--line); margin: .9rem 0 .8rem; }
+  .tab {
+    background: none; border: none; border-bottom: 2px solid transparent;
+    padding: .35rem .7rem; color: var(--muted); cursor: pointer; font: inherit; font-size: .85rem; font-weight: 600;
+  }
+  .tab[aria-selected="true"] { color: var(--text); border-bottom-color: var(--accent); }
+
+  .cmdblock { position: relative; margin: .5rem 0 .9rem; }
+  pre {
+    margin: 0; padding: .8rem .9rem; padding-right: 4.2rem;
+    background: var(--code-bg); color: var(--code-text);
+    border-radius: 6px; font-size: .8rem; line-height: 1.5;
+    overflow-x: auto; white-space: pre;
+  }
+  pre .c { color: var(--code-muted); }
+  .copy {
+    position: absolute; top: .45rem; right: .45rem;
+    background: transparent; border: 1px solid var(--code-muted); border-radius: 4px;
+    color: var(--code-text); font-size: .7rem; padding: .15rem .5rem; cursor: pointer;
+  }
+  .copy:hover { border-color: var(--code-text); }
+
+  .steps { margin: .4rem 0 .6rem 1.1rem; padding: 0; font-size: .88rem; }
+  .steps li { margin-bottom: .35rem; }
+  .steps a { color: var(--accent); }
+
+  footer { text-align: center; color: var(--muted); font-size: .78rem; padding: 0 1.6rem 2rem; }
+  footer a { color: var(--muted); }
+</style>
+
+<header>
+  <h1><span class="mono">$ tunaos</span> ISO builder</h1>
+  <p>Pick a variant and desktop. Published ISOs download instantly; everything else builds on your machine or your fork.</p>
+</header>
+
+<div class="wrap">
+  <section>
+    <p class="label">1 · Variant</p>
+    <div class="variants" id="variants" role="group" aria-label="Variant"></div>
+  </section>
+
+  <section>
+    <p class="label">2 · Desktop flavor</p>
+    <div class="chips" id="chips" role="group" aria-label="Flavor"></div>
+    <div class="result" id="result" style="margin-top:1rem">
+      <p class="placeholder">Select a variant to see its flavors.</p>
+    </div>
+  </section>
+</div>
+
+<footer>
+  Prototype for <a href="https://github.com/tuna-os/tunaOS/issues/667">tuna-os/tunaOS#667</a> ·
+  data mirrors <span class="mono">.github/build-config.yml</span> ·
+  ADR 0002 stages this toward in-browser ISO assembly (shell ISO + recipe injection)
+</footer>
+
+<script>
+"use strict";
+// Mirrors .github/build-config.yml (variants with build_image: true) and its
+// iso_groups. Regenerate at docs-site build time in the production version.
+const VARIANTS = [
+  {id:"yellowfin", emoji:"🐠", base:"AlmaLinux Kitten 10", flavors:["base","base-hwe","base-nvidia","gnome","cosmic","kde","niri","gnome-hwe","gnome-nvidia","gnome-nvidia-hwe","cosmic-hwe","cosmic-nvidia","kde-hwe","kde-nvidia","niri-hwe","niri-nvidia"]},
+  {id:"albacore", emoji:"🐟", base:"AlmaLinux 10", flavors:["base","base-hwe","base-nvidia","gnome","cosmic","kde","niri","gnome-hwe","gnome-nvidia","gnome-nvidia-hwe","cosmic-hwe","cosmic-nvidia","kde-hwe","kde-nvidia","niri-hwe","niri-nvidia"]},
+  {id:"skipjack", emoji:"🍣", base:"CentOS Stream 10", flavors:["base","base-hwe","base-nvidia","gnome","cosmic","kde","niri","gnome-hwe","gnome-nvidia","cosmic-hwe","cosmic-nvidia","kde-hwe","kde-nvidia","niri-hwe","niri-nvidia"]},
+  {id:"bonito", emoji:"🎣", base:"Fedora 44", flavors:["base","base-hwe","base-nvidia","gnome","cosmic","kde","niri","xfce","gnome-hwe","gnome-nvidia","cosmic-nvidia","kde-nvidia","niri-nvidia","xfce-nvidia"]},
+  {id:"bonito-rawhide", emoji:"🐉", base:"Fedora Rawhide", flavors:["base","base-hwe","base-nvidia","gnome","cosmic","kde","niri","xfce","gnome-hwe","gnome-nvidia","cosmic-nvidia","kde-nvidia","niri-nvidia","xfce-nvidia"]},
+  {id:"sailfin", emoji:"🦈", base:"openSUSE Tumbleweed", flavors:["base","gnome","kde","niri","xfce"]},
+  {id:"grouper", emoji:"🐟", base:"Ubuntu 26.04", flavors:["base","gnome","gnome-zfs","kde","niri","xfce"]},
+  {id:"marlin", emoji:"🚀", base:"Arch Linux", flavors:["base","gnome","kde","cosmic","niri","xfce","gnome-cachyos","kde-cachyos"]},
+  {id:"flounder", emoji:"🐡", base:"Debian Trixie", flavors:["base","gnome","kde","cosmic","niri","xfce"]},
+  {id:"flounder-sid", emoji:"☢️", base:"Debian Sid", flavors:["base","gnome","kde","cosmic","niri","xfce"]},
+  {id:"guppy", emoji:"🌈", base:"Gentoo", flavors:["base","gnome","kde"]},
+];
+const ISO_GROUPS = [
+  {suffix:"", name:"flagship", flavors:["gnome-nvidia","gnome-nvidia-hwe"],
+   offline:["gnome","gnome-hwe","gnome-nvidia","gnome-nvidia-hwe"]},
+  {suffix:"community", name:"community", flavors:["kde-nvidia","cosmic-nvidia","niri-nvidia","xfce-nvidia"],
+   offline:["kde","kde-hwe","cosmic","cosmic-hwe","niri","niri-hwe","xfce","kde-nvidia","cosmic-nvidia","niri-nvidia","xfce-nvidia"]},
+];
+const R2 = "https://download.tunaos.org/live-isos";
+
+let selVariant = null, selFlavor = null, selTab = "local";
+
+const el = (id) => document.getElementById(id);
+
+// A variant is in the published catalogue for a group when the group's boot
+// flavors intersect the variant's buildable flavors (same rule the publish
+// pipeline uses). The flavor is covered when it's in the group's offline store.
+function coverage(variant, flavor) {
+  for (const g of ISO_GROUPS) {
+    const publishes = g.flavors.some(f => variant.flavors.includes(f));
+    if (publishes && g.offline.includes(flavor)) {
+      const basename = g.suffix ? `${variant.id}-${g.suffix}` : variant.id;
+      return { basename, group: g.name };
+    }
+  }
+  return null;
+}
+
+function renderVariants() {
+  el("variants").replaceChildren(...VARIANTS.map(v => {
+    const b = document.createElement("button");
+    b.className = "variant";
+    b.setAttribute("aria-pressed", String(selVariant === v));
+    b.innerHTML = `<span>${v.emoji}</span>
+      <span><span class="name mono">${v.id}</span><span class="base">${v.base}</span></span>
+      <span class="count">${v.flavors.length} flavors</span>`;
+    b.addEventListener("click", () => { selVariant = v; selFlavor = null; renderAll(); });
+    return b;
+  }));
+}
+
+function renderChips() {
+  const c = el("chips");
+  if (!selVariant) { c.replaceChildren(); return; }
+  c.replaceChildren(...selVariant.flavors.map(f => {
+    const b = document.createElement("button");
+    b.className = "chip mono";
+    b.textContent = f;
+    b.setAttribute("aria-pressed", String(selFlavor === f));
+    b.addEventListener("click", () => { selFlavor = f; renderAll(); });
+    return b;
+  }));
+}
+
+function cmdBlock(text) {
+  const wrap = document.createElement("div");
+  wrap.className = "cmdblock";
+  const pre = document.createElement("pre");
+  pre.innerHTML = text;
+  const btn = document.createElement("button");
+  btn.className = "copy";
+  btn.textContent = "copy";
+  btn.addEventListener("click", () => {
+    navigator.clipboard.writeText(pre.textContent).then(() => {
+      btn.textContent = "copied"; setTimeout(() => { btn.textContent = "copy"; }, 1200);
+    });
+  });
+  wrap.append(pre, btn);
+  return wrap;
+}
+
+function renderResult() {
+  const r = el("result");
+  r.replaceChildren();
+  if (!selVariant || !selFlavor) {
+    const p = document.createElement("p");
+    p.className = "placeholder";
+    p.textContent = selVariant ? "Now pick a flavor." : "Select a variant to see its flavors.";
+    r.append(p);
+    return;
+  }
+  const v = selVariant, f = selFlavor;
+  const hit = coverage(v, f);
+
+  if (hit) {
+    r.insertAdjacentHTML("beforeend", `
+      <span class="pill ok">Published ISO</span>
+      <h2><span class="mono">${v.id}:${f}</span> ships in the ${hit.group} ISO</h2>
+      <p class="sub">The ${hit.group} live ISO embeds this desktop in its offline store —
+        the installer offers it at install time, no build needed.</p>
+      <a class="dl" href="${R2}/${hit.basename}-latest.iso">Download ${hit.basename}-latest.iso</a>
+      <p class="finePrint">Signed and boot-gated by CI. sha256 sits next to the ISO.
+        If the link 404s the current publish run hasn't landed yet — see issue #543.</p>`);
+    return;
+  }
+
+  r.insertAdjacentHTML("beforeend", `
+    <span class="pill warn">Build it yourself</span>
+    <h2><span class="mono">${v.id}:${f}</span> is outside the published set</h2>
+    <p class="sub">We publish a small catalogue and keep every other combination self-service.
+      Two supported paths today — both produce a normal bootable live ISO.
+      (Planned: build it right here — the page fetches a shell ISO and injects your
+      <span class="mono">recipe.json</span> in-browser; ADR 0002, Stage B.)</p>`);
+
+  const tabs = document.createElement("div");
+  tabs.className = "tabs";
+  tabs.setAttribute("role", "tablist");
+  for (const [id, name] of [["local", "Build locally"], ["fork", "Build on your fork"]]) {
+    const t = document.createElement("button");
+    t.className = "tab";
+    t.setAttribute("role", "tab");
+    t.setAttribute("aria-selected", String(selTab === id));
+    t.textContent = name;
+    t.addEventListener("click", () => { selTab = id; renderResult(); });
+    tabs.append(t);
+  }
+  r.append(tabs);
+
+  if (selTab === "local") {
+    r.insertAdjacentHTML("beforeend",
+      `<p class="sub">Needs Linux with <span class="mono">podman</span>, <span class="mono">just</span>, <span class="mono">yq</span>, <span class="mono">jq</span> and root (tacklebox partitions the ISO image).</p>`);
+    r.append(cmdBlock(
+`<span class="c"># ~20–40 min, ~30 GB scratch space</span>
+git clone https://github.com/tuna-os/tunaOS &amp;&amp; cd tunaOS
+just build ${v.id} ${f}
+sudo ./scripts/build-iso-tacklebox.sh ${v.id} ${f} local`));
+  } else {
+    const list = document.createElement("ol");
+    list.className = "steps";
+    list.innerHTML = `
+      <li><a href="https://github.com/tuna-os/tunaOS/fork">Fork tuna-os/tunaOS</a> (free).</li>
+      <li>In your fork: Actions → enable workflows.</li>
+      <li>Run the build with the GitHub CLI (or the Actions UI):</li>`;
+    r.append(list);
+    r.append(cmdBlock(
+`gh workflow run "Artifacts" --repo YOUR_USER/tunaOS \\
+  -f variant=${v.id} -f flavor=${f}
+<span class="c"># then download the ISO from the run's artifacts (kept 7 days)</span>`));
+    r.insertAdjacentHTML("beforeend",
+      `<p class="finePrint">Builds run on GitHub's free runners in <em>your</em> namespace —
+       your fork, your provenance. Nothing is uploaded to TunaOS infrastructure.</p>`);
+  }
+}
+
+function renderAll() { renderVariants(); renderChips(); renderResult(); }
+renderAll();
+</script>

--- a/prototype/iso-builder/index.html
+++ b/prototype/iso-builder/index.html
@@ -176,10 +176,27 @@
   </section>
 </div>
 
+<section class="wrap" style="display:block; padding-top:0">
+  <div class="result" id="inspect">
+    <p class="label">In-browser pipeline · stage 1: read the image</p>
+    <p class="sub" style="margin-top:0">The end state builds the whole ISO right here — no terminal, no
+      app, no extra published artifacts: the source is the bootc image already on ghcr.io.
+      This demo runs the first stage live: token → manifest index → platform manifest → config.
+      It needs the CORS shim (<span class="mono">worker/cors-shim.js</span>) because ghcr.io
+      refuses browser reads.</p>
+    <div style="display:flex; gap:.5rem; flex-wrap:wrap; align-items:center; margin:.6rem 0 .8rem">
+      <input id="shimUrl" class="mono" placeholder="shim base URL, e.g. https://ghcr-shim.tunaos.org"
+        style="flex:1; min-width:260px; padding:.45rem .6rem; border:1px solid var(--line); border-radius:6px; background:var(--panel); color:var(--text); font-size:.82rem">
+      <button id="inspectBtn" class="dl" style="margin:0; border:none; cursor:pointer; font:inherit; font-weight:650">Inspect image</button>
+    </div>
+    <div id="inspectOut" class="finePrint">Pick a variant and flavor above, then inspect.</div>
+  </div>
+</section>
+
 <footer>
   Prototype for <a href="https://github.com/tuna-os/tunaOS/issues/667">tuna-os/tunaOS#667</a> ·
   data mirrors <span class="mono">.github/build-config.yml</span> ·
-  ADR 0002 stages this toward in-browser ISO assembly (shell ISO + recipe injection)
+  ADR 0002: zero-publish in-browser ISO assembly, fed by the existing ghcr.io images
 </footer>
 
 <script>
@@ -298,8 +315,8 @@ function renderResult() {
     <h2><span class="mono">${v.id}:${f}</span> is outside the published set</h2>
     <p class="sub">We publish a small catalogue and keep every other combination self-service.
       Two supported paths today — both produce a normal bootable live ISO.
-      (Planned: build it right here — the page fetches a shell ISO and injects your
-      <span class="mono">recipe.json</span> in-browser; ADR 0002, Stage B.)</p>`);
+      (The goal: build it right here in the browser, straight from the ghcr.io image —
+      see the pipeline demo below and ADR 0002.)</p>`);
 
   const tabs = document.createElement("div");
   tabs.className = "tabs";
@@ -343,4 +360,62 @@ sudo ./scripts/build-iso-tacklebox.sh ${v.id} ${f} local`));
 
 function renderAll() { renderVariants(); renderChips(); renderResult(); }
 renderAll();
+
+// ── Stage 1 of the in-browser builder: OCI pull chain ─────────────────────
+// token → index → amd64 manifest → config blob. Layers are tar+zstd; later
+// stages add a WASM zstd stream + tar walker, then erofs/ISO authoring.
+const fmtMB = (b) => (b / 1048576).toFixed(1) + " MB";
+
+async function inspectImage() {
+  const out = el("inspectOut");
+  if (!selVariant || !selFlavor) { out.textContent = "Pick a variant and flavor above first."; return; }
+  const shim = el("shimUrl").value.trim().replace(/\/+$/, "");
+  const base = shim || "https://ghcr.io";
+  const img = selVariant.id, ref = selFlavor;
+  out.textContent = `Pulling ghcr.io/tuna-os/${img}:${ref} …`;
+  try {
+    const tokRes = await fetch(`${base}/token?scope=repository:tuna-os/${img}:pull`);
+    if (!tokRes.ok) throw new Error(`token HTTP ${tokRes.status}`);
+    const token = (await tokRes.json()).token;
+    const auth = { headers: { Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json" } };
+
+    const idxRes = await fetch(`${base}/v2/tuna-os/${img}/manifests/${ref}`, auth);
+    if (!idxRes.ok) throw new Error(`manifest HTTP ${idxRes.status}`);
+    let manifest = await idxRes.json();
+    let platformNote = "single-platform";
+    if (manifest.manifests) {
+      const m = manifest.manifests.find(x => x.platform.architecture === "amd64" && !x.platform.variant)
+        || manifest.manifests[0];
+      platformNote = `${m.platform.architecture}${m.platform.variant ? "/" + m.platform.variant : ""}`;
+      const mRes = await fetch(`${base}/v2/tuna-os/${img}/manifests/${m.digest}`, auth);
+      if (!mRes.ok) throw new Error(`platform manifest HTTP ${mRes.status}`);
+      manifest = await mRes.json();
+    }
+    const cfgRes = await fetch(`${base}/v2/tuna-os/${img}/blobs/${manifest.config.digest}`,
+      { headers: { Authorization: `Bearer ${token}` } });
+    if (!cfgRes.ok) throw new Error(`config blob HTTP ${cfgRes.status}`);
+    const cfg = await cfgRes.json();
+    const labels = (cfg.config && cfg.config.Labels) || {};
+    const total = manifest.layers.reduce((s, l) => s + l.size, 0);
+    const types = [...new Set(manifest.layers.map(l => l.mediaType.split(".").pop()))].join(", ");
+
+    out.innerHTML = `
+      <p style="margin:.2rem 0 .5rem"><span class="pill ok">image readable from this browser</span></p>
+      <p style="color:var(--text); font-size:.85rem; margin:0 0 .6rem">
+        <span class="mono">${img}:${ref}</span> · platform ${platformNote} ·
+        <strong>${manifest.layers.length} layers, ${fmtMB(total)}</strong> compressed (${types}) ·
+        bootc: <span class="mono">${labels["containers.bootc"] === "1" ? "yes" : "unknown"}</span> ·
+        version <span class="mono">${labels["org.opencontainers.image.version"] || "?"}</span></p>
+      <p>Next stages (not yet wired): zstd-decompress + tar-walk these layers for the kernel and
+        initramfs, author the erofs live root and ESP, wrap as ISO9660, stream to your disk.</p>`;
+  } catch (e) {
+    out.innerHTML = `<span style="color:var(--warn)">Pull failed: ${e.message}.</span>
+      Without a shim URL this is expected — ghcr.io sends no CORS headers, so the browser
+      discards its responses. Deploy <span class="mono">worker/cors-shim.js</span> and paste its URL.
+      (Hosts with a strict CSP, like this preview, block all outbound fetches either way —
+      run the page from the repo or the docs site.)`;
+  }
+}
+el("inspectBtn").addEventListener("click", inspectImage);
 </script>

--- a/prototype/iso-builder/worker/cors-shim.js
+++ b/prototype/iso-builder/worker/cors-shim.js
@@ -1,0 +1,65 @@
+// Stateless CORS shim for ghcr.io — the only server-side piece of the
+// browser ISO builder (ADR 0002). ghcr.io sends no Access-Control-Allow-Origin
+// headers, so browser JS cannot read its responses; this Worker relays the
+// three read-only endpoints the puller needs and adds the header. It stores
+// nothing, publishes nothing, and needs no updates when images change.
+//
+// Deploy: wrangler deploy (route e.g. ghcr-shim.tunaos.org/*).
+//
+//   GET /token?scope=repository:tuna-os/<image>:pull
+//   GET /v2/tuna-os/<image>/manifests/<ref>
+//   GET /v2/tuna-os/<image>/blobs/sha256:<digest>
+
+const UPSTREAM = "https://ghcr.io";
+// Only public images in this org — the shim must never become a general relay.
+const ORG = "tuna-os";
+
+const PATH_ALLOW = new RegExp(
+  `^/(token$|v2/${ORG}/[a-z0-9._-]+/(manifests|blobs)/[A-Za-z0-9._:@-]+$)`
+);
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+  "Access-Control-Allow-Headers": "Authorization, Accept",
+  "Access-Control-Expose-Headers":
+    "Content-Length, Content-Type, Docker-Content-Digest, WWW-Authenticate",
+  "Access-Control-Max-Age": "86400",
+};
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: CORS });
+    }
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("method not allowed", { status: 405, headers: CORS });
+    }
+    if (!PATH_ALLOW.test(url.pathname)) {
+      return new Response("path not allowed", { status: 403, headers: CORS });
+    }
+
+    const upstream = new URL(url.pathname + url.search, UPSTREAM);
+    const headers = new Headers();
+    for (const h of ["authorization", "accept"]) {
+      const v = request.headers.get(h);
+      if (v) headers.set(h, v);
+    }
+
+    // Blobs are content-addressed and immutable — let Cloudflare's edge cache
+    // absorb repeat pulls so ghcr.io isn't hammered.
+    const cacheable = url.pathname.includes("/blobs/");
+    const resp = await fetch(upstream, {
+      method: request.method,
+      headers,
+      redirect: "follow",
+      cf: cacheable ? { cacheEverything: true, cacheTtl: 604800 } : undefined,
+    });
+
+    const out = new Headers(resp.headers);
+    for (const [k, v] of Object.entries(CORS)) out.set(k, v);
+    return new Response(resp.body, { status: resp.status, headers: out });
+  },
+};


### PR DESCRIPTION
Addresses #667.

- **ADR 0002**: empirically tested feasibility (GHCR sends no `Access-Control-Allow-Origin` → browsers cannot pull from it; R2 has free egress + CORS). Staged architecture: (A) R2-hosted ISOs now, (B) MVP browser builder = one shell ISO + in-browser `recipe.json` injection over the fisherman `bootcDirect` network-pull path, (C) full offline WASM assembly from R2-mirrored OCI layouts.
- **Prototype** `prototype/iso-builder/index.html`: static configurator — variant × flavor → published grouped-ISO download link, or local-build / fork-and-dispatch commands. No backend, no tokens.

Side-finding: `download.tunaos.org` 404s on every path right now (#543).

🤖 Generated with [Claude Code](https://claude.com/claude-code)