### PR TITLE
fix(el10): pin EL10 to traditional ostree, not composefs

### DIFF
--- a/Containerfile.el10
+++ b/Containerfile.el10
@@ -144,6 +144,18 @@ RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=bind,from=context,source=/,target=/run/context \
    /run/context/build_scripts/99-cleanup.sh
 
+# EL10 is meant to stay traditional ostree (bootupctl + GRUB), not composefs
+# (tunaOS#748). Unlike the non-Fedora bases (see
+# build_scripts/bootc/sandbox/usr/lib/ostree/prepare-root.conf, copied by
+# Containerfile.ubuntu et al. to explicitly turn composefs ON), nothing in
+# this Containerfile ever touched prepare-root.conf — so whatever
+# quay.io/almalinuxorg/almalinux-bootc ships by default silently won any
+# time upstream's default changed. Pin it explicitly instead of inheriting
+# a default that already drifted once and broke wootc's Phase-2 boot
+# (tuna-os/wootc#28: composefs images skip bootupctl/GRUB entirely, so a
+# boot without the composefs karg drops to an emergency shell).
+RUN printf '[composefs]\nenabled = no\n\n[sysroot]\nreadonly = true\n' > /usr/lib/ostree/prepare-root.conf
+
 # ==============================================================================
 # Desktop Variant Stages
 # Each stage ends with the /opt symlink so chunkah can be run against them.


### PR DESCRIPTION
## Summary
Fixes #748. EL10 (AlmaLinux-based) images were shipping with composefs enabled — `/usr/lib/ostree/prepare-root.conf` declared `[composefs] enabled = yes` — even though the project intent is for EL10 to stay traditional ostree until it's deliberately ready to move (per @jreilly1821: composefs was enabled prematurely while experimenting with unified storage, not meant for EL10 yet).

Traced it: nothing in `Containerfile.el10` or the `build_scripts` it calls ever touches `prepare-root.conf`. `finalize.sh`/`mount-system.sh` (which DO set up the composefs-backed layout) are only invoked by the non-Fedora Containerfiles (Ubuntu, Debian, Arch, Gentoo, openSUSE) — EL10 relies entirely on whatever `quay.io/almalinuxorg/almalinux-bootc` ships out of the box. That default apparently drifted at some point, and nothing in this repo would have noticed either way, since EL10's own build never asserted a mode.

Surfaced via wootc's Phase-2 boot debugging (tuna-os/wootc#28): composefs images skip `bootupctl`/GRUB entirely, gated behind `ConditionKernelCommandLine=composefs`, so a boot without that karg drops straight to an emergency shell.

## Fix
Explicitly writes `prepare-root.conf` at the end of the `base-no-de` stage (so every downstream desktop stage inherits it) instead of trusting an unpinned upstream default.

## Test plan
- [ ] Real dispatched build confirms the image still builds/lints clean with this change
- [ ] Once merged, next daily build's `bootc container lint` / boot-gate confirms traditional ostree mode end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)