### PR TITLE
fix(asahi): dnf5's flag is --noautoremove, not --no-autoremove

### DIFF
--- a/build_scripts/overlay/asahi.sh
+++ b/build_scripts/overlay/asahi.sh
@@ -61,7 +61,7 @@ fedora)
 	dnf -y copr enable @asahi/fedora-remix-branding
 	dnf -y install asahi-repos
 	# Swap the stock 4K kernel for the 16K asahi build.
-	dnf -y remove --no-autoremove kernel kernel-core kernel-modules \
+	dnf -y remove --noautoremove kernel kernel-core kernel-modules \
 		kernel-modules-core kernel-modules-extra || true
 	dnf -y install kernel-16k kernel-16k-modules-extra \
 		asahi-platform-metapackage \
@@ -104,7 +104,7 @@ centos)
 		gpgcheck=1
 		gpgkey=${COPR_UBOOT}/pubkey.gpg
 	EOF
-	dnf -y remove --no-autoremove kernel kernel-core kernel-modules \
+	dnf -y remove --noautoremove kernel kernel-core kernel-modules \
 		kernel-modules-core kernel-modules-extra || true
 	# metapackage-core pulls kernel-16k, dracut-asahi, update-m1n1 (-> m1n1 +
 	# uboot-images-armv8), alsa-ucm-asahi, asahi-fwupdate.


### PR DESCRIPTION
yellowfin and albacore gnome-asahi both failed at the kernel-swap step: `dnf remove: error: unrecognized arguments: --no-autoremove`. It was masked by the trailing `|| true`, so the stock 4K `kernel-core` package stayed installed and later conflicted with `asahi-platform-metapackage-core` (`problem with installed package kernel-core-6.12.0-233.el10.aarch64`).

dnf5's own usage synopsis prints `--noautoremove` (no hyphen) — fixed in both the fedora and centos branches of the overlay (identical bug in each; bonito apparently didn't hit the conflict, so this had been latent).

Part of #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ