### PR TITLE
fix(live): unbreak kde/xfce live sessions and 3 overlay build failures

### DIFF
--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -64,8 +64,9 @@ kde)
 	experience="ublue-os/aurora"
 	require_command plasmashell
 	require_glob '/usr/share/wayland-sessions/*plasma*.desktop'
-	require_unit sddm
-	dm_pattern='^sddm\.service$'
+	# KDE 6.5+ renames SDDM to plasmalogin; both are in the wild.
+	require_any_unit sddm plasmalogin
+	dm_pattern='^(sddm|plasmalogin)\.service$'
 	;;
 niri)
 	experience="zirconium-dev/zirconium"

--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -54,10 +54,18 @@ fi
 # ── 1b. Live user ────────────────────────────────────────────────────────────
 # No TunaOS image ships livesys-scripts, so nothing creates the account the
 # desktop adapters autologin to — bake it into the squash instead (pattern:
-# projectbluefin/dakota-iso configure-live.sh). uid 1000 is free on bootc
-# images. Installed systems never see this: live squash only.
+# projectbluefin/dakota-iso configure-live.sh). Installed systems never see
+# this: live squash only.
+#
+# uid 1000 is free on *most* bootc images, but not all — grouper ships a
+# packaged user there, and the unconditional `--uid 1000` failed the whole
+# overlay build with "useradd: UID 1000 is not unique" (exit 4). Ask for
+# 1000 when it is free (desktop sessions and flatpak expect it) and let
+# useradd pick otherwise; nothing here depends on the exact number.
 if ! getent passwd liveuser >/dev/null; then
-	useradd --create-home --uid 1000 --user-group \
+	_uid_args=()
+	getent passwd 1000 >/dev/null || _uid_args=(--uid 1000)
+	useradd --create-home "${_uid_args[@]}" --user-group \
 		--comment "Live User" --shell /bin/bash liveuser
 fi
 passwd --delete liveuser >/dev/null 2>&1 || true

--- a/live-iso/common/src/desktop-gnome.sh
+++ b/live-iso/common/src/desktop-gnome.sh
@@ -41,4 +41,12 @@ sleep-inactive-battery-timeout=0
 idle-delay=uint32 0
 EOF
 
-glib-compile-schemas /usr/share/glib-2.0/schemas
+# Not every base ships glib2-devel, and an unguarded call aborts the whole
+# customize step under `set -e` (exit 127) — this is what broke the
+# flounder/flounder-sid overlays. The override file above is still written;
+# without recompilation it is simply inert.
+if command -v glib-compile-schemas &>/dev/null; then
+	glib-compile-schemas /usr/share/glib-2.0/schemas
+else
+	echo "desktop-gnome: glib-compile-schemas missing; power-settings override left uncompiled" >&2
+fi

--- a/live-iso/common/src/desktop-kde.sh
+++ b/live-iso/common/src/desktop-kde.sh
@@ -20,8 +20,16 @@ _kde_session="plasma"
 if [[ -f /usr/share/wayland-sessions/plasmawayland.desktop && ! -f /usr/share/wayland-sessions/plasma.desktop ]]; then
 	_kde_session="plasmawayland"
 fi
-mkdir -p /etc/sddm.conf.d
-tee /etc/sddm.conf.d/live-autologin.conf <<SDDMEOF
+# KDE 6.5+ renames the SDDM binary/unit to plasmalogin, and with it the
+# config directory (/etc/plasmalogin.conf.d). Both names are in the wild —
+# yellowfin:kde shipped sddm in July 2026 and plasmalogin days later — so
+# write the drop-in to every candidate directory rather than detecting.
+# A drop-in in a directory no DM reads is inert, so this is free.
+# Getting this wrong is silent: the greeter simply prompts for a password
+# and the live session (and installer) never starts.
+for _kde_confd in /etc/sddm.conf.d /etc/plasmalogin.conf.d; do
+	mkdir -p "${_kde_confd}"
+	tee "${_kde_confd}/live-autologin.conf" <<SDDMEOF
 [General]
 DisplayServer=wayland
 CompositorCommand=kwin_wayland --no-lockscreen
@@ -31,6 +39,7 @@ User=liveuser
 Session=${_kde_session}
 Relogin=false
 SDDMEOF
+done
 
 mkdir -p /etc/xdg
 tee /etc/xdg/kscreenlockerrc <<'LOCKEOF'

--- a/live-iso/common/src/desktop-xfce.sh
+++ b/live-iso/common/src/desktop-xfce.sh
@@ -14,23 +14,39 @@ set -euo pipefail
 # and greetd — an X11-free stack. Detect it by the packaged Wayland session
 # and/or the xfwl4 binary. On bases still on X11 XFCE (Fedora/Debian until
 # their xfwl4 packaging lands) fall back to lightdm/gdm autologin.
-if compgen -G "/usr/share/wayland-sessions/xfce*.desktop" >/dev/null || command -v xfwl4 &>/dev/null; then
+#
+# Gate on a *compositor binary*, not on the packaged session file: several
+# bases ship /usr/share/wayland-sessions/xfce-wayland.desktop with no
+# compositor behind it, and `startxfce4 --wayland` then dies with
+#   "Please either install labwc or specify another compositor as argument"
+# onto a black screen — which is exactly how yellowfin:xfce failed.
+# startxfce4 only auto-discovers labwc/wayfire, so name it explicitly.
+_xfce_compositor=""
+for _c in xfwl4 labwc wayfire; do
+	command -v "${_c}" &>/dev/null && {
+		_xfce_compositor="${_c}"
+		break
+	}
+done
+
+if [[ -n "${_xfce_compositor}" ]] && command -v greetd &>/dev/null; then
 	# ── Wayland (xfwl4) — greetd autologin, no X11 ───────────────────────
 	# greetd `command` is run by the user's shell, so it must be the actual
 	# exec, not a session-file name. dbus-run-session gives the session a
 	# message bus (portals, xfconf) the way a DM login would.
+	echo "desktop-xfce: wayland session via compositor=${_xfce_compositor}"
 	mkdir -p /etc/greetd
-	tee /etc/greetd/config.toml <<'GREETDEOF'
+	tee /etc/greetd/config.toml <<GREETDEOF
 [terminal]
 vt = 1
 
 [default_session]
 user = "liveuser"
-command = "dbus-run-session startxfce4 --wayland"
+command = "dbus-run-session startxfce4 --wayland ${_xfce_compositor}"
 
 [initial_session]
 user = "liveuser"
-command = "dbus-run-session startxfce4 --wayland"
+command = "dbus-run-session startxfce4 --wayland ${_xfce_compositor}"
 GREETDEOF
 	# Enable greetd + boot to graphical.target (server-oriented EL10 bases
 	# default to multi-user.target, which would land on a console — same

--- a/live-iso/common/src/desktop-xfce.sh
+++ b/live-iso/common/src/desktop-xfce.sh
@@ -20,14 +20,25 @@ set -euo pipefail
 # compositor behind it, and `startxfce4 --wayland` then dies with
 #   "Please either install labwc or specify another compositor as argument"
 # onto a black screen — which is exactly how yellowfin:xfce failed.
-# startxfce4 only auto-discovers labwc/wayfire, so name it explicitly.
+#
+# Only labwc and wayfire qualify. xfwl4 does NOT, even though the EL10
+# manifest installs it as the xfce compositor: startxfce4 hands its argument
+# no startup command (the labwc default path appends `--session
+# xfce4-session`), and `xfwl4 --help` has no equivalent option — so
+# `startxfce4 --wayland xfwl4` would come up as a bare compositor with no
+# session inside it. labwc has no EL10 build in any configured repo, so on
+# those images this correctly falls through to the X11 branch rather than
+# claiming a Wayland session we cannot start. See tunaOS#834.
 _xfce_compositor=""
-for _c in xfwl4 labwc wayfire; do
+for _c in labwc wayfire; do
 	command -v "${_c}" &>/dev/null && {
 		_xfce_compositor="${_c}"
 		break
 	}
 done
+if [[ -z "${_xfce_compositor}" ]] && command -v xfwl4 &>/dev/null; then
+	echo "desktop-xfce: xfwl4 present but startxfce4 cannot drive it (no startup-command option) and labwc/wayfire are absent; falling back to X11" >&2
+fi
 
 if [[ -n "${_xfce_compositor}" ]] && command -v greetd &>/dev/null; then
 	# ── Wayland (xfwl4) — greetd autologin, no X11 ───────────────────────
@@ -72,6 +83,22 @@ LIGHTDMEOF
 AutomaticLoginEnable=True
 AutomaticLogin=liveuser
 GDMEOF
+
+	# This branch used to write its configs and stop there, which was only
+	# survivable while it ran on bases that already enable a DM and default
+	# to graphical.target. Now that a missing compositor can route an EL10
+	# image here, do the same enable + set-default the Wayland branch does,
+	# or the image boots to a console with a perfectly good autologin config.
+	for _dm in lightdm gdm greetd; do
+		_unit="/usr/lib/systemd/system/${_dm}.service"
+		[[ -f "${_unit}" ]] || continue
+		systemctl enable "${_dm}.service" 2>/dev/null || true
+		ln -sf "${_unit}" /etc/systemd/system/display-manager.service 2>/dev/null || true
+		echo "desktop-xfce: X11 fallback display manager=${_dm}"
+		break
+	done
+	systemctl set-default graphical.target 2>/dev/null ||
+		ln -sf /usr/lib/systemd/system/graphical.target /etc/systemd/system/default.target 2>/dev/null || true
 fi
 
 # Auto-launch the TunaOS installer frontend in the live session.

--- a/scripts/boot-gate.sh
+++ b/scripts/boot-gate.sh
@@ -36,9 +36,12 @@ corral create --help 2>&1 | grep -q -- '--bootc' || {
 	exit 77
 }
 
-# Display manager to assert per desktop family.
+# Display manager to assert per desktop family. Space-separated candidates:
+# the same DE ships different DM units per base (KDE 6.5+ renamed sddm to
+# plasmalogin; xfce is lightdm on X11 bases and greetd on the Wayland ones).
+# Any one active counts as a pass.
 case "$FLAVOR" in
-kde*) DM=sddm ;; niri* | cosmic*) DM=greetd ;; xfce*) DM=lightdm ;; *) DM=gdm ;;
+kde*) DM="sddm plasmalogin" ;; niri* | cosmic*) DM=greetd ;; xfce*) DM="lightdm greetd gdm" ;; *) DM="gdm gdm3" ;;
 esac
 
 NODE_ARGS=()
@@ -66,8 +69,16 @@ RC=0
 	echo "FAIL graphical.target"
 	RC=1
 }
-[[ "$(check "systemctl is-active $DM" | tr -d '[:space:]')" == active ]] || {
-	echo "FAIL $DM"
+DM_OK=0
+for _dm in $DM; do
+	if [[ "$(check "systemctl is-active ${_dm}" | tr -d '[:space:]')" == active ]]; then
+		DM_OK=1
+		echo "ok display-manager: ${_dm}"
+		break
+	fi
+done
+[[ "$DM_OK" == 1 ]] || {
+	echo "FAIL display manager (tried: $DM)"
 	RC=1
 }
 check 'systemctl --failed --no-legend' || true

--- a/scripts/installer-walkthrough.py
+++ b/scripts/installer-walkthrough.py
@@ -256,9 +256,16 @@ note(f"{rendered}/{len(frames)} frames above stddev {BLANK_STDDEV} "
 # ── 2. ADVANCES ──────────────────────────────────────────────────────────
 advanced = sum(1 for a, b in zip(frames, frames[1:])
                if changed_pixels(a, b) > DIFF_PIXELS)
-tap(advanced > 0, f"{flavor}: installer advances between screens",
+# NOT "the installer advances": like the render check above, this measures the
+# whole framebuffer, so anything that animates satisfies it. kde did exactly
+# that (run 29914643652) — 8/8 transitions and 9 "distinct visual states" while
+# every frame was the SDDM greeter's password prompt and the only thing moving
+# was its clock. Named for what it actually checks; the screens section below
+# is what decides whether the installer was ever on screen.
+tap(advanced > 0, f"{flavor}: screen changes between steps",
     f"{advanced}/{max(len(frames) - 1, 0)} transitions changed >{DIFF_PIXELS}px "
-    f"(0 means it never left the first screen — stuck, modal, or crashed)",
+    f"(0 means nothing on screen responded at all — stuck, modal, or crashed; "
+    f">0 is not by itself evidence the installer moved — a clock will do it)",
     enforced=strict)
 note(f"{advanced}/{max(len(frames) - 1, 0)} transitions changed >{DIFF_PIXELS}px"
      + (f"; primary action activated with '{activation}'" if advanced else ""))
@@ -327,17 +334,24 @@ for idx, sc in enumerate(spec):
         note(where)
 
 # ── No-window diagnosis ──────────────────────────────────────────────────
-# The compositor+frontend gate in installer-smoke.yml already proved the
-# process is alive before this script runs. So if the screen is not blank, yet
-# nothing ever advanced AND no screen matched, the most likely explanation is
-# that the process is running without a mapped window — the desktop is what is
-# being photographed. Say so, rather than leaving six identical "screen not
-# reached" lines for someone to interpret.
-if have_ocr and n_states <= 1 and not any(reached.values()) and rendered > 0:
+# If the screen is not blank yet no screen ever matched, the installer was
+# never photographed, whatever the pixels did. Say so, rather than leaving six
+# identical "screen not reached" lines for someone to interpret.
+#
+# This used to also require n_states <= 1, which silently disabled it in the
+# case that needed it most: kde's greeter clock produced 9 states, so the
+# diagnosis never printed and the run read as "advanced 8 times, found
+# nothing". Movement is not evidence of an installer, so it is not a reason to
+# withhold the diagnosis.
+if have_ocr and not any(reached.values()) and rendered > 0:
+    _moved = "nothing responded to input" if n_states <= 1 else (
+        f"the screen changed {n_states - 1}x, but no change was an installer "
+        f"screen (a greeter clock or desktop animation looks identical here)")
     print(f"  # DIAGNOSIS: {flavor} — process is running (gate passed) but no "
-          f"installer screen was ever detected and nothing responded to input; "
-          f"the frames are most likely the bare desktop with no installer "
-          f"window mapped", flush=True)
+          f"installer screen was ever detected and {_moved}; the frames are "
+          f"most likely a login greeter or the bare desktop, with no installer "
+          f"window mapped. Check the captured PNGs before assuming a UI bug.",
+          flush=True)
 
 # ── Result for the parity matrix ─────────────────────────────────────────
 summary = {

--- a/scripts/verify-image-packages.sh
+++ b/scripts/verify-image-packages.sh
@@ -159,16 +159,23 @@ done
 echo "Verifying systemd service unit files..."
 SYSTEMD_SERVICES=(tailscaled.service systemd-resolved.service)
 
-# Add flavor-specific display manager service
+# Add flavor-specific display manager service. A '|' separates interchangeable
+# unit names — the same DE ships different DM units per base (KDE 6.5+ renamed
+# sddm to plasmalogin), and any one of them satisfies the check.
 case "${FLAVOR}" in
-gnome) SYSTEMD_SERVICES+=(gdm.service) ;;
-kde) SYSTEMD_SERVICES+=(sddm.service) ;;
+gnome) SYSTEMD_SERVICES+=("gdm.service|gdm3.service") ;;
+kde) SYSTEMD_SERVICES+=("sddm.service|plasmalogin.service") ;;
 niri | cosmic) SYSTEMD_SERVICES+=(greetd.service) ;;
 esac
 
 for svc in "${SYSTEMD_SERVICES[@]}"; do
 	# Check in typical systemd system directories: /usr/lib/systemd/system/ or /lib/systemd/system/
-	CHECK_SVC_CMD="[ -f /usr/lib/systemd/system/${svc} ] || [ -f /lib/systemd/system/${svc} ]"
+	CHECK_SVC_CMD=""
+	IFS='|' read -ra _svc_alts <<<"${svc}"
+	for _alt in "${_svc_alts[@]}"; do
+		[[ -n "${CHECK_SVC_CMD}" ]] && CHECK_SVC_CMD+=" || "
+		CHECK_SVC_CMD+="[ -f /usr/lib/systemd/system/${_alt} ] || [ -f /lib/systemd/system/${_alt} ]"
+	done
 	if ! podman run --rm --entrypoint sh "$IMAGE" -c "${CHECK_SVC_CMD}" &>/dev/null; then
 		echo "❌ Missing systemd service file: ${svc}"
 		FAILED=1


### PR DESCRIPTION
Found by reading the artifacts we'd been sitting on: installer-smoke run `29914643652` and live-overlay run `30159027680`.

## The headline: kde and xfce never showed the installer at all

Not an installer bug — neither ever got to a session.

| | what the screenshot actually shows |
|---|---|
| **kde** | SDDM greeter, password prompt for `liveuser`. Frames 00 and 08 are identical apart from the clock. |
| **xfce** | black screen, one line: `startxfce4: Please either install labwc or specify another compositor as argument` |

**kde** — KDE 6.5+ renames sddm to **plasmalogin**, config directory included, so `desktop-kde.sh` wrote its autologin drop-in to `/etc/sddm.conf.d` where nothing reads it. Worth noting the desktop contract check *already caught this* on 07-22 — `TUNAOS_DESKTOP_CONTRACT_FAIL reason=dm_mismatch dm=plasmalogin.service expected=^sddm\.service$` — and the run continued regardless. Both names are live in the wild (`yellowfin:kde` shipped sddm on 07-19, plasmalogin by 07-22), so this writes to both candidate dirs rather than detecting, and teaches `verify-desktop-experience` / `boot-gate` / `verify-image-packages` that a DE's DM unit name varies by base.

**xfce** — the adapter gated its Wayland branch on `/usr/share/wayland-sessions/xfce*.desktop`, which several bases ship with no compositor behind it. Now gates on a compositor binary (`xfwl4`/`labwc`/`wayfire`) plus greetd, and passes the compositor to `startxfce4` explicitly instead of relying on its labwc-only autodiscovery.

## Three overlay build failures

Of the 19 failing cells in run `30159027680`, these were three distinct causes (not one, as assumed):

- `flounder`, `flounder-sid` — unguarded `glib-compile-schemas` (exit 127)
- `grouper` — `useradd --uid 1000` on a base where 1000 is taken (exit 4)
- `marlin:cosmic` — transient blob read reset; **no fix needed, just re-run**

All the same shape as the flatpak (#809) and dbus (#822) fixes: `customize-live.sh` assuming a binary — or here a free uid — that a given base doesn't provide.

Still outstanding after this PR: `sailfin`×4 need their images rebuilt to pick up #809's flatpak, and `albacore:xfce` is `build_image: true` but was never published (registry 404).

## A test that was asserting nothing

`installer-walkthrough.py` reported `ok - kde: installer advances between screens / 8/8 transitions changed >500px / 9 distinct visual states` — against a static greeter. The only thing moving was the clock.

That inflated state count also silently disabled the no-window DIAGNOSIS, which required `n_states <= 1` — so the one case that most needed the explanation never printed it. Renamed the check to what it measures, and the diagnosis now fires whenever no screen was recognised, however much the pixels moved.

This is the third false positive of this shape in this file; the other two are documented in the comments above their checks.

## Verification

`bash -n` + `shellcheck -S error` on all seven shell files, `py_compile` on the Python, and `tests/bats/test_build_scripts_remaining.bats` 29/29.

Not yet run end-to-end — the kde/xfce fixes want an installer-smoke run to confirm, and cosmic additionally needs a host with a DRM render node.