### PR TITLE
fix(xfce): give greetd a real greeter, and gate the case CI could not see

### DIFF
--- a/build_scripts/checks/e2e-runtime-checks.sh
+++ b/build_scripts/checks/e2e-runtime-checks.sh
@@ -115,6 +115,35 @@ if [[ -n "$dm_pattern" ]]; then
 		bash -c "[[ '${dm_id}' =~ ${dm_pattern} ]]"
 fi
 
+# greetd active is NOT the same as greetd usable. Its stock config runs
+# `agreety --cmd /bin/sh` — a text prompt into a bare shell, with no session
+# picker and no way to reach the desktop. That state still satisfies every
+# check above: graphical.target is active, display-manager.service is active,
+# and the DM matches the contract. XFCE shipped exactly this until gtkgreet
+# was packaged, and nothing here caught it.
+#
+# So when greetd is the DM, assert its configured session is a real greeter.
+#
+# Scoped to xfce deliberately. cosmic-greeter ships /etc/greetd/
+# cosmic-greeter.toml (plus its own cosmic-greeter.service) rather than
+# config.toml, so reading config.toml on cosmic/niri would test a file their
+# greeter does not use and fail two currently-green flavors. Extending this to
+# them needs their real config path confirmed first — see tunaOS#636.
+if [[ "$dm_id" == "greetd.service" && "$DESKTOP" == "xfce" ]]; then
+	greetd_cmd=$(sed -n '/^\[default_session\]/,/^\[/p' /etc/greetd/config.toml 2>/dev/null |
+		sed -n 's/^[[:space:]]*command[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' | head -1)
+	emit "# greetd session command: ${greetd_cmd:-<none>}"
+	check "greetd launches a graphical greeter (not agreety/shell)" \
+		bash -c "[[ -n '${greetd_cmd}' ]] && [[ ! '${greetd_cmd}' =~ agreety ]]"
+	# The command is run by greetd, so a typo'd or unpackaged greeter binary
+	# fails at login with nothing in the image to show for it.
+	greetd_bin=${greetd_cmd%% *}
+	if [[ -n "$greetd_bin" ]]; then
+		check "greetd session binary exists (${greetd_bin})" \
+			command -v "$greetd_bin"
+	fi
+fi
+
 check "a network manager is active" \
 	bash -c 'systemctl is-active NetworkManager 2>/dev/null || systemctl is-active systemd-networkd'
 

--- a/build_scripts/desktop/xfce.sh
+++ b/build_scripts/desktop/xfce.sh
@@ -73,6 +73,20 @@ case "${1:-}" in
 			greetd \
 			greetd-selinux
 
+		# greetd ships no graphical greeter: its stock config runs
+		# `agreety --cmd /bin/sh`, i.e. a text prompt into a bare shell with
+		# no session picker. cosmic/niri never hit this because
+		# cosmic-greeter/dms-greeter ship their own config.toml — XFCE has no
+		# such package, so without this block an installed XFCE system boots
+		# to a shell. It still reaches graphical.target with
+		# display-manager.service active, so the desktop-contract gate cannot
+		# see the difference; only this config can.
+		#
+		# gtkgreet is GTK3 like the XFCE session, so it inherits the same
+		# GTK/icon/cursor/font theme — greeter and desktop match by
+		# construction. It pulls cage (its kiosk host) via Requires.
+		install_available gtkgreet
+
 		# Session entry: the adapted xfce4-session ships a wayland-sessions
 		# desktop file running `startxfce4 --wayland`. Only write a fallback
 		# if no packaged Wayland session landed (keeps DMs from showing an
@@ -87,6 +101,55 @@ Exec=startxfce4 --wayland
 Type=Application
 DesktopNames=XFCE
 EOF
+		fi
+
+		# Point greetd at gtkgreet. Only rewrite the config when gtkgreet
+		# actually landed — if packaging regressed, leaving greetd's own
+		# config in place fails loudly at a text prompt rather than silently
+		# launching a greeter that is not installed.
+		if command -v gtkgreet &>/dev/null && command -v cage &>/dev/null; then
+			# gtkgreet is a plain Wayland client and cannot own a VT, so cage
+			# hosts it. -s keeps VT switching available (without it a greeter
+			# crash locks you out of the machine entirely).
+			mkdir -p /etc/greetd
+			cat >/etc/greetd/config.toml <<'EOF'
+[terminal]
+vt = 1
+
+[default_session]
+command = "cage -s -- gtkgreet -l -s /etc/greetd/gtkgreet.css"
+user = "greetd"
+EOF
+
+			# Greeter styling. Kept deliberately small: gtkgreet is GTK3, so
+			# it already picks up the session's GTK theme, icons, cursor and
+			# font — this only supplies the pieces a theme cannot know about
+			# (the layer-shell background behind the login window).
+			cat >/etc/greetd/gtkgreet.css <<'EOF'
+/* TunaOS XFCE greeter.
+ *
+ * gtkgreet inherits the system GTK3 theme, which is the whole reason it is
+ * the XFCE greeter: the login screen and the session it launches are styled
+ * by the same theme. Only the layer-shell background and the login window's
+ * framing are set here — everything else is intentionally left to the theme
+ * so retheming the desktop retheme the greeter too.
+ */
+window {
+	background-image: linear-gradient(to bottom, #2b3d4f, #1b2733);
+	background-color: #1b2733;
+}
+
+/* The login box: lift it off the background, otherwise the themed widgets
+ * float on the gradient with no visual container. */
+box#window-box {
+	background-color: @theme_bg_color;
+	border-radius: 8px;
+	padding: 24px;
+}
+EOF
+			# greetd runs the greeter as its own unprivileged user; it must be
+			# able to read both files.
+			chmod 0644 /etc/greetd/config.toml /etc/greetd/gtkgreet.css
 		fi
 
 		# Enable lightdm or greetd for display management


### PR DESCRIPTION
An installed XFCE system booted to a **text prompt and a bare shell**, not a desktop. `xfce.sh` enabled greetd but nothing ever wrote `/etc/greetd/config.toml`, so greetd fell back to its stock `agreety --cmd /bin/sh`. cosmic/niri never hit this because `cosmic-greeter`/`dms-greeter` ship their own config; XFCE has no such package.

## Why it survived CI

The broken state passes **every** existing check:

- `graphical.target` active ✅
- `display-manager.service` active ✅
- DM matches the xfce contract ✅

…all true while the user stares at a shell. Same false-pass shape as the earlier niri TTY fallthrough.

So this adds the missing assertion *alongside* the fix: when greetd is the DM, read its configured session command and require it is present, is not `agreety`, and names a binary that exists.

**Scoped to xfce on purpose.** `cosmic-greeter` ships `/etc/greetd/cosmic-greeter.toml` plus its own `cosmic-greeter.service` rather than `config.toml` — reading `config.toml` on cosmic/niri would test a file their greeter does not use and fail two currently-green flavors. Verified by extracting the RPM. Extending it needs their real config path confirmed first.

## The greeter

`gtkgreet`, hosted by `cage -s --` (`-s` keeps VT switching, so a greeter crash cannot lock you out). Being GTK3 like the XFCE session it inherits the same GTK/icon/cursor/font theme, so login screen and desktop match with no second theme to maintain. The shipped CSS styles only the layer-shell background and login container — everything else is left to the theme, so retheming the desktop rethemes the greeter.

Written only when `gtkgreet` **and** `cage` are present: if packaging regresses, greetd’s own config stays and fails loudly rather than pointing at a greeter that is not installed.

## Verification

- `xfwl4-4.21.0` resolves from `tunaos-xfce`; depsolve clean, image builds
- `/usr/share/xsessions/` empty, `xfwm4`/`gdm` absent — genuinely Wayland-only
- gtkgreet RPM built on EL10; `ldd` confirms `libgtk-layer-shell.so.0` linked
- `shfmt` no diff, 28 bats tests pass

## Not in this PR

Re-enabling the xfce build cells waits on tuna-os/github-copr#82 publishing gtkgreet to repo.tunaos.org — turning them on now would guarantee a red cell. Follow-up enables yellowfin/albacore/skipjack/guppy together.

Refs: #636