### PR TITLE
fix(desktop): force graphical.target.wants for the DM (openSUSE never started GDM)

### DIFF
--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -302,6 +302,20 @@ if [[ -z "${_TD_DM}" || "${_TD_DM}" == "null" ]]; then
 fi
 if [[ -n "${_TD_DM}" && "${_TD_DM}" != "null" ]]; then
 	safe_enable "${_TD_DM}.service"
+	# openSUSE's gdm.service ships only `[Install] Alias=display-manager.service`
+	# with no `WantedBy=graphical.target` (it relies on a distro preset +
+	# openSUSE's own display-manager.service launcher, which our cross-distro
+	# gdm alias replaces). So `systemctl enable gdm` creates the alias but leaves
+	# graphical.target.wants empty — nothing pulls the DM at boot, and the image
+	# comes up to a bare console (sailfin desktop Gate: "no graphical session",
+	# contract service never runs because it Requires=display-manager.service).
+	# Force the wants link so graphical.target starts the DM, matching the
+	# WantedBy the rpm/deb DMs carry. Idempotent where enable already made it.
+	if [[ -f "/usr/lib/systemd/system/${_TD_DM}.service" ]]; then
+		mkdir -p /etc/systemd/system/graphical.target.wants
+		ln -sf "/usr/lib/systemd/system/${_TD_DM}.service" \
+			"/etc/systemd/system/graphical.target.wants/${_TD_DM}.service"
+	fi
 	# Server-oriented bootc bases such as AlmaLinux default to
 	# multi-user.target. Enabling a display manager alone does not change the
 	# boot target, so an otherwise complete desktop image would only reach a


### PR DESCRIPTION
sailfin desktop images build fine but the qcow2 **Gate times out with "no graphical session"**: the DM never starts → graphical.target never reached → `tunaos-desktop-contract.service` (Requires=display-manager.service) never runs → no marker.

**Cause:** openSUSE `gdm.service` has only `[Install] Alias=display-manager.service`, **no `WantedBy=graphical.target`** (it relies on a distro preset + openSUSE's own display-manager.service launcher, which our cross-distro gdm alias replaces). So `systemctl enable gdm` makes the alias but leaves `graphical.target.wants` **empty** — nothing pulls the DM at boot. Confirmed by inspecting `ghcr.io/tuna-os/sailfin:gnome`: `display-manager.service → gdm.service` present, `graphical.target.wants` absent.

**Fix:** force `graphical.target.wants/<dm>.service` after enabling, so graphical.target starts the DM regardless of the unit's `[Install]`. Idempotent where enable already made it; matches the WantedBy the rpm/deb DMs carry. Fixes sailfin and any list-shaped zypper/emerge base with the same unit shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvVVtmk8CqW8x643B6m84