### PR TITLE
ci(live-overlay): publish overlays for all image variants, not just yellowfin

### DIFF
--- a/.github/workflows/live-overlay.yml
+++ b/.github/workflows/live-overlay.yml
@@ -13,14 +13,14 @@ on:
   workflow_dispatch:
     inputs:
       variant:
-        description: "Variant"
+        description: "Variant id, or 'all'"
         required: false
-        default: "yellowfin"
+        default: "all"
         type: string
       flavors:
-        description: "Comma-separated flavors"
+        description: "Single desktop flavor id (gnome/kde/cosmic/niri/xfce), or 'all'"
         required: false
-        default: "gnome,kde,cosmic,niri,xfce"
+        default: "all"
         type: string
   schedule:
     # Weekly, after image builds.
@@ -35,19 +35,46 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
+      count: ${{ steps.gen.outputs.count }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install yq
+        run: sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
       - id: gen
         env:
-          FLAVORS: ${{ inputs.flavors || 'gnome,kde,cosmic,niri,xfce' }}
-          VARIANT: ${{ inputs.variant || 'yellowfin' }}
+          WANT_VARIANT: ${{ inputs.variant || 'all' }}
+          WANT_FLAVOR: ${{ inputs.flavors || 'all' }}
         run: |
-          M=$(jq -cn --arg v "$VARIANT" --arg f "$FLAVORS" \
-            '{include: ($f | split(",") | map({variant: $v, flavor: .}))}')
-          echo "matrix=$M" >> "$GITHUB_OUTPUT"
+          # Overlays carry the per-desktop live payload (installer flatpak,
+          # autologin, polkit) the browser ISO builder grafts in as
+          # live-overlay:<variant>-<flavor>. Filter on build_image (NOT
+          # build_iso): the browser builds ISOs from any published *image*,
+          # including image-only variants CI never cuts an ISO for — sailfin
+          # is exactly that case, so it had no overlay and booted with no
+          # installer. Restrict to the plain desktop tags the browser offers
+          # (gnome/kde/cosmic/niri/xfce, no -nvidia/-hwe); new variants are
+          # picked up automatically instead of the old yellowfin-only default.
+          MATRIX=$(yq -o json .github/build-config.yml | jq -c \
+            --arg v "$WANT_VARIANT" --arg f "$WANT_FLAVOR" '{
+              include: [
+                .variants[] as $var | $var.flavors[]
+                | select(.build_image == true)
+                | select(.id | test("^(gnome|kde|cosmic|niri|xfce)$"))
+                | select($v == "all" or $var.id == $v)
+                | select($f == "all" or .id == $f)
+                | {variant: $var.id, flavor: .id}
+              ]
+            }')
+          COUNT=$(echo "$MATRIX" | jq '.include | length')
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Building $COUNT overlay(s):"
+          echo "$MATRIX" | jq -r '.include[] | "  \(.variant):\(.flavor)"'
 
   overlay:
     name: ${{ matrix.variant }}:${{ matrix.flavor }}
     needs: generate-matrix
+    if: ${{ needs.generate-matrix.outputs.count != '0' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:


### PR DESCRIPTION
The browser ISO builder grafts in `live-overlay:<variant>-<flavor>` to give browser-built ISOs the installer flatpak + autologin + polkit. That workflow only built **yellowfin gnome,kde**, so every other variant’s browser ISO booted with **no installer** (observed: sailfin-gnome).

Now generates the matrix from `build-config.yml` (mirroring `publish-isos.yml`), filtering on **`build_image`** (not `build_iso`): the browser builds ISOs from any published *image*, including image-only variants CI never cuts an ISO for — **sailfin** is exactly that case. Restricted to the plain desktop tags the browser offers (gnome/kde/cosmic/niri/xfce); new variants are picked up automatically.

- Dispatch inputs default to `variant=all, flavor=all`; pass a single variant/flavor to target one overlay.
- Scheduled weekly run now builds the full set (**~50** overlays incl. `sailfin-*`).

Validated locally: matrix is valid JSON, `all/all` → 50 (sailfin=4), `sailfin` dispatch → the 4 sailfin desktops.

⚠️ 50 × ~45-min podman jobs weekly — heftier than before. Trim the desktop set or variants if that’s too much runner time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvVVtmk8CqW8x643B6m84