### PR TITLE
fix(desktop): don't index list-shaped OS sections with display_manager

### DIFF
--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -278,7 +278,20 @@ fi # end DNF path (el10/fedora)
 # Wayland-native greeter (greetd) on one base and gdm on another during a
 # transition. apt/pacman paths handle their own DM and exit earlier; this
 # block is reached by el10/fedora/zypper/emerge.
-_TD_DM=$($YQ -r ".packages.${_TD_OS}.display_manager // .display_manager // \"\"" "${_TD_MANIFEST}")
+# The per-OS section is only a map for some OSes: el10/fedora carry
+# `display_manager:` alongside `packages:`, while zypper/emerge/apt/pacman are
+# plain package LISTS. Indexing a list with a key makes yq exit non-zero —
+#   Error: cannot index array with 'display_manager'
+# — and `//` cannot rescue an error, only a null. That aborted the desktop
+# install on every list-shaped base (sailfin, flounder, grouper, marlin,
+# guppy), so check the node kind before reaching into it.
+_TD_DM=""
+if [[ "$($YQ -r ".packages.${_TD_OS} | type" "${_TD_MANIFEST}" 2>/dev/null)" == "!!map" ]]; then
+	_TD_DM=$($YQ -r ".packages.${_TD_OS}.display_manager // \"\"" "${_TD_MANIFEST}" 2>/dev/null)
+fi
+if [[ -z "${_TD_DM}" || "${_TD_DM}" == "null" ]]; then
+	_TD_DM=$($YQ -r '.display_manager // ""' "${_TD_MANIFEST}" 2>/dev/null)
+fi
 if [[ -n "${_TD_DM}" && "${_TD_DM}" != "null" ]]; then
 	safe_enable "${_TD_DM}.service"
 	# Server-oriented bootc bases such as AlmaLinux default to

--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -185,7 +185,15 @@ if [[ "${_TD_OS}" == "el10" || "${_TD_OS}" == "fedora" ]]; then
 	# which lives at its own R2 path (repo.tunaos.org/xfce/...), not the main
 	# $releasever tree. Must be added BEFORE groups/packages so the
 	# transaction can see them. COPR repos still go through the copr block.
-	_TD_REPO_COUNT=$($YQ -r ".packages.${_TD_OS}.repos | length // 0" "${_TD_MANIFEST}" 2>/dev/null)
+	# Same list-vs-map trap as the display_manager lookup below: indexing a
+	# list-shaped section makes yq exit 1, and under `set -e` the assignment
+	# aborts the whole install even with stderr suppressed. No dnf-path section
+	# is list-shaped today, so this is latent rather than broken — guarded so
+	# it stays that way if someone writes `el10:` as a plain package list.
+	_TD_REPO_COUNT=0
+	if [[ "$($YQ -r ".packages.${_TD_OS} | type" "${_TD_MANIFEST}" 2>/dev/null)" == "!!map" ]]; then
+		_TD_REPO_COUNT=$($YQ -r ".packages.${_TD_OS}.repos | length // 0" "${_TD_MANIFEST}" 2>/dev/null || echo 0)
+	fi
 	for ((i = 0; i < _TD_REPO_COUNT; i++)); do
 		_TD_RN=$($YQ -r ".packages.${_TD_OS}.repos[$i].name" "${_TD_MANIFEST}")
 		_TD_RB=$($YQ -r ".packages.${_TD_OS}.repos[$i].baseurl" "${_TD_MANIFEST}")


### PR DESCRIPTION
**I broke this in #685.** The per-OS `display_manager` override reads:

```bash
.packages.${OS}.display_manager // .display_manager // ""
```

But that section is only a **map** for some OSes. `el10`/`fedora` carry `display_manager:` alongside `packages:`; `zypper`/`emerge`/`apt`/`pacman` are plain package **lists**. Indexing a list with a key makes yq exit non-zero:

```
Error: cannot index array with 'display_manager'
  (strconv.ParseInt: parsing "displaymanager": invalid syntax)
```

`//` only rescues a *null*, never an *error* — and `install-desktop.sh` runs under `set -e`, so the desktop install aborted outright.

## Blast radius

**14 manifest/OS combinations** across gnome, kde, niri and xfce — every list-shaped base on every desktop flavor. It matches the build history exactly:

| Variant | Red since |
|---|---|
| sailfin | 2026-07-16 |
| flounder, grouper, marlin, guppy | 2026-07-17 |

I had been reading sailfin’s failures as the openssl skew in #643. **That is actually fixed** — sailfin built green on 07-14 and 07-15 after the switch to packaged bootc from OBS. This regression landed on top of it and masked the recovery.

## Fix + verification

Check the node kind before reaching into it, then fall back to the global key. Verified across **every** manifest × OS combination:

```
cosmic.yaml   el10    !!map   dm=greetd    <- override honoured
gnome.yaml    apt     !!seq   dm=gdm       <- falls back, no error
gnome.yaml    zypper  !!seq   dm=gdm
kde-arch.yaml el10    !!null  dm=sddm
...
any errors? NONE — every combo resolves cleanly
```

shellcheck count unchanged from main (6, all pre-existing); shfmt clean; bats suite passes.

Refs: #643