### PR TITLE
fix(asahi): retry the required home:mrkcee install on OBS mirror 404s

### DIFF
--- a/build_scripts/overlay/asahi.sh
+++ b/build_scripts/overlay/asahi.sh
@@ -192,8 +192,18 @@ opensuse* | *suse*)
 		"https://download.opensuse.org/repositories/home:/mrkcee/openSUSE_Factory_ARM/home:mrkcee.repo"
 	zypper --non-interactive --gpg-auto-import-keys refresh
 	zypper --non-interactive remove --no-confirm kernel-default || true
-	zypper --non-interactive install --no-confirm --no-recommends \
-		kernel-asahi m1n1 u-boot-asahi asahi-scripts
+	# home:mrkcee's OBS mirror occasionally 404s individual rpms mid-sync
+	# (single-maintainer project, no CDN warmup guarantee) — retry the
+	# required transaction a few times before giving up; `zypper refresh`
+	# re-reads the repo metadata, which is usually what clears a stale 404.
+	for attempt in 1 2 3; do
+		zypper --non-interactive install --no-confirm --no-recommends \
+			kernel-asahi m1n1 u-boot-asahi asahi-scripts && break
+		[ "$attempt" -eq 3 ] && { echo "ERROR: home:mrkcee install failed after 3 attempts" >&2; exit 1; }
+		echo "WARNING: required asahi package install failed (attempt ${attempt}/3) — refreshing repo and retrying" >&2
+		sleep $((attempt * 20))
+		zypper --non-interactive --gpg-auto-import-keys refresh
+	done
 	install_best_effort "zypper --non-interactive install --no-confirm --no-recommends" \
 		asahi-fwextract asahi-audio alsa-ucm-conf-asahi speakersafetyd \
 		triforce-lv2 bankstown-lv2 asahi-nvram tiny-dfr


### PR DESCRIPTION
Sailfin's retry with the CA fix (#802) got much further — the repo add/refresh/CA problems are resolved — but the required `kernel-asahi m1n1 u-boot-asahi asahi-scripts` transaction hit repeated 404s on individual rpms (`pipewire-tools`, `dbus-1`, `wireplumber` — transitive hard deps, not recommends) from the home:mrkcee OBS mirror:

```
Preloading: pipewire-spa-tools-1.6.7-1.2.aarch64.rpm [Error: "The requested URL returned error: 404", trying next mirror.]
```

This is exactly the caveat already documented in the overlay comment — single-maintainer `home:` project, no CDN warmup guarantee. Retry the required transaction up to 3 times with a `zypper refresh` + backoff between attempts, since a repo metadata refresh is usually what clears a stale mirror 404.

Part of #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ