### PR TITLE
fix(asahi): pre-create /boot/dtb — kernel-core preun devicetree hook fails without it

### DIFF
--- a/build_scripts/overlay/asahi.sh
+++ b/build_scripts/overlay/asahi.sh
@@ -61,6 +61,11 @@ fedora)
 	dnf -y copr enable @asahi/fedora-remix-branding
 	dnf -y install asahi-repos
 	# Swap the stock 4K kernel for the 16K asahi build.
+	# kernel-core's %preun runs kernel-install remove hooks; the
+	# 10-devicetree.install plugin does `ln ... /boot/dtb` and hard-fails
+	# ("No such file or directory") when /boot/dtb's parent doesn't exist
+	# — true in this build (/boot is an empty tmpfs mount). Pre-create it.
+	mkdir -p /boot/dtb
 	dnf -y remove --noautoremove kernel kernel-core kernel-modules \
 		kernel-modules-core kernel-modules-extra || true
 	dnf -y install kernel-16k kernel-16k-modules-extra \
@@ -104,6 +109,9 @@ centos)
 		gpgcheck=1
 		gpgkey=${COPR_UBOOT}/pubkey.gpg
 	EOF
+	# See the fedora branch above: kernel-core's %preun devicetree hook
+	# fails hard if /boot/dtb's parent doesn't exist yet.
+	mkdir -p /boot/dtb
 	dnf -y remove --noautoremove kernel kernel-core kernel-modules \
 		kernel-modules-core kernel-modules-extra || true
 	# metapackage-core pulls kernel-16k, dracut-asahi, update-m1n1 (-> m1n1 +


### PR DESCRIPTION
yellowfin's retry (with the dnf5 flag fix from #800) got further — the kernel removal was actually attempted this time — and hit a real scriptlet failure:

```
Error in PREUN scriptlet in rpm package kernel-core
ln: target '/boot/dtb': No such file or directory
/usr/lib/kernel/install.d/10-devicetree.install failed with exit status 1.
error: %preun(kernel-core-...) scriptlet failed, exit status 1
```

`kernel-core`'s `%preun` runs kernel-install remove hooks, and the `10-devicetree.install` plugin does `ln ... /boot/dtb` — hard-failing because `/boot` is an empty tmpfs mount in this build with no `dtb/` subdirectory for the link to land in. `mkdir -p /boot/dtb` before the kernel swap in both the fedora and centos branches.

Part of #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ