### PR TITLE
fix(asahi): regenerate CA bundle before zypper addrepo on sailfin

### DIFF
--- a/build_scripts/overlay/asahi.sh
+++ b/build_scripts/overlay/asahi.sh
@@ -183,6 +183,11 @@ opensuse* | *suse*)
 	# 158+ revisions, updated 2026-06. Caveat: a single-maintainer home:
 	# project, not a devel project — treat as upstream-worth-adopting
 	# (hardware:asahi would be the graduation path).
+	# Sailfin's base wipes /var (which owns openSUSE's CA bundle) and
+	# regenerates it for curl's benefit (see Containerfile.opensuse); zypper
+	# hit the same gap ("unable to get local issuer certificate") on its
+	# own libcurl instance against download.opensuse.org. Idempotent.
+	update-ca-certificates || true
 	zypper --non-interactive --gpg-auto-import-keys addrepo \
 		"https://download.opensuse.org/repositories/home:/mrkcee/openSUSE_Factory_ARM/home:mrkcee.repo"
 	zypper --non-interactive --gpg-auto-import-keys refresh


### PR DESCRIPTION
sailfin's first gnome-asahi build failed immediately at the OBS repo add:

```
Download (curl) error for '...home:mrkcee.repo':
Error code: The peer certificate could not be verified Curl error (60)
Error message: SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)
```

Containerfile.opensuse already regenerates the CA bundle after the base's `/var` wipe destroys it, specifically because `install-desktop.sh`'s yq fetch needs curl to work — but zypper apparently uses its own libcurl instance that hit the identical gap. `update-ca-certificates` before the repo add, same fix pattern.

Part of #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ