### PR TITLE
fix(sailfin): install flatpak in the openSUSE base image

### DIFF
--- a/Containerfile.opensuse
+++ b/Containerfile.opensuse
@@ -34,7 +34,7 @@ RUN zypper --non-interactive addrepo -fG \
     zypper --non-interactive --gpg-auto-import-keys refresh && \
     zypper install -y \
     bootc \
-    btrfs-progs ca-certificates ca-certificates-mozilla cpio curl dosfstools dracut e2fsprogs glib2 \
+    btrfs-progs ca-certificates ca-certificates-mozilla cpio curl dosfstools dracut e2fsprogs flatpak glib2 \
     kernel-default kernel-firmware-all openssh ostree skopeo \
     systemd systemd-boot udev xfsprogs zstd chrony && \
     update-ca-certificates && \


### PR DESCRIPTION
Every TunaOS image is expected to ship flatpak (`10-base-packages.sh` installs it on apt + dnf), but that script has **no zypper branch**, and `Containerfile.opensuse` omitted it — so **sailfin shipped without flatpak**.

That broke the live-overlay build for all 4 sailfin flavors: `customize-live.sh` hard-fails with `flatpak not installed; cannot pre-install <installer>` (confirmed in [run 30094141976](https://github.com/tuna-os/tunaOS/actions/runs/30094141976)). Without it, browser-built sailfin ISOs get no installer even once overlays cover them.

Adds `flatpak` to the base zypper install so all sailfin flavors have it, matching the dnf/apt bases.

⚠️ Needs a **sailfin image rebuild** before the sailfin overlays can be rebuilt (the overlay job pulls the published image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvVVtmk8CqW8x643B6m84