### PR TITLE
fix(qcow2): probe image for backend+sealed; sealed rootfs installs on ext4

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -276,8 +276,40 @@ qcow2 variant flavor='gnome' repo='local' tag='':
     # grouper (Ubuntu) has no bootupd package available via apt, so it ships
     # systemd-boot instead and installs via bootc's composefs-native backend,
     # which doesn't shell out to bootupd for bootloader management.
+    #
+    # Two INDEPENDENT signals, probed from the image rather than guessed from
+    # its name (the name-based heuristic is exactly what tuna-os/wootc had to
+    # rip out — see payload/deployer/deploy.sh "the crux fix"):
+    #
+    #   BACKEND=composefs-native → ships systemd-boot and no bootupctl, so
+    #     bootloader management can't go through bootupd: needs
+    #     --composefs-backend.
+    #   SEALED → prepare-root.conf has [composefs] enabled: the rootfs is
+    #     composefs-sealed and needs fs-verity, which XFS LACKS. On the xfs
+    #     default from 00-tunaos.toml the initramfs fails initrd-switch-root
+    #     and drops to dracut emergency mode — every composefs variant's
+    #     desktop Gate timed out at "no graphical session" (confirmed on
+    #     sailfin and grouper). ext4 is the proven sealed filesystem
+    #     (wootc deploy.sh:809-821); btrfs also has fs-verity but its ostree
+    #     deployment fails to mount (sysroot.mount timeout, wootc#35), so it
+    #     is deliberately NOT used here.
+    #
+    # Sealed is what drives the filesystem, and it is independent of the
+    # backend: traditional-ostree images can be sealed too.
+    PROBE=$(sudo podman run --rm --entrypoint="" "$IMG_REF" sh -c '
+        if test -f /usr/lib/systemd/boot/efi/systemd-bootx64.efi && ! command -v bootupctl >/dev/null 2>&1; then
+            echo BACKEND=composefs-native
+        else
+            echo BACKEND=ostree
+        fi
+        grep -A8 "^\[composefs\]" /usr/lib/ostree/prepare-root.conf 2>/dev/null \
+          | grep -qiE "enabled[[:space:]]*=[[:space:]]*(yes|true|1|signed)" && echo SEALED=1 || echo SEALED=0
+    ' 2>/dev/null) || PROBE=$(printf 'BACKEND=ostree\nSEALED=0\n')
+    echo "==> image probe: $(echo "$PROBE" | tr '\n' ' ')"
+
     COMPOSEFS_ARGS=()
-    [[ "$OUTPUT_NAME" == grouper* || "$OUTPUT_NAME" == sailfin* || "$OUTPUT_NAME" == guppy* || "$OUTPUT_NAME" == marlin* || "$OUTPUT_NAME" == flounder* ]] && COMPOSEFS_ARGS=(--composefs-backend)
+    grep -q '^BACKEND=composefs-native$' <<<"$PROBE" && COMPOSEFS_ARGS+=(--composefs-backend)
+    grep -q '^SEALED=1$' <<<"$PROBE" && COMPOSEFS_ARGS+=(--filesystem ext4)
 
     echo "==> Running bootc install to-disk (this takes a few minutes)..."
     sudo podman run \

--- a/system_files/usr/lib/bootc/install/00-tunaos.toml
+++ b/system_files/usr/lib/bootc/install/00-tunaos.toml
@@ -7,5 +7,18 @@ block = ["direct", "tpm2-luks"]
 kargs = ["audit=0"]
 
 [install.filesystem.root]
-# Default to XFS for root, matching standard enterprise Linux patterns.
+# XFS matches standard enterprise Linux patterns and is correct for the
+# traditional-ostree variants (el10: composefs explicitly disabled).
+#
+# WARNING: XFS is WRONG for composefs-SEALED images (prepare-root.conf
+# [composefs] enabled = yes — every non-el10 base). A sealed rootfs needs
+# fs-verity, which XFS lacks: the initramfs then fails initrd-switch-root and
+# the system drops to a dracut emergency shell. Those variants must install on
+# ext4 (the proven sealed filesystem — see tuna-os/wootc
+# payload/deployer/deploy.sh; btrfs also has fs-verity but its ostree
+# deployment fails to mount, wootc#35).
+#
+# The qcow2/Gate path probes the image and passes --filesystem ext4 for sealed
+# images, which overrides this key. Per-variant overrides belong in a
+# higher-sorting drop-in (e.g. 50-<variant>.toml) so they win over this file.
 type = "xfs"


### PR DESCRIPTION
Every composefs variant's desktop Gate timed out at "no graphical session" — **sailfin and grouper both confirmed**. The installed disk never reached userspace: it dropped to a **dracut emergency shell at `initrd-switch-root`**, because a composefs-**SEALED** rootfs needs **fs-verity**, and **XFS** (the `00-tunaos.toml` default) lacks it. Screenshot + serial evidence from the sailfin Gate artifact.

**1. Probe the image for two independent signals** instead of matching on variant name — the name-based heuristic is exactly what `tuna-os/wootc` had to rip out (`payload/deployer/deploy.sh`, "the crux fix"):

| signal | detection | effect |
|---|---|---|
| `BACKEND=composefs-native` | systemd-boot present, no `bootupctl` | `--composefs-backend` |
| `SEALED` | `prepare-root.conf` `[composefs] enabled` | `--filesystem ext4` |

Sealed drives the filesystem and is **independent** of the backend (traditional-ostree images can be sealed too). Verified against the real image: `sailfin:gnome` → `BACKEND=composefs-native SEALED=1`; `mkfs.ext4` + ext4 present in its initramfs.

**ext4, not btrfs** — ext4 is the proven sealed filesystem (wootc `deploy.sh:809-821`); btrfs also has fs-verity but its ostree deployment fails to mount (`sysroot.mount` timeout, wootc#35).

**2. Document the constraint in `00-tunaos.toml`** — xfs is right for traditional-ostree el10 (composefs disabled), wrong for every sealed image; per-variant overrides belong in a higher-sorting drop-in.

Justfile parses; probe validated against real images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvVVtmk8CqW8x643B6m84