### PR TITLE
fix(live): drop OnlyShowIn so the installer actually autostarts

### DIFF
--- a/live-iso/common/src/desktop-cosmic.sh
+++ b/live-iso/common/src/desktop-cosmic.sh
@@ -55,6 +55,20 @@ systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target 
 
 # Auto-launch the TunaOS installer frontend in the live session.
 # The app is baked into the live squash by customize-live.sh (tacklebox live_customize).
+# NOTE: deliberately no OnlyShowIn=. systemd-xdg-autostart-generator turns
+# each entry into a unit whose ExecCondition is
+# `systemd-xdg-autostart-condition "<desktop>"`, evaluated against
+# $XDG_CURRENT_DESKTOP in the *user manager's* environment. cosmic-session
+# does not export it, so on a live cosmic ISO every OnlyShowIn entry is
+# generated and then skipped:
+#
+#   app-org.tunaos.installer\x2dlive@autostart.service: Skipped due to
+#   'exec-condition'  (verified on hardware, 2026-07-26)
+#
+# gnome-keyring and CosmicInitialSetup were skipped the same way, which is
+# the tell: it is not our entry that is wrong, it is the filter. A live ISO
+# runs exactly one desktop, so OnlyShowIn buys nothing and costs the whole
+# feature.
 mkdir -p /etc/xdg/autostart
 tee /etc/xdg/autostart/org.tunaos.installer-live.desktop <<'DESKEOF'
 [Desktop Entry]
@@ -62,5 +76,4 @@ Type=Application
 Name=Install TunaOS
 Exec=flatpak run org.tunaos.InstallerCosmic
 Icon=org.tunaos.InstallerCosmic
-OnlyShowIn=COSMIC;
 DESKEOF

--- a/live-iso/common/src/desktop-kde.sh
+++ b/live-iso/common/src/desktop-kde.sh
@@ -69,6 +69,20 @@ systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target 
 
 # Auto-launch the TunaOS installer frontend in the live session.
 # The app is baked into the live squash by customize-live.sh (tacklebox live_customize).
+# NOTE: deliberately no OnlyShowIn=. systemd-xdg-autostart-generator turns
+# each entry into a unit whose ExecCondition is
+# `systemd-xdg-autostart-condition "<desktop>"`, evaluated against
+# $XDG_CURRENT_DESKTOP in the *user manager's* environment. cosmic-session
+# does not export it, so on a live cosmic ISO every OnlyShowIn entry is
+# generated and then skipped:
+#
+#   app-org.tunaos.installer\x2dlive@autostart.service: Skipped due to
+#   'exec-condition'  (verified on hardware, 2026-07-26)
+#
+# gnome-keyring and CosmicInitialSetup were skipped the same way, which is
+# the tell: it is not our entry that is wrong, it is the filter. A live ISO
+# runs exactly one desktop, so OnlyShowIn buys nothing and costs the whole
+# feature.
 mkdir -p /etc/xdg/autostart
 tee /etc/xdg/autostart/org.tunaos.installer-live.desktop <<'DESKEOF'
 [Desktop Entry]
@@ -76,6 +90,5 @@ Type=Application
 Name=Install TunaOS
 Exec=flatpak run org.tunaos.InstallerKde
 Icon=org.tunaos.InstallerKde
-OnlyShowIn=KDE;
 X-KDE-autostart-phase=2
 DESKEOF

--- a/live-iso/common/src/desktop-xfce.sh
+++ b/live-iso/common/src/desktop-xfce.sh
@@ -102,6 +102,20 @@ fi
 
 # Auto-launch the TunaOS installer frontend in the live session.
 # The app is baked into the live squash by customize-live.sh (tacklebox live_customize).
+# NOTE: deliberately no OnlyShowIn=. systemd-xdg-autostart-generator turns
+# each entry into a unit whose ExecCondition is
+# `systemd-xdg-autostart-condition "<desktop>"`, evaluated against
+# $XDG_CURRENT_DESKTOP in the *user manager's* environment. cosmic-session
+# does not export it, so on a live cosmic ISO every OnlyShowIn entry is
+# generated and then skipped:
+#
+#   app-org.tunaos.installer\x2dlive@autostart.service: Skipped due to
+#   'exec-condition'  (verified on hardware, 2026-07-26)
+#
+# gnome-keyring and CosmicInitialSetup were skipped the same way, which is
+# the tell: it is not our entry that is wrong, it is the filter. A live ISO
+# runs exactly one desktop, so OnlyShowIn buys nothing and costs the whole
+# feature.
 mkdir -p /etc/xdg/autostart
 tee /etc/xdg/autostart/org.tunaos.installer-live.desktop <<'DESKEOF'
 [Desktop Entry]
@@ -109,7 +123,6 @@ Type=Application
 Name=Install TunaOS
 Exec=flatpak run org.tunaos.InstallerXfce
 Icon=org.tunaos.InstallerXfce
-OnlyShowIn=XFCE;
 DESKEOF
 
 # Disable xfce4-screensaver locking and power suspend for the live session

--- a/scripts/iso-e2e-gpu.sh
+++ b/scripts/iso-e2e-gpu.sh
@@ -103,6 +103,10 @@ if [[ "${TBOX_E2E_REBUILD:-}" == "1" ]] || ! podman image exists "$IMAGE"; then
 	echo "==> building $IMAGE"
 	podman build -t "$IMAGE" -f - "$REPO_ROOT" <<'CONTAINERFILE'
 FROM registry.fedoraproject.org/fedora:41
+# vncdotool: screendump cannot capture a virgl guest once a Wayland
+# compositor scans out through GL ("Error: no surface"), so the VNC client
+# path in iso-e2e.sh's screenshot() is the only way to get an image of the
+# very sessions this GPU harness exists to test.
 RUN dnf -y install --setopt=install_weak_deps=False \
       qemu-system-x86-core \
       qemu-img \
@@ -113,8 +117,9 @@ RUN dnf -y install --setopt=install_weak_deps=False \
       virglrenderer \
       mesa-dri-drivers \
       mesa-libEGL \
-      socat sshpass swtpm swtpm-tools python3 openssh-clients \
+      socat sshpass swtpm swtpm-tools python3 python3-pip openssh-clients \
       bash coreutils util-linux procps-ng \
+ && python3 -m pip install --no-cache-dir vncdotool \
  && dnf clean all
 CONTAINERFILE
 fi

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -234,8 +234,30 @@ _gpu_mode="${TBOX_E2E_GPU:-auto}"
 QEMU_GPU_ARGS=(-vga virtio -display none)
 if [[ "$_gpu_mode" != "plain" ]] && { [[ "$_gpu_mode" == "virgl" ]] || [[ -e /dev/dri/renderD128 ]]; } \
 	&& "$QEMU" -device help 2>/dev/null | grep -q "virtio-vga-gl"; then
+	# egl-headless is NOT a display in its own right — it renders GL locally and
+	# expects another UI to present the result. On its own it exposes no
+	# console surface, so every `screendump` fails with:
+	#
+	#   (qemu) screendump /path/shot.ppm
+	#   Error: no surface
+	#
+	# That is silent in practice: iso-e2e.sh, installer-walkthrough.py,
+	# run-walkthrough.sh and the weekly screenshot workflows are ALL built on
+	# screendump, and their callers `|| true` past a failure — so switching to
+	# a GPU host would have produced zero screenshots while still reporting
+	# success. The gap never showed up because virgl only engages on a host
+	# with a render node, which CI runners do not have.
+	#
+	# Attaching VNC gives QEMU a surface to dump. A unix socket rather than a
+	# :N display keeps it off the network entirely and avoids port collisions
+	# between concurrent runs; nothing ever connects to it, it exists so the
+	# framebuffer is materialised. Verified on hardware 2026-07-26: identical
+	# 864015-byte PPM with either `-vnc :19` or `-vnc unix:...`.
+	# The -vnc argument needs OUTPUT_DIR, which is defined further down, so it
+	# is appended there rather than here.
 	QEMU_GPU_ARGS=(-device virtio-vga-gl -display "egl-headless,rendernode=/dev/dri/renderD128")
-	echo "==> GPU: virgl (virtio-vga-gl + egl-headless /dev/dri/renderD128) — Smithay compositors can render"
+	QEMU_NEEDS_VNC_SURFACE=1
+	echo "==> GPU: virgl (virtio-vga-gl + egl-headless /dev/dri/renderD128 + vnc surface) — Smithay compositors can render"
 else
 	echo "==> GPU: -vga virtio headless (no render node/virgl) — niri/xfwl4 will not render here"
 fi
@@ -300,6 +322,13 @@ LIVE_SERIAL_LOG="${OUTPUT_DIR}/live-serial.log"
 LUKS_EVIDENCE_LOG="${OUTPUT_DIR}/luks-evidence.log"
 INSTALL_DISK="${OUTPUT_DIR}/install-disk.qcow2"
 QEMU_PIDFILE="${OUTPUT_DIR}/qemu.pid"
+
+# See the egl-headless block above: it renders GL but presents nothing, so
+# screendump has no surface and every screenshot in this repo silently fails.
+# VNC on a unix socket materialises the framebuffer without opening a port.
+if [[ "${QEMU_NEEDS_VNC_SURFACE:-0}" == "1" ]]; then
+	QEMU_GPU_ARGS+=(-vnc "unix:${OUTPUT_DIR}/vnc.sock")
+fi
 
 record_luks_evidence() {
 	[[ "$LUKS" -eq 1 ]] || return 0

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -235,8 +235,7 @@ QEMU_GPU_ARGS=(-vga virtio -display none)
 if [[ "$_gpu_mode" != "plain" ]] && { [[ "$_gpu_mode" == "virgl" ]] || [[ -e /dev/dri/renderD128 ]]; } \
 	&& "$QEMU" -device help 2>/dev/null | grep -q "virtio-vga-gl"; then
 	# egl-headless is NOT a display in its own right — it renders GL locally and
-	# expects another UI to present the result. On its own it exposes no
-	# console surface, so every `screendump` fails with:
+	# expects another UI to present the result. Without one, `screendump` fails:
 	#
 	#   (qemu) screendump /path/shot.ppm
 	#   Error: no surface
@@ -248,11 +247,12 @@ if [[ "$_gpu_mode" != "plain" ]] && { [[ "$_gpu_mode" == "virgl" ]] || [[ -e /de
 	# success. The gap never showed up because virgl only engages on a host
 	# with a render node, which CI runners do not have.
 	#
-	# Attaching VNC gives QEMU a surface to dump. A unix socket rather than a
-	# :N display keeps it off the network entirely and avoids port collisions
-	# between concurrent runs; nothing ever connects to it, it exists so the
-	# framebuffer is materialised. Verified on hardware 2026-07-26: identical
-	# 864015-byte PPM with either `-vnc :19` or `-vnc unix:...`.
+	# -vnc is what makes capture possible at all, but note it does NOT rescue
+	# screendump: under GL scanout the monitor still answers "no surface". It
+	# is the VNC *client* path that works, because the server reads the texture
+	# back for its clients — see screenshot() below. A unix socket rather than
+	# a :N display keeps this off the network and avoids collisions between
+	# concurrent runs.
 	# The -vnc argument needs OUTPUT_DIR, which is defined further down, so it
 	# is appended there rather than here.
 	QEMU_GPU_ARGS=(-device virtio-vga-gl -display "egl-headless,rendernode=/dev/dri/renderD128")
@@ -325,6 +325,7 @@ QEMU_PIDFILE="${OUTPUT_DIR}/qemu.pid"
 
 # See the egl-headless block above: it renders GL but presents nothing, so
 # screendump has no surface and every screenshot in this repo silently fails.
+# (VNC alone does not fix screendump under GL scanout — see screenshot().)
 # VNC on a unix socket materialises the framebuffer without opening a port.
 if [[ "${QEMU_NEEDS_VNC_SURFACE:-0}" == "1" ]]; then
 	QEMU_GPU_ARGS+=(-vnc "unix:${OUTPUT_DIR}/vnc.sock")
@@ -487,13 +488,56 @@ boot_live_iso() {
 	return 1
 }
 
-# Take a screenshot via QEMU monitor. Best-effort.
+# Take a screenshot. Best-effort, and deliberately two-path.
+#
+# `screendump` cannot capture a guest that is scanning out through virgl. Once
+# a Wayland compositor takes over, the framebuffer lives in a GL texture that
+# QEMU's console layer never sees, and the monitor answers:
+#
+#   (qemu) screendump /path/shot.ppm
+#   Error: no surface
+#
+# Attaching -vnc is necessary but NOT sufficient: with VNC listening,
+# screendump still reports "no surface" under GL scanout. Verified on hardware
+# 2026-07-26 — it succeeds at the pre-GL text console and fails the moment
+# cosmic-comp starts, which is precisely the window we care about.
+#
+# The VNC *client* path does work, because the VNC server reads the texture
+# back for its clients. Capturing through it produced the first image ever
+# taken of the cosmic live session with the installer on screen.
+#
+# So: prefer VNC capture whenever the socket exists, and keep screendump as
+# the fallback for the plain -vga virtio path, where it is perfectly good.
 screenshot() {
 	local label="$1"
 	local out="${OUTPUT_DIR}/${label}.ppm"
+	local png="${OUTPUT_DIR}/${label}.png"
+	local vnc_sock="${OUTPUT_DIR}/vnc.sock"
+
+	if [[ -S "$vnc_sock" ]] && command -v vncdo &>/dev/null && command -v socat &>/dev/null; then
+		# vncdo speaks TCP, so bridge the unix socket for the moment of capture.
+		local port="${TBOX_E2E_VNC_PORT:-5999}"
+		socat "TCP-LISTEN:${port},reuseaddr,fork" "UNIX-CONNECT:${vnc_sock}" &
+		local bridge=$!
+		sleep 1
+		vncdo -s "127.0.0.1::${port}" capture "$png" >/dev/null 2>&1 || true
+		kill "$bridge" 2>/dev/null || true
+		if [[ -s "$png" ]]; then
+			echo "==> Screenshot saved: ${png} (vnc)"
+			return 0
+		fi
+		echo "==> VNC capture failed; falling back to screendump" >&2
+	fi
+
 	if [[ -S "$MONITOR_SOCK" ]] && command -v socat &>/dev/null; then
 		echo "screendump ${out}" | socat - "UNIX-CONNECT:${MONITOR_SOCK}" >/dev/null 2>&1 || true
-		[[ -f "$out" ]] && echo "==> Screenshot saved: ${out}"
+		if [[ -f "$out" ]]; then
+			echo "==> Screenshot saved: ${out}"
+		else
+			# Say so rather than leaving a silently absent artifact: on the
+			# virgl path this is expected, and vncdo is the missing piece.
+			echo "==> No screenshot captured (screendump found no surface; install vncdotool for the virgl path)" >&2
+		fi
 	fi
 }
 


### PR DESCRIPTION
**This is the answer to "does the cosmic installer work".** Proven on real hardware today (himachal, DRM render node + KVM), not inferred.

## What a live cosmic ISO actually does

I built the ISO and booted it under QEMU with the virgl path, then kept the VM alive and inspected it:

```
=== compositor ===        1591 cosmic-comp                 ← running
=== DM ===                greetd.service / active / graphical.target
=== sessions ===          liveuser  seat0  tty1            ← autologin worked
=== flatpak list ===      org.tunaos.InstallerCosmic       ← installed
=== installer ===         NO-INSTALLER-PROC                ← never launched
```

The full COSMIC desktop is up — `cosmic-panel`, `cosmic-launcher`, `cosmic-workspaces`, `cosmic-settings-daemon`. 13/13 live-image smoke checks pass. **cosmic-comp has never been shown running before**; on GPU-less GitHub runners it can't start at all, which is why this was invisible.

So the compositor was never the problem. The installer was, and for a reason nothing in the build could surface.

## Root cause

`systemd-xdg-autostart-generator` turns each `/etc/xdg/autostart` entry into a unit whose `ExecCondition` is `systemd-xdg-autostart-condition "<desktop>"`, evaluated against `$XDG_CURRENT_DESKTOP` **in the user manager's environment**. `cosmic-session` does not export it:

```
$ systemctl --user show-environment | grep -i xdg_current
(empty)
```

So the unit is generated and then skipped:

```
app-org.tunaos.installer\x2dlive@autostart.service: Skipped due to 'exec-condition'.
Condition check resulted in app-org.tunaos.installer\x2dlive@autostart.service - Install TunaOS being skipped.
```

**The tell:** gnome-keyring's three entries and `com.system76.CosmicInitialSetup` were skipped in exactly the same way, in the same journal, at the same second. It isn't our entry that's malformed — it's the filter. `xdg-desktop-autostart.target` itself reports `active`, which is what makes this look fine from every angle except the one that counts.

## The fix

A live ISO runs exactly one desktop, so `OnlyShowIn` discriminates nothing and costs the entire feature. Dropped from **cosmic, kde and xfce**.

Setting `XDG_CURRENT_DESKTOP` in the session would also work, but that depends on each compositor's launcher doing it correctly. This doesn't depend on anything.

## Scope caveat, stated plainly

Only **cosmic** is verified this far in. kde and xfce both fail earlier — plasmalogin failing to start (#836 adds the diagnostics) and the xfwl4 theme panic (tunaos-packages#123) respectively — so I could not observe their autostart at all. They carry the identical `OnlyShowIn` pattern, so this is very likely masking the same defect there, but I have not seen it and am not claiming it.

## Verification

`bash -n` + `shellcheck -S error` on all three adapters; bats `test_build_scripts_remaining` 29/29.