### PR TITLE
feat(marlin): add Arch desktop manifests for cosmic, niri and xfce

### DIFF
--- a/manifests/desktops/cosmic-arch.yaml
+++ b/manifests/desktops/cosmic-arch.yaml
@@ -1,0 +1,74 @@
+# COSMIC Desktop Manifest — Arch Linux / CachyOS
+#
+# Arch ships COSMIC in [extra], but two names differ from the Fedora set in
+# cosmic.yaml: cosmic-term is `cosmic-terminal` and cosmic-edit is
+# `cosmic-text-editor`. Using the Fedora names fails the whole build, because
+# pacman aborts the transaction on the first unknown target — the same way an
+# AUR-only package took marlin:kde down (tuna-os/tunaos-packages#126).
+#
+# Every package below was verified present in core/extra for x86_64.
+
+display_manager: greetd
+
+packages:
+  pacman:
+    # Session and compositor
+    - cosmic-session
+    - cosmic-comp
+    - cosmic-greeter
+    - greetd
+    # Shell surfaces
+    - cosmic-panel
+    - cosmic-app-library
+    - cosmic-applets
+    - cosmic-bg
+    - cosmic-launcher
+    - cosmic-notifications
+    - cosmic-osd
+    - cosmic-workspaces
+    - cosmic-idle
+    # Settings and tooling
+    - cosmic-settings
+    - cosmic-settings-daemon
+    - cosmic-randr
+    - cosmic-screenshot
+    # Applications
+    - cosmic-files
+    - cosmic-terminal
+    - cosmic-text-editor
+    - cosmic-store
+    # Theming
+    - cosmic-icon-theme
+    - cosmic-wallpapers
+    - pop-icon-theme
+    # Integration
+    - xdg-desktop-portal-cosmic
+    - xdg-desktop-portal-gtk
+    - xdg-user-dirs
+    - networkmanager
+    - pipewire
+    - wireplumber
+    - flatpak
+    - wl-clipboard
+    - power-profiles-daemon
+    - fwupd
+    - plymouth
+
+  # CachyOS adds its own repos on top of Arch — same pacman packages
+  # but with performance-optimized builds.
+  cachyos:
+    repos:
+      - name: cachyos
+        url: "https://mirror.cachyos.org/repo/$arch/cachyos"
+      - name: cachyos-extra
+        url: "https://mirror.cachyos.org/repo/$arch/cachyos-extra"
+    packages:
+      - linux-cachyos
+      - linux-cachyos-headers
+      - cachyos-settings
+
+versionlock: []
+
+# Post-install scripts to source (relative to build_scripts/)
+post_install:
+  - tuna-flatpak-remote.sh

--- a/manifests/desktops/niri-arch.yaml
+++ b/manifests/desktops/niri-arch.yaml
@@ -1,0 +1,68 @@
+# niri Desktop Manifest — Arch Linux / CachyOS
+#
+# niri.yaml builds the Fedora set out of three COPRs (yalter/niri-git,
+# avengemedia/danklinux, avengemedia/dms-git). Arch ships niri itself in
+# [extra], so no third-party repo is needed here — but the DankMaterialShell
+# pieces (quickshell, dms, dms-greeter) have no Arch equivalent in the official
+# repos, so this is a plain niri session rather than a DMS one.
+#
+# Two name differences from the Fedora list: SwayNotificationCenter is `swaync`
+# and adw-gtk3-theme is `adw-gtk-theme`.
+#
+# Every package below was verified present in core/extra for x86_64.
+
+display_manager: greetd
+
+packages:
+  pacman:
+    # Compositor and session
+    - niri
+    - greetd
+    - xwayland-satellite
+    # Shell surfaces
+    - waybar
+    - fuzzel
+    - swaync
+    - swaylock
+    - swayidle
+    # Integration
+    - xdg-desktop-portal-gnome
+    - xdg-desktop-portal-gtk
+    - xdg-user-dirs
+    - xdg-user-dirs-gtk
+    - polkit-gnome
+    - gnome-keyring
+    - wl-clipboard
+    # Hardware and media controls
+    - networkmanager
+    - pipewire
+    - wireplumber
+    - pavucontrol
+    - brightnessctl
+    - playerctl
+    - blueman
+    - power-profiles-daemon
+    - fwupd
+    - plymouth
+    # Applications and theming
+    - nautilus
+    - flatpak
+    - adw-gtk-theme
+    - papirus-icon-theme
+
+  cachyos:
+    repos:
+      - name: cachyos
+        url: "https://mirror.cachyos.org/repo/$arch/cachyos"
+      - name: cachyos-extra
+        url: "https://mirror.cachyos.org/repo/$arch/cachyos-extra"
+    packages:
+      - linux-cachyos
+      - linux-cachyos-headers
+      - cachyos-settings
+
+versionlock: []
+
+# Post-install scripts to source (relative to build_scripts/)
+post_install:
+  - tuna-flatpak-remote.sh

--- a/manifests/desktops/niri-arch.yaml
+++ b/manifests/desktops/niri-arch.yaml
@@ -11,6 +11,13 @@
 #
 # Every package below was verified present in core/extra for x86_64.
 
+# CAVEAT: greetd here has no greeter UI. Fedora gets dms-greeter from COPR;
+# Arch has no official equivalent, so greetd.service exists (which is what the
+# #857 desktop-contract gate checks) but nothing draws a login screen. LUKS E2E
+# never looks at the screen — it drives fisherman over SSH — so marlin:niri can
+# go green while booting to a blank greetd. Do not read a green LUKS cell here
+# as "the session is usable"; that needs installer smoke on a GPU host.
+# Tracked alongside the other niri packaging gaps.
 display_manager: greetd
 
 packages:

--- a/manifests/desktops/xfce-arch.yaml
+++ b/manifests/desktops/xfce-arch.yaml
@@ -1,0 +1,71 @@
+# XFCE Desktop Manifest — Arch Linux / CachyOS
+#
+# xfce.yaml installs Fedora's `xfce-desktop` group. Arch has an `xfce4` group
+# too, but groups expand to whatever the mirror holds on the day and pacman
+# --noconfirm takes all of it, so the set is listed explicitly here instead —
+# a build should not change shape because a group gained a member upstream.
+#
+# Note this is the X11 xfwm4 session. tunaOS prefers a Wayland compositor for
+# XFCE where one exists (xfwl4/labwc, see live-iso/common/src/desktop-xfce.sh),
+# and Arch has no xfwl4 package — so on marlin, XFCE is X11 only until
+# tuna-os/tunaos-packages#123 lands.
+#
+# Every package below was verified present in core/extra for x86_64.
+
+display_manager: gdm
+
+packages:
+  pacman:
+    # Core session
+    - xfce4-session
+    - xfwm4
+    - xfce4-panel
+    - xfce4-settings
+    - xfce4-appfinder
+    - xfconf
+    - xfdesktop
+    - gdm
+    # Panel plugins and daemons
+    - xfce4-power-manager
+    - xfce4-notifyd
+    - xfce4-screenshooter
+    - xfce4-taskmanager
+    - xfce4-pulseaudio-plugin
+    # Applications
+    - thunar
+    - thunar-volman
+    - thunar-archive-plugin
+    - xfce4-terminal
+    - mousepad
+    - ristretto
+    - file-roller
+    # Integration
+    - xdg-desktop-portal-gtk
+    - xdg-user-dirs
+    - xdg-user-dirs-gtk
+    - network-manager-applet
+    - networkmanager
+    - pipewire
+    - wireplumber
+    - flatpak
+    - wl-clipboard
+    - power-profiles-daemon
+    - fwupd
+    - plymouth
+
+  cachyos:
+    repos:
+      - name: cachyos
+        url: "https://mirror.cachyos.org/repo/$arch/cachyos"
+      - name: cachyos-extra
+        url: "https://mirror.cachyos.org/repo/$arch/cachyos-extra"
+    packages:
+      - linux-cachyos
+      - linux-cachyos-headers
+      - cachyos-settings
+
+versionlock: []
+
+# Post-install scripts to source (relative to build_scripts/)
+post_install:
+  - tuna-flatpak-remote.sh


### PR DESCRIPTION
## What

`cosmic.yaml`, `niri.yaml` and `xfce.yaml` have no `pacman` section and no `-arch` sibling, so on Arch `install-desktop.sh` had nothing to install. Before #857 that silently produced an image tagged for a desktop **with no desktop in it**. The gate added there now fails loudly instead:

```
ERROR: /run/context/manifests/desktops/cosmic.yaml has no .packages.pacman list.
```

That is three red cells in sweep [30249218614](https://github.com/tuna-os/tunaOS/actions/runs/30249218614) (`marlin` cosmic/niri/xfce) — **the gate working as designed, not a regression**. This PR supplies the missing lists.

## Verification

All **74 packages** were checked against the Arch `core`/`extra` databases directly (not the rate-limited search API), because pacman aborts the entire transaction on the first unknown target. That exact failure mode already cost us `marlin:kde`, which served a stale image for days after an AUR-only package got into `kde-arch.yaml` (tuna-os/tunaos-packages#126).

```
cosmic-arch.yaml: 35 packages, dm=greetd
niri-arch.yaml:   29 packages, dm=greetd
xfce-arch.yaml:   32 packages, dm=gdm
ALL PACKAGES PRESENT in Arch core/extra
```

Name differences that would have broken a copy-paste of the Fedora lists:

| Fedora | Arch |
|---|---|
| `cosmic-term` | `cosmic-terminal` |
| `cosmic-edit` | `cosmic-text-editor` |
| `SwayNotificationCenter` | `swaync` |
| `adw-gtk3-theme` | `adw-gtk-theme` |

## Deliberate scope limits (documented in the files)

- **niri** — Arch ships `niri` in `[extra]`, so no COPR equivalent is needed. But the DankMaterialShell pieces (`quickshell`, `dms`, `dms-greeter`) have no official Arch package, so this is a plain niri session rather than a DMS one.
- **xfce** — Arch has no `xfwl4`, so marlin gets the X11 `xfwm4` session until tuna-os/tunaos-packages#123 lands. The package set is listed explicitly rather than installing the `xfce4` group, so a build does not change shape because a group gained a member upstream.

## Note

This unblocks the *manifest* gate only. `marlin` gnome/kde currently fail later, at chunkah (#869), so these three cells will not go green until that lands too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvVVtmk8CqW8x643B6m84

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->