### PR TITLE
fix(installer): match screen headings, not any mention of a word

### DIFF
--- a/docs/INSTALLER-FRONTENDS.md
+++ b/docs/INSTALLER-FRONTENDS.md
@@ -68,13 +68,30 @@ Filled from each run's `walkthrough-<flavor>.json`.
 
 | Frontend | Launches | Renders | Advances | welcome | disk | encryption | summary | install | done |
 |----------|----------|---------|----------|---------|------|------------|---------|---------|------|
-| KDE | ✅ | ✅ 9/9 | ⚠️ space only | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| KDE | ✅ | ✅ 9/9 | ⚠️ space only | ✅ | ✅ | ❌ none | ✅ | ⬜ | ⬜ |
 | COSMIC | ✅ proc | ⚠️ desktop only | ❌ 0/8 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Niri | _pending_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ |
 | XFCE | _pending_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ | _GPU_ |
 | GNOME | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
 
 _GPU_ = needs a virgl-capable host to evaluate; blank on GPU-less CI is expected.
+
+### KDE — run 29684495194 (yellowfin, strict) — PASSES
+
+With the widened focus search the run reaches **6/8 transitions, 7 visual
+states**, and satisfies every required screen: welcome, disk and summary.
+Still space-only until tuna-os/tuna-installer-kde#5 lands.
+
+**KDE has no encryption screen.** Its pages are welcome, diskselection,
+confirm, progress, done — there is no LUKS step, even though fisherman
+supports encryption. An earlier run reported `encryption: reached`, which was
+the matcher hitting the string "Encryption: None" in the summary page's field
+list. The keywords now match headings rather than bare nouns, so this shows as
+the genuine feature gap it is. This is precisely the drift the matrix exists
+to expose, and the matcher was concealing it.
+
+`install` and `done` are unmeasured: the walkthrough stops before starting a
+real install, by design.
 
 ### COSMIC — run 29684495194 (yellowfin, strict)
 

--- a/tests/installer-screens.yaml
+++ b/tests/installer-screens.yaml
@@ -8,8 +8,16 @@
 # catches that — scripts/installer-walkthrough.py OCRs each captured frame and
 # records which screens each frontend actually reached.
 #
-# keywords: case-insensitive; a screen counts as reached if ANY keyword appears
-#           in the OCR text of ANY frame.
+# keywords: case-insensitive, matched per visual state (see
+#           scripts/installer-walkthrough.py). Write them as HEADINGS or
+#           prompts unique to that screen — never bare nouns.
+#
+#           A bare noun matches the same word used as a field label somewhere
+#           else. "encrypt" matched "Encryption: None" on KDE's Confirm
+#           Installation page, reporting an encryption screen that frontend
+#           does not have at all (its pages are welcome, diskselection,
+#           confirm, progress, done). Likewise "target" matches both the disk
+#           page's heading and the summary's "Target Disk: vda" row.
 # required: true  → a frontend missing it FAILS the walkthrough (core flow)
 #           false → recorded in the parity matrix but not fatal (feature drift
 #                   we want visible before we make it mandatory)
@@ -22,17 +30,24 @@ screens:
   - id: disk
     title: Disk / target selection
     required: true
-    keywords: ["disk", "drive", "storage", "partition", "target", "/dev/"]
+    # Heading/prompt text, not the "Target Disk: vda" row on the summary.
+    keywords: ["select target disk", "select a disk", "choose the disk",
+               "available disks", "where tunaos will be installed"]
 
   - id: encryption
     title: Disk encryption (LUKS)
     required: false
-    keywords: ["encrypt", "luks", "passphrase", "password protect"]
+    # NOT bare "encrypt": that matches the summary page's "Encryption: None"
+    # field label, which is the opposite of having reached an encryption
+    # screen. Require the screen's own heading or its passphrase prompt.
+    keywords: ["disk encryption", "encrypt this disk", "enter passphrase",
+               "luks passphrase", "encryption passphrase"]
 
   - id: summary
     title: Summary / confirm
     required: true
-    keywords: ["summary", "review", "confirm", "ready to install", "about to"]
+    keywords: ["confirm installation", "review your choices", "summary",
+               "ready to install", "about to install"]
 
   - id: install
     title: Install progress
@@ -43,8 +58,11 @@ screens:
     # phantom row the parity matrix must never publish.
     # NOT bare "install" either: the disk page reads "where TunaOS will be
     # installed", and the welcome page describes the whole flow.
-    keywords: ["installing tunaos", "installation progress", "copying files",
-               "deploying", "please wait"]
+    # NOT "installing tunaos": the welcome page says "guide you through
+    # installing TunaOS onto your computer". Progress screens say what they
+    # are DOING, so match that instead.
+    keywords: ["installation progress", "copying files", "deploying",
+               "please wait", "writing image"]
 
   - id: done
     title: Finished / reboot


### PR DESCRIPTION
The KDE run passed with `encryption: reached` — **which is false.** KDE has no encryption screen at all; its pages are welcome, diskselection, confirm, progress, done. The matcher hit the string `Encryption: None` in the summary page’s field list, i.e. it credited an encryption step to a screen that says encryption is switched **off**.

Same shape twice more:

| Keyword | Also matched |
|---|---|
| `target` | summary’s `Target Disk: vda` row |
| `installing tunaos` | welcome’s “guide you through installing TunaOS onto your computer” |
| `encrypt` | summary’s `Encryption: None` |

The state-aware grouping added earlier stops prose on the **first** screen from inventing later ones, but it cannot help when the stray word sits on a screen that genuinely *was* reached. Keywords have to identify a screen, so they are now headings and prompts rather than nouns.

## Verified against the real frame text

```
frame              welcome        disk  encryption     summary     install        done
welcome (00)           HIT           -           -           -           -           -
disk (01)                -         HIT           -           -           -           -
summary (04)             -           -           -         HIT           -           -

EXACTLY ONE screen per frame: PASS
```

Previously the summary frame matched **three**.

## This turns a false pass into a real finding

KDE not exposing LUKS while fisherman supports it is exactly the per-fork drift the matrix exists to surface — and the matcher was hiding it. The wider audit is filed as #734: **3 of 4 frontends cannot enable encryption at all**.

Refs: #678