### PR TITLE
fix(guppy): stop shipping the bootc compile tree in the image

### DIFF
--- a/Containerfile.gentoo
+++ b/Containerfile.gentoo
@@ -71,9 +71,22 @@ RUN emerge --verbose --deep --newuse \
 # tbox-live/tbox-root modules at ISO build time (tuna-os/tacklebox#90).
 
 FROM base AS builder
+# The cleanup below MUST stay in this RUN. Unlike Containerfile.arch — which
+# builds bootc in a throwaway stage and COPY --from=bootc-builder /output / —
+# this file is linear (base -> builder -> system), so every file created here
+# ships in the published image. Deleting the tree in a later RUN would only
+# write a whiteout; the layer would still carry the data.
+#
+# Without this, guppy:base shipped the whole bootc compile tree —
+# /tmp/bootc/target/release/deps/*.rmeta and friends — inflating pulls and
+# unpacked size, and it exhausted the browser builder's storage quota (#672).
+#
+# Gentoo cannot simply copy Arch's throwaway-builder pattern: this stage also
+# emerges dev-util/ostree, which the final system needs at runtime.
 RUN emerge --verbose dev-util/ostree && \
     git clone --depth 1 https://github.com/bootc-dev/bootc.git /tmp/bootc && \
-    make -C /tmp/bootc bin install-all
+    make -C /tmp/bootc bin install-all && \
+    rm -rf /tmp/bootc /root/.cargo /root/.rustup /var/tmp/portage
 
 FROM builder AS system
 RUN KVER=$(ls /usr/lib/modules | head -1) && \


### PR DESCRIPTION
`guppy:base` carried the whole bootc build tree — `/tmp/bootc/target/release/deps/*.rmeta` and friends — into the published image, inflating pulls and unpacked size and exhausting the browser builder’s storage quota.

## The cause is stage shape, not a missing cleanup call

`Containerfile.arch` builds bootc in a **throwaway** stage and lifts only the result:

```dockerfile
FROM ${BASE_IMAGE} AS bootc-builder
... make install-all DESTDIR=/output

COPY --from=bootc-builder /output /
```

`Containerfile.gentoo` is **linear** — `base → builder → system`, and `builder` is *also* the parent of `desktop-build` — so everything the builder stage creates ships in every descendant.

## Why the placement matters

The tree is removed in the **same RUN that creates it**. That is load-bearing: deleting it in a later RUN only writes a whiteout while the earlier layer still carries the data. This is exactly why the existing `rm -rf /var ...` in the system stage never reclaimed any of it.

## Why not just copy Arch’s pattern

Gentoo’s builder stage also `emerge`s `dev-util/ostree`, which the **final system needs at runtime** — so the stage cannot simply be discarded. Restructuring around that is a larger change than the bloat fix warrants, so the reasoning is recorded inline for whoever revisits it.

Also drops `/root/.cargo`, `/root/.rustup` and `/var/tmp/portage` in the same layer — same class of build-only artifact, same whiteout trap. Portage recreates its build dir on the next emerge, so later stages are unaffected.

Verified the Containerfile still parses (`podman build --target context`).

Closes #672