### PR TITLE
fix(asahi): bananas-archive keyring must land at /etc/apt/keyrings/

### DIFF
--- a/build_scripts/overlay/asahi.sh
+++ b/build_scripts/overlay/asahi.sh
@@ -157,8 +157,12 @@ debian)
 	apt-get update -y
 	apt-get install -y --no-install-recommends curl ca-certificates
 	BANANAS=https://bananas-archive.debian.net/bananas-archive
+	# The team's own .sources file hardcodes Signed-By: /etc/apt/keyrings/...
+	# (verified by fetching it) — not /usr/share/keyrings/ like most other
+	# third-party repos in this codebase. Match it exactly.
+	install -d /etc/apt/keyrings
 	curl -fsSL "${BANANAS}/bananas-archive-keyring.gpg" \
-		-o /usr/share/keyrings/bananas-archive-keyring.gpg
+		-o /etc/apt/keyrings/bananas-archive-keyring.gpg
 	SUITE=trixie
 	grep -q sid /etc/debian_version 2>/dev/null && SUITE=unstable
 	curl -fsSL "${BANANAS}/bananas-${SUITE}.sources" -o /etc/apt/sources.list.d/bananas.sources


### PR DESCRIPTION
flounder's first gnome-asahi build failed at `apt-get update`:

```
Sub-process /usr/bin/sqv returned an error code (1): Failed to parse keyring "/etc/apt/keyrings/bananas-archive-keyring.gpg": No such file or directory
E: The repository '...trixie-bananas InRelease' is not signed.
```

Fetched the Bananas team's own `bananas-trixie.sources` directly — it hardcodes `Signed-By: /etc/apt/keyrings/bananas-archive-keyring.gpg`, but the overlay downloaded the keyring to `/usr/share/keyrings/` (the convention most other third-party repos in this codebase use, just not this one). Match their path exactly.

Part of #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bGymcRkVtV7DPToWDjZyZ