### PR TITLE
fix(e2e,cosmic): overridable SSH port; write the idle config cosmic-idle actually reads

### DIFF
--- a/live-iso/common/src/desktop-cosmic.sh
+++ b/live-iso/common/src/desktop-cosmic.sh
@@ -36,7 +36,31 @@ ln -sf /usr/lib/systemd/system/greetd.service /etc/systemd/system/display-manage
 systemctl set-default graphical.target 2>/dev/null || \
   ln -sf /usr/lib/systemd/system/graphical.target /etc/systemd/system/default.target 2>/dev/null || true
 
-# Disable screen lock for the live session
+# Disable idle screen-off / lock / suspend for the live session.
+#
+# cosmic-idle is what actually locks the session: its binary contains both
+# `loginctl lock-session` and `systemctl suspend`, and it reads its timers from
+# the cosmic-config store `com.system76.CosmicIdle` (keys: screen_off_time,
+# suspend_on_ac_time, suspend_on_battery_time) — NOT from the
+# cosmic-settings-daemon override written below, which it never opens. So the
+# override alone left a live ISO able to lock itself, and liveuser is
+# passwordless, which is a poor place to end up.
+#
+# cosmic-config is one file per key holding a RON value; `None` disables an
+# Option-typed timer (see /usr/share/cosmic/com.system76.CosmicAppList/v1/
+# filter_top_levels, which is literally "None"). Written to /usr/share/cosmic
+# because that is where this image's defaults demonstrably live, and to
+# /etc/cosmic as the sysadmin-override location, so this does not depend on
+# which of the two libcosmic happens to consult first.
+for _cosmic_root in /usr/share/cosmic /etc/cosmic; do
+	mkdir -p "${_cosmic_root}/com.system76.CosmicIdle/v1"
+	for _k in screen_off_time suspend_on_ac_time suspend_on_battery_time; do
+		echo "None" >"${_cosmic_root}/com.system76.CosmicIdle/v1/${_k}"
+	done
+done
+
+# Kept as well: this is the right home for the power/time settings the
+# settings daemon itself owns, even though it is not what gates the lock.
 mkdir -p /etc/xdg
 tee /etc/xdg/cosmic-settings-daemon.override <<'COSMICEOF'
 [time]

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -81,6 +81,12 @@ TIMEOUT=300
 OUTPUT_DIR="./iso-e2e-out"
 MEMORY=4096
 CPUS=4
+# Host port forwarded to the guest's sshd. Overridable because the harness
+# otherwise cannot coexist with anything else on 2222 — on a shared GPU host
+# a rootless container already held it and QEMU died with
+# "Could not set up host forwarding rule 'tcp::2222-:22'" — and because two
+# runs on one host would collide with each other.
+SSH_PORT="${TBOX_E2E_SSH_PORT:-2222}"
 NO_KVM=0
 KEEP_VM=0
 LUKS=0
@@ -313,6 +319,17 @@ else
 	CPU_ARG="qemu64,+sse4.1,+sse4.2,+aes,+xsave,+xsaveopt,+xsavec,+xsaves,+popcnt,+avx,+avx2"
 fi
 
+# Fail early and legibly if the forward port is taken. QEMU's own error —
+# "Could not set up host forwarding rule 'tcp::2222-:22'" — arrives after the
+# disk image is created and reads like a QEMU fault rather than "something
+# else is already listening".
+if command -v ss &>/dev/null && ss -tln 2>/dev/null | grep -q ":${SSH_PORT} "; then
+	echo "ERROR: port ${SSH_PORT} is already in use; the guest SSH forward cannot bind." >&2
+	echo "       Set TBOX_E2E_SSH_PORT to a free port, e.g.:" >&2
+	echo "         TBOX_E2E_SSH_PORT=2322 $0 $*" >&2
+	exit 77
+fi
+
 # ── Per-run scratch files ───────────────────────────────────────────────────
 
 OVMF_VARS="${OUTPUT_DIR}/OVMF_VARS.fd"
@@ -468,7 +485,7 @@ boot_live_iso() {
 		-device scsi-cd,drive=iso \
 		-drive "if=none,id=disk,file=${INSTALL_DISK},format=qcow2" \
 		-device virtio-blk-pci,drive=disk \
-		-netdev "user,id=net0,hostfwd=tcp::2222-:22" \
+		-netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22" \
 		-device virtio-net-pci,netdev=net0 \
 		-monitor "unix:${MONITOR_SOCK},server,nowait" \
 		-serial "file:${SERIAL_LOG}" \
@@ -661,7 +678,7 @@ check_ssh() {
 	fi
 	local opts="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
 	# shellcheck disable=SC2086
-	if sshpass -p live ssh $opts liveuser@127.0.0.1 -p 2222 true 2>/dev/null; then
+	if sshpass -p live ssh $opts liveuser@127.0.0.1 -p "$SSH_PORT" true 2>/dev/null; then
 		echo "==> SSH OK"
 		return 0
 	fi
@@ -678,8 +695,8 @@ run_smoke_checks() {
 	local script_dir
 	script_dir="$(dirname "${BASH_SOURCE[0]}")"
 	local -a COMMON_SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
-	local ssh_cmd=(sshpass -p live ssh "${COMMON_SSH_OPTS[@]}" -p 2222 liveuser@127.0.0.1)
-	local scp_cmd=(sshpass -p live scp "${COMMON_SSH_OPTS[@]}" -P 2222)
+	local ssh_cmd=(sshpass -p live ssh "${COMMON_SSH_OPTS[@]}" -p "$SSH_PORT" liveuser@127.0.0.1)
+	local scp_cmd=(sshpass -p live scp "${COMMON_SSH_OPTS[@]}" -P "$SSH_PORT")
 
 	"${scp_cmd[@]}" "${script_dir}/lib/e2e-assert.sh" liveuser@127.0.0.1:/tmp/e2e-assert.sh
 	"${scp_cmd[@]}" "${script_dir}/e2e-smoke-checks.sh" liveuser@127.0.0.1:/tmp/e2e-smoke-checks.sh
@@ -751,8 +768,8 @@ run_install() {
 	# with the wrong flag silently makes scp treat the port number as a
 	# source-file argument ("stat local 2222: No such file or directory").
 	local -a COMMON_SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
-	local ssh_cmd=(sshpass -p live ssh "${COMMON_SSH_OPTS[@]}" -p 2222 liveuser@127.0.0.1)
-	local scp_cmd=(sshpass -p live scp "${COMMON_SSH_OPTS[@]}" -P 2222)
+	local ssh_cmd=(sshpass -p live ssh "${COMMON_SSH_OPTS[@]}" -p "$SSH_PORT" liveuser@127.0.0.1)
+	local scp_cmd=(sshpass -p live scp "${COMMON_SSH_OPTS[@]}" -P "$SSH_PORT")
 
 	# Bug #20: fisherman's network pull stalled indefinitely mid-blob (layer
 	# 42/65, no error, no further output) after dozens of smaller layers
@@ -1078,7 +1095,7 @@ EOF
 		-drive "if=pflash,format=raw,file=${OVMF_VARS}" \
 		-drive "if=none,id=disk,file=${INSTALL_DISK},format=qcow2" \
 		-device virtio-blk-pci,drive=disk \
-		-netdev "user,id=net0,hostfwd=tcp::2222-:22" \
+		-netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22" \
 		-device virtio-net-pci,netdev=net0 \
 		-monitor "unix:${MONITOR_SOCK},server,nowait" \
 		-serial "file:${SERIAL_LOG}" \
@@ -1142,7 +1159,7 @@ boot_disk_image() {
 		-drive "if=pflash,format=raw,file=${OVMF_VARS}" \
 		-drive "if=none,id=disk,file=${ISO_PATH},format=${fmt}" \
 		-device virtio-blk-pci,drive=disk \
-		-netdev "user,id=net0,hostfwd=tcp::2222-:22" \
+		-netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22" \
 		-device virtio-net-pci,netdev=net0 \
 		-monitor "unix:${MONITOR_SOCK},server,nowait" \
 		-serial "file:${SERIAL_LOG}" \
@@ -1305,7 +1322,7 @@ app-launch)
 		app_idx=$((app_idx + 1))
 		label="20-app-$(printf '%02d' "$app_idx")-${app##*.}"
 		echo "==> Launching app via SSH: $app"
-		sshpass -p live ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 liveuser@127.0.0.1 \
+		sshpass -p live ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p "$SSH_PORT" liveuser@127.0.0.1 \
 			"env $SSH_APP_ENV gtk-launch $app 2>&1" || echo "  (app launch may have failed)"
 		sleep 8
 		screenshot "$label"
@@ -1324,7 +1341,7 @@ app-launch)
 		# Best-effort stop (openQA closes each app before the next): match the
 		# desktop id's last segment, lowercased, against the process table.
 		app_proc="${app##*.}"
-		sshpass -p live ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 liveuser@127.0.0.1 \
+		sshpass -p live ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p "$SSH_PORT" liveuser@127.0.0.1 \
 			"pkill -f '${app_proc,,}' 2>/dev/null" || true
 		sleep 2
 	done


### PR DESCRIPTION
Two fixes found by running the harness on a **shared** GPU host rather than an idle one.

## 1. The harness couldn't coexist with anything on port 2222

`iso-e2e.sh` hardcoded `2222` in seven places. On himachal a rootless container of James's already held it, and QEMU died with:

```
qemu-kvm: -netdev user,id=net0,hostfwd=tcp::2222-:22:
  Could not set up host forwarding rule 'tcp::2222-:22'
```

That error arrives *after* the install disk is created and reads like a QEMU fault rather than "something else is listening" — so there's now a preflight check that names the real cause and suggests the override.

`TBOX_E2E_SSH_PORT` defaults to 2222, so nothing existing moves. Two runs on one host no longer collide either, which matters if the GPU host ever runs the matrix in parallel.

Verified end-to-end: booted the cosmic ISO on 2322 alongside the existing container, 13/13 smoke checks.

## 2. The cosmic live session's lock config went to a file nothing reads

`desktop-cosmic.sh` disabled screen lock via `/etc/xdg/cosmic-settings-daemon.override` with `screen_lock = false`. **cosmic-idle never opens that file.**

cosmic-idle is what performs the lock — its binary contains both `loginctl lock-session` and `systemctl suspend` — and it reads its timers from the cosmic-config store `com.system76.CosmicIdle`:

```
$ strings $(command -v cosmic-idle) | grep -E 'screen_off_time|CosmicIdle|lock-session'
com.system76.CosmicIdle
loginctl lock-session
screen_off_time  suspend_on_ac_time  suspend_on_battery_time
```

Neither `/etc/cosmic` nor `/usr/share/cosmic` carried that component in the image, so it ran on built-in defaults with nothing overriding them. On a live ISO that ends at a password prompt for a **passwordless** `liveuser` — an unenterable session.

Now writes RON `None` for all three keys, to both `/usr/share/cosmic` (where this image's other defaults demonstrably live — `com.system76.CosmicAppList/v1/filter_top_levels` is literally `None`) and `/etc/cosmic`, so it doesn't depend on which location libcosmic consults first. Validated in a live session on hardware: files accepted, cosmic-idle restarts against them with no parse error.

### Scope — please read this bit

What's **proven**: our existing override is inert for this purpose, and cosmic-idle owns the lock.

What's **not**: I observed a live session locked at a cosmic-greeter password prompt earlier today, but that was *after* I'd interfered with the session, so I can't attribute it to the idle timer. What the stock default does, and after how long, is unconfirmed — a fresh session sat idle for the duration of this work and did not lock (`LockedHint=no`).

So this is a **defensive fix for a demonstrated gap, not a reproduce-and-fix**. I'd rather say that than imply I chased down a lock I only half-saw.

The settings-daemon override stays — it's the right home for the power/time settings that daemon *does* own — but its comment no longer claims to disable the lock.

## Verification

`bash -n` + `shellcheck -S error` clean, bats `test_iso_e2e` 57/57 and `test_build_scripts_remaining` 29/29.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787720725&installation_model_id=429180&pr_number=854&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F854&signature=3674b67bffb6a715ec0c9c524c42d0241456b8677a2f5989c981119850957e11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->