### PR TITLE
fix(docs): measure each matrix axis against the set it actually schedules

### DIFF
--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -60,6 +60,8 @@ Measured against the set `luks-e2e.yml` schedules: every published desktop image
 | **skipjack** | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **yellowfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 
+NVIDIA cells are **out of scope** for this workflow — `luks-e2e.yml` excludes them deliberately, because `-nvidia` takes the identical LUKS path in headless QEMU. 24 stale pre-exclusion result(s) remain from before that change; they are not a gap and will age out.
+
 Newest result 2026-07-27, oldest still-authoritative result 2026-07-23. Results older than the most recent round of fixes are the best available data, not current data.
 
 ## Installer smoke

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -42,23 +42,25 @@ green on 2026-07-23, while the installer GUI had never once been observed.
 
 ## LUKS E2E
 
-**12 of 37** non-NVIDIA ISO cells green (37 tested, 0 never tested).
+**15 of 50** cells green (50 tested, 0 never tested).
+
+Measured against the set `luks-e2e.yml` schedules: every published desktop image (`build_image`), not only the ones that ship an ISO. That is wider than the ISO matrix below on purpose — the browser ISO builder can make an ISO from any image, so image-only variants (`sailfin`, `guppy`, `flounder-sid`) need boot and install coverage too.
 
 | Variant | gnome | kde | cosmic | niri | xfce |
 |---|:--:|:--:|:--:|:--:|:--:|
 | **albacore** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **bonito** | ❌ | ✅ | ❌ | ❌ | ✅ |
+| **bonito** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **bonito-rawhide** | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **flounder** | ❌ | ❌ | — | — | — |
+| **flounder** | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **flounder-sid** | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **grouper** | ❌ | ❌ | — | ❌ | ❌ |
-| **marlin** | ❌ | ❌ | — | — | — |
+| **guppy** | ❌ | ❌ | — | — | — |
+| **marlin** | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **sailfin** | ❌ | ❌ | — | ❌ | ❌ |
 | **skipjack** | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **yellowfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-NVIDIA cells are **out of scope** for this workflow — `luks-e2e.yml` excludes them deliberately, because `-nvidia` takes the identical LUKS path in headless QEMU. 24 stale pre-exclusion result(s) remain from before that change; they are not a gap and will age out.
-
-Newest result 2026-07-26, oldest still-authoritative result 2026-07-23. Results older than the most recent round of fixes are the best available data, not current data.
+Newest result 2026-07-27, oldest still-authoritative result 2026-07-23. Results older than the most recent round of fixes are the best available data, not current data.
 
 ## Installer smoke
 
@@ -89,10 +91,9 @@ Missing for 1 ISO cell(s): `marlin-kde`
 
 | Date | Run | Cells |
 |---|---|---|
+| 2026-07-27 | [30249218614](https://github.com/tuna-os/tunaOS/actions/runs/30249218614) | 50 |
 | 2026-07-27 | [30234237855](https://github.com/tuna-os/tunaOS/actions/runs/30234237855) | 2 |
-| 2026-07-26 | [30198679407](https://github.com/tuna-os/tunaOS/actions/runs/30198679407) | 1 |
-| 2026-07-24 | [30098218493](https://github.com/tuna-os/tunaOS/actions/runs/30098218493) | 4 |
-| 2026-07-23 | [29978067348](https://github.com/tuna-os/tunaOS/actions/runs/29978067348) | 56 |
+| 2026-07-23 | [29978067348](https://github.com/tuna-os/tunaOS/actions/runs/29978067348) | 24 |
 | 2026-07-22 | [29914643652](https://github.com/tuna-os/tunaOS/actions/runs/29914643652) | 2 |
 
 <!-- END GENERATED -->
@@ -162,6 +163,29 @@ any new harness code:
   `/usr/share/tunaos/missing-on-*.txt` inside the built image, which nothing
   reads on a schedule. Three package gaps were found this way in one morning:
   `tunaos-packages#120`, `#121`, `#122`.
+- **A failing install cell blames the registry when the real fault is 90 lines
+  earlier.** `iso-e2e.sh` probes the ISO's embedded offline store and falls back
+  to a network pull when it misses. That fallback fails after four retries ten
+  minutes apart, so the last line of the log is a TLS timeout against ghcr.io —
+  40 minutes after the actual mistake, which was that the probe looked for the
+  wrong name. Nine cells in run `30249218614` looked like a flaky registry and
+  were not; all nine had already passed their live-ISO checks. One grep
+  separates the two:
+
+  ```
+  passing: ==> Found canonical offline image ghcr.io/... — bootcDirect
+  failing: ==> No local image in offline store, falling back to network pull
+  ```
+
+  Note also that `(mount failed)` in the offline-store diagnostics is **benign**
+  — it means "already mounted", and passing cells print it too.
+
+**Two different denominators, on purpose.** LUKS E2E is measured against
+`build_image` (every published desktop image), because `luks-e2e.yml` builds its
+matrix that way: the browser ISO builder can make an ISO from any image, so
+image-only variants (`sailfin`, `guppy`, `flounder-sid`) need boot and install
+coverage too. Installer smoke is measured against `build_iso`. The two totals
+answer different questions and should not be compared directly.
 
 ---
 

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -53,8 +53,8 @@ def gh_json(*args: str):
     return json.loads(out) if out.strip() else None
 
 
-def iso_matrix() -> dict[str, set[str]]:
-    """variant -> {flavors with build_iso: true}, from build-config.yml."""
+def _matrix(key: str, desktops_only: bool) -> dict[str, set[str]]:
+    """variant -> {flavors where <key> is true}, from build-config.yml."""
     try:
         import yaml
     except ImportError:
@@ -63,11 +63,34 @@ def iso_matrix() -> dict[str, set[str]]:
     out: dict[str, set[str]] = {}
     for variant in cfg.get("variants", []):
         flavors = {
-            f["id"] for f in variant.get("flavors", []) if f.get("build_iso")
+            f["id"]
+            for f in variant.get("flavors", [])
+            if f.get(key) and (not desktops_only or f["id"] in DESKTOPS)
         }
         if flavors:
             out[variant["id"]] = flavors
     return out
+
+
+def iso_matrix() -> dict[str, set[str]]:
+    """Cells that ship an ISO. The denominator for installer smoke."""
+    return _matrix("build_iso", desktops_only=False)
+
+
+def luks_matrix() -> dict[str, set[str]]:
+    """Cells LUKS E2E actually covers — the denominator for that axis.
+
+    luks-e2e.yml builds its matrix from build_image, NOT build_iso, and says
+    why: the browser ISO builder makes an ISO from any published image, so
+    image-only variants (sailfin, guppy, flounder-sid) need boot+install
+    coverage too. Measuring that axis against build_iso understated the work
+    being done and forced a "promote any result over not-built" special case
+    in cell() to stop sailfin's four tested cells from vanishing.
+
+    Using the workflow's own definition removes the special case: a cell is in
+    the LUKS denominator exactly when luks-e2e.yml would schedule it.
+    """
+    return _matrix("build_image", desktops_only=True)
 
 
 def latest_results(workflow: str, name_re: str) -> dict[str, tuple[str, str, str]]:
@@ -186,7 +209,13 @@ def nvidia_tally(matrix, results, key_fmt):
 
 
 def build() -> str:
+    # Two different denominators on purpose — each axis is measured against the
+    # set of cells that axis actually schedules. Sharing one matrix made the
+    # LUKS numbers wrong in both directions: image-only variants were missing
+    # from the total, while cells that ship no ISO were counted once a run
+    # happened to touch them.
     matrix = iso_matrix()
+    lmatrix = luks_matrix()
     luks = latest_results("luks-e2e.yml", r"^LUKS ")
     smoke = latest_results("installer-smoke.yml", r":")
     tags = overlay_tags()
@@ -209,19 +238,29 @@ def build() -> str:
     ]
 
     # ── LUKS ────────────────────────────────────────────────────────────────
-    total, tested, passed = tally(matrix, luks, luks_key)
-    nv_stale = nvidia_tally(matrix, luks, luks_key)
+    total, tested, passed = tally(lmatrix, luks, luks_key)
+    nv_stale = nvidia_tally(lmatrix, luks, luks_key)
     out += [
         "## LUKS E2E",
         "",
-        f"**{passed} of {total}** non-NVIDIA ISO cells green "
+        f"**{passed} of {total}** cells green "
         f"({tested} tested, {total - tested} never tested).",
         "",
+        "Measured against the set `luks-e2e.yml` schedules: every published "
+        "desktop image (`build_image`), not only the ones that ship an ISO. "
+        "That is wider than the ISO matrix below on purpose — the browser ISO "
+        "builder can make an ISO from any image, so image-only variants "
+        "(`sailfin`, `guppy`, `flounder-sid`) need boot and install coverage "
+        "too.",
+        "",
     ]
-    out += desktop_table(matrix, luks, luks_key)
+    out += desktop_table(lmatrix, luks, luks_key)
+    # Unconditional: the blank line used to live inside the NVIDIA block, so
+    # when no stale NVIDIA results remained the next paragraph butted straight
+    # up against the table.
+    out += [""]
     if nv_stale:
         out += [
-            "",
             f"NVIDIA cells are **out of scope** for this workflow — "
             f"`luks-e2e.yml` excludes them deliberately, because `-nvidia` "
             f"takes the identical LUKS path in headless QEMU. "

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -253,12 +253,14 @@ def build() -> str:
         f"**{passed} of {total}** cells green "
         f"({tested} tested, {total - tested} never tested).",
         "",
-        "Measured against the set `luks-e2e.yml` schedules: every published "
-        "desktop image (`build_image`), not only the ones that ship an ISO. "
-        "That is wider than the ISO matrix below on purpose — the browser ISO "
-        "builder can make an ISO from any image, so image-only variants "
-        "(`sailfin`, `guppy`, `flounder-sid`) need boot and install coverage "
-        "too.",
+        (
+            "Measured against the set `luks-e2e.yml` schedules: every published "
+            "desktop image (`build_image`), not only the ones that ship an ISO. "
+            "That is wider than the ISO matrix below on purpose — the browser ISO "
+            "builder can make an ISO from any image, so image-only variants "
+            "(`sailfin`, `guppy`, `flounder-sid`) need boot and install coverage "
+            "too."
+        ),
         "",
     ]
     out += desktop_table(lmatrix, luks, luks_key)

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -239,7 +239,14 @@ def build() -> str:
 
     # ── LUKS ────────────────────────────────────────────────────────────────
     total, tested, passed = tally(lmatrix, luks, luks_key)
-    nv_stale = nvidia_tally(lmatrix, luks, luks_key)
+    # NOT lmatrix: it is desktops_only, so no flavor in it can ever contain
+    # "nvidia" and the stale count would be a permanent 0 — silently deleting
+    # the out-of-scope disclosure below, while section 3 still points at it.
+    # That is exactly the absence-of-evidence failure this document exists to
+    # prevent, so count over every published flavor instead.
+    nv_stale = nvidia_tally(
+        _matrix("build_image", desktops_only=False), luks, luks_key
+    )
     out += [
         "## LUKS E2E",
         "",


### PR DESCRIPTION
## The bug

LUKS E2E was scored against `build_iso`. But `luks-e2e.yml` builds its matrix from **`build_image`**, deliberately, and says why in a comment:

> the browser ISO builder makes ISOs from any image, so image-only variants (sailfin, guppy, flounder-sid) need boot+install coverage too

Using the wrong denominator was wrong in **both** directions:

- Image-only variants were missing from the total. That is why `cell()` carried a "promote any real result over not-built" special case — it existed to stop `sailfin`'s four tested cells from silently vanishing. A workaround for the wrong denominator, not a feature.
- Once a sweep ran with `flavor=all`, cells that ship no ISO started being counted as *ISO* coverage.

## The check that it is right now

The headline moves from **12 of 37** to **15 of 50** — and **50 is exactly the number of cells the last full sweep dispatched** ([30249218614](https://github.com/tuna-os/tunaOS/actions/runs/30249218614)). The denominator now equals the set the workflow schedules, which is the property that was missing.

Installer smoke keeps `build_iso`; it answers a different question. The doc now says so explicitly, so the two totals are not compared by mistake.

## Also in here

- **Markdown fix**: the blank line after the LUKS table lived *inside* the NVIDIA block, so once no stale NVIDIA results remained the next paragraph butted straight up against the table.
- **New entry in "failures that look like successes"**: the offline-store fallback trap. A cell fails with a ghcr.io TLS timeout after 4 retries — but the cause is a wrong probe name 90 lines earlier, and the cell had already passed its live-ISO checks. Nine cells in the last sweep looked like a flaky registry and were not. Also records that `(mount failed)` in those diagnostics is benign ("already mounted") and appears in passing cells too.

## Verification

`--check` is idempotent against live CI data, and `py_compile` is clean.

> **Note on the PR drift check**: it regenerates from the live Actions API, so it can legitimately fail while a sweep is mid-flight and cells are still flipping. That is pre-existing behaviour, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvVVtmk8CqW8x643B6m84

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->