### PR TITLE
feat(ci): publish installer-smoke screenshots to docs for kde/cosmic/niri/xfce

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -265,3 +265,98 @@ jobs:
             smoke-out/*.tap
             smoke-out/serial.log
           if-no-files-found: warn
+
+  # Publishes the walkthrough-*.png frames captured above to docs, the same
+  # way installer-screenshots.yml already does for its gnome/cosmic full-install
+  # flow. That workflow only covers two flavors because it drives a hardcoded
+  # sendkey choreography (scripts/run-walkthrough.sh) written for one page
+  # layout; this job reuses installer-walkthrough.py instead, which already
+  # runs across all four independent frontend forks with per-frontend
+  # navigation handling (KDE's Enter-key fix, tab-count widening, etc.), so it
+  # is the only harness that actually generalizes across kde/cosmic/niri/xfce.
+  publish-screenshots:
+    name: Publish installer screenshots
+    needs: smoke
+    if: always() && !cancelled()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Download walkthrough artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: installer-smoke-*
+          merge-multiple: true
+          path: /tmp/installer-smoke
+
+      - name: Stage walkthrough frames
+        id: stage
+        run: |
+          mkdir -p docs/images/installer
+          count=0
+          # installer-walkthrough.py names frames walkthrough-<flavor>-NN.png;
+          # rename to smoke-<flavor>_NN.png so gen-screenshot-gallery.sh's
+          # prefix grouping treats each flavor as its own flow. The smoke-
+          # prefix keeps this distinct from installer-screenshots.yml's
+          # cosmic_NN_name.png (that one walks a full install to a bootable
+          # disk on gnome/cosmic only; this one is launch-smoke evidence
+          # across all four frontends) — same R2 path convention, different
+          # source, so they must not collide on cosmic's filenames.
+          : > /tmp/staged-basenames.txt
+          for png in /tmp/installer-smoke/walkthrough-*.png; do
+            [[ -f "$png" ]] || continue
+            base="$(basename "$png" .png)"
+            # walkthrough-kde-03 -> smoke-kde_03
+            renamed="$(echo "$base" | sed -E 's/^walkthrough-([a-z]+)-([0-9]+)$/smoke-\1_\2/')"
+            cp "$png" "docs/images/installer/${renamed}.png"
+            echo "$renamed" >> /tmp/staged-basenames.txt
+            count=$((count + 1))
+          done
+          echo "staged=${count}" >> "$GITHUB_OUTPUT"
+          echo "Staged ${count} screenshot(s)"
+
+      # tunaos.org's InstallerWalkthrough component reads these:
+      # screenshots/installer/<name>-latest.png on download.tunaos.org.
+      - name: Publish captures to R2
+        if: steps.stage.outputs.staged != '0'
+        env:
+          RCLONE_CONFIG_R2_TYPE: s3
+          RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          RCLONE_CONFIG_R2_REGION: auto
+          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+        run: |
+          if [[ -z "${RCLONE_CONFIG_R2_ACCESS_KEY_ID:-}" ]]; then
+            echo "::notice::R2 credentials not configured; skipping publish."
+            exit 0
+          fi
+          sudo apt-get install -y -qq rclone 2>/dev/null || true
+          while IFS= read -r base; do
+            [[ -n "$base" ]] || continue
+            png="docs/images/installer/${base}.png"
+            [[ -f "$png" ]] || continue
+            rclone copyto --s3-no-check-bucket --log-level ERROR \
+              "$png" "R2:${{ secrets.R2_BUCKET }}/screenshots/installer/${base}-latest.png"
+          done < /tmp/staged-basenames.txt
+          echo "Published capture(s) to R2"
+
+      - name: Regenerate screenshot gallery
+        if: steps.stage.outputs.staged != '0'
+        run: bash scripts/gen-screenshot-gallery.sh
+
+      - name: Commit and push
+        if: steps.stage.outputs.staged != '0'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/images/installer docs/SCREENSHOTS.md
+          if git diff --cached --quiet; then
+            echo "No screenshot changes to commit"
+            exit 0
+          fi
+          git commit -m "docs: refresh installer frontend walkthrough screenshots ($(date +%Y-%m-%d)) [skip ci]"
+          git pull --rebase origin main
+          git push origin HEAD:main


### PR DESCRIPTION
## Summary
- `installer-screenshots.yml` already publishes a weekly walkthrough gallery to tunaos.org, but only for gnome/cosmic — it drives `scripts/run-walkthrough.sh`, a hardcoded sendkey choreography written for one page layout, so it can't generalize across the four independent installer frontend forks.
- `installer-smoke.yml` already runs `installer-walkthrough.py` weekly across all four (kde/cosmic/niri/xfce), with the per-frontend navigation robustness built up this session (Enter→space activation escalation, tab-count widening, OCR-verified screen matching). It's the only harness that actually generalizes.
- Adds a `publish-screenshots` job that stages the captured frames (`smoke-<flavor>_NN.png`), publishes to R2 under the same `screenshots/installer/` convention `installer-screenshots.yml` already uses, and commits to `docs/images/installer/` + regenerates `docs/SCREENSHOTS.md`.
- `smoke-` prefix keeps this distinct from `installer-screenshots.yml`'s own `cosmic_NN_name.png` output — different measurement (launch smoke vs. full install-to-disk), different source, must not collide.

## Related
- Docs-site wiring: tuna-os/docs#88 (adds `InstallerWalkthrough` sections for kde/niri/xfce, fixes stale "TunaOS First Setup" prose)

## Test plan
- [ ] Next scheduled `Installer Smoke` run (or manual `workflow_dispatch`) confirms `publish-screenshots` stages, publishes, and commits successfully
- [ ] `docs/SCREENSHOTS.md` regenerates with new `smoke-kde`/`smoke-cosmic`/`smoke-niri`/`smoke-xfce` flow sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)