### PR TITLE
feat(asahi): gnome-asahi flavors for EL family, sailfin, flounder

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -110,6 +110,15 @@ variants:
         build_image: true
         build_iso: false
         build_qcow2: false
+      # Apple Silicon (M1/M2, Asahi Linux) — overlay/asahi.sh, CentOS
+      # Hyperscale SIG packages-asahi (EXPERIMENTAL: kernel + glue only; boot
+      # payloads pending #777). aarch64 only; no ISO (asahi-installer path).
+      - id: gnome-asahi
+        stage: 3
+        platforms: ["linux/arm64"]
+        build_image: true
+        build_iso: false
+        build_qcow2: false
       - id: gnome-nvidia
         stage: 3
         build_image: true
@@ -234,6 +243,15 @@ variants:
         build_image: true
         build_iso: false
         build_qcow2: false
+      # Apple Silicon (M1/M2, Asahi Linux) — overlay/asahi.sh, CentOS
+      # Hyperscale SIG packages-asahi (EXPERIMENTAL: kernel + glue only; boot
+      # payloads pending #777). aarch64 only; no ISO (asahi-installer path).
+      - id: gnome-asahi
+        stage: 3
+        platforms: ["linux/arm64"]
+        build_image: true
+        build_iso: false
+        build_qcow2: false
       - id: gnome-nvidia
         stage: 3
         build_image: true
@@ -355,6 +373,15 @@ variants:
       # HWE: no ISO — install the standard ISO then `bootc switch` to *-hwe
       - id: gnome-hwe
         stage: 3
+        build_image: true
+        build_iso: false
+        build_qcow2: false
+      # Apple Silicon (M1/M2, Asahi Linux) — overlay/asahi.sh, CentOS
+      # Hyperscale SIG packages-asahi (EXPERIMENTAL: kernel + glue only; boot
+      # payloads pending #777). aarch64 only; no ISO (asahi-installer path).
+      - id: gnome-asahi
+        stage: 3
+        platforms: ["linux/arm64"]
         build_image: true
         build_iso: false
         build_qcow2: false
@@ -510,12 +537,25 @@ variants:
     base_image: "registry.opensuse.org/opensuse/tumbleweed:latest"
     platforms: ["linux/amd64"]
     flavors:
+      # base + gnome carry an arm64 leg solely as the parent chain for
+      # gnome-asahi (Tumbleweed is multiarch; bootc comes from zypper).
+      # Other DEs stay amd64 until someone asks for them on arm64.
       - id: base
         stage: 1
+        platforms: ["linux/amd64", "linux/arm64"]
         build_image: true
       - id: gnome
         stage: 2
+        platforms: ["linux/amd64", "linux/arm64"]
         build_image: true
+      # Apple Silicon (M1/M2, Asahi Linux) — overlay/asahi.sh, OBS
+      # home:mrkcee full stack. aarch64 only; no ISO (asahi-installer path).
+      - id: gnome-asahi
+        stage: 3
+        platforms: ["linux/arm64"]
+        build_image: true
+        build_iso: false
+        build_qcow2: false
       - id: kde
         stage: 2
         build_image: true
@@ -731,13 +771,26 @@ variants:
     base_image: "docker.io/library/debian:trixie"
     platforms: ["linux/amd64"]
     flavors:
+      # base + gnome carry an arm64 leg solely as the parent chain for
+      # gnome-asahi (debian:trixie is multiarch; the bootc toolchain
+      # publishes latest-arm64). Other DEs stay amd64 for now.
       - id: base
         stage: 1
+        platforms: ["linux/amd64", "linux/arm64"]
         build_image: true
       - id: gnome
         stage: 2
+        platforms: ["linux/amd64", "linux/arm64"]
         build_image: true
         build_iso: true
+      # Apple Silicon (M1/M2, Asahi Linux) — overlay/asahi.sh, Debian
+      # Bananas archive. aarch64 only; no ISO (asahi-installer path).
+      - id: gnome-asahi
+        stage: 3
+        platforms: ["linux/arm64"]
+        build_image: true
+        build_iso: false
+        build_qcow2: false
       - id: kde
         stage: 2
         build_image: true

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -26,13 +26,14 @@ ARG IMAGE_NAME_VARIANT
 FROM ${BASE_IMAGE} AS bootc-builder
 ARG BASE_IMAGE
 ARG ORAS_VERSION=1.2.0
+ARG TARGETARCH
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends curl ca-certificates tar gzip && \
-    curl -fsSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
+    curl -fsSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${TARGETARCH}.tar.gz" \
       | tar -xz -C /usr/local/bin oras && \
     case "${BASE_IMAGE}" in *sid*) TC=sid ;; *) TC=trixie ;; esac && \
     mkdir -p /fetch /output && cd /fetch && \
-    oras pull "ghcr.io/tuna-os/bootc-toolchain-${TC}:latest" && \
+    oras pull "ghcr.io/tuna-os/bootc-toolchain-${TC}:latest-${TARGETARCH}" && \
     tar -xzf toolchain.tar.gz -C /output && \
     rm -rf /fetch
 


### PR DESCRIPTION
Extends the #774 asahi wiring to every variant whose overlay path can build today. `resolve-flavor.sh` is already generic, so this is build-graph config plus one Containerfile fix:

- **yellowfin / albacore / skipjack**: `gnome-asahi` stage 3, arm64-only, via the CentOS Hyperscale SIG branch of `overlay/asahi.sh`. EXPERIMENTAL: the SIG repo has the 16K kernel + dracut/update-m1n1 glue but no m1n1/u-boot/audio packages until #777 — the overlay installs best-effort and warns loudly.
- **sailfin / flounder**: these variants were amd64-only. `base` + `gnome` grow an arm64 leg purely as the parent chain, plus `gnome-asahi` stage 3. Other DEs stay amd64.
- **Containerfile.debian**: ports the TARGETARCH oras/toolchain pattern from Containerfile.ubuntu (it hardcoded `linux_amd64` and the unsuffixed `:latest` toolchain tag). Verified `bootc-toolchain-{trixie,sid}:latest-arm64` exist on GHCR.

Deliberately **not** wired: marlin (blocked on the ALARM base, #778), guppy (binhost stub by design), flounder-sid and bonito-rawhide (validate trixie/stable first).

PR builds are unaffected (matrix generation forces amd64 + gnome-only on PRs). First real validation is a dispatched build per variant once the runner queue drains, then the 35-point verify harness — same loop as #776.

Part of #781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ