### PR TITLE
fix(ci): stagger daily variant-build crons; debounce common:latest churn

### DIFF
--- a/.github/workflows/build-bonito-rawhide.yml
+++ b/.github/workflows/build-bonito-rawhide.yml
@@ -1,7 +1,7 @@
 name: Build Bonito-rawhide
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "30 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-bonito.yml
+++ b/.github/workflows/build-bonito.yml
@@ -1,7 +1,7 @@
 name: Build Bonito
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "15 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-flounder-sid.yml
+++ b/.github/workflows/build-flounder-sid.yml
@@ -1,7 +1,7 @@
 name: Build Flounder-sid
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 2 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-flounder.yml
+++ b/.github/workflows/build-flounder.yml
@@ -1,7 +1,7 @@
 name: Build Flounder
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "45 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-grouper.yml
+++ b/.github/workflows/build-grouper.yml
@@ -1,7 +1,7 @@
 name: Build Grouper
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "15 2 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-guppy.yml
+++ b/.github/workflows/build-guppy.yml
@@ -1,7 +1,7 @@
 name: Build Guppy
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "30 2 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-marlin.yml
+++ b/.github/workflows/build-marlin.yml
@@ -1,7 +1,7 @@
 name: Build Marlin
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "45 2 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-sailfin.yml
+++ b/.github/workflows/build-sailfin.yml
@@ -1,7 +1,7 @@
 name: Build Sailfin
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 3 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-skipjack.yml
+++ b/.github/workflows/build-skipjack.yml
@@ -1,7 +1,7 @@
 name: Build Skipjack
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "15 3 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-yellowfin.yml
+++ b/.github/workflows/build-yellowfin.yml
@@ -1,7 +1,7 @@
 name: Build Yellowfin
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "30 3 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/renovate.json
+++ b/renovate.json
@@ -68,6 +68,11 @@
       "matchManagers": ["git-submodules"],
       "groupName": "submodules",
       "automerge": true
+    },
+    {
+      "description": "ghcr.io/projectbluefin/common:latest moves upstream multiple times a day, and digest-tracking PRs get superseded rather than updated in place — three separate PRs (each a full CI run) landed in ~33 hours (tunaOS#753). Debounce: wait for a digest to sit still for a few days before opening a PR, so rapid upstream churn coalesces into one PR instead of several.",
+      "matchPackageNames": ["ghcr.io/projectbluefin/common"],
+      "minimumReleaseAge": "3 days"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Fixes #752 and #753 — both found while investigating Actions queue depth org-wide.

**#752**: all 11 daily variant builds fired at the identical `0 1 * * *`, each fanning out into a multi-job matrix. Spread across a 2.5-hour window (15 min apart) instead of all colliding at once.

**#753**: `ghcr.io/projectbluefin/common:latest` moves upstream multiple times a day; Renovate opened 3 separate PRs (each a full CI run) in ~33 hours since digest-tracking supersedes rather than updates. Added `minimumReleaseAge: 3 days` for that one dependency so rapid churn coalesces into one PR.

## Test plan
- [x] All 11 modified workflow YAMLs parse valid
- [x] `renovate.json` valid JSON
- [ ] Next scheduled window confirms the builds no longer all queue at once
- [ ] Next `common:latest` digest move confirms Renovate waits instead of opening immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)