### PR TITLE
ci: retry the OS base pull with backoff — CDN blob EOFs kill nightlies

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -201,6 +201,17 @@ jobs:
         run: |
           set -x
           just=$(which just)
+          # Pre-pull the OS base with retries: quay's CDN drops blobs
+          # mid-transfer often enough to kill nightly builds (rawhide:
+          # #675). podman build then finds the base in local storage.
+          BASE=$(yq -r ".variants[] | select(.id == \"${IMAGE_VARIANT}\") | .base_image // \"\"" .github/build-config.yml)
+          if [ -n "$BASE" ] && [ -z "${CHAIN_BASE_IMAGE}" ]; then
+            for i in 1 2 3 4; do
+              sudo podman pull --platform "${PLATFORM}" "$BASE" && break
+              echo "base pull attempt $i failed; retrying..."
+              sleep $((i * 15))
+            done
+          fi
           build_start=$(date +%s)
           # --preserve-env: sudo otherwise strips the cache/rechunk knobs
           # (the old layer cache never worked for exactly this reason).


### PR DESCRIPTION
Pre-pulls the variant's `base_image` (4 attempts, backoff) before `podman build`, so quay/registry CDN mid-blob EOFs — which have killed bonito-rawhide nightlies to the point of **zero rawhide tags on GHCR** (#675) and struck almalinux pulls tonight too — stop failing whole matrix cells. Step is a no-op for chained builds.

Part of getting every variant publishing to GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)