### PR TITLE
feat(ci): widen live-overlay parity artifacts to all 5 desktop flavors

### DIFF
--- a/.github/workflows/live-overlay.yml
+++ b/.github/workflows/live-overlay.yml
@@ -20,7 +20,7 @@ on:
       flavors:
         description: "Comma-separated flavors"
         required: false
-        default: "gnome,kde"
+        default: "gnome,kde,cosmic,niri,xfce"
         type: string
   schedule:
     # Weekly, after image builds.
@@ -38,7 +38,7 @@ jobs:
     steps:
       - id: gen
         env:
-          FLAVORS: ${{ inputs.flavors || 'gnome,kde' }}
+          FLAVORS: ${{ inputs.flavors || 'gnome,kde,cosmic,niri,xfce' }}
           VARIANT: ${{ inputs.variant || 'yellowfin' }}
         run: |
           M=$(jq -cn --arg v "$VARIANT" --arg f "$FLAVORS" \


### PR DESCRIPTION
## Summary
tunaOS#673's goal: browser-built ISOs must be identical to CI-published ones **by default**, with customization as an opt-in layered on top — not the other way around.

`live-overlay.yml` already implements the mechanism (publish the `customize-live.sh` delta as `ghcr.io/tuna-os/live-overlay:<variant>-<flavor>`, which the browser applies as extra layers onto its unpacked base tree — same digests, same content), but its default scope only covered `gnome,kde`. Cosmic, Niri and XFCE were left without parity artifacts, so the browser builder could only guarantee "no compromise" for two of the five real desktop flavors (`base` excluded — no DE, not installer-relevant).

## Test plan
- [ ] Dispatch confirms the overlay publishes clean for cosmic/niri/xfce, not just gnome/kde

🤖 Generated with [Claude Code](https://claude.com/claude-code)