### PR TITLE
docs: README — download or build your own ISO (browser builder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,15 @@ Browse the currently published installation media on the download page:
 
 ### Build your own ISO or VM image
 
-Use [tacklebox](https://github.com/tuna-os/tacklebox) to build ISOs:
+**In your browser — no tools, no root, nothing uploaded:**
+
+**[🛠️ tunaos.org/iso-builder](https://tunaos.org/iso-builder)** — point it
+at any TunaOS image (or your own bootc image), pick your flatpaks, and it
+authors a bootable live ISO entirely in WebAssembly using the same
+[tacklebox](https://github.com/tuna-os/tacklebox) engine CI uses.
+[User guide](https://tunaos.org/docs/iso-builder).
+
+**Or locally with [tacklebox](https://github.com/tuna-os/tacklebox):**
 
 ```bash
 # ISO (requires root)


### PR DESCRIPTION
Users now see both options: download pre-built media, or build their own — in the browser at [tunaos.org/iso-builder](https://tunaos.org/iso-builder) (same tacklebox engine as CI, WASM), or locally with tacklebox. Pairs with the tunaos.org homepage/download-page links just shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)