### PR TITLE
docs: kde also needs a GPU; fix a self-matching pgrep in the harness

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -229,7 +229,13 @@ jobs:
             $SSH 'ls -l /dev/dri/ 2>/dev/null; echo "--- eglinfo/vulkaninfo ---"; (eglinfo 2>&1 | head -20) || true; (vulkaninfo --summary 2>&1 | head -20) || true' 2>/dev/null || true
             echo
             echo "=== windows the compositor actually has ==="
-            $SSH 'pgrep -xl "cosmic-comp|niri|xfwl4|kwin_wayland" 2>/dev/null || pgrep -l -x cosmic-comp || pgrep -l -x niri || pgrep -l -x xfwl4 || pgrep -l -x kwin_wayland || echo "(no compositor matched)"; ps -eo pid,comm,args | grep -iE "[I]nstaller" || echo "(no installer process)"' 2>/dev/null || true
+            # -x matches comm exactly, so this cannot self-match the way a
+            # bare `pgrep -f` does — but the fallbacks below it were reporting
+            # this very command line as a running compositor (run 30234237855
+            # line 11046: "bash -c pgrep -xl \"cosmic-comp|niri|...\"").
+            # Bracket the first letter so the pattern never matches its own
+            # argv, the same defence the frontend check above already uses.
+            $SSH 'pgrep -xl "[c]osmic-comp|[n]iri|[x]fwl4|[k]win_wayland" 2>/dev/null || echo "(no compositor matched)"; ps -eo pid,comm,args | grep -iE "[I]nstaller" || echo "(no installer process)"' 2>/dev/null || true
           } > "$out" 2>&1
           echo "--- captured $(wc -l < "$out") lines ---"
           tail -30 "$out"

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -77,20 +77,20 @@ This is the only axis that checks a human could actually install. For 29 combina
 | **skipjack** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | **yellowfin** | ⬜ | ❌ | ❌ | ✅ | ❌ |
 
-cosmic, niri and xfwl4 need a DRM render node; a ❌ for those on hosted CI may be a harness limitation rather than a product failure. See *Known systemic gaps*.
+cosmic, niri, xfwl4 and kde all need a DRM render node; a ❌ for those on hosted CI may be a harness limitation rather than a product failure. See *Known systemic gaps*.
 
 ## Live overlay
 
-**37** tags published.
+**38** tags published.
 
-Missing for 2 ISO cell(s): `albacore-xfce`, `marlin-kde`
+Missing for 1 ISO cell(s): `marlin-kde`
 
 ## Provenance
 
 | Date | Run | Cells |
 |---|---|---|
+| 2026-07-27 | [30234237855](https://github.com/tuna-os/tunaOS/actions/runs/30234237855) | 2 |
 | 2026-07-26 | [30198679407](https://github.com/tuna-os/tunaOS/actions/runs/30198679407) | 1 |
-| 2026-07-26 | [30191933429](https://github.com/tuna-os/tunaOS/actions/runs/30191933429) | 2 |
 | 2026-07-24 | [30098218493](https://github.com/tuna-os/tunaOS/actions/runs/30098218493) | 4 |
 | 2026-07-23 | [29978067348](https://github.com/tuna-os/tunaOS/actions/runs/29978067348) | 56 |
 | 2026-07-22 | [29914643652](https://github.com/tuna-os/tunaOS/actions/runs/29914643652) | 2 |
@@ -102,11 +102,22 @@ Missing for 2 ISO cell(s): `albacore-xfce`, `marlin-kde`
 **NVIDIA.** Every NVIDIA cell fails, across every variant — see the generated
 tally above. Untouched, and the single biggest uniform block of red.
 
-**CI cannot test three of five desktops.** cosmic, niri and xfwl4 need a DRM
-render node. GitHub runners have none, so on hosted CI the compositor never
-starts — no configuration change alters this. `scripts/iso-e2e-gpu.sh` runs the
-harness on a GPU host and is the intended answer; it currently has to be driven
-by hand.
+**CI cannot test four of five desktops.** cosmic, niri, xfwl4 **and kde** need a
+DRM render node. GitHub runners have none, so on hosted CI the compositor never
+starts — no configuration change alters this.
+
+kde was previously believed to be the exception. It is not: on run
+`30234237855`, plasmalogin's autologin session and its greeter both exit
+immediately (`plasmalogin-helper exited with 5`) in a restart loop, and
+`eglinfo` on that runner lists **no `EGL_EXT_device_drm` at all**, putting
+kwin_wayland in the same position as the Smithay compositors.
+
+That leaves **gnome** as the only desktop still thought verifiable without a
+render node — and that is now an untested assumption rather than a
+demonstrated fact, because the smoke matrix has never run gnome.
+
+`scripts/iso-e2e-gpu.sh` runs the harness on a GPU host and is the intended
+answer; it currently has to be driven by hand.
 
 **Screenshots on the GPU path.** `screendump` returns `Error: no surface` once a
 guest scans out through virgl, and attaching VNC does not rescue it — the VNC
@@ -114,6 +125,12 @@ guest scans out through virgl, and attaching VNC does not rescue it — the VNC
 `installer-walkthrough.py`, `run-walkthrough.sh` and the weekly screenshot
 workflows still call `screendump` directly and will silently produce nothing on
 a GPU host.
+
+**Confirmed working, so nobody re-debugs it.** The plasmalogin autologin
+drop-in (#833) *is* being read — run `30234237855` shows
+`pam_unix(plasmalogin-autologin:session): session opened for user liveuser`
+before the session dies on the GPU limitation above. Autologin is not the kde
+blocker.
 
 **Failures that look like successes.** Recurring shape, worth checking for in
 any new harness code:

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -56,7 +56,7 @@ green on 2026-07-23, while the installer GUI had never once been observed.
 | **skipjack** | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **yellowfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-NVIDIA: **0 of 24** cells green. A uniform block of red is one systemic issue, not N issues.
+NVIDIA cells are **out of scope** for this workflow — `luks-e2e.yml` excludes them deliberately, because `-nvidia` takes the identical LUKS path in headless QEMU. 24 stale pre-exclusion result(s) remain from before that change; they are not a gap and will age out.
 
 Newest result 2026-07-26, oldest still-authoritative result 2026-07-23. Results older than the most recent round of fixes are the best available data, not current data.
 
@@ -99,8 +99,15 @@ Missing for 1 ISO cell(s): `marlin-kde`
 
 ## 3. Known systemic gaps
 
-**NVIDIA.** Every NVIDIA cell fails, across every variant — see the generated
-tally above. Untouched, and the single biggest uniform block of red.
+**NVIDIA is out of scope, not failing.** `luks-e2e.yml` excludes `-nvidia`
+deliberately (commit `5c730e9`): those flavors take the identical LUKS path in
+headless QEMU, so testing them there exercises nothing NVIDIA-specific. The
+stale results still visible above predate that change and will age out.
+
+The honest position is that **NVIDIA is untested rather than broken**, and no
+current workflow is designed to test it. Doing so needs a host with a real
+NVIDIA GPU — a different problem from the render-node gap above, and not one
+`iso-e2e-gpu.sh` solves.
 
 **CI cannot test four of five desktops.** cosmic, niri, xfwl4 **and kde** need a
 DRM render node. GitHub runners have none, so on hosted CI the compositor never

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -165,16 +165,24 @@ def tally(matrix, results, key_fmt):
 
 
 def nvidia_tally(matrix, results, key_fmt):
-    total = passed = 0
+    """Count NVIDIA cells that still carry a stale result.
+
+    luks-e2e.yml deliberately excludes -nvidia (commit 5c730e9, 2026-07-24):
+    "-nvidia takes the identical LUKS path in headless QEMU (no GPU)". That is
+    a sound scoping decision, so these cells are OUT OF SCOPE, not failing.
+
+    Reporting them as "0 of 24 green" implied a 24-cell gap that nobody was
+    ever going to close, which is its own kind of dishonest status page — the
+    mirror image of the problem this document exists to fix. What is worth
+    surfacing is only how many stale pre-exclusion results are still lying
+    around, so the number shrinks to zero as they age out.
+    """
+    stale = 0
     for variant, flavors in matrix.items():
         for f in flavors:
-            if "nvidia" not in f:
-                continue
-            total += 1
-            hit = results.get(key_fmt(variant, f))
-            if hit and hit[0] == "success":
-                passed += 1
-    return total, passed
+            if "nvidia" in f and results.get(key_fmt(variant, f)):
+                stale += 1
+    return stale
 
 
 def build() -> str:
@@ -202,7 +210,7 @@ def build() -> str:
 
     # ── LUKS ────────────────────────────────────────────────────────────────
     total, tested, passed = tally(matrix, luks, luks_key)
-    nv_total, nv_pass = nvidia_tally(matrix, luks, luks_key)
+    nv_stale = nvidia_tally(matrix, luks, luks_key)
     out += [
         "## LUKS E2E",
         "",
@@ -211,12 +219,16 @@ def build() -> str:
         "",
     ]
     out += desktop_table(matrix, luks, luks_key)
-    out += [
-        "",
-        f"NVIDIA: **{nv_pass} of {nv_total}** cells green. A uniform block of "
-        "red is one systemic issue, not N issues.",
-        "",
-    ]
+    if nv_stale:
+        out += [
+            "",
+            f"NVIDIA cells are **out of scope** for this workflow — "
+            f"`luks-e2e.yml` excludes them deliberately, because `-nvidia` "
+            f"takes the identical LUKS path in headless QEMU. "
+            f"{nv_stale} stale pre-exclusion result(s) remain from before "
+            "that change; they are not a gap and will age out.",
+            "",
+        ]
 
     dates = sorted({v[1] for v in luks.values()})
     if dates:

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -244,7 +244,7 @@ def build() -> str:
     out += desktop_table(matrix, smoke, smoke_key)
     out += [
         "",
-        "cosmic, niri and xfwl4 need a DRM render node; a ❌ for those on "
+        "cosmic, niri, xfwl4 and kde all need a DRM render node; a ❌ for those on "
         "hosted CI may be a harness limitation rather than a product failure. "
         "See *Known systemic gaps*.",
         "",

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -227,9 +227,22 @@ fi
 #   xfce:   greetd: check_children: greeter exited without creating a session
 #           greetd.service: Failed with result 'start-limit-hit'
 #
-# There is no software fallback for any of them. Only gnome and kde are
-# genuinely verifiable without a render node. For the rest, use
-# scripts/iso-e2e-gpu.sh on a host that has one.
+# There is no software fallback for any of them. KDE is NOT the exception this
+# comment previously claimed: plasmalogin's autologin session and its greeter
+# both die instantly on a hosted runner (installer-smoke run 30234237855):
+#
+#   plasmalogin-helper: Starting Wayland user session ... startplasma-wayland
+#   plasmalogin-helper: pam_unix(plasmalogin-autologin:session): session closed
+#   plasmalogin: Auth: plasmalogin-helper exited with 5
+#   ... then the same for the greeter, in a restart loop
+#
+# `eglinfo` on that runner lists no EGL_EXT_device_drm at all, so kwin_wayland
+# is in the same position as the Smithay compositors.
+#
+# GNOME is the only desktop still believed verifiable without a render node,
+# and that belief is now untested rather than demonstrated — the smoke matrix
+# has never run gnome. For everything else use scripts/iso-e2e-gpu.sh on a
+# host with a real render node.
 _gpu_mode="${TBOX_E2E_GPU:-auto}"
 QEMU_GPU_ARGS=(-vga virtio -display none)
 if [[ "$_gpu_mode" != "plain" ]] && { [[ "$_gpu_mode" == "virgl" ]] || [[ -e /dev/dri/renderD128 ]]; } \


### PR DESCRIPTION
The #836 diagnostics paid for themselves on their first run. Two findings from installer-smoke run `30234237855` — one good, one a correction to our own docs.

## Good news first: autologin is **not** the kde blocker

The plasmalogin drop-in from #833 **is** being read:

```
plasmalogin-helper: pam_kwallet5(plasmalogin-autologin:session): pam_sm_open_session
plasmalogin-helper: pam_unix(plasmalogin-autologin:session): session opened for user liveuser
```

Recorded in MATRIX-STATUS.md under a new "Confirmed working, so nobody re-debugs it" note. Before this run we had no idea whether the fix landed, because the unit never got far enough to say.

## Correction: kde is not verifiable without a render node

Both `iso-e2e.sh` and `MATRIX-STATUS.md` asserted that *"Only gnome and kde are genuinely verifiable without a render node."* **That's wrong for kde.**

The autologin session starts and dies instantly, then the greeter does the same, in a restart loop:

```
plasmalogin-helper: Starting Wayland user session ... startplasma-wayland
plasmalogin-helper: pam_unix(plasmalogin-autologin:session): session closed for user liveuser
plasmalogin: Auth: plasmalogin-helper exited with 5
```

And `eglinfo` on that runner lists **no `EGL_EXT_device_drm`** at all — kwin_wayland is in exactly the same position as the Smithay compositors.

So it's **four of five desktops** hosted CI cannot test, not three. Which leaves **gnome** as the only one still believed testable there — and I've written that down as an *untested assumption* rather than a fact, because **the smoke matrix has never run gnome**. Worth someone actually checking before we lean on it.

## The harness was reporting its own diagnostic as a compositor

Run `30234237855`, line 11046:

```
5287 bash  bash -c pgrep -xl "cosmic-comp|niri|xfwl4|kwin_wayland" ...
```

Bracketed the first letter of each pattern — the same defence the installer-frontend check a few lines above already uses and documents.

**Third instance of this trap today.** It's endemic in this repo's tooling, and it's the worst kind of bug for a test harness: it makes a dead desktop look alive.

## Verification

`bash -n` + `shellcheck -S error` clean; `actionlint` finding count unchanged from baseline (4 pre-existing, none added); bats `test_iso_e2e` 57/57; `gen-matrix-status.py --check` clean after regenerating.

Note the doc's generated block picked up the new run automatically — the drift check caught that it was stale before I'd touched it, which is the automation from #847 working as intended.