### PR TITLE
fix(ci): rootless podman needs cgroupfs on Blacksmith runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+# Blacksmith-hosted runner labels. actionlint only knows GitHub's own labels
+# and treats anything else as a typo, so without this every workflow moved to
+# Blacksmith fails `Lint (actionlint)` with "label ... is unknown".
+self-hosted-runner:
+  labels:
+    - blacksmith-2vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-8vcpu-ubuntu-2404
+    - blacksmith-16vcpu-ubuntu-2404

--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -136,6 +136,29 @@ jobs:
             /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
           df -h /
 
+      # Blacksmith runners provide no systemd user session, so rootless
+      # podman's default cgroup manager cannot create a scope and every
+      # container build dies before running anything:
+      #
+      #   error running container: from /usr/bin/crun creating container for
+      #   [/bin/sh -c echo "${BUILD_SCRIPTS_HASH}" > /dev/null]:
+      #   sd-bus call: Interactive authentication required.
+      #
+      # That is polkit refusing a sd-bus call with no active session behind
+      # it — not a build error, though it surfaces as one at a random RUN
+      # step. All 50 cells of run 30243113215 failed this way. cgroupfs needs
+      # no session; GitHub-hosted images happen to ship a session, which is
+      # why this never appeared there.
+      - name: Use the cgroupfs cgroup manager (no user session on this runner)
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.config/containers
+          cat >~/.config/containers/containers.conf <<'CONF'
+          [engine]
+          cgroup_manager = "cgroupfs"
+          CONF
+          podman info --format '{{.Host.CgroupManager}}'
+
       - name: Maximize build space
         uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6 # main as of 2026-02-11
 


### PR DESCRIPTION
Follow-up to #861. The move to Blacksmith worked — jobs start immediately instead of queueing for 45 minutes — but the first full sweep on those runners (run `30243113215`) came back **50 failures out of 50**.

That's not 50 product bugs. Every cell died identically, part-way through the image build:

```
error running container: from /usr/bin/crun creating container for
  [/bin/sh -c echo "${BUILD_SCRIPTS_HASH}" > /dev/null]:
  sd-bus call: Interactive authentication required.
```

## Cause

That message is polkit refusing an sd-bus call with **no active session behind it**. Rootless podman defaults to the **systemd** cgroup manager, which needs a systemd user session + dbus to create a scope. Blacksmith runners don't provide one; GitHub-hosted images happen to, which is why this never showed up before the move.

`cgroupfs` needs no session. Selected via `~/.config/containers/containers.conf` before any build step, and the step echoes the resolved manager so the next person can see which one was actually in use rather than inferring it.

## Also: actionlint doesn't know the Blacksmith labels

```
label "blacksmith-4vcpu-ubuntu-2404" is unknown. available labels are ...
```

`Lint (actionlint)` would fail on `main` for every workflow moved to Blacksmith. Adding `.github/actionlint.yaml` declares the label set once — including the 8 and 16 vCPU tiers — so future migrations don't each need their own fix.

## Worth noting how this presented

Fifty red cells that looked exactly like fifty product failures were a single environment difference. And it surfaced as a build error at an arbitrary `RUN echo "${BUILD_SCRIPTS_HASH}"` line — a step that does nothing — rather than as anything mentioning sessions or cgroups. Had the sweep been partially red I'd probably have gone hunting per-variant; it was only the *uniformity* that made it obviously infrastructural.

## Verification

`actionlint` clean with the new config (and confirmed it's the config doing it — the same file fails without it), `yamllint` clean.

**Not yet proven end-to-end** — that needs a re-run of the sweep on this branch, which is the obvious next step once this lands. I'd rather land the fix and re-dispatch than burn another 50 cells proving it from a branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->