### PR TITLE
fix(live): create the home base before useradd --create-home

### DIFF
--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -162,17 +162,34 @@ if [[ "${_TD_OS}" == "pacman" ]]; then
 	fi
 
 	readarray -t _TD_PKGS < <($YQ -r ".packages.pacman[]" "${_TD_MANIFEST}" 2>/dev/null || true)
-	if ((${#_TD_PKGS[@]} > 0)); then
-		pacman -S --noconfirm --needed "${_TD_PKGS[@]}"
+	# An empty list here is a misconfigured manifest, not "nothing to do".
+	# cosmic.yaml, niri.yaml and xfce.yaml have no `pacman` section and no
+	# -arch sibling, so on Arch this silently installed NOTHING and the script
+	# still exited 0 — producing images tagged cosmic/niri/xfce with no
+	# desktop in them at all (tunaOS#858). The VM boot Gate caught it much
+	# later, after the image had already been built and pushed.
+	if ((${#_TD_PKGS[@]} == 0)); then
+		echo "ERROR: ${_TD_MANIFEST} has no .packages.pacman list." >&2
+		echo "       Installing no packages would yield an image tagged" >&2
+		echo "       '${_TD_DESKTOP}' with no desktop in it. Add a pacman" >&2
+		echo "       section, or a manifests/desktops/${_TD_DESKTOP}-arch.yaml." >&2
+		exit 1
 	fi
+	pacman -S --noconfirm --needed "${_TD_PKGS[@]}"
 
 	# Enable display manager
 	_TD_DM=$($YQ -r '.display_manager' "${_TD_MANIFEST}")
 	if [[ -n "${_TD_DM}" ]]; then
-		systemctl enable "${_TD_DM}" || true
+		# Not `|| true`: a manifest naming a DM that the packages did not
+		# provide means the package set is wrong. This printed "Failed to
+		# enable unit: Unit greetd.service does not exist" and carried on.
+		systemctl enable "${_TD_DM}"
 	fi
 	printf "::endgroup::\n"
-	exit 0
+	# Deliberately NO `exit 0` here. The pacman branch used to return early,
+	# skipping the desktop-experience contract check below — which is exactly
+	# the check that would have caught an image with no session files. Arch
+	# now runs the same gate every other package manager does.
 fi
 
 # ── DNF path (el10/fedora only) ──────────────────────────────────────────────

--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -63,6 +63,19 @@ fi
 # 1000 when it is free (desktop sessions and flatpak expect it) and let
 # useradd pick otherwise; nothing here depends on the exact number.
 if ! getent passwd liveuser >/dev/null; then
+	# bootc images ship /home as a symlink to var/home, but /var is empty in
+	# the container layer, so useradd --create-home follows the symlink to a
+	# directory that does not exist and dies:
+	#
+	#   useradd: cannot create directory /home        (exit 12)
+	#
+	# That is what actually broke the marlin:kde overlay — misread as a
+	# transient registry blob error three separate times, because exit 12 was
+	# the only thing surfaced. readlink -f resolves a dangling symlink to its
+	# intended target, so this materialises whichever base the image means.
+	_home_base="$(readlink -f /home 2>/dev/null || echo /home)"
+	mkdir -p "${_home_base}"
+
 	_uid_args=()
 	getent passwd 1000 >/dev/null || _uid_args=(--uid 1000)
 	useradd --create-home "${_uid_args[@]}" --user-group \

--- a/manifests/desktops/kde-arch.yaml
+++ b/manifests/desktops/kde-arch.yaml
@@ -17,7 +17,11 @@ packages:
     - qt5-wayland
     - ksshaskpass
     - ksystemlog
-    - input-remapper
+    # input-remapper is AUR-only — not in any official Arch repo, so pacman
+    # fails the whole kde build with "target not found: input-remapper"
+    # and marlin:kde has been serving a stale image ever since.
+    # Tracked for packaging in tuna-os/tunaos-packages#126.
+    # - input-remapper
     - libratbag
     - solaar
     - pam-u2f


### PR DESCRIPTION
The last remaining overlay failure — and it was never the registry.

## What actually happens

```
+ useradd --create-home --uid 1000 --user-group --comment 'Live User' --shell /bin/bash liveuser
useradd: cannot create directory /home
##[error]Process completed with exit code 12
```

`marlin:kde` (Arch-based):

```
lrwxrwxrwx /home -> var/home
ls: cannot access '/var/home': No such file or directory
HOME=/home            # /etc/default/useradd
```

bootc images ship `/home` as a symlink to `var/home`, but `/var` is empty in the container layer, so `--create-home` follows the symlink to a directory that doesn't exist. `readlink -f` resolves a dangling symlink to its intended target, so this creates whichever base the image actually means rather than hardcoding `/home` or `/var/home`.

Same family as the `--uid 1000` collision fixed in #833: `customize-live.sh` making a `useradd` assumption a given base doesn't hold.

## Worth recording: this was misdiagnosed three times

Twice by me. I wrote *"failed twice now, so no longer plausibly transient"* and **still** filed it as a registry blob error, because `exit 12` was all the summary showed and I never opened the log past the last error line. The actual cause was one line above it the whole time.

The generalisable bit: an exit code plus the *last* error line is not a diagnosis. The marlin log's final lines are git-credential cleanup — the real failure was 30 lines earlier, and every grep I ran for `error|denied|reset` matched the cleanup noise instead.

## Separate defect found alongside — not fixed here

`marlin:kde` ships **no `/usr/share/wayland-sessions/` at all**, so `customize-live.sh` detects `DESKTOP=gnome` and installs the GNOME installer frontend into an image tagged `kde`:

```
+ [[ -f /usr/share/wayland-sessions/plasma.desktop ]]     # absent
customize-live: detected desktop=gnome
```

So even with this fix, `marlin:kde` produces an overlay for the wrong desktop. That's an image-build problem rather than a live-payload one — the tag doesn't match the contents — and belongs in its own issue against the marlin build. Flagging it here so the green overlay this PR produces isn't mistaken for `marlin:kde` being correct.

## Verification

`bash -n` + `shellcheck -S error` clean, bats 29/29. The real proof is a `marlin:kde` overlay run once merged; happy to dispatch on the branch first if preferred.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->