### PR TITLE
fix(build): preserve DBPath/RootDir settings during cachyos-keyring pacman -U bootstrap

### DIFF
--- a/build_scripts/overlay/cachyos.sh
+++ b/build_scripts/overlay/cachyos.sh
@@ -15,12 +15,19 @@ pacman-key --populate archlinux || true
 pacman-key --recv-keys F3B607488DB35A47 --keyserver keyserver.ubuntu.com || true
 pacman-key --lsign-key F3B607488DB35A47 || true
 
+# Ensure pacman database directory structure exists
+mkdir -p /var/lib/pacman /usr/lib/sysimage/lib/pacman
+
 # Fetch and install CachyOS keyring and mirrorlists directly
 mirror_url="https://mirror.cachyos.org/repo/x86_64/cachyos"
-pacman -U --noconfirm --config <(echo -e "[options]\nSigLevel = Never") \
+tmpconf="$(mktemp)"
+cp /etc/pacman.conf "$tmpconf"
+sed -i 's/SigLevel *=.*/SigLevel = Never/' "$tmpconf" || true
+pacman -U --noconfirm --config "$tmpconf" \
 	"${mirror_url}/cachyos-keyring-20240331-1-any.pkg.tar.zst" \
 	"${mirror_url}/cachyos-mirrorlist-27-1-any.pkg.tar.zst" \
 	"${mirror_url}/cachyos-v3-mirrorlist-27-1-any.pkg.tar.zst"
+rm -f "$tmpconf"
 
 # Add cachyos repository definitions to pacman.conf if missing
 if ! grep -q "^\[cachyos\]" /etc/pacman.conf; then


### PR DESCRIPTION
Copies `/etc/pacman.conf` to a temporary config file and modifies `SigLevel = Never` in-place rather than using process substitution `<(echo ...)`, which stripped `DBPath` and `RootDir` settings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->