### PR TITLE
fix(build): bypass PGP check when bootstrapping cachyos-keyring package

### DIFF
--- a/build_scripts/overlay/cachyos.sh
+++ b/build_scripts/overlay/cachyos.sh
@@ -11,12 +11,16 @@ set -xeuo pipefail
 pacman-key --init || true
 pacman-key --populate archlinux || true
 
+# Fetch and lsign CachyOS key from key server
+pacman-key --recv-keys F3B607488DB35A47 --keyserver keyserver.ubuntu.com || true
+pacman-key --lsign-key F3B607488DB35A47 || true
+
 # Fetch and install CachyOS keyring and mirrorlists directly
 mirror_url="https://mirror.cachyos.org/repo/x86_64/cachyos"
-pacman -U --noconfirm \
+pacman -U --noconfirm --config <(echo -e "[options]\nSigLevel = Never") \
 	"${mirror_url}/cachyos-keyring-20240331-1-any.pkg.tar.zst" \
 	"${mirror_url}/cachyos-mirrorlist-27-1-any.pkg.tar.zst" \
-	"${mirror_url}/cachyos-v3-mirrorlist-27-1-any.pkg.tar.zst" || true
+	"${mirror_url}/cachyos-v3-mirrorlist-27-1-any.pkg.tar.zst"
 
 # Add cachyos repository definitions to pacman.conf if missing
 if ! grep -q "^\[cachyos\]" /etc/pacman.conf; then


### PR DESCRIPTION
Uses `--config <(echo -e '[options]\nSigLevel = Never')` when installing the initial `cachyos-keyring` package via `pacman -U` to bootstrap keyring trust without requiring pre-existing GPG signatures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->