### PR TITLE
ci: bump tacklebox — dracut exec-bit fix un-breaks live-ISO boots

### DIFF
--- a/.github/workflows/publish-iso-groups.yml
+++ b/.github/workflows/publish-iso-groups.yml
@@ -123,7 +123,7 @@ jobs:
           # The low-disk offline-store implementation must be reproducible and
           # available before the release-container workflow finishes publishing.
           TACKLEBOX_FROM_SOURCE: '1'
-          TACKLEBOX_SHA: b8175c5d1dadb46d9c74daaa69fa3fb8c118bedd
+          TACKLEBOX_SHA: 18a2eb16c9ced6869ea41dc395d72b7d31eb3ad4
         run: |
           sudo --preserve-env=GITHUB_REPOSITORY_OWNER,TACKLEBOX_FROM_SOURCE,TACKLEBOX_SHA \
             just iso-group "${{ matrix.variant }}" "${{ matrix.group }}" ghcr

--- a/.github/workflows/publish-iso-groups.yml
+++ b/.github/workflows/publish-iso-groups.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y just podman jq rclone golang-go git
+          sudo apt-get install -y just podman jq rclone golang-go git systemd-boot-efi xorriso mtools squashfs-tools dosfstools gdisk
           sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
 
       - name: Log in to GHCR

--- a/.github/workflows/publish-iso-groups.yml
+++ b/.github/workflows/publish-iso-groups.yml
@@ -123,7 +123,7 @@ jobs:
           # The low-disk offline-store implementation must be reproducible and
           # available before the release-container workflow finishes publishing.
           TACKLEBOX_FROM_SOURCE: '1'
-          TACKLEBOX_SHA: 18a2eb16c9ced6869ea41dc395d72b7d31eb3ad4
+          TACKLEBOX_SHA: 04f3c6251062c489f807e6ba1cf8da4450c50264
         run: |
           sudo --preserve-env=GITHUB_REPOSITORY_OWNER,TACKLEBOX_FROM_SOURCE,TACKLEBOX_SHA \
             just iso-group "${{ matrix.variant }}" "${{ matrix.group }}" ghcr

--- a/.github/workflows/publish-iso-groups.yml
+++ b/.github/workflows/publish-iso-groups.yml
@@ -123,7 +123,7 @@ jobs:
           # The low-disk offline-store implementation must be reproducible and
           # available before the release-container workflow finishes publishing.
           TACKLEBOX_FROM_SOURCE: '1'
-          TACKLEBOX_SHA: dd5b29b2f46aeda539ba447f6884218926788080
+          TACKLEBOX_SHA: b8175c5d1dadb46d9c74daaa69fa3fb8c118bedd
         run: |
           sudo --preserve-env=GITHUB_REPOSITORY_OWNER,TACKLEBOX_FROM_SOURCE,TACKLEBOX_SHA \
             just iso-group "${{ matrix.variant }}" "${{ matrix.group }}" ghcr

--- a/Justfile
+++ b/Justfile
@@ -185,7 +185,10 @@ iso variant='skipjack' flavor='gnome' repo='local' tag='' dev='0':
 # Build ONE combined dedup ISO containing every desktop in an iso_group (#455).
 # group: '' / default (flagship gnome+hwe), community (kde/cosmic/niri), nvidia.
 iso-group variant='yellowfin' group='default' repo='ghcr':
-    sudo bash ./scripts/build-iso-group.sh "{{ variant }}" "{{ group }}" "{{ repo }}"
+    # --preserve-env: the inner sudo must not strip the CI-pinned tacklebox
+    # source build vars (a plain sudo here silently fell back to the stale
+    # ghcr tacklebox image while CI believed it was testing pinned fixes).
+    sudo --preserve-env=GITHUB_REPOSITORY_OWNER,TACKLEBOX_FROM_SOURCE,TACKLEBOX_SHA,TACKLEBOX_IMAGE,TACKLEBOX_CACHE bash ./scripts/build-iso-group.sh "{{ variant }}" "{{ group }}" "{{ repo }}"
 # Generate a QCOW2 disk image using bootc install to-disk (via loopback in a privileged container)
 qcow2 variant flavor='gnome' repo='local' tag='':
     #!/usr/bin/env bash


### PR DESCRIPTION
Pulls in tuna-os/tacklebox#96: `tbox-live-generator` was non-executable in every built initramfs, so systemd skipped it and every live boot hung into emergency at the fstab-generator's bogus `sysroot.mount` — while the live root was fully prepared. Probable root cause of this pipeline's boot-gate timeouts and therefore of the empty R2 catalogue (#543's supply side).

Diagnosis trail: tuna-os/tacklebox#95 (found while boot-testing a pure-Go-authored ISO; fix boot-verified to `login:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)