### PR TITLE
fix(verify-asahi): install lsinitrd so initramfs checks actually run

### DIFF
--- a/.github/workflows/verify-asahi.yml
+++ b/.github/workflows/verify-asahi.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Install lsinitrd
+        # dracut-core provides lsinitrd; without it the harness skips the
+        # initramfs-content checks with a warning instead of verifying them.
+        run: sudo apt-get update -y && sudo apt-get install -y --no-install-recommends dracut-core
+
       - name: Login to GHCR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
First real harness run against `bonito:gnome-asahi-testing` (run 30037380244) came back **35 passed / 0 failed** with one warning: `lsinitrd unavailable — initramfs content not verified`. Install dracut-core on the runner so those checks verify instead of skip.

Part of #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ