### PR TITLE
fix(overlay): record base digest and the baseline gap in overlay labels

### DIFF
--- a/.github/workflows/live-overlay.yml
+++ b/.github/workflows/live-overlay.yml
@@ -97,8 +97,24 @@ jobs:
 
           for i in 1 2 3; do sudo podman pull "$IMG" && break; sleep $((i*15)); done
 
-          # Exactly tacklebox's CustomizeLive invocation (cap SYS_ADMIN +
-          # network; script dir mounted read-only, cwd inside it).
+          # The digest of the base we ACTUALLY built from. The base label
+          # below records only a tag, and tags move — so on its own it cannot
+          # tell a consumer whether this overlay came from the base image a
+          # build currently points at, or one from three weeks ago. Anything
+          # that consumes overlays instead of re-running the customize
+          # scripts needs this to detect staleness; without it a stale
+          # overlay silently ships an old rootfs.
+          BASE_DIGEST="$(sudo podman image inspect --format '{{.Digest}}' "$IMG")"
+          echo "base digest: ${BASE_DIGEST}"
+
+          # NOTE: this runs ONLY customize-live.sh. tacklebox's CustomizeLive
+          # additionally prepends its embedded src/live/baseline.sh (live
+          # user, DM autologin, live networking, sleep masking), so what we
+          # publish is base + customize-live.sh — NOT the full live payload a
+          # CI-built ISO gets. The browser path compensates by calling
+          # EnsureLiveUser / EnsureAutologin after grafting the overlay, which
+          # is why the gap went unnoticed. Recorded in the baseline label
+          # below so no consumer mistakes this for a complete live image.
           sudo podman rm -f tbx-overlay 2>/dev/null || true
           sudo podman run --name tbx-overlay \
             --cap-add sys_admin --security-opt label=disable \
@@ -108,6 +124,8 @@ jobs:
 
           sudo podman commit \
             --change "LABEL org.tunaos.live-overlay.base=${IMG}" \
+            --change "LABEL org.tunaos.live-overlay.base-digest=${BASE_DIGEST}" \
+            --change "LABEL org.tunaos.live-overlay.baseline=false" \
             tbx-overlay "$OUT"
           sudo podman rm -f tbx-overlay
           sudo podman push "$OUT"


### PR DESCRIPTION
Labels only — nothing about what is built or published changes. This is the **prerequisite** for handoff §3 step 3 (ISO build consumes the overlay with fallback), which cannot be done safely today.

Found while scoping that step. Two facts a consumer needs before it can use a published overlay instead of re-running the customize scripts, neither of which was recorded:

## 1. Staleness is undetectable

The only provenance label was:

```
org.tunaos.live-overlay.base=ghcr.io/tuna-os/yellowfin:kde
```

That's a **tag**, and tags move. Nothing distinguishes an overlay built from the base a build currently points at from one built three weeks ago. With coverage at 22/50 and intermittent overlay build failures, consuming one blind would eventually ship a stale rootfs with no way to notice.

Now also records `org.tunaos.live-overlay.base-digest`, taken from `podman image inspect` of the image actually pulled.

## 2. The overlay is not a complete live image

This workflow runs **only** `customize-live.sh`. tacklebox's `CustomizeLive` additionally prepends its embedded `src/live/baseline.sh` — live user, DM autologin, live networking, sleep masking.

So the published artifact is `base + customize-live.sh`, **not** the payload a CI-built ISO gets. Switching the ISO build to consume it as-is would silently drop the baseline.

The browser path happens to compensate, by calling `EnsureLiveUser`/`EnsureAutologin` *after* grafting — which is precisely why this gap went unnoticed.

Recorded as `org.tunaos.live-overlay.baseline=false` rather than silently papered over. **Changing what the overlay contains is a separate decision** and deliberately not made here.

## Verified

- `yamllint` / `actionlint` clean
- `podman image inspect --format '{{.Digest}}'` returns a usable digest against the real `ghcr.io/tuna-os/yellowfin:kde`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvVVtmk8CqW8x643B6m84