### PR TITLE
fix(live): restore xfwl4, surface the kde DM failure, unbreak local ISO builds

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -124,7 +124,14 @@ jobs:
             echo "::error::${FLAVOR}: no compositor process running (stuck at greeter or TTY?)"
             echo "--- loginctl / runtime / user manager:"
             $SSH 'loginctl list-sessions; ls /run/user/$(id -u)/ 2>/dev/null; systemctl --user status 2>/dev/null | head' 2>/dev/null || true
-            echo "--- greetd journal:"
+            # Dump the DM that actually got resolved, not a hardcoded guess.
+            # This step used to only ever dump greetd's journal, so when kde's
+            # plasmalogin.service failed to start (run 30191933429) the reason
+            # was nowhere in the artifacts and the failure was undiagnosable
+            # from CI alone.
+            echo "--- display-manager journal:"
+            $SSH 'DM=$(systemctl show -P Id display-manager.service 2>/dev/null); echo "resolved display-manager.service -> ${DM:-<unresolved>}"; sudo journalctl -u "${DM:-display-manager.service}" -b --no-pager 2>/dev/null | tail -60; echo "--- unit state:"; systemctl status --no-pager "${DM:-display-manager.service}" 2>/dev/null | head -20' 2>/dev/null || true
+            echo "--- greetd journal (if in use):"
             $SSH 'sudo journalctl -u greetd --no-pager 2>/dev/null | tail -40' 2>/dev/null || true
             echo "--- SELinux mode + AVC denials (compositor/greetd):"
             $SSH 'getenforce 2>/dev/null; sudo journalctl -b --no-pager 2>/dev/null | grep -iE "avc: *denied" | grep -iE "niri|greet|xfwl|wayland|xdm" | tail -30 || true' 2>/dev/null || true

--- a/build_scripts/checks/e2e-runtime-checks.sh
+++ b/build_scripts/checks/e2e-runtime-checks.sh
@@ -105,7 +105,7 @@ dm_id=$(systemctl show -P Id display-manager.service 2>/dev/null || true)
 emit "# display manager: ${dm_id:-unknown}"
 case "$DESKTOP" in
 gnome) dm_pattern='^(gdm|gdm3)\.service$' ;;
-kde) dm_pattern='^sddm\.service$' ;;
+kde) dm_pattern='^(sddm|plasmalogin)\.service$' ;; # KDE 6.5+ renamed sddm
 niri | cosmic) dm_pattern='^greetd\.service$' ;;
 xfce) dm_pattern='^(gdm|gdm3|lightdm|greetd)\.service$' ;;
 *) dm_pattern='' ;;

--- a/live-iso/common/src/desktop-xfce.sh
+++ b/live-iso/common/src/desktop-xfce.sh
@@ -21,24 +21,23 @@ set -euo pipefail
 #   "Please either install labwc or specify another compositor as argument"
 # onto a black screen — which is exactly how yellowfin:xfce failed.
 #
-# Only labwc and wayfire qualify. xfwl4 does NOT, even though the EL10
-# manifest installs it as the xfce compositor: startxfce4 hands its argument
-# no startup command (the labwc default path appends `--session
-# xfce4-session`), and `xfwl4 --help` has no equivalent option — so
-# `startxfce4 --wayland xfwl4` would come up as a bare compositor with no
-# session inside it. labwc has no EL10 build in any configured repo, so on
-# those images this correctly falls through to the X11 branch rather than
-# claiming a Wayland session we cannot start. See tunaOS#834.
+# xfwl4 is listed first: it is what the EL10 manifest installs, and run
+# 30191933429 shows `startxfce4 --wayland xfwl4` really does launch it —
+# xfwl4 came up on renderD128 and created wayland-1 before panicking on
+# "Failed to find theme named Default" (missing xfwm4 theme data,
+# tunaos-packages#123). An earlier revision of this file excluded xfwl4 on
+# the theory that startxfce4 appends no startup command to a named
+# compositor; that reasoning was not borne out, and excluding it was
+# strictly worse — the X11 branch is a dead end on a base that ships no
+# /usr/share/xsessions at all. Whether xfce4-session follows xfwl4 up is
+# still unproven: xfwl4 dies before we find out.
 _xfce_compositor=""
-for _c in labwc wayfire; do
+for _c in xfwl4 labwc wayfire; do
 	command -v "${_c}" &>/dev/null && {
 		_xfce_compositor="${_c}"
 		break
 	}
 done
-if [[ -z "${_xfce_compositor}" ]] && command -v xfwl4 &>/dev/null; then
-	echo "desktop-xfce: xfwl4 present but startxfce4 cannot drive it (no startup-command option) and labwc/wayfire are absent; falling back to X11" >&2
-fi
 
 if [[ -n "${_xfce_compositor}" ]] && command -v greetd &>/dev/null; then
 	# ── Wayland (xfwl4) — greetd autologin, no X11 ───────────────────────

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -92,10 +92,35 @@ tunaos_import_to_root_storage() {
 	fi
 
 	echo "==> Importing ${image} from ${real_user}'s podman storage into root's..."
-	if ! sudo -u "$real_user" podman save "$image" 2>/dev/null | podman load; then
-		echo "ERROR: failed to import ${image} from ${real_user}" >&2
+
+	# XDG_RUNTIME_DIR must be set explicitly. `sudo -u "$real_user"` from a
+	# root context inherits no user session, so rootless podman falls back to
+	# root's /run/containers/storage, cannot write there, and dies with
+	#   "RunRoot ... is not writable ... acquiring runtime init lock:
+	#    open /run/libpod/alive.lck: permission denied"
+	# Its stderr was being sent to /dev/null, so all the caller ever saw was
+	# `podman load` choking on an empty stream ("index.json: not a directory"),
+	# which points at the wrong end of the pipe entirely.
+	local real_uid
+	real_uid=$(id -u "$real_user" 2>/dev/null || echo)
+	if [[ -z "$real_uid" ]]; then
+		echo "ERROR: cannot resolve uid for ${real_user}" >&2
 		return 1
 	fi
+
+	local save_err
+	save_err=$(mktemp)
+	if ! sudo -u "$real_user" env "XDG_RUNTIME_DIR=/run/user/${real_uid}" \
+		podman save "$image" 2>"$save_err" | podman load; then
+		echo "ERROR: failed to import ${image} from ${real_user}" >&2
+		[[ -s "$save_err" ]] && {
+			echo "--- podman save (as ${real_user}) said:" >&2
+			cat "$save_err" >&2
+		}
+		rm -f "$save_err"
+		return 1
+	fi
+	rm -f "$save_err"
 
 	if ! podman image exists "$image"; then
 		echo "ERROR: ${image} still not present after import" >&2

--- a/tests/bats/common_test.bats
+++ b/tests/bats/common_test.bats
@@ -177,6 +177,36 @@ teardown() {
 
 # ── tunaos_import_to_root_storage tests ─────────────────────────────────────
 
+# Regression: the import ran `sudo -u "$real_user" podman save` with no
+# XDG_RUNTIME_DIR. With no user session inherited, rootless podman falls back
+# to root's /run/containers/storage, can't write there, and dies on
+# /run/libpod/alive.lck — so every local `just iso` off a rootless image
+# failed. Unlike the neighbouring tests this exercises the REAL function.
+@test "tunaos_import_to_root_storage: passes XDG_RUNTIME_DIR to the invoking user's podman" {
+  local spy="${BATS_TEST_TMPDIR}/sudo-args"
+  run bash -c '
+    set +e
+    source "'"${BATS_TEST_DIRNAME}"'/../../scripts/lib/common.sh"
+    SUDO_USER=testuser
+    id() { echo 4242; }
+    sudo() { echo "$*" >>"'"${spy}"'"; return 0; }
+    _calls=0
+    podman() {
+      if [[ "$1 $2" == "image exists" ]]; then
+        # Absent the first time (forces the import), present afterwards.
+        _calls=$((_calls + 1))
+        [[ $_calls -gt 1 ]] && return 0
+        return 1
+      fi
+      cat >/dev/null 2>&1
+      return 0
+    }
+    tunaos_import_to_root_storage "localhost/yellowfin:cosmic"
+  '
+  [ "$status" -eq 0 ]
+  grep -q "XDG_RUNTIME_DIR=/run/user/4242" "$spy"
+}
+
 @test "tunaos_import_to_root_storage: returns 0 when image already exists" {
   run bash -c '
     tunaos_import_to_root_storage() {


### PR DESCRIPTION
Follow-up to #833, driven by what installer-smoke run `30191933429` actually showed, plus one blocker found driving a real ISO build on hardware. **The first item is a correction to #833** — worth reading first.

## 1. Restoring xfwl4 (correcting #833)

#833 excluded xfwl4 from the compositor candidates on my reasoning that `startxfce4` appends no startup command to a *named* compositor, so naming it would yield a bare compositor with no session. **The serial console disproves that:**

```
INFO xfwl4: Starting xfwl4 on a tty using udev
INFO xfwl4::backend::udev: Using renderD128 as primary GPU
INFO smithay::wayland::socket: Created new socket name=Some("wayland-1")
thread 'main' (2485) panicked at src/core/state.rs:308:74:
Failed to load initial config: Failed to find theme named Default
```

xfwl4 launches fine and dies on **missing xfwm4 theme data** — a packaging gap, now filed as tuna-os/tunaos-packages#123. Excluding xfwl4 was strictly worse than leaving it: the fallback is an X11 session that base ships no `/usr/share/xsessions` for at all.

To be explicit about what's still unknown: whether `xfce4-session` comes up *inside* xfwl4 is unverified, because xfwl4 panics before we get there. Expect a second round of findings once #123 lands. The comment in the file says so rather than implying the path is proven.

## 2. A second copy of the kde DM assertion

`e2e-runtime-checks.sh` had its own `kde) dm_pattern='^sddm\.service$'`, which #833 missed — so the live ISO still reported `not ok - display manager matches kde contract` against plasmalogin.

This also settles a doubt I raised on #833. I'd noted that a fresh pull of `ghcr.io/tuna-os/yellowfin:kde` shows sddm, so the plasmalogin fix might be inert. It isn't: the **dev ISO builds from packages**, so it sees today's EL10 KDE (`plasmalogin.service` — "Plasma Login Manager"), while the published ghcr image is stale on sddm. plasmalogin is current, not transient.

## 3. The kde failure was undiagnosable from CI

`plasmalogin.service` **failed to start** — kde didn't reach a greeter, it got no DM at all. (The two `liveuser` sessions in `loginctl` are the harness's own sshpass login, not autologin — easy to misread as success.)

The reason is nowhere in the artifacts, because this step only ever dumped `journalctl -u greetd` — hardcoded, and kde doesn't use greetd. So it now resolves `display-manager.service` and dumps *that* unit's journal and status. **This PR does not fix kde** — it makes the next run able to tell us why.

## 4. Local ISO builds off a rootless image always failed

Found driving a cosmic ISO build on real hardware, where it stopped the build dead.

`just iso ... 1` builds into the developer's **rootless** podman storage, then runs `build-iso-tacklebox.sh` under sudo, which uses **root's**. `tunaos_import_to_root_storage` bridges them with `sudo -u "$real_user" podman save | podman load` — but sets no `XDG_RUNTIME_DIR`, so rootless podman inherits no user session, falls back to root's `/run/containers/storage`, and dies:

```
RunRoot is pointing to a path (/run/containers/storage) which is not writable...
Error: acquiring runtime init lock: open /run/libpod/alive.lck: permission denied
```

That stderr was going to `/dev/null`, so the only visible symptom was `podman load` choking on an empty stream — `open /var/tmp/podman.../index.json: not a directory` — which points at the wrong end of the pipe entirely. Now sets `XDG_RUNTIME_DIR` from the user's uid and surfaces save's stderr on failure.

Covered by a test that exercises the **real** function, unlike the neighbouring ones which redefine it inline.

## Verification

`bash -n` + `shellcheck -S error` on the shell, `actionlint` on the workflow (adds one info-level SC2016, matching the intentional single-quoting every other remote-SSH line in that block uses), and bats `common_test` 11/11, `test_iso_e2e` + `test_build_scripts_remaining` green.

Companion: tuna-os/tacklebox#151 restores xfwl4 on the browser path too.