### PR TITLE
fix(gentoo): install flatpak in the base image

### DIFF
--- a/Containerfile.gentoo
+++ b/Containerfile.gentoo
@@ -59,9 +59,17 @@ RUN NPROC="$(nproc)" && \
 RUN emerge --verbose --deep --newuse @world
 
 # 3) Install the bootc/base tooling, prebuilt kernel, and extra base packages.
+# sys-apps/flatpak is not optional despite looking like a desktop nicety:
+# live-iso/common/src/customize-live.sh pre-installs the TunaOS installer as
+# a flatpak, and without it every guppy live-overlay build fails with
+#   ERROR: flatpak not installed; cannot pre-install org.tunaos.Installer<DE>
+# (runs 30159027680, 30196443189). Gentoo was the last Containerfile without
+# it — every other base already installs flatpak. Same class as #809, which
+# added it to the openSUSE base.
 RUN emerge --verbose --deep --newuse \
         app-arch/cpio btrfs-progs dev-vcs/git dosfstools sys-fs/xfsprogs \
         linux-firmware rust skopeo sys-kernel/gentoo-kernel-bin systemd \
+        sys-apps/flatpak \
         net-vpn/tailscale gui-apps/wl-clipboard media-video/ffmpeg media-plugins/gst-plugins-meta && \
     curl -fsSL -o /tmp/just.tar.gz https://github.com/casey/just/releases/download/1.35.0/just-1.35.0-x86_64-unknown-linux-musl.tar.gz && \
     tar -xzf /tmp/just.tar.gz -C /usr/bin just && rm /tmp/just.tar.gz && \


### PR DESCRIPTION
The last remaining *systematic* overlay failure, and the smallest fix of the lot.

`live-iso/common/src/customize-live.sh` pre-installs the TunaOS installer as a flatpak. guppy is Gentoo-based, and **`Containerfile.gentoo` was the only Containerfile without flatpak** — arch, debian, el10, opensuse and ubuntu all install it. So every guppy overlay build dies with:

```
ERROR: flatpak not installed; cannot pre-install org.tunaos.InstallerKde
```

Seen in run `30159027680`, and again in `30196443189` after the other overlay fixes landed — which is what ruled out the causes fixed in #833 and left this one isolated.

Exactly the same class as #809, which added flatpak to the openSUSE base.

## Caveat worth weighing

Gentoo builds from source, so `sys-apps/flatpak` and its dependency closure will **lengthen the guppy image build**. `dev-util/ostree` is already emerged further down, which covers the heaviest shared dependency, but this isn't free. If guppy build time is already near a limit, that's a reason to schedule this deliberately rather than merge blind.

The alternative — leaving guppy without flatpak — means guppy can never ship a working installer, so the cost buys something real.

## Overlay status

With this, the 19 original failures are accounted for:

| Cause | Cells | Status |
|---|---|---|
| `glib-compile-schemas` unguarded | flounder, flounder-sid | ✅ fixed in #833, **verified** 5/5 green |
| `useradd --uid 1000` collision | grouper | ✅ fixed in #833, **verified** green |
| flatpak missing (Gentoo) | guppy ×2 | ⬅️ this PR |
| flatpak missing (openSUSE) | sailfin ×4 | images need rebuilding to pick up #809 |
| base image never published | `albacore:xfce` | separate — registry 404 |
| registry blob read reset | marlin ×4 | transient; failed twice now, worth a third look if it persists |