### PR TITLE
feat(ci): route Manifest/Sign/Gate/Promote to Runs-On

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -447,7 +447,7 @@ jobs:
             /tmp/outputs/digests/*.txt
   manifest:
     name: Manifest
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=build-amd64
     if: always()
     needs:
       - generate_matrix
@@ -705,7 +705,7 @@ jobs:
     name: Sign
     needs: manifest
     if: ${{ inputs.publish && github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=build-amd64
     permissions:
       contents: read
       packages: write
@@ -735,7 +735,7 @@ jobs:
       inputs.publish && github.event_name != 'pull_request' &&
       !startsWith(inputs.flavor, 'base') &&
       contains(inputs.platforms, 'amd64')
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=build-amd64
     timeout-minutes: 60
     permissions:
       contents: read
@@ -814,7 +814,7 @@ jobs:
       !cancelled() && github.event_name != 'pull_request' &&
       needs.manifest.result == 'success' &&
       (needs.verify_boot.result == 'success' || needs.verify_boot.result == 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=build-amd64
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
- AWS's new-account EC2 restriction has cleared; `build_push` jobs already succeeded on Runs-On.
- These four lightweight jobs (Manifest, Sign, Gate, Promote) were still on `ubuntu-latest` and queuing behind GitHub's 20-concurrent-job cap while the actual builds sailed through on Runs-On.
- `Gate` does real x86 QEMU/KVM boot verification; Nitro-based EC2 instances provide hardware KVM natively without needing `nested-virt` (that's only for nested/L2 hypervisors).

## Test plan
- [ ] Confirm a subsequent variant build run picks up Runs-On for all five jobs (build_push, Manifest, Sign, Gate, Promote) and completes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->