### PR TITLE
ci: deduplicate push and PR formatter runs

### DIFF
--- a/.github/workflows/just-fix.yml
+++ b/.github/workflows/just-fix.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # A branch push and its pull_request event represent the same work; use the
+  # source branch for both so the later event replaces the duplicate run.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Normalize Just Fix concurrency on the source branch name so a branch push and its pull_request event share one group instead of creating duplicate formatter runs.

Validated with actionlint, yamllint, and git diff checks.