### PR TITLE
fix(build): only mount dnf caches into dnf-based variants

### DIFF
--- a/scripts/setup-build-cache.sh
+++ b/scripts/setup-build-cache.sh
@@ -23,9 +23,22 @@ BASE_VARIANT="${BASE_VARIANT%-hwe}"
 BASE_VARIANT="${BASE_VARIANT%-kde}"
 BASE_VARIANT="${BASE_VARIANT%-dx}"
 
-if [[ "$BASE_VARIANT" == "grouper" ]]; then
-	exit 0
-fi
+# Only dnf-based variants get these mounts. The mounts land on /var/cache/dnf,
+# /var/cache/libdnf5 and /var/lib/rpm, which are meaningless to zypper, portage,
+# pacman and apt — but they are still *mounts under /var*, and the bootc layout
+# step later does an unguarded `rm -rf /var`. rm cannot unlink a mountpoint, so
+# it exits non-zero and `set -e` kills the build. That is why sailfin (zypper)
+# and guppy (portage) died at "Device or resource busy" on /var/cache/libdnf5 —
+# a Gentoo build has no dnf at all, yet was being handed a dnf cache.
+#
+# This was previously a denylist naming only grouper, which meant every non-dnf
+# variant added since then silently inherited mounts it could not use.
+# An allowlist fails safe: a new variant gets no cache until someone opts it in,
+# which costs a slower build rather than a broken one.
+case "$BASE_VARIANT" in
+yellowfin | albacore | skipjack | bonito | bonito-rawhide) ;;
+*) exit 0 ;;
+esac
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CACHE_BASE="${REPO_ROOT}/.rpm-cache/shared"


### PR DESCRIPTION
## What

`scripts/setup-build-cache.sh` bind-mounts `/var/cache/dnf`, `/var/cache/libdnf5` and `/var/lib/rpm` into **every** build container. Replaces the `grouper`-only denylist with an allowlist of the actually-dnf variants.

## Why

Those caches are inert for zypper/portage/pacman/apt — but they are still *mounts under `/var`*, and the bootc layout step later runs an unguarded `rm -rf /var`. `rm` cannot unlink a mountpoint, so it exits non-zero and `set -e` kills the build:

```
rm: cannot remove '/var/cache/libdnf5': Device or resource busy
rm: cannot remove '/var/cache/dnf': Device or resource busy
Error: building at STEP "RUN mkdir -p /sysroot/ostree ... rm -rf ... /var"
```

A Gentoo build has no dnf at all, yet was being handed a dnf cache.

This is the entire cause of 5 red cells in LUKS sweep [30249218614](https://github.com/tuna-os/tunaOS/actions/runs/30249218614): `sailfin` gnome/kde/niri/xfce and `guppy:kde`. None of them ever produced an ISO.

It stayed hidden because sailfin previously failed *earlier* — a zypper `addrepo` error on 2026-07-24 — so the `/var` wipe was never reached on that variant before.

## Verification

```
yellowfin       6 lines      sailfin       0 lines
albacore        6 lines      guppy         0 lines
skipjack        6 lines      marlin        0 lines
bonito          6 lines      flounder      0 lines
bonito-rawhide  6 lines      flounder-sid  0 lines
albacore-nvidia 6 lines      grouper       0 lines
```

Every currently-green LUKS cell is on the allowlist, so no passing variant loses its cache. `shellcheck` clean.

## Note on the allowlist direction

The previous denylist meant each new non-dnf variant silently inherited mounts it could not use. An allowlist fails safe — a new variant gets no cache until someone opts it in, which costs a slower build rather than a broken one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvVVtmk8CqW8x643B6m84

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->