### PR TITLE
fix(build): dev ISOs for stage-3 flavors chain on a nonexistent parent

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -128,7 +128,25 @@ build variant='albacore' flavor='gnome' target_platform='' is_ci="0" tag='latest
         # CI chains on the -testing stream tag
         BASE_FOR_BUILD=$(./scripts/published-image-ref.sh "{{ variant }}" "${PARENT_FLAVOR}-testing" ghcr)
     else
+        # Stage-3 flavors (-nvidia, -hwe) chain on their parent flavor's image.
+        # Locally that is normally in podman storage from an earlier `just
+        # build`, but it is NOT there for a dev/e2e ISO: `just iso ... dev=1`
+        # calls build with is_ci="0" hardcoded, so on a CI runner this branch
+        # asked for an image nobody had built and buildah tried to resolve
+        # "localhost" as a registry:
+        #
+        #   Error: initializing source docker://localhost/yellowfin:gnome:
+        #   pinging container registry localhost
+        #
+        # That is the single cause of all 24 NVIDIA cells failing LUKS E2E
+        # (run 29978067348) — one systemic issue, not 24. Fall back to the
+        # published parent when the local one is absent, which also makes
+        # `just iso <variant> <flavor>-nvidia ... 1` work on a clean machine.
         BASE_FOR_BUILD="localhost/{{ variant }}:${PARENT_FLAVOR}"
+        if ! podman image exists "${BASE_FOR_BUILD}" 2>/dev/null; then
+            echo "==> ${BASE_FOR_BUILD} not in local storage; chaining on the published parent instead"
+            BASE_FOR_BUILD=$(./scripts/published-image-ref.sh "{{ variant }}" "${PARENT_FLAVOR}-testing" ghcr)
+        fi
     fi
 
     if [[ -n "{{ chain_base_image }}" ]] && [[ "${FLAVOR}" != "base" ]]; then


### PR DESCRIPTION
**All 24 NVIDIA cells fail LUKS E2E, and it is one cause, not 24.** The matrix status doc (#847) surfaced the uniform block; this is what was behind it.

## Root cause

Stage-3 flavors (`-nvidia`, `-hwe`) chain on their parent flavor's image. `just iso ... dev=1` calls `just build` with **`is_ci="0"` hardcoded** (Justfile:181), so on a CI runner the *local* branch ran:

```bash
BASE_FOR_BUILD="localhost/{{ variant }}:${PARENT_FLAVOR}"
```

That image was never built on the LUKS runner, so buildah tried to resolve `localhost` as a registry:

```
Error: initializing source docker://localhost/yellowfin:gnome:
  pinging container registry localhost: Get "https://localhost/v2/"
error: Recipe `iso` failed with exit code 125
```

Byte-identical in `yellowfin:gnome-nvidia` and `yellowfin:cosmic-nvidia` (run `29978067348`).

**Worth stating plainly: NVIDIA has never actually been tested.** Every cell died at image build, ~40 seconds in, long before QEMU. The 24 red cells say nothing about NVIDIA support — only that the harness could not construct the image.

## Fix

Fall back to the published `<parent>-testing` ref when the local parent isn't present.

I checked the fallback target actually exists before relying on it — `yellowfin:gnome-testing`, `cosmic-testing`, `kde-testing` all return 200 — rather than swapping one broken ref for another.

## Why not the tidier fix

It would be cleaner to stop hardcoding `is_ci="0"` in the `iso` recipe. But that flag also drives submodule init/deinit and selects which argument set `_build` receives, so flipping it wholesale risks more than it repairs. This change touches base resolution only.

Side benefit: `just iso <variant> <flavor>-nvidia ghcr "" 1` now works on a clean machine, where it previously required building the parent flavor by hand first.

## Verification

`just --fmt --check` clean, bats 29/29. **Not yet proven end-to-end** — that needs a LUKS E2E run on an NVIDIA cell, which is ~35 min. Happy to dispatch one before merge if you'd rather not take it on the log evidence; the failure mode is unambiguous in the logs but the fix itself is unexercised.