### PR TITLE
fix(grouper): stage Apple DTBs from Ubuntu's firmware device-tree path

### DIFF
--- a/build_scripts/ubuntu-kernel.sh
+++ b/build_scripts/ubuntu-kernel.sh
@@ -77,14 +77,24 @@ cp "/boot/vmlinuz-${KVER}" "/usr/lib/modules/${KVER}/vmlinuz"
 
 # DTBs: Debian-family kernels ship devicetrees under /usr/lib/linux-image-<kver>/.
 # Stage the Apple ones at /usr/lib/modules/<kver>/dtb/ — the layout update-m1n1
-# harvests and our verify harness checks.
-if [ -d "/usr/lib/linux-image-${KVER}" ]; then
-    mkdir -p "/usr/lib/modules/${KVER}/dtb"
-    cp -r "/usr/lib/linux-image-${KVER}/apple" "/usr/lib/modules/${KVER}/dtb/" 2>/dev/null \
-        || cp -r "/usr/lib/linux-image-${KVER}/." "/usr/lib/modules/${KVER}/dtb/"
+# harvests and our verify harness checks. Ubuntu kernels ship DTBs in
+# linux-modules at /lib/firmware/<kver>/device-tree/ (that's also Ubuntu's
+# own update-m1n1 DTBS default); Debian-style packages use
+# /usr/lib/linux-image-<kver>/.
+if [ ! -d "/usr/lib/modules/${KVER}/dtb/apple" ]; then
+    for src in \
+        "/usr/lib/firmware/${KVER}/device-tree" \
+        "/lib/firmware/${KVER}/device-tree" \
+        "/usr/lib/linux-image-${KVER}"; do
+        if [ -d "${src}/apple" ]; then
+            mkdir -p "/usr/lib/modules/${KVER}/dtb"
+            cp -r "${src}/apple" "/usr/lib/modules/${KVER}/dtb/"
+            break
+        fi
+    done
 fi
 ls "/usr/lib/modules/${KVER}/dtb/apple/" >/dev/null 2>&1 \
-    || echo "WARNING: no apple DTBs staged — check /usr/lib/linux-image-${KVER} layout"
+    || echo "WARNING: no apple DTBs staged — checked firmware/device-tree and linux-image layouts for ${KVER}"
 
 # Dracut modules: finalize.sh builds the initramfs with dracut. If the deb
 # packaging didn't ship the asahi dracut modules (Debian/Ubuntu default to


### PR DESCRIPTION
The first grouper gnome-asahi build's kernel step passed but warned `no apple DTBs staged`: the UbuntuAsahi kernel ships DTBs in linux-modules at `/lib/firmware/<kver>/device-tree/` — verified against Ubuntu's own asahi-scripts packaging, whose update-m1n1 defaults DTBS to exactly that path — not the Debian `/usr/lib/linux-image-<kver>/` layout the staging assumed. Probe the firmware path first, keep the Debian path as fallback. Without this the 35-point harness DTB checks and update-m1n1 would fail on grouper.

Companion fix in bootc-installer-asahi (pushed): payload harvest + asahi-bootbin-sync now probe `/usr/lib/u-boot-asahi/u-boot-nodtb.bin`, Ubuntu's u-boot location.

Part of #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ