### PR TITLE
fix(build): replace mkinitcpio with dracut --force in cachyos overlay

### DIFF
--- a/build_scripts/overlay/cachyos.sh
+++ b/build_scripts/overlay/cachyos.sh
@@ -46,5 +46,6 @@ pacman -Syu --noconfirm --needed \
 install -D /dev/null /etc/cachyos-release
 printf 'CachyOS\n' >/etc/cachyos-release
 
-mkinitcpio -P
+# Rebuild initramfs via dracut
+dracut --force "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v '\.img' | tail -1)/initramfs.img"
 pacman -Scc --noconfirm || true


### PR DESCRIPTION
Replaces `mkinitcpio -P` (which fails with command not found in the Arch/bootc container) with `dracut --force` for initramfs generation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->