### PR TITLE
docs: NVIDIA coverage is planned, not abandoned

### DIFF
--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -104,10 +104,17 @@ deliberately (commit `5c730e9`): those flavors take the identical LUKS path in
 headless QEMU, so testing them there exercises nothing NVIDIA-specific. The
 stale results still visible above predate that change and will age out.
 
-The honest position is that **NVIDIA is untested rather than broken**, and no
-current workflow is designed to test it. Doing so needs a host with a real
-NVIDIA GPU — a different problem from the render-node gap above, and not one
-`iso-e2e-gpu.sh` solves.
+The honest position is that **NVIDIA is untested rather than broken**. No
+current workflow is designed to test it, because doing so needs a host with a
+real NVIDIA GPU — a different problem from the render-node gap above, and not
+one `iso-e2e-gpu.sh` solves.
+
+**This is planned, not abandoned.** NVIDIA coverage is expected once GPU
+capacity lands (AWS grant, driven through runs-on). When it does, the work is
+to add `-nvidia` back to `luks-e2e.yml`'s matrix filter and point it at those
+runners — and tuna-os/tunaOS#848 is a prerequisite, since stage-3 flavors
+currently cannot build a dev ISO at all. Until then the ⬜/stale cells above
+should be read as *not yet covered*, not as a backlog of broken cells.
 
 **CI cannot test four of five desktops.** cosmic, niri, xfwl4 **and kde** need a
 DRM render node. GitHub runners have none, so on hosted CI the compositor never


### PR DESCRIPTION
Small follow-up to #851.

The matrix doc currently says NVIDIA is "out of scope" and "untested rather than broken". Both true today, but together they read as a decision to *never* cover it. That's wrong — coverage is expected once GPU capacity lands (AWS grant, driven through runs-on).

So it now records what the work will actually be, rather than leaving the plan in someone's head:

- re-add `-nvidia` to `luks-e2e.yml`'s matrix filter and point it at the GPU runners
- **#848 is a prerequisite** — stage-3 flavors can't build a dev ISO at all right now, so NVIDIA cells would fail at image build before touching a GPU

The distinction changes how the stale cells read: *not yet covered*, rather than a backlog of broken ones. Given the doc's whole purpose is making "no data" legible, having it imply "abandoned" when the truth is "queued behind hardware" is exactly the failure mode in miniature.

`gen-matrix-status.py --check` clean — the edit is outside the generated block, which is what those markers are for.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->