### PR TITLE
feat(xfce): enable Wayland-only XFCE on the EL10 variants

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -92,18 +92,16 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-      # DISABLED: xfce4-wayland stack not yet published to repo.tunaos.org.
-      # Re-enable when tuna-os/github-copr#65 lands (specs + build-order tier).
-      # - id: xfce
-      #   stage: 2
-      #   build_image: true
-      #   build_iso: true
-      #   build_qcow2: false
-      #   # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
-      #   # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
-      #   platforms:
-      #     - linux/amd64
-      #     - linux/amd64/v2
+      - id: xfce
+        stage: 2
+        build_image: true
+        build_iso: true
+        build_qcow2: false
+        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
+        # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
+        platforms:
+          - linux/amd64
+          - linux/amd64/v2
 
       # ── Stage 3 ────────────────────────────────────────────────────────────
       # HWE: no ISO — install the standard ISO then `bootc switch` to *-hwe
@@ -152,30 +150,26 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-      # DISABLED: xfce4-wayland stack not yet published to repo.tunaos.org.
-      # Re-enable when tuna-os/github-copr#65 lands (specs + build-order tier).
-      # - id: xfce-hwe
-      #   stage: 3
-      #   build_image: true
-      #   build_iso: false
-      #   build_qcow2: false
-      #   # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
-      #   # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
-      #   platforms:
-      #     - linux/amd64
-      #     - linux/amd64/v2
-      # DISABLED: xfce4-wayland stack not yet published to repo.tunaos.org.
-      # Re-enable when tuna-os/github-copr#65 lands (specs + build-order tier).
-      # - id: xfce-nvidia
-      #   stage: 3
-      #   build_image: true
-      #   build_iso: true
-      #   build_qcow2: false
-      #   # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
-      #   # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
-      #   platforms:
-      #     - linux/amd64
-      #     - linux/amd64/v2
+      - id: xfce-hwe
+        stage: 3
+        build_image: true
+        build_iso: false
+        build_qcow2: false
+        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
+        # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
+        platforms:
+          - linux/amd64
+          - linux/amd64/v2
+      - id: xfce-nvidia
+        stage: 3
+        build_image: true
+        build_iso: true
+        build_qcow2: false
+        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
+        # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
+        platforms:
+          - linux/amd64
+          - linux/amd64/v2
 
   - id: albacore
     emoji: "🐟"
@@ -222,18 +216,16 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-      # DISABLED: xfce4-wayland stack not yet published to repo.tunaos.org.
-      # Re-enable when tuna-os/github-copr#65 lands (specs + build-order tier).
-      # - id: xfce
-      #   stage: 2
-      #   build_image: true
-      #   build_iso: true
-      #   build_qcow2: false
-      #   # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
-      #   # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
-      #   platforms:
-      #     - linux/amd64
-      #     - linux/amd64/v2
+      - id: xfce
+        stage: 2
+        build_image: true
+        build_iso: true
+        build_qcow2: false
+        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
+        # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
+        platforms:
+          - linux/amd64
+          - linux/amd64/v2
 
       # ── Stage 3 ────────────────────────────────────────────────────────────
       # HWE: no ISO — install the standard ISO then `bootc switch` to *-hwe
@@ -282,30 +274,26 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-      # DISABLED: xfce4-wayland stack not yet published to repo.tunaos.org.
-      # Re-enable when tuna-os/github-copr#65 lands (specs + build-order tier).
-      # - id: xfce-hwe
-      #   stage: 3
-      #   build_image: true
-      #   build_iso: false
-      #   build_qcow2: false
-      #   # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
-      #   # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
-      #   platforms:
-      #     - linux/amd64
-      #     - linux/amd64/v2
-      # DISABLED: xfce4-wayland stack not yet published to repo.tunaos.org.
-      # Re-enable when tuna-os/github-copr#65 lands (specs + build-order tier).
-      # - id: xfce-nvidia
-      #   stage: 3
-      #   build_image: true
-      #   build_iso: true
-      #   build_qcow2: false
-      #   # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
-      #   # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
-      #   platforms:
-      #     - linux/amd64
-      #     - linux/amd64/v2
+      - id: xfce-hwe
+        stage: 3
+        build_image: true
+        build_iso: false
+        build_qcow2: false
+        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
+        # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
+        platforms:
+          - linux/amd64
+          - linux/amd64/v2
+      - id: xfce-nvidia
+        stage: 3
+        build_image: true
+        build_iso: true
+        build_qcow2: false
+        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
+        # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
+        platforms:
+          - linux/amd64
+          - linux/amd64/v2
 
   - id: skipjack
     emoji: "🍣"
@@ -353,17 +341,15 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-      # DISABLED: xfce4-wayland stack not yet published to repo.tunaos.org.
-      # Re-enable when tuna-os/github-copr#65 lands (specs + build-order tier).
-      # - id: xfce
-      #   stage: 2
-      #   build_image: true
-      #   build_iso: true
-      #   build_qcow2: false
-      #   # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
-      #   # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
-      #   platforms:
-      #     - linux/amd64
+      - id: xfce
+        stage: 2
+        build_image: true
+        build_iso: true
+        build_qcow2: false
+        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
+        # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
+        platforms:
+          - linux/amd64
 
       # ── Stage 3 ────────────────────────────────────────────────────────────
       # HWE: no ISO — install the standard ISO then `bootc switch` to *-hwe


### PR DESCRIPTION
> ⚠️ **DRAFT — blocked on tuna-os/github-copr#82** publishing gtkgreet to repo.tunaos.org.

Re-enables all seven EL10 xfce flavors:

| Variant | Flavors |
|---|---|
| yellowfin | xfce, xfce-hwe, xfce-nvidia |
| albacore | xfce, xfce-hwe, xfce-nvidia |
| skipjack | xfce |

## Why now

The blocks were commented out waiting on the xfce-wayland stack being published. It is — `repo.tunaos.org/xfce/10-stream-x86_64` serves **98 packages**, and a local build of `yellowfin:xfce` resolved `xfwl4 4.21.0` from it with a clean depsolve:

```
xfwl4    x86_64   4.21.0-1.el10    tunaos-xfce   4.4 M
```

The built image is genuinely Wayland-only — `/usr/share/xsessions/` is empty, and neither `xfwm4` nor `gdm` is installed.

## Arch pinning is load-bearing

Every block keeps its original `linux/amd64` + `linux/amd64/v2` pinning, **no arm64**. The repo publishes x86_64 only, so an arm64 cell would fail at depsolve. I asserted after uncommenting that no xfce flavor carries an arm platform — that check is the reason this is safe to do in bulk.

## Why it must not merge yet

Without gtkgreet the images **still build** — `install_available` skips what it cannot resolve. They just boot to greetd’s stock `agreety --cmd /bin/sh`, a text prompt into a bare shell, because `xfce.sh` only writes the greetd config when gtkgreet **and** cage are both present.

The runtime gate added in #725 would then correctly fail those cells. Merging early buys seven red cells and a broken desktop, not seven working ones.

Refs: #636