### PR TITLE
feat(asahi): ship asahi-bootbin-sync in all asahi flavors

### DIFF
--- a/build_scripts/asahi/install-bootbin-sync.sh
+++ b/build_scripts/asahi/install-bootbin-sync.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Install asahi-bootbin-sync (tunaOS#779): bootc deploys never run package
+# scriptlets, so update-m1n1 never re-runs after `bootc upgrade` — new
+# DTBs/m1n1/U-Boot would silently never reach <ESP>/m1n1/boot.bin. This
+# oneshot compares a content stamp against the ESP and regenerates boot.bin
+# when stale. Apple-DT-gated: a no-op on non-Apple hardware, so it is safe
+# to ship in every asahi flavor unconditionally.
+#
+# Vendored at a pinned ref from tuna-os/bootc-installer-asahi (same pattern
+# as the asahi-scripts dracut vendoring in overlay/asahi.sh).
+set -euo pipefail
+
+BOOTBIN_SYNC_REF=f9dbe4a3d98af94e3317eb420c0a5ecbfdac8368
+BASE="https://raw.githubusercontent.com/tuna-os/bootc-installer-asahi/${BOOTBIN_SYNC_REF}/components/asahi-bootbin-sync"
+
+install -d /usr/libexec /usr/lib/systemd/system /usr/lib/systemd/system-preset
+curl -fsSL "${BASE}/asahi-bootbin-sync.sh" -o /usr/libexec/asahi-bootbin-sync
+chmod 0755 /usr/libexec/asahi-bootbin-sync
+curl -fsSL "${BASE}/asahi-bootbin-sync.service" \
+	-o /usr/lib/systemd/system/asahi-bootbin-sync.service
+printf 'enable asahi-bootbin-sync.service\n' \
+	> /usr/lib/systemd/system-preset/90-asahi-bootbin-sync.preset
+
+# Verify the vendored pair is coherent (unit must exec what we installed).
+grep -q "ExecStart=/usr/libexec/asahi-bootbin-sync" \
+	/usr/lib/systemd/system/asahi-bootbin-sync.service
+
+# Presets only apply to future first-boots on some flows; enable directly
+# too (symlink — systemctl may be unavailable in-container).
+install -d /usr/lib/systemd/system/multi-user.target.wants
+ln -sf ../asahi-bootbin-sync.service \
+	/usr/lib/systemd/system/multi-user.target.wants/asahi-bootbin-sync.service
+
+echo "asahi-bootbin-sync installed (ref ${BOOTBIN_SYNC_REF})"

--- a/build_scripts/overlay/asahi.sh
+++ b/build_scripts/overlay/asahi.sh
@@ -244,6 +244,10 @@ esac
 		printf 'add_dracutmodules+=" asahi-firmware kernel-modules-asahi "\n' \
 			> /usr/lib/dracut/dracut.conf.d/10-asahi.conf
 	fi
+	# boot.bin lifecycle on bootc (update-m1n1 scriptlets never re-run on
+	# deploys) — tunaOS#779.
+	"$(dirname "$0")/../asahi/install-bootbin-sync.sh"
+
 	# (Re)build the initramfs with the asahi modules in scope — package
 	# postinst hooks do not reliably run dracut in container builds, and the
 	# ESP vendor-firmware flow silently dies without these modules.

--- a/build_scripts/ubuntu-kernel.sh
+++ b/build_scripts/ubuntu-kernel.sh
@@ -105,4 +105,8 @@ if ! grep -rqs "asahi-firmware" /usr/lib/dracut/dracut.conf.d/ /etc/dracut.conf.
         > /usr/lib/dracut/dracut.conf.d/10-asahi.conf
 fi
 
+# boot.bin lifecycle on bootc (update-m1n1 scriptlets never re-run on
+# deploys) — tunaOS#779.
+"$(dirname "$0")/asahi/install-bootbin-sync.sh"
+
 apt-get clean -y && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Closes #779.

bootc deploys never run package scriptlets, so `update-m1n1` never re-runs after `bootc upgrade` — new DTBs/m1n1/U-Boot silently never reach `<ESP>/m1n1/boot.bin`. This vendors the asahi-bootbin-sync component (stamp-compare + backup + regenerate oneshot) from tuna-os/bootc-installer-asahi at a pinned ref, via a shared `build_scripts/asahi/install-bootbin-sync.sh` called from:

- the overlay common section in `overlay/asahi.sh` (all families — Fedora/EL/Arch/Debian/openSUSE), and
- grouper's `ENABLE_ASAHI` path in `ubuntu-kernel.sh`.

Installs `/usr/libexec/asahi-bootbin-sync`, the systemd oneshot unit, a preset, and a direct `multi-user.target.wants` symlink; a grep gate verifies the unit execs the installed path. Apple-DT-gated — a no-op on non-Apple hardware, so it ships unconditionally in asahi flavors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ