### PR TITLE
fix(ci): move LUKS E2E to Blacksmith to unclog org concurrency

### DIFF
--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -41,7 +41,7 @@ jobs:
   # desktop flavor with a published image), narrowed by the dispatch filters.
   generate-matrix:
     name: Generate matrix
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
     steps:
@@ -114,7 +114,7 @@ jobs:
   luks:
     name: LUKS ${{ matrix.variant }}:${{ matrix.flavor }}
     needs: generate-matrix
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     # 90 min was sized for the old local-only bootc install (no network
     # pull). fisherman now does a full image pull over the QEMU guest's NAT
     # networking (see docs/ci-troubleshooting.md §4 bug #19) — slower than a


### PR DESCRIPTION
## Summary
- `generate-matrix` was stuck queued ~50min against GitHub's 20-concurrent-job org cap, blocking the whole LUKS E2E matrix behind it.
- Points both jobs at Blacksmith runners (vendor-hosted, works today) instead of `ubuntu-latest`/`ubuntu-24.04`.
- Note: the `luks` job does real QEMU boot verification (needs `/dev/kvm` for reasonable performance). Blacksmith claims GitHub-runner environment parity, but this wasn't independently KVM-verified before merging — worth watching the first run.

## Test plan
- [ ] Confirm LUKS E2E picks up a Blacksmith runner and the `luks` job's QEMU boot verification isn't falling back to slow software emulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->