### PR TITLE
fix(alarm-base): disable pacman sandbox in buildah rootfs build

### DIFF
--- a/.github/workflows/build-archlinuxarm-base.yml
+++ b/.github/workflows/build-archlinuxarm-base.yml
@@ -53,6 +53,12 @@ jobs:
           # The tarball is a device rootfs: drop the board bits a container
           # never uses; alarm/root users stay (standard ALARM accounts).
           sudo rm -rf "$mnt/boot"/* "$mnt/etc/fstab"
+          # pacman's Landlock/alpm-user sandbox cannot apply inside a
+          # buildah run container ("switching to sandbox user 'alpm'
+          # failed") — disable it in the image; consumers building FROM
+          # this base need it off for the same reason.
+          sudo sed -i '/^\[options\]/a DisableSandbox' "$mnt/etc/pacman.conf"
+          grep -q '^DisableSandbox' "$mnt/etc/pacman.conf"
           # Initialize pacman inside the rootfs (native arm64 runner).
           sudo buildah run "$ctr" -- pacman-key --init
           sudo buildah run "$ctr" -- pacman-key --populate archlinuxarm


### PR DESCRIPTION
First dispatch of the ALARM base build (run 30020735396) failed at `pacman -Syu`: pacman's Landlock/alpm-user sandbox can't apply inside a buildah run container. Disable it in the image's pacman.conf — the asahi-alarm project's own Dockerfiles carry the same workaround, and consumers building FROM this base need it off for the same reason. A grep gate verifies the sed matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ