### PR TITLE
fix(build): fall back when /run/user/<uid> does not exist

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -108,9 +108,30 @@ tunaos_import_to_root_storage() {
 		return 1
 	fi
 
+	# /run/user/<uid> only exists where systemd-logind has created a session.
+	# Blacksmith runners have none, so pointing at it produced:
+	#
+	#   Failed to get rootless runtime dir: lstat /run/user/1001: no such file
+	#   error creating temporary file: No such file or directory
+	#   invalid internal status, try resetting the pause process with
+	#   "podman system migrate"
+	#
+	# and the pipe then fed `podman load` nothing, which reported the useless
+	# "payload does not match any of the supported image formats". Fall back to
+	# a private directory owned by the user — the same shape
+	# build-iso-tacklebox.sh already uses for its dropped-privilege podman ops.
+	local xdg_dir="/run/user/${real_uid}"
+	if [[ ! -d "$xdg_dir" ]]; then
+		xdg_dir="/tmp/tbox-xdg-${real_user}"
+		install -d -o "$real_user" -g "$(id -g "$real_user")" -m 700 "$xdg_dir" || {
+			echo "ERROR: cannot create a runtime dir for ${real_user} at ${xdg_dir}" >&2
+			return 1
+		}
+	fi
+
 	local save_err
 	save_err=$(mktemp)
-	if ! sudo -u "$real_user" env "XDG_RUNTIME_DIR=/run/user/${real_uid}" \
+	if ! sudo -u "$real_user" env "XDG_RUNTIME_DIR=${xdg_dir}" \
 		podman save "$image" 2>"$save_err" | podman load; then
 		echo "ERROR: failed to import ${image} from ${real_user}" >&2
 		[[ -s "$save_err" ]] && {

--- a/tests/bats/common_test.bats
+++ b/tests/bats/common_test.bats
@@ -182,18 +182,17 @@ teardown() {
 # to root's /run/containers/storage, can't write there, and dies on
 # /run/libpod/alive.lck — so every local `just iso` off a rootless image
 # failed. Unlike the neighbouring tests this exercises the REAL function.
-@test "tunaos_import_to_root_storage: passes XDG_RUNTIME_DIR to the invoking user's podman" {
+@test "tunaos_import_to_root_storage: passes a usable XDG_RUNTIME_DIR" {
   local spy="${BATS_TEST_TMPDIR}/sudo-args"
   run bash -c '
     set +e
     source "'"${BATS_TEST_DIRNAME}"'/../../scripts/lib/common.sh"
-    SUDO_USER=testuser
-    id() { echo 4242; }
+    SUDO_USER=$(id -un)
     sudo() { echo "$*" >>"'"${spy}"'"; return 0; }
+    install() { command install "$@"; }
     _calls=0
     podman() {
       if [[ "$1 $2" == "image exists" ]]; then
-        # Absent the first time (forces the import), present afterwards.
         _calls=$((_calls + 1))
         [[ $_calls -gt 1 ]] && return 0
         return 1
@@ -204,7 +203,13 @@ teardown() {
     tunaos_import_to_root_storage "localhost/yellowfin:cosmic"
   '
   [ "$status" -eq 0 ]
-  grep -q "XDG_RUNTIME_DIR=/run/user/4242" "$spy"
+  # The contract is that a runtime dir is passed AND that it exists. Asserting
+  # the literal /run/user/<uid> was wrong: that path only exists where
+  # systemd-logind made a session, which Blacksmith runners do not.
+  grep -q "XDG_RUNTIME_DIR=" "$spy"
+  local dir
+  dir=$(grep -o 'XDG_RUNTIME_DIR=[^ ]*' "$spy" | head -1 | cut -d= -f2)
+  [ -d "$dir" ]
 }
 
 @test "tunaos_import_to_root_storage: returns 0 when image already exists" {


### PR DESCRIPTION
Second Blacksmith environment fix, same root cause as #862: **no systemd user session on these runners.**

## What happened

#862 worked — `podman info` now reports `cgroupfs`, and the jobs got **9× further** (8912 log lines vs 965). They then all failed at the image import:

```
==> Importing localhost/yellowfin:gnome from runner's podman storage into root's...
--- podman save (as runner) said:
  Failed to get rootless runtime dir for DefaultAPIAddress: lstat /run/user/1001: no such file or directory
  error creating temporary file: No such file or directory
  invalid internal status, try resetting the pause process with "podman system migrate"
Error: payload does not match any of the supported image formats
```

#836 set `XDG_RUNTIME_DIR=/run/user/<uid>` so rootless podman would work under `sudo -u`. That path only exists where systemd-logind made a session. No session ⇒ no directory ⇒ `podman save` writes nothing ⇒ `podman load` reports **"payload does not match any of the supported image formats"**, which points at the wrong end of the pipe entirely.

Now falls back to a private `/tmp/tbox-xdg-<user>` owned by the invoking user — the same shape `build-iso-tacklebox.sh` already uses for its dropped-privilege podman ops.

## The diagnostic paid for itself

That `--- podman save (as runner) said:` block is from #836, added precisely because the bare `podman load` error had misled me once already. It's the reason this took minutes rather than hours — without it the visible error is again about image formats, and says nothing about runtime directories.

## About the failing test

`common_test.bats` had my test from #836 asserting the literal `/run/user/<uid>`. It failed here, **correctly** — that assumption is exactly what changed. Rewritten to assert the contract that actually matters: a runtime dir is passed **and it exists**. That version would have caught this class of bug; the old one encoded the environment I happened to be on.

## Worth flagging

Anything else in the repo assuming `/run/user/<uid>` will break on Blacksmith the same way. I've fixed the one that bit; a sweep for others is probably worth it before more workflows migrate.

## Verification

`bash -n` + `shellcheck -S error` clean, bats `common_test` 11/11. End-to-end proof needs another sweep, which I'll dispatch once this lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->