### PR TITLE
fix(verify-asahi): tolerate Ubuntu's non-Fedora 16K kernel + hook naming

### DIFF
--- a/build_scripts/ubuntu-kernel.sh
+++ b/build_scripts/ubuntu-kernel.sh
@@ -75,6 +75,15 @@ case "$KVER" in
 esac
 cp "/boot/vmlinuz-${KVER}" "/usr/lib/modules/${KVER}/vmlinuz"
 
+# linux-buildinfo ships the kernel .config — the only distro-independent
+# proof that this build actually has CONFIG_ARM64_16K_PAGES=y (Apple
+# Silicon's DART IOMMU requires 16K pages; Ubuntu's asahi-arm version
+# string doesn't encode it the way Fedora's +16k suffix does). Optional:
+# don't fail the build if it's missing, the verify harness will catch it.
+apt-get install -y --no-install-recommends "linux-buildinfo-${KVER}" 2>/dev/null &&
+    cp "/usr/lib/linux/${KVER}/config" "/usr/lib/modules/${KVER}/config" 2>/dev/null ||
+    echo "WARNING: linux-buildinfo-${KVER} unavailable — kernel config not staged"
+
 # DTBs: Debian-family kernels ship devicetrees under /usr/lib/linux-image-<kver>/.
 # Stage the Apple ones at /usr/lib/modules/<kver>/dtb/ — the layout update-m1n1
 # harvests and our verify harness checks. Ubuntu kernels ship DTBs in

--- a/scripts/verify-asahi-image.sh
+++ b/scripts/verify-asahi-image.sh
@@ -39,7 +39,18 @@ if [[ ${#kvers[@]} -eq 1 ]]; then ok "exactly one kernel: ${kvers[0]}"
 else bad "expected exactly 1 kernel in /usr/lib/modules, found ${#kvers[@]}: ${kvers[*]:-none}"; fi
 kver="${kvers[0]:-}"
 M="$mnt/usr/lib/modules/$kver"
-[[ "$kver" == *+16k ]]     && ok "16K page-size kernel flavor (+16k)" || bad "kernel is not the 16k flavor: $kver"
+# 16K pages are a hard requirement of Apple Silicon's DART IOMMU, not a
+# distro naming convention — Fedora encodes it in the version (+16k),
+# Ubuntu's asahi-arm kernels don't but do carry CONFIG_ARM64_16K_PAGES=y
+# (verified against the linux-buildinfo config, 2026-07-24). Trust the
+# version suffix where present; fall back to the shipped kernel config.
+if [[ "$kver" == *+16k ]]; then
+    ok "16K page-size kernel flavor (+16k)"
+elif [[ -f "$M/config" ]] && grep -qx "CONFIG_ARM64_16K_PAGES=y" "$M/config"; then
+    ok "16K page-size kernel (CONFIG_ARM64_16K_PAGES=y)"
+else
+    bad "kernel is not confirmed 16K-page: $kver"
+fi
 [[ "$kver" == *asahi* ]]   && ok "asahi kernel build" || bad "kernel version lacks 'asahi': $kver"
 [[ -f "$M/vmlinuz" ]]      && ok "vmlinuz present" || bad "vmlinuz missing"
 [[ -f "$M/initramfs.img" ]] && ok "initramfs.img present" || bad "initramfs.img missing (bootc images must ship a prebuilt initramfs)"
@@ -71,7 +82,7 @@ check_any() { # label, candidate paths...
 check_any "m1n1 payload" /usr/lib64/m1n1/m1n1.bin /usr/lib/m1n1/m1n1.bin /usr/lib/asahi-boot/m1n1.bin /boot/m1n1.bin
 check_any "Apple U-Boot payload" /usr/share/uboot/apple_m1/u-boot-nodtb.bin /usr/lib/u-boot/apple_m1/u-boot-nodtb.bin /usr/lib/asahi-boot/u-boot.bin
 check_file /usr/bin/update-m1n1
-check_any "update-m1n1 kernel hook" /usr/lib/kernel/install.d/15-update-m1n1.install /etc/kernel/postinst.d/update-m1n1
+check_any "update-m1n1 kernel hook" /usr/lib/kernel/install.d/15-update-m1n1.install /etc/kernel/postinst.d/update-m1n1 /etc/kernel/postinst.d/zz-update-m1n1
 
 echo "== firmware handling =="
 check_file /usr/bin/asahi-fwextract


### PR DESCRIPTION
grouper's DTB-complete gnome-asahi rebuild scored **34/35** on the harness (run 30057695451) — both remaining failures were harness assumptions, not image defects:

1. **`kernel is not the 16k flavor`** — the check hardcoded Fedora's `+16k` version suffix. Ubuntu's asahi kernel (`7.0.0-1002-asahi-arm`) doesn't encode page size in its version string, but I extracted its actual `.config` from the `linux-buildinfo` package and confirmed `CONFIG_ARM64_16K_PAGES=y` — it genuinely is 16K (Apple Silicon's DART IOMMU requires this regardless of distro, so it could never have shipped otherwise). Falls back to checking a staged kernel config when the version suffix isn't there.
2. **`update-m1n1 kernel hook missing`** — Ubuntu's asahi-scripts packaging uses `/etc/kernel/postinst.d/zz-update-m1n1`, not `update-m1n1`. Added to the `check_any` list.

`ubuntu-kernel.sh` now best-effort installs `linux-buildinfo-<kver>` and stages its `.config` at `/usr/lib/modules/<kver>/config` so the harness fallback has something to check — doesn't fail the build if unavailable.

No change to Fedora/EL behavior (the `+16k` branch still matches first).

Part of #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ