### PR TITLE
feat(asahi): EL10 full stack + Arch Linux ARM base pipeline

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -692,15 +692,28 @@ variants:
     emoji: "🚀"
     description: "Based on Arch Linux (rolling)"
     base_image: "docker.io/archlinux/archlinux:latest"
+    # arm64 legs use ghcr.io/tuna-os/archlinuxarm instead (docker.io/archlinux
+    # is x86_64-only) — see get-base-image.sh + build-archlinuxarm-base.yml
+    # (#778). Only the gnome-asahi parent chain builds arm64.
     platforms: ["linux/amd64"]
     flavors:
       - id: base
         stage: 1
+        platforms: ["linux/amd64", "linux/arm64"]
         build_image: true
       - id: gnome
         stage: 2
+        platforms: ["linux/amd64", "linux/arm64"]
         build_image: true
         build_iso: true
+      # Apple Silicon (M1/M2, Asahi Linux) — overlay/asahi.sh, Asahi-ALARM
+      # repos. aarch64 only; no ISO (asahi-installer path).
+      - id: gnome-asahi
+        stage: 3
+        platforms: ["linux/arm64"]
+        build_image: true
+        build_iso: false
+        build_qcow2: false
       - id: kde
         stage: 2
         build_image: true

--- a/.github/workflows/build-archlinuxarm-base.yml
+++ b/.github/workflows/build-archlinuxarm-base.yml
@@ -1,0 +1,85 @@
+name: Build Arch Linux ARM base
+
+# Builds ghcr.io/tuna-os/archlinuxarm from the official Arch Linux ARM
+# aarch64 rootfs tarball (os.archlinuxarm.org) — the marlin arm64 /
+# asahi (#778) base. docker.io/archlinux is x86_64-only and ALARM
+# publishes no OCI image, so we make our own from their canonical
+# tarball, verified against their published MD5 (all they sign tarballs
+# with; the pacman keyring takes over from first sync onward).
+#
+# Weekly rebuild keeps the snapshot fresh; consumers run pacman -Syu at
+# build time anyway, so staleness only costs download time.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "40 2 * * 1"
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/build-archlinuxarm-base.yml
+
+concurrency:
+  group: build-archlinuxarm-base-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Fetch and verify ALARM rootfs
+        run: |
+          set -euo pipefail
+          curl -fsSL -o rootfs.tar.gz \
+            "http://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz"
+          curl -fsSL -o rootfs.tar.gz.md5 \
+            "http://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz.md5"
+          # The .md5 references the canonical filename
+          sed 's/ArchLinuxARM-aarch64-latest.tar.gz/rootfs.tar.gz/' rootfs.tar.gz.md5 | md5sum -c -
+
+      - name: Build image from rootfs
+        run: |
+          set -euo pipefail
+          ctr=$(sudo buildah from scratch)
+          mnt=$(sudo buildah mount "$ctr")
+          sudo tar -xpf rootfs.tar.gz -C "$mnt" --numeric-owner
+          # The tarball is a device rootfs: drop the board bits a container
+          # never uses; alarm/root users stay (standard ALARM accounts).
+          sudo rm -rf "$mnt/boot"/* "$mnt/etc/fstab"
+          # Initialize pacman inside the rootfs (native arm64 runner).
+          sudo buildah run "$ctr" -- pacman-key --init
+          sudo buildah run "$ctr" -- pacman-key --populate archlinuxarm
+          sudo buildah run "$ctr" -- pacman -Syu --noconfirm
+          sudo buildah run "$ctr" -- pacman -Scc --noconfirm
+          sudo buildah config \
+            --arch arm64 --os linux \
+            --env LANG=C.UTF-8 \
+            --cmd /usr/bin/bash \
+            --label org.opencontainers.image.title="Arch Linux ARM base" \
+            --label org.opencontainers.image.description="Arch Linux ARM aarch64 rootfs as an OCI base image (marlin arm64/asahi prerequisite)" \
+            --label org.opencontainers.image.source="https://github.com/${{ github.repository }}" \
+            "$ctr"
+          sudo buildah commit --format oci "$ctr" archlinuxarm:build
+
+      - name: Smoke test
+        run: |
+          set -euo pipefail
+          sudo podman run --rm archlinuxarm:build bash -c \
+            'pacman -Q base >/dev/null && [ "$(uname -m)" = aarch64 ] && pacman -Sp --noconfirm linux-aarch64 >/dev/null'
+
+      - name: Push to GHCR
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.GITHUB_TOKEN }}" | sudo podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+          REF="ghcr.io/${{ github.repository_owner }}/archlinuxarm"
+          DATE=$(date -u +%Y%m%d)
+          sudo podman tag archlinuxarm:build "$REF:latest" "$REF:$DATE"
+          sudo podman push "$REF:latest"
+          sudo podman push "$REF:$DATE"

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -204,7 +204,11 @@ jobs:
           # Pre-pull the OS base with retries: quay's CDN drops blobs
           # mid-transfer often enough to kill nightly builds (rawhide:
           # #675). podman build then finds the base in local storage.
-          BASE=$(yq -r ".variants[] | select(.id == \"${IMAGE_VARIANT}\") | .base_image // \"\"" .github/build-config.yml)
+          # Platform-aware: single-arch bases (marlin/archlinux) have an
+          # arm64 override in get-base-image.sh; keep the pre-pull in sync
+          # with what the build will actually use.
+          BASE=$(./scripts/get-base-image.sh "${IMAGE_VARIANT}" "${PLATFORM}" 2>/dev/null || \
+            yq -r ".variants[] | select(.id == \"${IMAGE_VARIANT}\") | .base_image // \"\"" .github/build-config.yml)
           if [ -n "$BASE" ] && [ -z "${CHAIN_BASE_IMAGE}" ]; then
             for i in 1 2 3 4; do
               sudo podman pull --platform "${PLATFORM}" "$BASE" && break

--- a/Containerfile.arch
+++ b/Containerfile.arch
@@ -80,6 +80,10 @@ RUN grep "= */var" /etc/pacman.conf | sed "/= *\/var/s/.*=// ; s/ //" | \
 # for the cachyos repo in pacman.conf and install linux-cachyos instead of
 # stock linux.
 RUN KERNEL_PKG="linux"; \
+    # Arch Linux ARM names its stock kernel linux-aarch64
+    if [ "$(uname -m)" = "aarch64" ]; then \
+        KERNEL_PKG="linux-aarch64"; \
+    fi; \
     if grep -q "^\[cachyos\]" /etc/pacman.conf 2>/dev/null; then \
         KERNEL_PKG="linux-cachyos"; \
     fi && \

--- a/Justfile
+++ b/Justfile
@@ -123,7 +123,7 @@ build variant='albacore' flavor='gnome' target_platform='' is_ci="0" tag='latest
 
     # Resolve BASE_FOR_BUILD based on PARENT_FLAVOR
     if [[ -z "${PARENT_FLAVOR}" ]]; then
-        BASE_FOR_BUILD=$(./scripts/get-base-image.sh "{{ variant }}")
+        BASE_FOR_BUILD=$(./scripts/get-base-image.sh "{{ variant }}" "${PLATFORM}")
     elif [[ "{{ is_ci }}" = "1" ]]; then
         # CI chains on the -testing stream tag
         BASE_FOR_BUILD=$(./scripts/published-image-ref.sh "{{ variant }}" "${PARENT_FLAVOR}-testing" ghcr)

--- a/build_scripts/overlay/asahi.sh
+++ b/build_scripts/overlay/asahi.sh
@@ -5,13 +5,17 @@
 #   fedora (bonito)    — @asahi COPRs, same package set as Fedora Asahi Remix /
 #                        the fedora-asahi-remix-atomic-desktops images. Most
 #                        mature path.
-#   EL10 family        — CentOS Hyperscale SIG packages-asahi repo (skipjack,
-#                        yellowfin, albacore, redfin — centos/almalinux/rhel
-#                        IDs all take this branch). The SIG repo lags upstream
-#                        (~6.16 era) and lacks m1n1/u-boot/audio packages;
-#                        EXPERIMENTAL, expect loud warnings.
-#   arch (marlin)      — community Asahi-ALARM repo. Requires an Arch Linux ARM
-#                        base (Arch proper is x86_64-only); EXPERIMENTAL.
+#   EL10 family        — CentOS Hyperscale SIG packages-asahi (kernel-16k,
+#                        glue, metapackages) + EPEL10 (m1n1, audio stack) +
+#                        @asahi/u-boot COPR (apple_m1 uboot-images-armv8).
+#                        Complete stack as of 2026-07 except tiny-dfr; kernel
+#                        lags upstream (6.16 era vs 7.0). skipjack, yellowfin,
+#                        albacore, redfin — centos/almalinux/rhel IDs all take
+#                        this branch.
+#   arch (marlin)      — community Asahi-ALARM repo on the tuna-os ALARM base
+#                        (ghcr.io/tuna-os/archlinuxarm, built by
+#                        build-archlinuxarm-base.yml from the official rootfs
+#                        tarball — #778); EXPERIMENTAL.
 #   debian (flounder)  — official Bananas-team userspace from the Debian
 #                        archive (trixie+); kernel + mesa from the team's side
 #                        archive. EXPERIMENTAL.
@@ -66,7 +70,14 @@ fedora)
 		asahi-fwupdate dracut-asahi update-m1n1
 	;;
 centos)
-	printf "::group:: === Asahi (CentOS Hyperscale SIG) — EXPERIMENTAL ===\n"
+	printf "::group:: === Asahi (CentOS Hyperscale SIG + EPEL10 + @asahi/u-boot) ===\n"
+	# Full stack, three sources (verified 2026-07-23):
+	#   Hyperscale packages-asahi — kernel-16k, dracut-asahi, update-m1n1,
+	#     asahi-scripts/-fwupdate/-battery, linux-firmware-vendor, metapackages
+	#   EPEL10 — m1n1, asahi-audio, alsa-ucm-asahi, speakersafetyd
+	#   @asahi/u-boot COPR (epel-10-aarch64) — uboot-images-armv8 with the
+	#     apple_m1 payload update-m1n1 hard-requires (in no EL repo yet)
+	# Still unpackaged for EL10: tiny-dfr (Touch Bar; best-effort below).
 	KEY=/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-HyperScale
 	if [ ! -f "$KEY" ]; then
 		curl -fsSL "https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-HyperScale" -o "$KEY"
@@ -81,21 +92,32 @@ centos)
 			gpgkey=file://${KEY}
 		EOF
 	done
+	# TunaOS EL10 bases enable EPEL in 10-base-packages.sh; make sure anyway
+	# (m1n1 + the audio stack resolve from there).
+	rpm -q epel-release >/dev/null 2>&1 || dnf -y install epel-release || true
+	COPR_UBOOT="https://download.copr.fedorainfracloud.org/results/@asahi/u-boot"
+	cat >/etc/yum.repos.d/asahi-u-boot-copr.repo <<-EOF
+		[copr-asahi-u-boot]
+		name=Copr @asahi/u-boot (apple_m1 uboot-images-armv8 for EL10)
+		baseurl=${COPR_UBOOT}/epel-10-\$basearch/
+		enabled=1
+		gpgcheck=1
+		gpgkey=${COPR_UBOOT}/pubkey.gpg
+	EOF
 	dnf -y remove --no-autoremove kernel kernel-core kernel-modules \
 		kernel-modules-core kernel-modules-extra || true
-	# The SIG builds 16k asahi kernel flavors + the dracut/update-m1n1 glue.
-	dnf -y install kernel-16k dracut-asahi update-m1n1
+	# metapackage-core pulls kernel-16k, dracut-asahi, update-m1n1 (-> m1n1 +
+	# uboot-images-armv8), alsa-ucm-asahi, asahi-fwupdate.
+	dnf -y install kernel-16k kernel-16k-modules-extra \
+		asahi-platform-metapackage-core
 	install_best_effort "dnf -y install" \
-		asahi-platform-metapackage-core asahi-fwupdate asahi-scripts \
-		linux-firmware-vendor asahi-battery
-	echo "WARNING: the Hyperscale SIG asahi repo has no m1n1/u-boot-asahi/asahi-audio" \
-		"packages as of 2026-07 — boot payloads and audio need another source" \
-		"before this image can run on hardware."
+		asahi-platform-metapackage-audio asahi-scripts \
+		linux-firmware-vendor asahi-battery tiny-dfr
 	;;
 arch | archarm)
 	printf "::group:: === Asahi (Asahi-ALARM) — EXPERIMENTAL ===\n"
-	# Requires an Arch Linux ARM base image; marlin's default base
-	# (docker.io/archlinux) is x86_64-only and never reaches this branch
+	# Runs on the tuna-os ALARM base (ghcr.io/tuna-os/archlinuxarm);
+	# marlin's amd64 base (docker.io/archlinux) never reaches this branch
 	# (aarch64 guard above).
 	cat >/etc/pacman.d/mirrorlist.asahi-alarm <<-'EOF'
 		Server = https://github.com/asahi-alarm/asahi-alarm/releases/download/$arch
@@ -115,7 +137,8 @@ arch | archarm)
 	install_best_effort "pacman -S --noconfirm --needed" \
 		m1n1 uboot-asahi asahi-audio alsa-ucm-conf-asahi \
 		speakersafetyd tiny-dfr asahi-fwextract
-	mkinitcpio -P
+	# No mkinitcpio here: marlin images are dracut-based like every other
+	# TunaOS variant; the common section below rebuilds the initramfs.
 	pacman -Scc --noconfirm || true
 	;;
 debian)
@@ -177,8 +200,8 @@ gentoo)
 	;;
 esac
 
-# ── Common verification + staging (dracut families; Arch uses mkinitcpio) ────
-if [ "${ID}" != "arch" ] && [ "${ID}" != "archarm" ]; then
+# ── Common verification + staging (all families are dracut-based) ────────────
+{
 	KVER=$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d | sort -V | tail -1 | xargs basename)
 	case "$KVER" in
 	*asahi* | *16k*) ;;
@@ -188,9 +211,16 @@ if [ "${ID}" != "arch" ] && [ "${ID}" != "archarm" ]; then
 		;;
 	esac
 	# Stage vmlinuz where bootc expects it (Fedora/EL RPMs do this natively;
-	# Debian kernels put it in /boot).
-	[ -f "/usr/lib/modules/${KVER}/vmlinuz" ] ||
-		cp "/boot/vmlinuz-${KVER}" "/usr/lib/modules/${KVER}/vmlinuz"
+	# Debian kernels put it in /boot; Arch names it after the package).
+	if [ ! -f "/usr/lib/modules/${KVER}/vmlinuz" ]; then
+		for cand in "/boot/vmlinuz-${KVER}" /boot/vmlinuz-linux-asahi /boot/Image; do
+			[ -f "$cand" ] && cp "$cand" "/usr/lib/modules/${KVER}/vmlinuz" && break
+		done
+	fi
+	[ -f "/usr/lib/modules/${KVER}/vmlinuz" ] || {
+		echo "ERROR: no kernel image found for ${KVER}" >&2
+		exit 1
+	}
 	# Debian-family kernels ship DTBs under /usr/lib/linux-image-<kver>/;
 	# stage the Apple ones at the layout update-m1n1 harvests.
 	if [ ! -d "/usr/lib/modules/${KVER}/dtb/apple" ] && [ -d "/usr/lib/linux-image-${KVER}/apple" ]; then
@@ -220,6 +250,6 @@ if [ "${ID}" != "arch" ] && [ "${ID}" != "archarm" ]; then
 	dracut --force --no-hostonly --reproducible \
 		--kver "${KVER}" "/usr/lib/modules/${KVER}/initramfs.img"
 	command -v dnf >/dev/null 2>&1 && dnf clean all || true
-fi
+}
 
 printf "::endgroup::\n"

--- a/scripts/get-base-image.sh
+++ b/scripts/get-base-image.sh
@@ -3,6 +3,19 @@
 set -euo pipefail
 
 variant="$1"
+# Optional: target platform (e.g. linux/arm64). Variants whose default base
+# is single-arch declare an arm64-specific base here (docker.io/archlinux is
+# x86_64-only; the ALARM base comes from build-archlinuxarm-base.yml — #778).
+platform="${2:-}"
+
+if [[ "$platform" == *arm64* ]]; then
+	case "$variant" in
+	"marlin")
+		echo "ghcr.io/tuna-os/archlinuxarm:latest"
+		exit 0
+		;;
+	esac
+fi
 
 case "$variant" in
 "yellowfin") echo "quay.io/almalinuxorg/almalinux-bootc:10-kitten" ;;


### PR DESCRIPTION
Two advances for #781, from fresh research (2026-07-23):

## EL10: the Hyperscale asahi stack is complete now
James was right — the EL10 gap closed. Verified against live repo metadata:
- **Hyperscale packages-asahi** grew proper metapackages (`asahi-platform-metapackage{,-core,-audio,-desktop,-plasma}`), `asahi-battery`, `linux-firmware-vendor`, kernel-16k 6.16.4.
- **EPEL10 aarch64** now carries `m1n1`, `asahi-audio`, `alsa-ucm-asahi`, `speakersafetyd`, `widevine-installer`.
- **@asahi/u-boot COPR** builds `uboot-images-armv8` 2026.04 for **epel-10-aarch64** — I verified the rpm payload contains `/usr/share/uboot/apple_m1/u-boot-nodtb.bin`, which `update-m1n1` hard-requires and no EL repo ships.

The overlay's centos branch now wires all three sources and installs `asahi-platform-metapackage-core` + `-audio`; the 'no boot payloads' warning is gone. Only `tiny-dfr` (Touch Bar) remains unpackaged for EL10 (best-effort install). #777 narrows to just that.

## Arch: marlin arm64 base (#778)
- **`build-archlinuxarm-base.yml`**: builds `ghcr.io/tuna-os/archlinuxarm` weekly from the official ALARM aarch64 rootfs tarball (md5-verified, pacman keyring initialized, `pacman -Syu`'d, smoke-tested) on a native arm64 runner. Same source the asahi-alarm project builds from; no third-party image trust.
- **`get-base-image.sh`** gains an optional platform arg; marlin arm64 resolves to the ALARM base (Justfile + reusable-workflow pre-pull updated).
- **`Containerfile.arch`**: kernel package is `linux-aarch64` on arm64 (ALARM naming).
- **build-config**: marlin `base`+`gnome` grow arm64 legs (parent chain only), `gnome-asahi` stage 3 arm64.
- **overlay arch branch**: dropped `mkinitcpio -P` (marlin ships dracut, not mkinitcpio); the common asahi verification/staging/dracut section now runs for all families, with tolerant vmlinuz staging for Arch naming.

Sequencing note: the ALARM base workflow must merge to main before it can be dispatched; the first marlin arm64 build needs `ghcr.io/tuna-os/archlinuxarm:latest` published (and the package made public) first.

Part of #781. Closes #778.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ