### PR TITLE
fix(qcow2): put ttyS0 last so the Gate captures userspace boot output

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -311,6 +311,12 @@ qcow2 variant flavor='gnome' repo='local' tag='':
     grep -q '^BACKEND=composefs-native$' <<<"$PROBE" && COMPOSEFS_ARGS+=(--composefs-backend)
     grep -q '^SEALED=1$' <<<"$PROBE" && COMPOSEFS_ARGS+=(--filesystem ext4)
 
+    # Console ORDER matters: the LAST console= is the primary /dev/console, and
+    # that is where dracut/systemd (all userspace) writes. With tty0 last,
+    # initramfs failures were visible only on the VGA screen (the Gate's
+    # screenshot) while the captured serial.log held nothing but kernel printk —
+    # an emergency-mode boot with no recorded reason. ttyS0 last puts the boot
+    # log the Gate captures where it is actually useful.
     echo "==> Running bootc install to-disk (this takes a few minutes)..."
     sudo podman run \
         --rm \
@@ -327,7 +333,7 @@ qcow2 variant flavor='gnome' repo='local' tag='':
             --via-loopback \
             --generic-image \
             "${COMPOSEFS_ARGS[@]}" \
-            --karg console=ttyS0 --karg console=tty0 \
+            --karg console=tty0 --karg console=ttyS0 \
             --karg systemd.unit=graphical.target \
             "${SSH_KEY_ARGS[@]}" \
             --source-imgref "containers-storage:${IMG_REF}" \


### PR DESCRIPTION
The **last** `console=` on the cmdline is the primary `/dev/console` — where dracut and systemd write. Installing with `console=ttyS0 console=tty0` made **tty0** primary, so initramfs failures went to the VGA screen while the `serial.log` the Gate captures held only kernel printk.

That is why the composefs Gate failures recorded an emergency-mode boot **with no reason**: the real `ostree-prepare-root` / `initrd-switch-root` error was only ever in the (cropped) screenshot artifact.

Swaps to `console=tty0 console=ttyS0` so the captured serial log is the useful one. Diagnostic-only; no behaviour change to the installed system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvVVtmk8CqW8x643B6m84