### PR TITLE
ci(installer): capture the installer's own stderr

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -193,6 +193,40 @@ jobs:
             echo "::warning::no QEMU monitor socket — walkthrough skipped"
           fi
 
+      # The installer's own stderr is the one thing this workflow never
+      # captured, and it is exactly what distinguishes "no window" causes.
+      # cosmic launches, connects to Wayland, then loses its GPU path:
+      #   libEGL warning: failed to get driver name for fd -1
+      #   MESA: error: ZINK: failed to choose pdev
+      #   libEGL warning: egl: failed to create dri2 screen
+      # Reproduced on real hardware; there it survived by falling back to
+      # Vulkan llvmpipe. Under plain virtio-vga that fallback may not exist,
+      # which would leave a live process with no surface — precisely the state
+      # observed in run 29684495194. Without this capture the gate can only
+      # report "process running, nothing on screen".
+      - name: Capture installer stderr and session journal
+        if: always()
+        env:
+          FLAVOR: ${{ matrix.flavor }}
+        run: |
+          SSH="sshpass -p live ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null liveuser@127.0.0.1"
+          out="smoke-out/installer-stderr-${FLAVOR}.log"
+          {
+            echo "=== user journal (installer + portal + flatpak) ==="
+            $SSH 'journalctl --user -b --no-pager 2>/dev/null | grep -iE "installer|flatpak|portal|wgpu|EGL|MESA|wayland|vulkan" | tail -120' 2>/dev/null || true
+            echo
+            echo "=== system journal (compositor / greetd / GPU) ==="
+            $SSH 'sudo journalctl -b --no-pager 2>/dev/null | grep -iE "EGL|MESA|drm|vulkan|llvmpipe|virtio|cosmic|niri|xfwl4" | tail -80' 2>/dev/null || true
+            echo
+            echo "=== rendering capability in the live session ==="
+            $SSH 'ls -l /dev/dri/ 2>/dev/null; echo "--- eglinfo/vulkaninfo ---"; (eglinfo 2>&1 | head -20) || true; (vulkaninfo --summary 2>&1 | head -20) || true' 2>/dev/null || true
+            echo
+            echo "=== windows the compositor actually has ==="
+            $SSH 'pgrep -xl "cosmic-comp|niri|xfwl4|kwin_wayland" 2>/dev/null || pgrep -l -x cosmic-comp || pgrep -l -x niri || pgrep -l -x xfwl4 || pgrep -l -x kwin_wayland || echo "(no compositor matched)"; ps -eo pid,comm,args | grep -iE "[I]nstaller" || echo "(no installer process)"' 2>/dev/null || true
+          } > "$out" 2>&1
+          echo "--- captured $(wc -l < "$out") lines ---"
+          tail -30 "$out"
+
       - name: Screenshot desktop evidence
         if: always()
         run: |


### PR DESCRIPTION
The smoke workflow could report *"process running, nothing on screen"* and nothing more — which is exactly where the COSMIC investigation stalled. The installer’s own stderr was never collected.

## What the missing evidence looks like

I built `tuna-installer-cosmic` from source and ran it under headless weston on real hardware (kanpur, Intel Iris Xe). It starts, connects to Wayland, then loses its GPU path:

```
wgpu_hal::gles::egl: Using Wayland platform          <- Wayland OK
libEGL warning: failed to get driver name for fd -1
libEGL warning: MESA-LOADER: failed to retrieve device information
MESA: error: ZINK: failed to choose pdev
libEGL warning: egl: failed to create dri2 screen
...
Adapter Vulkan AdapterInfo { name: "llvmpipe", device_type: Cpu }   <- software fallback
```

There it **survived** by falling back to Vulkan llvmpipe. The installer is a wgpu/iced app, so it needs a working render backend — and under plain `virtio-vga` (the same constraint that keeps niri and xfwl4 from rendering in CI) that fallback may not exist, leaving a live process with no surface. That is the state observed in [run 29684495194](https://github.com/tuna-os/tunaOS/actions/runs/29684495194).

**This is a hypothesis, not a conclusion.** The deciding evidence is the installer’s stderr *on the ISO*, which is what this step now collects:

- user journal filtered for installer / flatpak / portal / wgpu / EGL / MESA / vulkan
- system journal for GPU and compositor lines
- `/dev/dri` contents plus `eglinfo` / `vulkaninfo --summary`
- which compositor and installer processes actually exist

Uploaded alongside the existing evidence, and runs with `if: always()` so a **failed** walkthrough still produces it — that failure is precisely when it is wanted.

actionlint findings unchanged from baseline (3).

Refs: #678, tuna-os/tuna-installer-cosmic#4