### PR TITLE
feat(grouper): arm64 enablement + Apple Silicon (Asahi) kernel path

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -635,8 +635,11 @@ variants:
     description: "Based on Ubuntu 26.04 Resolute Raccoon"
     base_image: "docker.io/library/ubuntu:resolute"
     # Built directly from stock Ubuntu and bootcified in Containerfile.ubuntu
-    # (bootc from the bootc-shindig/bootc-deb apt repo). See RFC 010.
-    platforms: ["linux/amd64"]
+    # (bootc from the tuna-os bootc-toolchain-sid oras artifact). See RFC 010.
+    # arm64: toolchain publishes latest-{amd64,arm64}; Containerfile.ubuntu is
+    # TARGETARCH-aware. Apple Silicon (Asahi) support gated behind
+    # ENABLE_ASAHI=1 (build_scripts/ubuntu-kernel.sh) — flavor wiring TBD.
+    platforms: ["linux/amd64", "linux/arm64"]
     flavors:
       - id: base
         stage: 1

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -28,10 +28,12 @@ permissions:
 
 jobs:
   toolchain:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:
+        arch: [amd64, arm64]
+        base: [trixie, sid]
         include:
           - base: trixie
             image: docker.io/library/debian:trixie
@@ -58,7 +60,7 @@ jobs:
         run: |
           set -euo pipefail
           ORAS_VERSION=1.2.0
-          curl -fsSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
+          curl -fsSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${{ matrix.arch }}.tar.gz" \
             | sudo tar -xz -C /usr/local/bin oras
           oras version
 
@@ -90,11 +92,17 @@ jobs:
           set -euo pipefail
           REPO="ghcr.io/tuna-os/bootc-toolchain-${{ matrix.base }}"
           BOOTC="${{ steps.ver.outputs.bootc }}"
+          ARCH="${{ matrix.arch }}"
+          # Arch-suffixed tags are canonical (Containerfiles pull
+          # :latest-${TARGETARCH}); amd64 keeps the historical unsuffixed
+          # tags so pre-multiarch consumers don't break.
           oras push \
             --artifact-type application/vnd.tunaos.bootc-toolchain \
             --annotation "org.opencontainers.image.source=https://github.com/tuna-os/tunaOS" \
             --annotation "dev.tunaos.bootc.version=${BOOTC}" \
-            "${REPO}:${BOOTC}" \
+            "${REPO}:${BOOTC}-${ARCH}" \
             toolchain.tar.gz:application/vnd.tunaos.bootc-toolchain.layer.tar+gzip
-          # Move the :latest tag to this build.
-          oras tag "${REPO}:${BOOTC}" latest
+          oras tag "${REPO}:${BOOTC}-${ARCH}" "latest-${ARCH}"
+          if [ "$ARCH" = "amd64" ]; then
+            oras tag "${REPO}:${BOOTC}-${ARCH}" "${BOOTC}" latest
+          fi

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -26,12 +26,13 @@ FROM ${ZIRCONIUM_IMAGE_REF} AS zirconium
 
 FROM ${BASE_IMAGE} AS bootc-builder
 ARG ORAS_VERSION=1.2.0
+ARG TARGETARCH
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends curl ca-certificates tar gzip && \
-    curl -fsSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
+    curl -fsSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${TARGETARCH}.tar.gz" \
       | tar -xz -C /usr/local/bin oras && \
     mkdir -p /fetch /output && cd /fetch && \
-    oras pull "ghcr.io/tuna-os/bootc-toolchain-sid:latest" && \
+    oras pull "ghcr.io/tuna-os/bootc-toolchain-sid:latest-${TARGETARCH}" && \
     tar -xzf toolchain.tar.gz -C /output && \
     rm -rf /fetch
 
@@ -127,12 +128,14 @@ RUN printf '#!/bin/sh\nexit 0\n' | tee \
     chmod +x /etc/kernel/postinst.d/kdump-tools
 
 # Install the kernel + firmware and stage vmlinuz where bootc expects it.
-RUN apt-get update -y && \
-    apt-get -o Dpkg::Options::="--force-confold" install -y --no-install-recommends \
-        linux-generic linux-firmware && \
-    KVER=$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d | sort -V | tail -1 | xargs basename) && \
-    cp "/boot/vmlinuz-${KVER}" "/usr/lib/modules/${KVER}/vmlinuz" && \
-    apt-get clean -y && rm -rf /var/lib/apt/lists/*
+# ENABLE_ASAHI=1 (arm64 only) swaps in the UbuntuAsahi PPA 16K-page Apple
+# Silicon kernel + platform userspace instead of linux-generic — see
+# build_scripts/ubuntu-kernel.sh.
+ARG ENABLE_ASAHI="${ENABLE_ASAHI:-0}"
+ENV ENABLE_ASAHI=${ENABLE_ASAHI}
+RUN --mount=type=tmpfs,dst=/tmp \
+  --mount=type=bind,from=context,source=/,target=/run/context \
+  /run/context/build_scripts/ubuntu-kernel.sh
 
 # Ensure /opt is a real directory for the build scripts (finalize.sh turns it
 # into a bind-mount target later).

--- a/build_scripts/ubuntu-kernel.sh
+++ b/build_scripts/ubuntu-kernel.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Kernel + firmware install for grouper (Ubuntu). Two paths:
+#
+#   default          — stock linux-generic + linux-firmware (all arches)
+#   ENABLE_ASAHI=1   — Apple Silicon (M1/M2) support from the UbuntuAsahi PPA:
+#                      16K-page asahi kernel, m1n1 + U-Boot payloads,
+#                      update-m1n1, ESP firmware extraction, audio DSP stack.
+#                      arm64 only. https://ubuntuasahi.org
+#
+# Both paths stage vmlinuz into /usr/lib/modules/<kver>/ where bootc expects
+# it. The asahi path also stages DTBs at /usr/lib/modules/<kver>/dtb/ (the
+# layout update-m1n1 harvests) and ensures the asahi dracut modules are
+# present — finalize.sh builds the initramfs with dracut, and the vendor
+# firmware flow (ESP firmware.cpio -> /lib/firmware/vendor tmpfs before udev)
+# only works if 99asahi-firmware + 91kernel-modules-asahi are in that build.
+set -xeuo pipefail
+
+apt-get update -y
+
+if [ "${ENABLE_ASAHI:-0}" != "1" ]; then
+    apt-get -o Dpkg::Options::="--force-confold" install -y --no-install-recommends \
+        linux-generic linux-firmware
+    KVER=$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d | sort -V | tail -1 | xargs basename)
+    cp "/boot/vmlinuz-${KVER}" "/usr/lib/modules/${KVER}/vmlinuz"
+    apt-get clean -y && rm -rf /var/lib/apt/lists/*
+    exit 0
+fi
+
+# ─── Asahi path ──────────────────────────────────────────────────────────────
+if [ "$(dpkg --print-architecture)" != "arm64" ]; then
+    echo "ERROR: ENABLE_ASAHI=1 requires an arm64 build" >&2
+    exit 1
+fi
+
+apt-get install -y --no-install-recommends curl ca-certificates gpg jq
+
+# UbuntuAsahi PPA. The signing-key fingerprint comes from the Launchpad API so
+# it tracks key rotations instead of being baked in stale.
+PPA_FPR=$(curl -fsSL "https://api.launchpad.net/1.0/~ubuntu-asahi/+archive/ubuntu/ubuntu-asahi" | jq -r .signing_key_fingerprint)
+curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${PPA_FPR}" \
+    | gpg --dearmor -o /usr/share/keyrings/ubuntu-asahi.gpg
+. /etc/os-release
+echo "deb [signed-by=/usr/share/keyrings/ubuntu-asahi.gpg] https://ppa.launchpadcontent.net/ubuntu-asahi/ubuntu-asahi/ubuntu ${VERSION_CODENAME} main" \
+    > /etc/apt/sources.list.d/ubuntu-asahi.list
+apt-get update -y
+
+# Kernel: resolve the image package name rather than hardcoding it (the PPA
+# has used linux-image-asahi / linux-image-<ver>-asahi-arm namings).
+KERNEL_PKG=$(apt-cache search --names-only '^linux-image-.*asahi' | awk '{print $1}' | sort -V | tail -1)
+if [ -z "$KERNEL_PKG" ]; then
+    echo "ERROR: no linux-image-*asahi package found in the UbuntuAsahi PPA for ${VERSION_CODENAME}" >&2
+    exit 1
+fi
+echo "Using asahi kernel package: ${KERNEL_PKG}"
+apt-get -o Dpkg::Options::="--force-confold" install -y --no-install-recommends \
+    "${KERNEL_PKG}" linux-firmware
+
+# Platform userspace. Installed one by one: the PPA's package set has shifted
+# over releases, and a missing optional piece should be a warning we read in
+# the build log, not a failed image. REQUIRED failures are fatal below.
+REQUIRED_PKGS=(m1n1 u-boot-asahi asahi-scripts)
+OPTIONAL_PKGS=(asahi-fwextract asahi-audio alsa-ucm-conf-asahi speakersafetyd tiny-dfr asahi-nvram)
+for pkg in "${REQUIRED_PKGS[@]}"; do
+    apt-get install -y --no-install-recommends "$pkg"
+done
+for pkg in "${OPTIONAL_PKGS[@]}"; do
+    apt-get install -y --no-install-recommends "$pkg" \
+        || echo "WARNING: optional asahi package unavailable: $pkg"
+done
+
+KVER=$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d | sort -V | tail -1 | xargs basename)
+case "$KVER" in
+    *asahi*) ;;
+    *) echo "ERROR: newest kernel '${KVER}' is not an asahi kernel" >&2; exit 1 ;;
+esac
+cp "/boot/vmlinuz-${KVER}" "/usr/lib/modules/${KVER}/vmlinuz"
+
+# DTBs: Debian-family kernels ship devicetrees under /usr/lib/linux-image-<kver>/.
+# Stage the Apple ones at /usr/lib/modules/<kver>/dtb/ — the layout update-m1n1
+# harvests and our verify harness checks.
+if [ -d "/usr/lib/linux-image-${KVER}" ]; then
+    mkdir -p "/usr/lib/modules/${KVER}/dtb"
+    cp -r "/usr/lib/linux-image-${KVER}/apple" "/usr/lib/modules/${KVER}/dtb/" 2>/dev/null \
+        || cp -r "/usr/lib/linux-image-${KVER}/." "/usr/lib/modules/${KVER}/dtb/"
+fi
+ls "/usr/lib/modules/${KVER}/dtb/apple/" >/dev/null 2>&1 \
+    || echo "WARNING: no apple DTBs staged — check /usr/lib/linux-image-${KVER} layout"
+
+# Dracut modules: finalize.sh builds the initramfs with dracut. If the deb
+# packaging didn't ship the asahi dracut modules (Debian/Ubuntu default to
+# initramfs-tools), vendor them from upstream asahi-scripts (pinned ref).
+ASAHI_SCRIPTS_REF=b6f72e6c03550a6dab391cd7bc1bcb854fc5bacb
+if [ ! -d /usr/lib/dracut/modules.d/99asahi-firmware ]; then
+    echo "asahi dracut modules not shipped by packages — vendoring from AsahiLinux/asahi-scripts@${ASAHI_SCRIPTS_REF}"
+    curl -fsSL "https://github.com/AsahiLinux/asahi-scripts/archive/${ASAHI_SCRIPTS_REF}.tar.gz" | tar -xz -C /tmp
+    SRC="/tmp/asahi-scripts-${ASAHI_SCRIPTS_REF}/dracut"
+    mkdir -p /usr/lib/dracut/modules.d /usr/lib/dracut/dracut.conf.d
+    cp -r "${SRC}/modules.d/91kernel-modules-asahi" "${SRC}/modules.d/99asahi-firmware" /usr/lib/dracut/modules.d/
+    cp "${SRC}/dracut.conf.d/"*.conf /usr/lib/dracut/dracut.conf.d/ 2>/dev/null || true
+    rm -rf "/tmp/asahi-scripts-${ASAHI_SCRIPTS_REF}"
+fi
+# Make sure dracut actually includes them.
+if ! grep -rqs "asahi-firmware" /usr/lib/dracut/dracut.conf.d/ /etc/dracut.conf.d/ 2>/dev/null; then
+    printf 'add_dracutmodules+=" asahi-firmware kernel-modules-asahi "\n' \
+        > /usr/lib/dracut/dracut.conf.d/10-asahi.conf
+fi
+
+apt-get clean -y && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Track B of the Apple Silicon plan. Grouper (Ubuntu 26.04) is the best non-Fedora Asahi bet: the UbuntuAsahi PPA is current (asahi kernel 7.0, m1n1 1.5.2, full audio stack) and 26.04 is explicitly supported.

## What

1. **bootc toolchain goes multiarch** — `build-toolchain.yml` now builds `bootc-toolchain-{trixie,sid}` on amd64 + arm64 (native arm runners). Canonical tags become `:latest-<arch>` / `:<ver>-<arch>`; amd64 keeps the unsuffixed tags so existing consumers don't break. This was the hard blocker for grouper arm64: no arm64 bootc deb exists anywhere (shindig-deb publishes amd64 only).
2. **Containerfile.ubuntu is TARGETARCH-aware** — oras binary + toolchain pull follow the build platform; the kernel install RUN moved into `build_scripts/ubuntu-kernel.sh` (default path byte-for-byte equivalent: linux-generic + vmlinuz staging).
3. **`ENABLE_ASAHI=1` build path** (arm64 only): UbuntuAsahi PPA (signing key resolved live from the Launchpad API), asahi kernel package resolved dynamically (`linux-image-*asahi`), required stack (m1n1, u-boot-asahi, asahi-scripts) fatal-if-missing, audio/extras warn-if-missing, Apple DTBs staged at `/usr/lib/modules/<kver>/dtb/` (update-m1n1's harvest layout), and the asahi dracut modules guaranteed present (vendored from pinned AsahiLinux/asahi-scripts@b6f72e6 if the debs don't ship them) so finalize.sh's dracut initramfs gets the ESP→`/lib/firmware/vendor` flow.
4. **build-config**: grouper `platforms` += `linux/arm64`.

## Deliberately out of scope

- **Asahi flavor id in the flavor graph** — the stage machinery deserves its own PR; until then: `podman build -f Containerfile.ubuntu --platform linux/arm64 --build-arg ENABLE_ASAHI=1 ...`
- `build_scripts/bootc/install-bootc.sh` is dead code (nothing references it) with a stale `bootc-shindig` URL (org renamed to atomic-shindig, Pages 404s) — flagging for a separate cleanup.

## Verification

- Static: bash -n + yaml validated. First real signal will be the toolchain workflow (auto-triggers on merge via its own paths filter) publishing `latest-arm64`, then a grouper arm64 build.
- Asahi image contents can be gated with the 35-point verify harness derived from the known-good Fedora Asahi Silverblue image (checks 16K asahi kernel, 12 hardware modules, DTBs, m1n1/U-Boot payloads, dracut firmware flow, audio stack).
- Boot-on-Mac is a later milestone (M1/M2 only; installs go through asahi-installer — no live-ISO path on Apple Silicon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ