### PR TITLE
fix(grouper): install gnome-session explicitly — resolute 50.1 dropped it

### DIFF
--- a/build_scripts/desktop/gnome.sh
+++ b/build_scripts/desktop/gnome.sh
@@ -10,7 +10,13 @@ case "${1:-}" in
 	if [[ "$PKG_MGR" == "apt" ]]; then
 		# Ubuntu 26.04 ships GNOME 48 via ubuntu-desktop-minimal.
 		# --no-install-recommends avoids bringing in games, LibreOffice, etc.
-		pkg_install ubuntu-desktop-minimal gnome-shell-extension-manager
+		# gnome-session + ubuntu-session are explicit: since resolute's
+		# GNOME 50.1 update they are no longer dragged in without
+		# recommends, and without them /usr/share/wayland-sessions has no
+		# *gnome*.desktop — configure-desktop-runtime.sh hard-fails
+		# (grouper gnome red since 2026-07-21).
+		pkg_install ubuntu-desktop-minimal gnome-shell-extension-manager \
+			gnome-session ubuntu-session
 
 		# Additional GNOME utilities (mirrors the RPM set where possible)
 		pkg_install \


### PR DESCRIPTION
grouper gnome has been red on **all arches** since the 2026-07-21 nightly (pre-existing, not asahi fallout — surfaced while validating `grouper:gnome-asahi`, whose asahi kernel/userspace step passed cleanly on the first try).

Root cause: with `--no-install-recommends`, `ubuntu-desktop-minimal` no longer drags in a session package after resolute's GNOME 50.1 update, so `/usr/share/wayland-sessions` contains no `*gnome*.desktop` and `configure-desktop-runtime.sh` hard-fails at its required-path check. Install `gnome-session` + `ubuntu-session` explicitly.

Remaining known grouper-asahi item (separate, non-fatal): the UbuntuAsahi kernel package stages no Apple DTBs at `/usr/lib/linux-image-<kver>` — the overlay warned; needs the package's real DTB path wired into the staging fallback.

Part of #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ