### PR TITLE
fix(ci): judge platform completeness against the flavor's platforms

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -580,10 +580,17 @@ jobs:
         run: |
           set -e
 
-          # Use strenv() for robust environment variable access in yq
-          DEFAULT_PLATFORMS=$(yq -r '.variants[] | select(.id == strenv(IMAGE_VARIANT)) | .platforms | join(",")' .github/build-config.yml)
-
-
+          # Expected platforms = what this flavor actually declares. The
+          # build matrix resolves per-flavor platform overrides into
+          # inputs.platforms (gnome-asahi is arm64-only; judging it against
+          # the variant's amd64+arm64 list made Promote silently skip
+          # forever). Fall back to the variant list only if the input is
+          # somehow empty. PR builds force amd64 here but never promote.
+          DEFAULT_PLATFORMS="${PLATFORMS}"
+          if [ -z "$DEFAULT_PLATFORMS" ]; then
+            # Use strenv() for robust environment variable access in yq
+            DEFAULT_PLATFORMS=$(yq -r '.variants[] | select(.id == strenv(IMAGE_VARIANT)) | .platforms | join(",")' .github/build-config.yml)
+          fi
           if [ -z "$DEFAULT_PLATFORMS" ]; then
             echo "Unknown variant: ${IMAGE_VARIANT}"
             DEFAULT_PLATFORMS="linux/arm64,linux/amd64"


### PR DESCRIPTION
Follow-up to #788: the gnome-asahi rebuild ([30038343741](https://github.com/tuna-os/tunaOS/actions/runs/30038343741)) went fully green — Gate skipped as designed, Promote ran and reported success — but the bare `:gnome-asahi` tag was never written: `all_platforms_built` judges built digests against the **variant's** platform list (amd64+arm64), so an arm64-only flavor can never be 'complete' and Promote takes the leave-bare-tags branch forever.

Judge against `inputs.platforms` instead — the build matrix already resolves per-flavor platform overrides into it — falling back to the variant list if empty. PR builds force amd64 into inputs.platforms but never reach Promote.

Part of #776/#781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ