### PR TITLE
diag(e2e): log why podman drops an additional image store

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -873,6 +873,24 @@ run_install() {
 	echo "--- podman images (all) ---"
 	"${ssh_cmd[@]}" "sudo podman images 2>&1 || echo '(empty or error)'" || true
 
+	# skipjack fails here in a way the dump above cannot explain: the store is
+	# mounted, storage.conf lists it in additionalimagestores, overlay-images/
+	# holds an image directory and images.json — and `podman images` is still
+	# empty. Structurally identical to a passing cell, so comparing the two
+	# dumps does not converge.
+	#
+	# These two do. podman logs at debug level *why* it drops an additional
+	# image store (driver mismatch, unreadable lock, version skew); images.json
+	# is ~1 KB and states the names actually recorded, which distinguishes
+	# "store ignored" from "image recorded under a name we never probe".
+	echo "--- why podman does or does not see the additional store ---"
+	"${ssh_cmd[@]}" "sudo podman --log-level=debug images 2>&1 \
+		| grep -iE 'additional|superiso|store|driver' | head -40 \
+		|| echo '(no matching debug lines)'" || true
+	echo "--- names recorded in the offline store ---"
+	"${ssh_cmd[@]}" "sudo cat /var/lib/superiso-store/overlay-images/images.json 2>&1 \
+		|| echo '(unreadable)'" || true
+
 	# Probe the guest's containers-storage for a locally-available image.
 	local found_local=0 found_ref=""
 	for candidate_ref in "$prod_ref" "$local_ref"; do


### PR DESCRIPTION
## Why

`skipjack`'s five LUKS cells fail in a way the existing diagnostics **cannot** explain. The store is mounted, `storage.conf` lists it in `additionalimagestores`, `overlay-images/` holds an image directory and an `images.json` — and `podman images` is still empty, so the harness falls back to a network pull and dies 40 minutes later.

Side by side with a passing cell, the dumps are structurally identical:

```
                       yellowfin:gnome (pass)      skipjack:kde (fail)
store service          active (exited)             active (exited)
findmnt                /dev/loop1 squashfs         /dev/loop1 squashfs
additionalimagestores  ["/var/lib/superiso-store"] same
overlay-images/        1 image dir + images.json   1 image dir + images.json
graphDriverName        overlay                     overlay
podman images          1 image, R/O true           EMPTY
```

Comparing those two does not converge on a cause. Guessing from them is what I would otherwise be doing, and this cell has already burned two sweeps.

## What

Two commands that turn the guess into a read:

- `podman --log-level=debug images` — podman logs *why* it drops an additional image store (driver mismatch, unreadable lock, version skew). Filtered to the relevant lines so the log stays readable.
- `cat overlay-images/images.json` — ~1 KB, and it states the names actually recorded. That separates **"store ignored entirely"** from **"image recorded under a name we never probe for"**, which are different bugs with different fixes.

Note the second one is a real possibility here and not idle: #866 fixes exactly that class of mismatch for `bonito-rawhide`, where the ISO embedded `bonito:gnome-rawhide` while the harness probed `bonito-rawhide:gnome`. `skipjack`'s ref looked correct, but `images.json` is the way to confirm rather than assume.

## Scope

Diagnostics only — no behaviour change, nothing gated on the output. The surrounding block is already marked `debug: remove once stable`; this goes with it when that happens.

`bash -n` clean; no new shellcheck findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjvVVtmk8CqW8x643B6m84

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->