### PR TITLE
fix(ci): skip x86 boot gate for arm64-only flavors

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -718,9 +718,16 @@ jobs:
   verify_boot:
     name: Gate
     needs: manifest
+    # amd64-only: this gate is an x86 QEMU/KVM boot (qemu-system-x86 +
+    # OVMF), so arm64-only flavors (gnome-asahi) can never pass it —
+    # skopeo dies with "no image for architecture amd64" before qemu even
+    # starts. Promote treats a skipped gate as pass; asahi images are
+    # verified by the dispatched "Verify Asahi image" 35-point harness
+    # instead (no aarch64 KVM on GH runners — TCG boot gate is future work).
     if: >-
       inputs.publish && github.event_name != 'pull_request' &&
-      !startsWith(inputs.flavor, 'base')
+      !startsWith(inputs.flavor, 'base') &&
+      contains(inputs.platforms, 'amd64')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
First gnome-asahi build (run 30004082336) built, manifested, and signed successfully — then the boot Gate failed instantly: it is an x86 QEMU/KVM gate (`qemu-system-x86` + OVMF on `ubuntu-latest`), and skopeo finds no amd64 image in an arm64-only manifest (`no image found in image index for architecture amd64`). Promotion was blocked purely by gate architecture mismatch.

Skip the gate when the flavor has no amd64 platform — `Promote` already treats a skipped gate as a pass. Asahi images are instead verified by the dispatched **Verify Asahi image** 35-point harness (tunaOS#776 flow). GH arm64 runners have no KVM, so a native TCG boot gate for arm64 flavors is future work.

Part of #776/#781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ