### PR TITLE
fix(live-iso): make the DE matrix actually bootable — liveuser, autologin, detection, networking

### DIFF
--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -22,13 +22,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # TUNA_SESSION_ROOT lets the bats tests point detection at a fake root.
 _SR="${TUNA_SESSION_ROOT:-}"
 DESKTOP="gnome"
-if [[ -f "${_SR}/usr/share/wayland-sessions/plasma.desktop" ]]; then
+if [[ -f "${_SR}/usr/share/wayland-sessions/plasma.desktop" || -f "${_SR}/usr/share/wayland-sessions/plasmawayland.desktop" ]]; then
 	DESKTOP="kde"
 elif [[ -f "${_SR}/usr/share/wayland-sessions/niri.desktop" ]]; then
 	DESKTOP="niri"
 elif [[ -f "${_SR}/usr/share/wayland-sessions/cosmic.desktop" ]]; then
 	DESKTOP="cosmic"
-elif compgen -G "${_SR}/usr/share/xsessions/xfce*.desktop" >/dev/null; then
+elif compgen -G "${_SR}/usr/share/xsessions/xfce*.desktop" >/dev/null ||
+	compgen -G "${_SR}/usr/share/wayland-sessions/xfce*.desktop" >/dev/null; then
 	DESKTOP="xfce"
 fi
 echo "customize-live: detected desktop=${DESKTOP}"
@@ -48,6 +49,25 @@ esac
 if [[ "${TUNA_DETECT_ONLY:-0}" == "1" ]]; then
 	echo "DETECTED ${DESKTOP} ${INSTALLER_APP:-none}"
 	exit 0
+fi
+
+# ── 1b. Live user ────────────────────────────────────────────────────────────
+# No TunaOS image ships livesys-scripts, so nothing creates the account the
+# desktop adapters autologin to — bake it into the squash instead (pattern:
+# projectbluefin/dakota-iso configure-live.sh). uid 1000 is free on bootc
+# images. Installed systems never see this: live squash only.
+if ! getent passwd liveuser >/dev/null; then
+	useradd --create-home --uid 1000 --user-group \
+		--comment "Live User" --shell /bin/bash liveuser
+fi
+passwd --delete liveuser >/dev/null 2>&1 || true
+
+# ── 1c. Live networking ──────────────────────────────────────────────────────
+# Server-ish bases (grouper/Ubuntu) ship NetworkManager without enabling it,
+# leaving the live env with no DHCP at all (bug #17). Enabling here is a
+# no-op on variants that already enable it.
+if systemctl list-unit-files NetworkManager.service --no-legend 2>/dev/null | grep -q NetworkManager; then
+	systemctl enable NetworkManager.service || true
 fi
 
 # ── 2. Desktop adapter (autologin, screen-lock, suspend masking) ─────────────

--- a/live-iso/common/src/desktop-gnome.sh
+++ b/live-iso/common/src/desktop-gnome.sh
@@ -9,11 +9,24 @@
 
 set -euo pipefail
 
+# GDM autologin straight into the live session. Debian/Ubuntu read
+# /etc/gdm3/, everyone else /etc/gdm/ — write whichever exists (both when
+# neither does, harmlessly).
+for _gdm_dir in /etc/gdm /etc/gdm3; do
+	[[ -d "${_gdm_dir}" || "${_gdm_dir}" == "/etc/gdm" ]] || continue
+	mkdir -p "${_gdm_dir}"
+	tee "${_gdm_dir}/custom.conf" <<'GDMEOF'
+[daemon]
+AutomaticLoginEnable=True
+AutomaticLogin=liveuser
+GDMEOF
+done
+
 # Set up the GNOME dock for the installer
 tee /usr/share/glib-2.0/schemas/zz2-tunaos-installer.gschema.override <<'EOF'
 [org.gnome.shell]
 welcome-dialog-last-shown-version='4294967295'
-favorite-apps = ['bootc-installer.desktop', 'firefox.desktop', 'org.gnome.Nautilus.desktop']
+favorite-apps = ['org.bootcinstaller.Installer.desktop', 'bootc-installer.desktop', 'firefox.desktop', 'org.gnome.Nautilus.desktop']
 EOF
 
 # Disable suspend/sleep so the installer doesn't go to sleep mid-install

--- a/live-iso/common/src/desktop-kde.sh
+++ b/live-iso/common/src/desktop-kde.sh
@@ -15,15 +15,20 @@ set -euo pipefail
 # (an installer mid-run can't recover from S3), and mask suspend
 # targets so KDE's own power-management prefs can't override.
 
+# openSUSE names the session plasmawayland.desktop; everyone else plasma.
+_kde_session="plasma"
+if [[ -f /usr/share/wayland-sessions/plasmawayland.desktop && ! -f /usr/share/wayland-sessions/plasma.desktop ]]; then
+	_kde_session="plasmawayland"
+fi
 mkdir -p /etc/sddm.conf.d
-tee /etc/sddm.conf.d/live-autologin.conf <<'SDDMEOF'
+tee /etc/sddm.conf.d/live-autologin.conf <<SDDMEOF
 [General]
 DisplayServer=wayland
 CompositorCommand=kwin_wayland --no-lockscreen
 
 [Autologin]
 User=liveuser
-Session=plasma
+Session=${_kde_session}
 Relogin=false
 SDDMEOF
 

--- a/live-iso/common/src/desktop-xfce.sh
+++ b/live-iso/common/src/desktop-xfce.sh
@@ -9,7 +9,34 @@
 
 set -euo pipefail
 
-# GDM autologin straight into the live session
+# XFCE's display manager varies: lightdm (deb/EL10-x11), greetd (EL10
+# wayland fallback), gdm on odd builds. Configure all three; only the
+# active one reads its file.
+mkdir -p /etc/lightdm/lightdm.conf.d
+tee /etc/lightdm/lightdm.conf.d/50-live-autologin.conf <<'LIGHTDMEOF'
+[Seat:*]
+autologin-user=liveuser
+autologin-user-timeout=0
+LIGHTDMEOF
+# lightdm requires the autologin user in the 'autologin' group on deb.
+groupadd -f autologin && usermod -aG autologin liveuser || true
+
+_xfce_session="startxfce4"
+compgen -G "/usr/share/wayland-sessions/xfce*.desktop" >/dev/null && _xfce_session="xfce-wayland-session"
+mkdir -p /etc/greetd
+tee /etc/greetd/config.toml <<GREETDEOF
+[terminal]
+vt = 1
+
+[default_session]
+user = "liveuser"
+command = "${_xfce_session}"
+
+[initial_session]
+user = "liveuser"
+command = "${_xfce_session}"
+GREETDEOF
+
 mkdir -p /etc/gdm
 tee /etc/gdm/custom.conf <<'GDMEOF'
 [daemon]


### PR DESCRIPTION
Sanity audit of the live-ISO setup across every variant × DE, fixing what was clearly broken (testing follows separately):

| Issue | Blast radius | Fix |
|---|---|---|
| `liveuser` never created (no livesys-scripts anywhere) | **every** live ISO autologins into a ghost user | baked into squash at customize (dakota pattern) |
| GNOME adapter had zero autologin | all gnome ISOs → empty greeter | GDM custom.conf (`/etc/gdm` + `/etc/gdm3`) |
| XFCE adapter configured GDM, xfce runs lightdm/greetd | all xfce ISOs | lightdm + greetd configs w/ real session name |
| sailfin KDE session is `plasmawayland.desktop` | sailfin:kde misdetected as gnome | detect both; SDDM `Session=` matches shipped file |
| xfce-wayland session invisible to detection | EL10 xfce once re-enabled | glob `wayland-sessions/xfce*` too |
| grouper live has no DHCP (bug #17) | all grouper ISOs | `systemctl enable NetworkManager` when shipped |

Verified fine during the audit: flatpak + fuse-overlayfs + tunaos-live-ready enabled in all variants; installer flatpaks all published on the OCI remote (`tuna-os/tuna-installer-{kde,niri,cosmic,xfce}` + bootc-installer bundles); niri/cosmic greetd adapters correct; gentoo ships dracut. Known remaining packaging gaps (not addressed here): grouper xfce lightdm crash-loop (#15), grouper gnome wayland-session, EL10 xfce awaiting xfce4-wayland repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)