### PR TITLE
fix(guppy): pin the gentoo base in build-config to the digest it actually builds

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -529,7 +529,14 @@ variants:
   - id: guppy
     emoji: "🌈"
     description: "Based on Gentoo Linux (source-based)"
-    base_image: "docker.io/gentoo/stage3:latest"
+    # Digest-pinned to match Containerfile.gentoo's FROM exactly. This value
+    # is not decorative: reusable-build-image.yml pre-pulls it to warm local
+    # storage before the build (a workaround for quay/docker CDN blob drops,
+    # #675). With a bare :latest here it warmed whatever latest happened to be
+    # while the Containerfile built from the pinned digest, so the pre-pull
+    # fetched an image the build never used and the workaround silently did
+    # nothing for guppy. Keep the two in lockstep when bumping.
+    base_image: "docker.io/gentoo/stage3:latest@sha256:9d03b48eda632da09f469d384ce77ec05618060ed4e9ac295f8192a196e7539a"
     platforms: ["linux/amd64"]
     flavors:
       - id: base


### PR DESCRIPTION
`Containerfile.gentoo` **already** builds from a digest-pinned stage3:

```
FROM docker.io/gentoo/stage3:latest@sha256:9d03b48e... AS base
```

so the build was reproducible and the security concern in #665 was largely already handled. But `build-config.yml` still carried a bare `:latest` — and that value is **not decorative**.

## The actual bug

`reusable-build-image.yml` reads `base_image` and **pre-pulls** it to warm local storage before the build — the workaround for CDN blob drops that #675 tracks:

```yaml
BASE=$(yq -r ".variants[] | select(.id == \"${IMAGE_VARIANT}\") | .base_image // \"\"" ...)
sudo podman pull --platform "${PLATFORM}" "$BASE"
```

With `:latest` there and a digest in the Containerfile, guppy pre-pulled whatever `latest` happened to be that day, then built from a *different*, pinned image. **The pre-pull fetched something the build never used** — so the CDN workaround silently did nothing for guppy while appearing to be in place.

## Verification

- both now name the same digest, compared programmatically — identical
- the pinned digest still resolves in the registry (manifest request → HTTP 200)
- `generate-workflows.py` reproduces all workflows with 0 drift after the change
- bats build-iso-group tests pass

## Adjacent finding, deliberately not fixed here

`ARG BASE_IMAGE` is declared in `Containerfile.gentoo` but never reaches a `FROM` — the base is hardcoded at line 23. The other Containerfiles *do* use that arg, which means **guppy cannot be rebased via `CHAIN_BASE_IMAGE` the way the others can**. That is a real inconsistency but a different change, so it deserves its own issue rather than a drive-by fix.

Closes #665