### PR TITLE
feat: apply curated desktop experience layers

### DIFF
--- a/Containerfile.arch
+++ b/Containerfile.arch
@@ -7,7 +7,8 @@
 #   buildah build --target=base-no-de --file Containerfile.arch .
 #   buildah build --target=kde --file Containerfile.arch .
 
-ARG BASE_IMAGE="docker.io/archlinux/archlinux:latest@sha256:b40a74759ba638617cf7463fbd718d20d8ddcd7d22c7b79ed145241cbbb7a178"
+ARG BASE_IMAGE="docker.io/archlinux/archlinux:latest@sha256:c9bb62ee977703c2792c999ddf9c4bf96d5e6fb2c15011e3771bcfb1cd767b97"
+ARG COMMON_IMAGE_REF="ghcr.io/projectbluefin/common:unpinned-must-override"
 
 ARG DESKTOP_FLAVOR="${DESKTOP_FLAVOR:-gnome}"
 ARG IMAGE_NAME
@@ -39,6 +40,8 @@ COPY system_files /files
 COPY system_files_overrides /overrides
 COPY build_scripts /build_scripts
 COPY manifests /manifests
+
+FROM ${COMMON_IMAGE_REF} AS common
 
 # ── Base system (bootc-compatible Arch) ──────────────────────────────────────
 FROM ${BASE_IMAGE} AS base-no-de
@@ -161,6 +164,8 @@ RUN rm -rf /boot /home /root /usr/local /srv /opt /mnt \
 
 # Validate
 LABEL containers.bootc 1
+COPY --from=context /files /
+COPY --from=common /system_files/shared /
 RUN bootc container lint
 
 # Cache-bust so build_scripts edits invalidate the desktop stages' install
@@ -178,6 +183,7 @@ RUN ln -sf /var/opt /opt 2>/dev/null || true
 # Desktop stages — manifest-driven via install-desktop.sh
 # ==============================================================================
 FROM base-no-de AS gnome
+COPY --from=common /system_files/bluefin /
 RUN --mount=type=bind,from=context,source=/,target=/run/context \
     /run/context/build_scripts/desktop/install-desktop.sh gnome
 RUN ln -sf /var/opt /opt 2>/dev/null || true

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -8,6 +8,7 @@
 #     --target=kde --file Containerfile.debian .
 
 ARG BASE_IMAGE="docker.io/library/debian:trixie@sha256:fac46bff2e02f51425b6e33b0e1169f55dfb053d83511ca28aa50c09fd5ed7a4"
+ARG COMMON_IMAGE_REF="ghcr.io/projectbluefin/common:unpinned-must-override"
 
 ARG DESKTOP_FLAVOR="${DESKTOP_FLAVOR:-gnome}"
 ARG IMAGE_NAME
@@ -44,6 +45,8 @@ COPY system_files_overrides /overrides
 COPY build_scripts /build_scripts
 COPY manifests /manifests
 COPY image-versions.yaml /image-versions.yaml
+
+FROM ${COMMON_IMAGE_REF} AS common
 
 # ── Base system (bootc-compatible Debian) ────────────────────────────────────
 FROM ${BASE_IMAGE} AS base-no-de
@@ -162,6 +165,8 @@ RUN sed -i 's|^HOME=.*|HOME=/var/home|' /etc/default/useradd && \
         > /usr/lib/ostree/prepare-root.conf
 
 LABEL containers.bootc 1
+COPY --from=context /files /
+COPY --from=common /system_files/shared /
 RUN bootc container lint
 
 # Cache-bust so build_scripts edits invalidate the desktop stages' install
@@ -176,6 +181,7 @@ FROM base-no-de AS base
 RUN ln -sf /var/opt /opt 2>/dev/null || true
 
 FROM base-no-de AS gnome
+COPY --from=common /system_files/bluefin /
 RUN --mount=type=bind,from=context,source=/,target=/run/context \
     /run/context/build_scripts/desktop/install-desktop.sh gnome
 RUN ln -sf /var/opt /opt 2>/dev/null || true

--- a/Containerfile.el10
+++ b/Containerfile.el10
@@ -202,11 +202,17 @@ FROM base-no-de AS niri
 # Zirconium (DMS/Niri upstream) config payload — niri images only.
 COPY --from=zirconium /usr/share/zirconium /usr/share/zirconium
 COPY --from=zirconium /usr/share/xdg-terminal-exec /usr/share/xdg-terminal-exec
+COPY --from=zirconium /usr/share/factory/etc/greetd /etc/greetd
+COPY --from=zirconium /usr/share/factory/etc/profile.d /etc/profile.d
 COPY --from=zirconium /usr/share/greetd /usr/share/greetd
 COPY --from=zirconium /usr/share/dms /usr/share/dms
-COPY --from=zirconium /usr/lib/pam.d /usr/lib/pam.d
+COPY --from=zirconium /usr/lib/pam.d/greetd-spawn /usr/lib/pam.d/greetd-spawn
+COPY --from=zirconium /usr/lib/sysusers.d/dms-greeter.conf /usr/lib/sysusers.d/dms-greeter.conf
+COPY --from=zirconium /usr/lib/tmpfiles.d/99-dms-greeter.conf /usr/lib/tmpfiles.d/99-dms-greeter.conf
 COPY --from=zirconium /usr/lib/systemd/user/chezmoi-init.service /usr/lib/systemd/user/chezmoi-init.service
 COPY --from=zirconium /usr/lib/systemd/user/chezmoi-update.service /usr/lib/systemd/user/chezmoi-update.service
+COPY --from=zirconium /usr/lib/systemd/user/dms.service.d /usr/lib/systemd/user/dms.service.d
+COPY --from=zirconium /usr/share/flatpak/preinstall.d /usr/share/flatpak/preinstall.d
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \

--- a/Containerfile.gentoo
+++ b/Containerfile.gentoo
@@ -2,6 +2,7 @@
 # Based on bootcrew/gentoo-bootc but adapted for TunaOS manifest-driven desktop installs.
 
 ARG BASE_IMAGE
+ARG COMMON_IMAGE_REF="ghcr.io/projectbluefin/common:unpinned-must-override"
 
 ARG IMAGE_NAME
 ARG IMAGE_VENDOR
@@ -19,6 +20,8 @@ COPY manifests /manifests
 COPY build_scripts /build_scripts
 COPY system_files /files
 COPY system_files_overrides /overrides
+
+FROM ${COMMON_IMAGE_REF} AS common
 
 FROM docker.io/gentoo/stage3:latest@sha256:b5317fd2127e15ace5ff7a2c8aab1ed37a22736a8218546f3b00b4d94b78e500 AS base
 # Speed: pull prebuilt, gpg-verified binary packages from Gentoo's official
@@ -173,10 +176,13 @@ RUN sed -i 's|^HOME=.*|HOME=/var/home|' "/etc/default/useradd" && \
     printf '[composefs]\nenabled = yes\n[sysroot]\nreadonly = true\n' > /usr/lib/ostree/prepare-root.conf
 
 LABEL containers.bootc=1 ostree.bootable=1
+COPY --from=context /files /
+COPY --from=common /system_files/shared /
 RUN bootc container lint
 
 # Per-flavor target aliases so the build's `--target=<flavor>` resolves. Each
 # resolves to the desktop stage above, specialized by the DESKTOP_FLAVOR
 # build-arg (target and build-arg always agree — see resolve-flavor.sh).
 FROM desktop AS gnome
+COPY --from=common /system_files/bluefin /
 FROM desktop AS kde

--- a/Containerfile.opensuse
+++ b/Containerfile.opensuse
@@ -3,6 +3,7 @@
 #
 # ARG BASE_IMAGE = registry.opensuse.org/opensuse/tumbleweed:latest
 ARG BASE_IMAGE
+ARG COMMON_IMAGE_REF="ghcr.io/projectbluefin/common:unpinned-must-override"
 ARG IMAGE_NAME
 ARG IMAGE_VENDOR
 ARG SHA_HEAD_SHORT
@@ -19,6 +20,8 @@ COPY manifests /manifests
 COPY build_scripts /build_scripts
 COPY system_files /files
 COPY system_files_overrides /overrides
+
+FROM ${COMMON_IMAGE_REF} AS common
 
 FROM ${BASE_IMAGE} AS base
 
@@ -129,6 +132,12 @@ RUN mkdir -p /etc/containers && \
     [ -s /etc/containers/policy.json ] || \
     printf '{ "default": [ { "type": "insecureAcceptAnything" } ] }\n' > /etc/containers/policy.json
 
+# The shared Bluefin layer is configuration and hardware integration, not a
+# package dependency. Keep it as a transparent, pinned build-time file copy so
+# Sailfin has the same curated base experience as the EL10 variants.
+COPY --from=context /files /
+COPY --from=common /system_files/shared /
+
 # Cache-bust: the build_scripts RUNs in the desktop stages below are invoked via
 # a bind mount, whose content is NOT part of buildah's layer cache key — so
 # editing install-desktop.sh etc. would silently reuse a stale cached layer.
@@ -174,7 +183,10 @@ RUN bootc container lint
 # Per-flavor target aliases so the build's `--target=<flavor>` resolves. Each
 # resolves to the desktop stage above, specialized by the DESKTOP_FLAVOR
 # build-arg (target and build-arg always agree — see resolve-flavor.sh).
+# Bluefin's GNOME branding/defaults are deliberately scoped to the GNOME image;
+# do not leak them into KDE, Niri, or XFCE targets.
 FROM desktop AS gnome
+COPY --from=common /system_files/bluefin /
 FROM desktop AS kde
 FROM desktop AS niri
 FROM desktop AS xfce

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -20,8 +20,10 @@ ARG BASE_IMAGE="docker.io/library/ubuntu:resolute@sha256:3131b4cc82a783df6c9df07
 ARG ENABLE_HWE="${ENABLE_HWE:-0}"  
 ARG ENABLE_NVIDIA="${ENABLE_NVIDIA:-0}"
 ARG DESKTOP_FLAVOR="${DESKTOP_FLAVOR:-gnome}"
+ARG COMMON_IMAGE_REF="ghcr.io/projectbluefin/common:unpinned-must-override"
 ARG ZIRCONIUM_IMAGE_REF="ghcr.io/zirconium-dev/zirconium:unpinned-must-override"
 
+FROM ${COMMON_IMAGE_REF} AS common
 FROM ${ZIRCONIUM_IMAGE_REF} AS zirconium
 
 FROM ${BASE_IMAGE} AS bootc-builder
@@ -40,17 +42,7 @@ FROM scratch AS context
 COPY system_files /files
 COPY build_scripts /build_scripts
 COPY image-versions.yaml /image-versions.yaml
-# Copy Niri-related system files from Zirconium (greetd, dms-greeter, session files)
-# Omit RPM-specific files (dnf plugins, SELinux, COPR repos) deliberately.
-COPY --from=zirconium /usr/share/factory/etc/greetd /files/etc/greetd
-COPY --from=zirconium /usr/share/dms /files/usr/share/dms
-COPY --from=zirconium /usr/share/factory/etc/profile.d /files/etc/profile.d
-COPY --from=zirconium /usr/share/greetd /files/usr/share/greetd
-COPY --from=zirconium /usr/lib/pam.d/greetd-spawn /files/usr/lib/pam.d/greetd-spawn
-COPY --from=zirconium /usr/lib/sysusers.d/dms-greeter.conf /files/usr/lib/sysusers.d/dms-greeter.conf
-COPY --from=zirconium /usr/lib/tmpfiles.d/99-dms-greeter.conf /files/usr/lib/tmpfiles.d/99-dms-greeter.conf
-COPY --from=zirconium /usr/lib/systemd/user/dms.service.d /files/usr/lib/systemd/user/dms.service.d
-COPY --from=zirconium /usr/share/flatpak/preinstall.d /files/usr/share/flatpak/preinstall.d
+COPY --from=common /system_files/shared /files
 
 # ==============================================================================
 # Base stage (no DE) — shared layer, built on stock Ubuntu with apt intact
@@ -204,6 +196,7 @@ RUN --mount=type=tmpfs,dst=/tmp \
   /run/context/build_scripts/bootc/finalize.sh
 
 FROM base-no-de AS gnome
+COPY --from=common /system_files/bluefin /
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
@@ -234,6 +227,17 @@ RUN --mount=type=tmpfs,dst=/tmp \
   /run/context/build_scripts/bootc/finalize.sh
 
 FROM base-no-de AS niri
+# Zirconium's curated DMS/Niri integration is session-specific. Keep its
+# config, policy, and greeter files out of every other desktop image.
+COPY --from=zirconium /usr/share/factory/etc/greetd /etc/greetd
+COPY --from=zirconium /usr/share/factory/etc/profile.d /etc/profile.d
+COPY --from=zirconium /usr/share/dms /usr/share/dms
+COPY --from=zirconium /usr/share/greetd /usr/share/greetd
+COPY --from=zirconium /usr/lib/pam.d/greetd-spawn /usr/lib/pam.d/greetd-spawn
+COPY --from=zirconium /usr/lib/sysusers.d/dms-greeter.conf /usr/lib/sysusers.d/dms-greeter.conf
+COPY --from=zirconium /usr/lib/tmpfiles.d/99-dms-greeter.conf /usr/lib/tmpfiles.d/99-dms-greeter.conf
+COPY --from=zirconium /usr/lib/systemd/user/dms.service.d /usr/lib/systemd/user/dms.service.d
+COPY --from=zirconium /usr/share/flatpak/preinstall.d /usr/share/flatpak/preinstall.d
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \

--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -350,6 +350,15 @@ for cmd in "${_TD_POST_INLINE[@]}"; do
 	fi
 done
 
+# Desktop communities own their curated defaults as plain files. This keeps
+# opinions reviewable and portable without creating a package for a few config
+# files; any contributor can maintain experiences/<desktop>/files/.
+_TD_EXPERIENCE_FILES="${_TD_CTX}/experiences/${_TD_DESKTOP}/files"
+if [[ -d "${_TD_EXPERIENCE_FILES}" ]]; then
+	echo "Applying curated ${_TD_DESKTOP} experience defaults"
+	cp -a "${_TD_EXPERIENCE_FILES}/." /
+fi
+
 # A package transaction is not sufficient evidence that the requested desktop
 # exists. Validate its session, compositor and display manager, then install a
 # runtime contract checked by the VM promotion gate. The contract unit also

--- a/experiences/README.md
+++ b/experiences/README.md
@@ -1,0 +1,12 @@
+# Contributor-owned desktop experiences
+
+Each directory here is a small, reviewable layer of opinionated defaults for
+one desktop. It is copied after that desktop's packages are installed by the
+manifest-driven installer. It is intentionally not an RPM/DEB: these are
+configuration files, not independently versioned software.
+
+To maintain an experience, edit `experiences/<desktop>/files/`, update its
+README with the behavior and upstream rationale, and add a focused check under
+`tests/`. Desktop maintainers are invited to own reviews for their directory;
+until a GitHub team is established, ownership remains open and the project lead
+reviews changes.

--- a/experiences/cosmic/README.md
+++ b/experiences/cosmic/README.md
@@ -1,0 +1,6 @@
+# COSMIC experience
+
+This is the contributor-owned home for TunaOS COSMIC defaults: session-safe
+settings, curated application behavior, and greeter-adjacent configuration.
+Keep defaults in `files/` portable across supported distributions. Do not add
+packages or external repositories here.

--- a/experiences/cosmic/files/etc/skel/.config/cosmic/README.md
+++ b/experiences/cosmic/files/etc/skel/.config/cosmic/README.md
@@ -1,0 +1,3 @@
+TunaOS COSMIC user defaults belong in this directory.  Keep files compatible
+with COSMIC's upstream settings format and document each behavioral choice in
+../README.md.

--- a/experiences/xfce/README.md
+++ b/experiences/xfce/README.md
@@ -1,0 +1,6 @@
+# XFCE experience
+
+This is the contributor-owned home for TunaOS XFCE defaults: panel/session
+behavior, greeter styling, and portable user defaults. Keep defaults in
+`files/` portable across supported distributions. Do not add packages or
+external repositories here.

--- a/experiences/xfce/files/etc/skel/.config/xfce4/README.md
+++ b/experiences/xfce/files/etc/skel/.config/xfce4/README.md
@@ -1,0 +1,3 @@
+TunaOS XFCE user defaults belong in this directory. Keep settings compatible
+with upstream Xfce/Xfconf formats and document every curated choice in
+../README.md.

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -216,3 +216,16 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
     "${REPO_ROOT}/Containerfile.el10"
   [ "$status" -ne 0 ]
 }
+
+@test "Sailfin installs shared Bluefin config and GNOME-only Bluefin branding" {
+  local containerfile="${REPO_ROOT}/Containerfile.opensuse"
+  grep -qF 'FROM ${COMMON_IMAGE_REF} AS common' "$containerfile"
+  grep -qF 'COPY --from=common /system_files/shared /' "$containerfile"
+  grep -qF 'COPY --from=common /system_files/bluefin /' "$containerfile"
+
+  # GNOME branding must remain at the GNOME target, not the shared system base.
+  local gnome_line shared_line
+  gnome_line=$(grep -nF 'FROM desktop AS gnome' "$containerfile" | cut -d: -f1)
+  shared_line=$(grep -nF 'COPY --from=common /system_files/shared /' "$containerfile" | cut -d: -f1)
+  [ "$gnome_line" -gt "$shared_line" ]
+}


### PR DESCRIPTION
## Summary
- apply shared Bluefin configuration and GNOME-only branding across supported non-EL bases
- scope Zirconium DMS/Niri integration to Niri and include its required config files
- create contributor-owned COSMIC and XFCE experience-default surfaces

## Validation
- `bash -n build_scripts/desktop/install-desktop.sh`
- `bats tests/bats/test_build_scripts_remaining.bats` (29 passing)
- `git diff --check`