### PR TITLE
fix(el10): don't build cosmic for aarch64 — fprintd-pam doesn't exist there

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -81,6 +81,13 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
+        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
+        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
+        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
+        # dependency exists for arm64.
+        platforms:
+          - linux/amd64
+          - linux/amd64/v2
 
       - id: kde
         stage: 2
@@ -127,11 +134,25 @@ variants:
         build_image: true
         build_iso: false
         build_qcow2: false
+        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
+        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
+        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
+        # dependency exists for arm64.
+        platforms:
+          - linux/amd64
+          - linux/amd64/v2
       - id: cosmic-nvidia
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
+        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
+        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
+        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
+        # dependency exists for arm64.
+        platforms:
+          - linux/amd64
+          - linux/amd64/v2
       - id: kde-hwe
         stage: 3
         build_image: true
@@ -212,6 +233,13 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
+        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
+        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
+        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
+        # dependency exists for arm64.
+        platforms:
+          - linux/amd64
+          - linux/amd64/v2
       - id: kde
         stage: 2
         build_image: true
@@ -257,11 +285,25 @@ variants:
         build_image: true
         build_iso: false
         build_qcow2: false
+        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
+        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
+        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
+        # dependency exists for arm64.
+        platforms:
+          - linux/amd64
+          - linux/amd64/v2
       - id: cosmic-nvidia
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
+        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
+        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
+        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
+        # dependency exists for arm64.
+        platforms:
+          - linux/amd64
+          - linux/amd64/v2
       - id: kde-hwe
         stage: 3
         build_image: true
@@ -342,6 +384,12 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
+        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
+        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
+        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
+        # dependency exists for arm64.
+        platforms:
+          - linux/amd64
 
       - id: kde
         stage: 2
@@ -385,11 +433,23 @@ variants:
         build_image: true
         build_iso: false
         build_qcow2: false
+        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
+        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
+        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
+        # dependency exists for arm64.
+        platforms:
+          - linux/amd64
       - id: cosmic-nvidia
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
+        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
+        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
+        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
+        # dependency exists for arm64.
+        platforms:
+          - linux/amd64
       - id: kde-hwe
         stage: 3
         build_image: true


### PR DESCRIPTION
yellowfin, albacore and skipjack fail their cosmic cells with an unsatisfiable depsolve on arm64:

```
Problem 1: nothing provides fprintd-pam needed by
           cosmic-greeter-1.3.0-1.el10.aarch64
Problem 2: cosmic-session-1.3.0-1.el10.aarch64 requires
           cosmic-greeter >= 1.3.0, but none of the providers can be installed
```

The COPR builds `cosmic-greeter` for aarch64, but its **hard dependency is not available for that arch on EL10**. Measured:

| | fprintd-pam |
|---|---|
| EL10 x86_64 | 1.94.5 |
| EL10 aarch64 | **NOT AVAILABLE** |

So the whole cosmic stack is uninstallable on EL10 arm64 — **nine cells** (3 variants × cosmic, cosmic-hwe, cosmic-nvidia) that could never have succeeded. Pinned to x86_64: same treatment and the same class of reason as the xfce flavors, whose packages are x86_64-only.

## Deliberately scoped to EL10

Fedora ships `fprintd-pam` for **both** arches:

```
fedora x86_64    fprintd-pam-1.94.5.x86_64
fedora aarch64   fprintd-pam-1.94.5.aarch64
```

so bonito/bonito-rawhide keep their arm64 cosmic builds. Their failures are a *different* problem, and pinning them here would hide it rather than fix it.

## Verification

- no EL10 cosmic flavor carries an arm platform
- non-cosmic EL10 flavors keep arm64 (base/gnome/kde unchanged)
- other distros untouched
- `generate-workflows.py` reproduces workflows with **0 drift**

## Context

This is one of two independent causes of the current matrix redness. The other — a yq list/map regression I introduced in #685 — was fixed in #731 and accounts for sailfin/flounder/grouper/marlin/guppy. This one accounts for the EL10 variants.