### PR TITLE
fix(build): skip chunkah on images that have no rpmdb

### DIFF
--- a/scripts/build-image-inner.sh
+++ b/scripts/build-image-inner.sh
@@ -166,6 +166,34 @@ if ! podman image inspect "${CHUNKAH_IMAGE}" &>/dev/null; then
 	fi
 fi
 
+# chunkah is a CoreOS tool and unconditionally loads an rpmdb from the rootfs it
+# is given. On an image that has none it does not degrade — it aborts:
+#
+#   error: cannot open Packages database in /proc/self/fd/4/var/lib/rpm
+#   Error: loading components
+#   Caused by: 0: loading rpmdb  1: loading rpmdb from rootfs
+#
+# That killed 9 cells of LUKS sweep 30249218614: flounder and flounder-sid
+# (Debian) and marlin (Arch). Rechunking is a layer-layout optimisation, so
+# skipping it costs some dedup on those variants and nothing else — whereas
+# attempting it costs the entire build.
+#
+# Probe the image rather than hardcoding a variant list: a new distro then gets
+# the right behaviour without anyone remembering to update this file. Both rpmdb
+# locations are checked because rpm-based distros are mid-migration from
+# /var/lib/rpm to /usr/lib/sysimage/rpm. Emptiness, not existence, is the test —
+# a bind mount during the build leaves an empty /var/lib/rpm directory committed
+# in the image even though its contents were never part of it.
+if ! podman run --rm --entrypoint="" \
+	--mount "type=image,source=${PRE_CHUNK_TAG},target=/img" \
+	"${CHUNKAH_IMAGE}" sh -c '
+		[ -n "$(ls -A /img/usr/lib/sysimage/rpm 2>/dev/null)" ] ||
+		[ -n "$(ls -A /img/var/lib/rpm 2>/dev/null)" ]'; then
+	echo "==> ${PRE_CHUNK_TAG} has no rpmdb — skipping chunkah (not an rpm image)"
+	${BUILDER} tag "${PRE_CHUNK_TAG}" "${IMAGE_TAG}"
+	exit 0
+fi
+
 CHUNK_OUT=$(mktemp -d)
 # Some base images (e.g. Gentoo stage3) bake static device nodes into their
 # layers. Those can't be reliably deleted via `rm` in a later Containerfile


### PR DESCRIPTION
## What

`chunkah` is a CoreOS tool and **unconditionally loads an rpmdb** from the rootfs it is given. On an image that has none it does not degrade — it aborts:

```
error: cannot open Packages database in /proc/self/fd/4/var/lib/rpm
Error: loading components
Caused by: 0: loading rpmdb  1: loading rpmdb from rootfs
```

## Why it matters

This is the **single largest cause of red cells** in LUKS sweep [30249218614](https://github.com/tuna-os/tunaOS/actions/runs/30249218614) — nine of them:

| variant | base | cells |
|---|---|---|
| `flounder` | Debian trixie | gnome, kde, niri |
| `flounder-sid` | Debian sid | gnome, kde, niri, xfce |
| `marlin` | Arch | gnome, kde |

Every affected variant is non-rpm. Rechunking is a layer-layout optimisation, so skipping it costs some dedup on those variants and nothing else — whereas attempting it costs the entire build.

## Approach

Probe the image rather than hardcoding a variant list, so a new distro gets the right behaviour without anyone remembering to update this file.

Two details that matter:

- **Both rpmdb locations are checked**, because rpm distros are mid-migration from `/var/lib/rpm` to `/usr/lib/sysimage/rpm`.
- **The test is emptiness, not existence.** A build-time bind mount leaves an empty `/var/lib/rpm` *directory* committed in the image even though its contents never were — which is precisely how a Debian image ends up with a `/var/lib/rpm` at all. (See #865, which stops emitting that mount for non-dnf variants; this fix is correct with or without it.)

## Verification

Ran the exact probe against real images:

```
debian:trixie          -> skip       (flounder's base)
empty /var/lib/rpm     -> skip       (the bind-mount artifact)
fedora:latest          -> rechunk
opensuse/tumbleweed    -> rechunk    (sailfin keeps current behaviour)
```

`shellcheck` and `bash -n` clean.

## Relationship to the other open fixes

Together with #865 (dnf caches into non-dnf variants) and #866 (published image ref), these three cover **23 of the 35 red cells** in the last sweep. Remaining and still unresolved: `skipjack` ×5 (offline store populated but `podman images` empty), `grouper` ×4 (dracut `tpm2-tss`, plus two cells where SSH never comes up), and `marlin` cosmic/niri/xfce (manifests genuinely lack a `pacman` list — the #857 gate working as designed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvVVtmk8CqW8x643B6m84

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->