### PR TITLE
fix(alarm-base): sudo the DisableSandbox grep gate

### DIFF
--- a/.github/workflows/build-archlinuxarm-base.yml
+++ b/.github/workflows/build-archlinuxarm-base.yml
@@ -58,7 +58,7 @@ jobs:
           # failed") — disable it in the image; consumers building FROM
           # this base need it off for the same reason.
           sudo sed -i '/^\[options\]/a DisableSandbox' "$mnt/etc/pacman.conf"
-          grep -q '^DisableSandbox' "$mnt/etc/pacman.conf"
+          sudo grep -q '^DisableSandbox' "$mnt/etc/pacman.conf"
           # Initialize pacman inside the rootfs (native arm64 runner).
           sudo buildah run "$ctr" -- pacman-key --init
           sudo buildah run "$ctr" -- pacman-key --populate archlinuxarm


### PR DESCRIPTION
Round 2 of the ALARM base build got past pacman (the DisableSandbox fix worked) and died on my own verification grep: the buildah mount is root-owned, the grep wasn't sudo'd. One word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ