### PR TITLE
fix(installer): the renders check never measured the installer

### DIFF
--- a/docs/INSTALLER-FRONTENDS.md
+++ b/docs/INSTALLER-FRONTENDS.md
@@ -23,7 +23,7 @@ Nothing about "it built" or "it launched" catches that — this page does.
 |---|-------|-----|---------|
 | 1 | **Desktop is up** | `pgrep -x` the exact compositor binary | greeter loops, TTY fallback |
 | 2 | **Frontend launched** | `flatpak ps` matches the desktop's app id | wrong/missing frontend, autostart broken |
-| 3 | **It renders** | grayscale stddev of each frame > 0.02 | blank window, crashed-on-start |
+| 3 | **Screen is not blank** | grayscale stddev of each frame > 0.02 | black screen, no GL, dead compositor |
 | 4 | **It advances** | consecutive frames differ > 500px | stuck on one screen, modal error |
 | 5 | **Which screens** | OCR each frame vs `tests/installer-screens.yaml` | **feature drift between forks** |
 
@@ -69,12 +69,30 @@ Filled from each run's `walkthrough-<flavor>.json`.
 | Frontend | Launches | Renders | Advances | welcome | disk | encryption | summary | install | done |
 |----------|----------|---------|----------|---------|------|------------|---------|---------|------|
 | KDE | ✅ | ✅ 9/9 | ⚠️ space only | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| COSMIC | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+| COSMIC | ✅ proc | ⚠️ desktop only | ❌ 0/8 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Niri | _pending_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ |
 | XFCE | _pending_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ |
 | GNOME | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
 
 _GPU_ = needs a virgl-capable host to evaluate; blank on GPU-less CI is expected.
+
+### COSMIC — run 29684495194 (yellowfin, strict)
+
+**The process runs but no window ever appears.** The compositor+frontend gate
+passes (`flatpak ps` matches `org.tunaos.InstallerCosmic`), yet every frame is
+the bare COSMIC desktop; between frame 00 and frame 08, six minutes apart, the
+only thing that changes is the clock. 0/8 transitions, 1 visual state, and OCR
+matched no screen at all — not even `welcome`. Filed as
+tuna-os/tuna-installer-cosmic#4.
+
+This exposed a flaw in check 3. It was called "installer renders actual
+content" while measuring stddev over the **whole framebuffer**, so a booted
+desktop with no installer window passes it — cosmic scored 9/9. It is now named
+"screen is not blank", which is what it measures. Proving the installer window
+specifically is mapped is what checks 4 and 5 do, and here they correctly
+failed. The walkthrough now also prints an explicit diagnosis when the gate
+passed but nothing advanced and no screen matched, rather than leaving six
+identical "not reached" lines to interpret.
 
 ### KDE — run 29681255102 (yellowfin, strict)
 

--- a/scripts/installer-walkthrough.py
+++ b/scripts/installer-walkthrough.py
@@ -242,11 +242,16 @@ for f in frames:
     sd = stddev(f)
     if sd > BLANK_STDDEV:
         rendered += 1
-tap(rendered > 0, f"{flavor}: installer renders actual content",
+# NOT "the installer renders": this measures the whole framebuffer, so a
+# booted desktop with no installer window at all passes it. cosmic did exactly
+# that (run 29684495194) — 9/9 frames "rendered" while every frame was the bare
+# COSMIC desktop, clock ticking, no window. Named for what it actually checks.
+tap(rendered > 0, f"{flavor}: screen is not blank",
     f"{rendered}/{len(frames)} frames above stddev {BLANK_STDDEV} "
     f"(blank everywhere usually means no GL — niri/xfwl4 need virgl)",
     enforced=strict)
-note(f"{rendered}/{len(frames)} frames above stddev {BLANK_STDDEV}")
+note(f"{rendered}/{len(frames)} frames above stddev {BLANK_STDDEV} "
+     f"(whole screen, not the installer window)")
 
 # ── 2. ADVANCES ──────────────────────────────────────────────────────────
 advanced = sum(1 for a, b in zip(frames, frames[1:])
@@ -320,6 +325,19 @@ for idx, sc in enumerate(spec):
         enforced=strict and sc.get("required", False))
     if hit:
         note(where)
+
+# ── No-window diagnosis ──────────────────────────────────────────────────
+# The compositor+frontend gate in installer-smoke.yml already proved the
+# process is alive before this script runs. So if the screen is not blank, yet
+# nothing ever advanced AND no screen matched, the most likely explanation is
+# that the process is running without a mapped window — the desktop is what is
+# being photographed. Say so, rather than leaving six identical "screen not
+# reached" lines for someone to interpret.
+if have_ocr and n_states <= 1 and not any(reached.values()) and rendered > 0:
+    print(f"  # DIAGNOSIS: {flavor} — process is running (gate passed) but no "
+          f"installer screen was ever detected and nothing responded to input; "
+          f"the frames are most likely the bare desktop with no installer "
+          f"window mapped", flush=True)
 
 # ── Result for the parity matrix ─────────────────────────────────────────
 summary = {


### PR DESCRIPTION
COSMIC exposed this. Run [29684495194](https://github.com/tuna-os/tunaOS/actions/runs/29684495194) reported:

```
ok - cosmic: installer renders actual content
  # 9/9 frames above stddev 0.02
```

…while **every frame was the bare COSMIC desktop with no installer window at all**. Between frame 00 and frame 08, six minutes apart, the only thing that changed was the clock.

The check takes grayscale stddev of the **whole framebuffer**, so any booted desktop passes it whether or not the installer ever mapped a window.

## Renamed to what it measures

Now `screen is not blank`. It still earns its place — it catches a black screen, missing GL, a dead compositor — but it was making a claim about *the installer* that it cannot support, and on cosmic that claim was flatly false.

Proving the installer window is mapped is what checks 4 and 5 do, and here they **correctly failed**: 0/8 transitions, 1 visual state, no screen matched, not even `welcome`.

## Added the diagnosis the data already supported

The smoke gate proves the process is alive *before* this script runs. So "process alive + screen not blank + nothing advanced + no screen matched" has one likely reading, and the walkthrough now states it:

```
# DIAGNOSIS: cosmic — process is running (gate passed) but no installer
# screen was ever detected and nothing responded to input; the frames are
# most likely the bare desktop with no installer window mapped
```

instead of six identical "screen not reached" lines to piece together. Verified it fires on cosmic’s real numbers and stays silent on kde’s.

## Parity matrix

| Frontend | Launches | Screen | Advances | welcome | disk | rest |
|---|---|---|---|---|---|---|
| KDE | ✅ | ✅ 9/9 | ⚠️ space only | ✅ | ✅ | unmeasured |
| COSMIC | ✅ proc | ⚠️ desktop only | ❌ 0/8 | ❌ | ❌ | ❌ |

Underlying defect filed as tuna-os/tuna-installer-cosmic#4.

Refs: #678