### PR TITLE
fix(grouper): install the TPM2 userspace so dracut can build an initramfs

### DIFF
--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -97,13 +97,29 @@ COPY --from=bootc-builder /output /
 
 # Install bootc dependencies and the bootc runtime tooling needed for
 # `bootc container lint`, plus the static composefs/bootc overlay. apt intact.
+#
+# The tpm2/tss2 packages are here because dracut's tpm2-tss module is part of
+# Ubuntu's default module set, and dracut treats a requested-but-unsatisfiable
+# module as fatal rather than skipping it:
+#
+#   dracut[E]: Module 'tpm2-tss' cannot be installed.
+#
+# That killed every grouper build that reached finalize.sh. Installing the TPM2
+# userspace is the right resolution rather than omitting the module — LUKS
+# auto-unlock is enrolled post-install (`ujust enable-luks-tpm2`), so the
+# initramfs has to be able to talk to the TPM when that happens.
+#
+# The t64 suffixes are Ubuntu's 64-bit time_t transition; the unsuffixed names
+# do not exist in resolute. All five were verified against the base image.
 RUN --mount=type=bind,from=context,source=/,target=/run/context \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
         ca-certificates curl gpg \
         ostree libostree-1-1 dracut \
         btrfs-progs dosfstools e2fsprogs xfsprogs skopeo jq \
-        systemd-boot systemd-boot-efi dmsetup && \
+        systemd-boot systemd-boot-efi dmsetup \
+        tpm2-tools libtss2-tcti-device0t64 libtss2-tctildr0t64 \
+        libtss2-rc0t64 libtss2-esys-3.0.2-0t64 && \
     cp -a /run/context/build_scripts/bootc/sandbox/. / && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## What

Every `grouper` build that reached `finalize.sh` died here:

```
dracut[E]: Module 'tpm2-tss' cannot be installed.
```

dracut's `73tpm2-tss` check is literally `require_binaries tpm2 || return 1`, and `ubuntu:resolute` ships no `tpm2` binary. A module that fails `check()` is **fatal rather than skipped** once something depends on it, so the initramfs build — and with it the whole image — stopped.

## Why install rather than omit

Omitting `tpm2-tss` would also make the build pass, but it trades a loud build failure for a silently unbootable encrypted system later. LUKS auto-unlock is enrolled *after* install (`ujust enable-luks-tpm2`), so the initramfs must be able to talk to the TPM when that happens.

## Verification

Against `docker.io/library/ubuntu:resolute` — the actual base image, not a guess:

```
before: tpm2 ABSENT
after:  /usr/bin/tpm2, version 5.7, tctis="libtss2-tctildr"
```

The reported tcti confirms `libtss2-tctildr0t64` is genuinely used rather than added on spec.

The `t64` suffixes are Ubuntu's 64-bit `time_t` transition — the unsuffixed names (`libtss2-tcti-device0`, `libtss2-tctildr0`, `libtss2-mu0`) do not exist in resolute at all. I checked each against the image; `libtss2-mu0t64` does not exist either and is not included.

## Scope — corrected

This accounts for **`LUKS grouper:gnome` only**.

I originally claimed `grouper:niri` too. That was wrong, and re-reading its log disproves it: `grouper:niri` contains **zero** `tpm2-tss` occurrences and fails at a different step entirely — a corrupted chezmoi download in `00-copy-files.sh`:

```
+ sha256sum -c -
sha256sum: WARNING: 1 computed checksum did NOT match
/tmp/chezmoi_2.71.1_linux_amd64.deb: FAILED
```

The pin is not stale — `grouper:gnome` fetched the same file successfully in the same sweep — so this is a truncated transfer that `curl --fail` did not catch. Worth hardening separately; not part of this PR.

Also not fixed here: `grouper:kde` and `grouper:xfce`, where the ISO builds but SSH never comes up in the live environment (`ERROR: SSH not available` after 7 retries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvVVtmk8CqW8x643B6m84