### PR TITLE
feat(el10): re-enable cosmic aarch64 + skipjack:gnome-nvidia-hwe

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -81,13 +81,6 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
-        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
-        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
-        # dependency exists for arm64.
-        platforms:
-          - linux/amd64
-          - linux/amd64/v2
 
       - id: kde
         stage: 2
@@ -132,25 +125,11 @@ variants:
         build_image: true
         build_iso: false
         build_qcow2: false
-        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
-        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
-        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
-        # dependency exists for arm64.
-        platforms:
-          - linux/amd64
-          - linux/amd64/v2
       - id: cosmic-nvidia
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
-        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
-        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
-        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
-        # dependency exists for arm64.
-        platforms:
-          - linux/amd64
-          - linux/amd64/v2
       - id: kde-hwe
         stage: 3
         build_image: true
@@ -227,13 +206,6 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
-        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
-        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
-        # dependency exists for arm64.
-        platforms:
-          - linux/amd64
-          - linux/amd64/v2
       - id: kde
         stage: 2
         build_image: true
@@ -277,25 +249,11 @@ variants:
         build_image: true
         build_iso: false
         build_qcow2: false
-        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
-        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
-        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
-        # dependency exists for arm64.
-        platforms:
-          - linux/amd64
-          - linux/amd64/v2
       - id: cosmic-nvidia
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
-        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
-        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
-        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
-        # dependency exists for arm64.
-        platforms:
-          - linux/amd64
-          - linux/amd64/v2
       - id: kde-hwe
         stage: 3
         build_image: true
@@ -372,12 +330,6 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
-        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
-        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
-        # dependency exists for arm64.
-        platforms:
-          - linux/amd64
 
       - id: kde
         stage: 2
@@ -419,23 +371,11 @@ variants:
         build_image: true
         build_iso: false
         build_qcow2: false
-        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
-        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
-        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
-        # dependency exists for arm64.
-        platforms:
-          - linux/amd64
       - id: cosmic-nvidia
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
-        # cosmic-greeter hard-requires fprintd-pam, which EL10 does not
-        # build for aarch64 (present on x86_64 as 1.94.5, absent on arm64),
-        # so cosmic-session is unsatisfiable there. Pin to x86_64 until the
-        # dependency exists for arm64.
-        platforms:
-          - linux/amd64
       - id: kde-hwe
         stage: 3
         build_image: true

--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -363,9 +363,16 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-      # gnome-nvidia-hwe (stage 4) omitted — blocked by gnome-shell-49 vs
-      # gnome-shell-common-48 file conflict on CentOS Stream 10.
-      # See: tuna-os/github-copr#23, IMPROVEMENT_PLAN Phase 1.1
+      # gnome-nvidia-hwe re-enabled (tunaOS#639): the gnome-shell-49 vs
+      # gnome-shell-common-48 file conflict is fixed upstream in the spec
+      # (tuna-os/github-copr#23 merged: Obsoletes: gnome-shell-common <
+      # %{major_version}), verified live in the published spec, not just
+      # by the PR having merged.
+      - id: gnome-nvidia-hwe
+        stage: 4
+        build_image: true
+        build_iso: false
+        build_qcow2: false
       - id: cosmic-hwe
         stage: 3
         build_image: true

--- a/build_scripts/desktop/cosmic.sh
+++ b/build_scripts/desktop/cosmic.sh
@@ -65,27 +65,6 @@ case "${1:-}" in
 		xdg-desktop-portal-cosmic \
 		adw-gtk3-theme
 
-	# cosmic-greeter hard-requires fprintd-pam, which CentOS Stream 10 only
-	# builds for x86_64 — that gap is why aarch64 cosmic was pinned off in
-	# build-config.yml (tunaOS#732). It's now built (tuna-os/github-copr#110,
-	# same pinned version as x86_64's 1.94.5) and published at its own R2
-	# path, separate from the main tuna-os.repo used above — enable it only
-	# on aarch64, only for this one install.
-	if [[ "$(uname -m)" == "aarch64" ]]; then
-		cat >/etc/yum.repos.d/tuna-os-fprintd.repo <<-'EOF'
-		[tuna-os-fprintd]
-		name=Tuna OS - fprintd (aarch64)
-		baseurl=https://repo.tunaos.org/fprintd/10-stream-aarch64/
-		enabled=1
-		gpgcheck=0
-		gpgkey=https://repo.tunaos.org/public.gpg
-		repo_gpgcheck=0
-		metadata_expire=3600
-		priority=10
-		skip_if_unavailable=False
-		EOF
-	fi
-
 	# Install COSMIC session, greetd and COSMIC greeter separately (handles greetd-selinux conflict)
 	# Use --nobest and --allowerasing to resolve EL10 policy conflicts
 	dnf -y --enablerepo copr:copr.fedorainfracloud.org:yselkowitz:cosmic-epel \

--- a/build_scripts/desktop/cosmic.sh
+++ b/build_scripts/desktop/cosmic.sh
@@ -65,6 +65,27 @@ case "${1:-}" in
 		xdg-desktop-portal-cosmic \
 		adw-gtk3-theme
 
+	# cosmic-greeter hard-requires fprintd-pam, which CentOS Stream 10 only
+	# builds for x86_64 — that gap is why aarch64 cosmic was pinned off in
+	# build-config.yml (tunaOS#732). It's now built (tuna-os/github-copr#110,
+	# same pinned version as x86_64's 1.94.5) and published at its own R2
+	# path, separate from the main tuna-os.repo used above — enable it only
+	# on aarch64, only for this one install.
+	if [[ "$(uname -m)" == "aarch64" ]]; then
+		cat >/etc/yum.repos.d/tuna-os-fprintd.repo <<-'EOF'
+		[tuna-os-fprintd]
+		name=Tuna OS - fprintd (aarch64)
+		baseurl=https://repo.tunaos.org/fprintd/10-stream-aarch64/
+		enabled=1
+		gpgcheck=0
+		gpgkey=https://repo.tunaos.org/public.gpg
+		repo_gpgcheck=0
+		metadata_expire=3600
+		priority=10
+		skip_if_unavailable=False
+		EOF
+	fi
+
 	# Install COSMIC session, greetd and COSMIC greeter separately (handles greetd-selinux conflict)
 	# Use --nobest and --allowerasing to resolve EL10 policy conflicts
 	dnf -y --enablerepo copr:copr.fedorainfracloud.org:yselkowitz:cosmic-epel \

--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -59,6 +59,19 @@ packages:
       - pop-icon-theme
 
   el10:
+    # cosmic-greeter hard-requires fprintd-pam, which CentOS Stream 10 only
+    # builds for x86_64 -- that gap is why aarch64 cosmic was pinned off in
+    # tunaOS's build-config.yml (tunaOS#732). It's now built
+    # (tuna-os/github-copr#110, same pinned version as x86_64's 1.94.5) and
+    # published at its own R2 path, separate from the main tuna-os.repo.
+    # baseurl is not $basearch-templated (only aarch64 RPMs are published
+    # here), so this is harmless to enable unconditionally on x86_64 --
+    # dnf just finds no matching-arch packages and falls back to CentOS
+    # Stream's own x86_64 fprintd-pam as before.
+    repos:
+      - name: tuna-os-fprintd
+        baseurl: https://repo.tunaos.org/fprintd/10-stream-aarch64/
+        priority: 10
     copr:
       - repo: yselkowitz/cosmic-epel
         packages:


### PR DESCRIPTION
## Summary
Two independent EL10 re-enablements, verified with real dispatched builds before merging (not just config flips):

**Cosmic on aarch64** (tunaOS#732): `cosmic-greeter` hard-requires `fprintd-pam`, which CentOS Stream 10 only built for x86_64. That gap is now closed (tuna-os/github-copr#110 — libfprint 1.94.8 + fprintd 1.94.5, same pinned versions x86_64 ships, built for real on a native aarch64 runner). Removes the `platforms` restriction pinning cosmic/cosmic-hwe/cosmic-nvidia off `linux/arm64` across yellowfin/albacore/skipjack, and adds the new fprintd repo to `manifests/desktops/cosmic.yaml`.

**Took two attempts to get the repo wiring right** — first attempt edited `build_scripts/desktop/cosmic.sh`, which a real build proved is dead code for this path (cosmic installs via `install-desktop.sh` reading `manifests/desktops/cosmic.yaml`, confirmed from the actual build log). Reverted that and put the fix where the schema is actually read (`.packages.el10.repos[]`).

**Result**: [run 29786441318](https://github.com/tuna-os/tunaOS/actions/runs/29786441318) — `cosmic / linux-arm64` now builds clean (previously failed outright on "nothing provides fprintd-pam"). The run's `Gate` step still fails, but on an unrelated, already-tracked, pre-existing issue (tunaOS#626 — `dm_mismatch`, cosmic-greeter.service active instead of greetd.service) that predates this change and affects x86_64 too; posted the sharper diagnostic there. Not a regression from this PR.

**skipjack:gnome-nvidia-hwe** (tunaOS#639): was disabled for a `gnome-shell-49` vs `gnome-shell-common-48` file conflict. That's fixed upstream — verified live in the published spec (`Obsoletes: gnome-shell-common < %{major_version}` in `gnome-shell.spec`, tuna-os/github-copr#23, merged) before re-enabling here.

## Test plan
- [x] `yellowfin:cosmic` real build confirms aarch64 now installs `fprintd-pam`/`cosmic-greeter` successfully (image build + manifest + sign all succeed)
- [x] `skipjack:gnome-nvidia-hwe` verified by real dispatched build on amd64 and arm64 — image builds, pushes, SBOM uploads, and multi-arch manifest all succeeded ([run 29790935560](https://github.com/tuna-os/tunaOS/actions/runs/29790935560)); Gate and Sign also succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)