### PR TITLE
fix(installer): widen the focus search, drop the "%" keyword, record KDE

### DIFF
--- a/docs/INSTALLER-FRONTENDS.md
+++ b/docs/INSTALLER-FRONTENDS.md
@@ -68,13 +68,37 @@ Filled from each run's `walkthrough-<flavor>.json`.
 
 | Frontend | Launches | Renders | Advances | welcome | disk | encryption | summary | install | done |
 |----------|----------|---------|----------|---------|------|------------|---------|---------|------|
-| KDE | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+| KDE | ✅ | ✅ 9/9 | ⚠️ space only | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | COSMIC | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
 | Niri | _pending_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ |
 | XFCE | _pending_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ |
 | GNOME | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
 
 _GPU_ = needs a virgl-capable host to evaluate; blank on GPU-less CI is expected.
+
+### KDE — run 29681255102 (yellowfin, strict)
+
+First frontend measured end to end. It launches, and renders on all 9 frames.
+
+**⚠️ Advances by space only.** Enter does nothing on any page: no button in
+`tuna-installer-kde` is a Qt *default* button and nothing handles
+`Qt::Key_Return`, so a focused `QPushButton` responds to space alone. That is a
+real defect, not a harness artifact — a keyboard-only user cannot leave the
+welcome screen. Filed as tuna-os/tuna-installer-kde#4. The walkthrough now
+escalates `ret` → `spc` and reports which key worked, so this stays visible
+instead of being papered over.
+
+**Reached `welcome` and `disk` only.** The run stalled on Select Target Disk:
+focus starts in the disk list, and a fixed two tabs never reached *Continue*, so
+space just re-toggled the list. The driver now widens its focus search each time
+a step produces no change. Until a run gets past that page, `encryption`,
+`summary`, `install` and `done` are **unmeasured, not absent** — do not read the
+❌ as "the frontend lacks these screens".
+
+An earlier run (29675493401) reported `disk`, `encryption` and `install` as
+reached while every frame was the welcome screen; the welcome copy mentions all
+three. Screen matching is now per visual state, so prose can no longer
+manufacture a row here.
 
 ## Design review
 

--- a/scripts/installer-walkthrough.py
+++ b/scripts/installer-walkthrough.py
@@ -196,23 +196,38 @@ if p:
 # step produces no visual change — and report which key worked, because
 # "Return does not activate the primary action" is itself a UX finding worth
 # seeing rather than silently working around.
+# The tab count is escalated too. A fixed two tabs cannot work across pages
+# with different widget counts: run 29681255102 advanced welcome -> disk with
+# 'spc', then stalled for seven steps on Select Target Disk, where focus starts
+# in the disk list and Continue is several widgets away — space just re-toggled
+# the list selection. Each step with no visual change adds a tab, so focus
+# sweeps outward until it lands on the primary action, and resets once a page
+# advances.
 activation = "ret"
 switched = False
+tabs = 2
+MAX_TABS = 8
 for i in range(1, steps + 1):
-    send_keys("tab", "tab", activation)
+    send_keys(*(["tab"] * tabs), activation)
     time.sleep(3)
     p = shot(i, f"after advance {i}")
     if p:
         prev = frames[-1] if frames else None
         frames.append(p)
-        if (prev and not switched
-                and changed_pixels(prev, p) <= DIFF_PIXELS
-                and activation == "ret"):
-            activation = "spc"
-            switched = True
-            print("  # 'ret' did not advance the installer — "
-                  "escalating to 'spc' (space) for the remaining steps",
-                  flush=True)
+        moved = bool(prev) and changed_pixels(prev, p) > DIFF_PIXELS
+        if moved:
+            tabs = 2          # new page, start over from the usual position
+        elif prev:
+            if not switched and activation == "ret":
+                activation = "spc"
+                switched = True
+                print("  # 'ret' did not advance the installer — "
+                      "escalating to 'spc' (space) for the remaining steps",
+                      flush=True)
+            elif tabs < MAX_TABS:
+                tabs += 1
+                print(f"  # no change — widening focus search to {tabs} tabs",
+                      flush=True)
 
 print(f"\n# walkthrough verification ({flavor}) — {len(frames)} frames, "
       f"strict={strict}\n", flush=True)

--- a/tests/installer-screens.yaml
+++ b/tests/installer-screens.yaml
@@ -37,7 +37,14 @@ screens:
   - id: install
     title: Install progress
     required: false
-    keywords: ["installing", "progress", "copying", "deploying", "%"]
+    # NOT "%" — a single character matches OCR noise from anywhere on screen
+    # (taskbar, clock, window chrome). Run 29681255102 credited 'install' to
+    # the Select Target Disk screen because of it, which is exactly the kind of
+    # phantom row the parity matrix must never publish.
+    # NOT bare "install" either: the disk page reads "where TunaOS will be
+    # installed", and the welcome page describes the whole flow.
+    keywords: ["installing tunaos", "installation progress", "copying files",
+               "deploying", "please wait"]
 
   - id: done
     title: Finished / reboot


### PR DESCRIPTION
Follow-up to the first walkthrough run that actually worked ([29681255102](https://github.com/tuna-os/tunaOS/actions/runs/29681255102)). Both #726 fixes did their jobs:

```
# ret did not advance the installer — escalating to spc (space)
ok - kde: installer advances between screens
  # 1/8 transitions changed >500px; primary action activated with spc
  # 2 distinct visual state(s) across 9 frames
ok - kde: reached welcome  # seen on visual state(s) [0]
ok - kde: reached disk     # seen on visual state(s) [1]
```

`encryption`/`summary`/`done` are no longer fabricated. Three problems remain, visible **only** because that run got far enough to expose them.

## 1. Fixed tab count cannot work

The run advanced welcome → disk, then **stalled for seven steps** on Select Target Disk: focus starts in the disk list and *Continue* is several widgets away, so space just re-toggled the list selection.

Each step with no visual change now adds a tab (capped at 8), resetting when a page advances, so focus sweeps outward until it finds the primary action. Simulated against the observed move pattern:

```
step1: tabs=2 key=ret moved=False
step2: tabs=2 key=spc moved=True
step3: tabs=2 key=spc moved=False
step4: tabs=3 ... step8: tabs=7
```

## 2. `"%"` matched OCR noise

It credited `install` to the **Select Target Disk** screen — a phantom row of exactly the kind the parity matrix must never publish. Bare `"install"` is no better: that page reads “where TunaOS will be install**ed**”. Replaced with phrases that only appear on a progress screen.

## 3. KDE’s first real row — including what is *not* known

| Frontend | Launches | Renders | Advances | welcome | disk | encryption | summary | install | done |
|---|---|---|---|---|---|---|---|---|---|
| KDE | ✅ | ✅ 9/9 | ⚠️ space only | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |

The doc states explicitly that the run never got past disk selection, so those four are **unmeasured, not absent**. An unqualified ❌ would read as “this frontend lacks these screens”, which this run does not establish.

## The Qt finding

Enter does nothing on *any* page: no button in `tuna-installer-kde` is a Qt default button and nothing handles `Qt::Key_Return`, so a focused `QPushButton` responds to space alone. A keyboard-only user cannot leave the welcome screen. Filed as tuna-os/tuna-installer-kde#4. The walkthrough reports which key worked so this stays visible rather than papered over.

Refs: #678