### PR TITLE
fix(e2e): resolve the published image ref instead of guessing it

### DIFF
--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -180,6 +180,17 @@ jobs:
             qemu-system-x86 qemu-utils ovmf swtpm socat sshpass imagemagick \
             systemd-boot-efi mtools squashfs-tools xorriso dosfstools gdisk
 
+      # iso-e2e.sh resolves the published image ref through
+      # scripts/published-image-ref.sh, which needs yq. Without it the script
+      # falls back to a guessed ref that is wrong for bonito-rawhide and
+      # flounder-sid. The matrix job installs yq the same way.
+      - name: Install yq
+        run: |
+          sudo curl -fsSL -o /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
       - name: Log in to GHCR
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -840,10 +840,35 @@ run_install() {
 	# real production install machine (with no embedded local store) uses
 	# too. Requires network access, which the LUKS E2E runner already has
 	# (and already does a GHCR login earlier in the job).
-	local target_imgref="ghcr.io/tuna-os/${VARIANT:-}:${FLAVOR:-}"
-	local local_ref="localhost/${VARIANT:-}:${FLAVOR:-}"      # dev=1 ISO
-	local prod_ref="ghcr.io/tuna-os/${VARIANT:-}:${FLAVOR:-}" # production ISO
-	local recipe_image=""                                     # set below after probing the VM
+	# The published ref is NOT always ghcr.io/tuna-os/<variant>:<flavor>.
+	# build-config.yml gives bonito-rawhide `publish_name: bonito` +
+	# `tag_suffix: rawhide`, so it ships as bonito:<flavor>-rawhide; flounder-sid
+	# is flounder:<flavor>-sid. Constructing the ref by hand here meant we probed
+	# the embedded offline store for a name it never contained, concluded the
+	# image was absent, and fell back to a network pull of a tag that does not
+	# exist — four retries ten minutes apart, then a 40-minute-late failure that
+	# looked like a flaky registry. All nine such cells had already passed their
+	# live-ISO checks ("13 passed, 0 failed") before this hit.
+	#
+	# published-image-ref.sh is the same resolver build-variant.yml and
+	# publish-iso-groups.yml use, so there is one definition of the mapping.
+	local published_ref=""
+	if ! published_ref=$(
+		TUNAOS_BUILD_CONFIG="${SCRIPT_DIR}/../.github/build-config.yml" \
+			"${SCRIPT_DIR}/published-image-ref.sh" "${VARIANT:-}" "${FLAVOR:-}" ghcr 2>/dev/null
+	) || [[ -z "$published_ref" ]]; then
+		published_ref="ghcr.io/tuna-os/${VARIANT:-}:${FLAVOR:-}"
+		# Loud, because this fallback is silently wrong for exactly the variants
+		# the resolver exists to handle, and a quiet wrong ref costs 40 minutes.
+		echo "WARNING: published-image-ref.sh failed (is yq installed?);" >&2
+		echo "WARNING: guessing ${published_ref}. This is WRONG for any variant" >&2
+		echo "WARNING: with publish_name/tag_suffix set in build-config.yml." >&2
+	fi
+
+	local target_imgref="$published_ref"
+	local local_ref="localhost/${VARIANT:-}:${FLAVOR:-}" # dev=1 ISO
+	local prod_ref="$published_ref"                      # production ISO
+	local recipe_image=""                                # set below after probing the VM
 	local composefs_backend="false" bootloader="grub2"
 	# grouper (Ubuntu) has no bootupd package available via apt, so it ships
 	# systemd-boot instead and installs via bootc's composefs-native backend.


### PR DESCRIPTION
## What

`iso-e2e.sh` built the production ref as `ghcr.io/tuna-os/<variant>:<flavor>`. That is wrong for any variant with `publish_name`/`tag_suffix` in `build-config.yml`:

| variant | actually published as |
|---|---|
| `bonito-rawhide` | `bonito:<flavor>-rawhide` |
| `flounder-sid` | `flounder:<flavor>-sid` |

## Why it was expensive

The harness probed the ISO's embedded offline store for a name it never contained, concluded the image was absent, and fell back to a **network pull of a tag that does not exist** — four attempts, ten minutes apart:

```
==> Probing for ghcr.io/tuna-os/bonito-rawhide:gnome...
==> No local image in offline store, falling back to network pull over QEMU NAT
ERROR: failed to pull ghcr.io/tuna-os/bonito-rawhide:gnome after 4 attempts
```

…while the ISO actually held `ghcr.io/tuna-os/bonito:gnome-rawhide`:

```
>>> [offline-store] copying localhost/bonito-rawhide:gnome
    -> ghcr.io/tuna-os/bonito:gnome-rawhide in embedded store
```

Every affected cell had **already passed its live-ISO checks** (`13 passed, 0 failed`) before the pull. The job then failed 40 minutes later with a TLS timeout, which reads as a flaky registry rather than a naming bug — the real mistake was ~90 lines earlier in the log.

## Fix

Use `scripts/published-image-ref.sh`, the same resolver `build-variant.yml` and `publish-iso-groups.yml` already use, so the mapping has one definition rather than three. It needs `yq`, which the e2e job did not install — added. The fallback is deliberately loud, because a quiet wrong ref costs 40 minutes.

```
yellowfin       -> ghcr.io/tuna-os/yellowfin:gnome
bonito          -> ghcr.io/tuna-os/bonito:gnome
bonito-rawhide  -> ghcr.io/tuna-os/bonito:gnome-rawhide     ← was bonito-rawhide:gnome
flounder-sid    -> ghcr.io/tuna-os/flounder:gnome-sid       ← was flounder-sid:gnome
skipjack        -> ghcr.io/tuna-os/skipjack:gnome
```

## Scope

Fixes 4 cells in LUKS sweep [30249218614](https://github.com/tuna-os/tunaOS/actions/runs/30249218614) (`bonito-rawhide` gnome/kde/cosmic/niri) and pre-empts the identical failure for `flounder-sid`, whose 5 cells were still running when this was diagnosed.

**Not** fixed here: `skipjack`'s 5 cells fail the same way but its ref was already correct — its offline store mounts and is populated, yet `podman images` in the guest returns empty. Separate bug, still under investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvVVtmk8CqW8x643B6m84

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->