### PR TITLE
fix(build): add tpm2-tss package to cachyos overlay

### DIFF
--- a/build_scripts/overlay/cachyos.sh
+++ b/build_scripts/overlay/cachyos.sh
@@ -40,7 +40,7 @@ fi
 
 pacman -Syu --noconfirm --needed \
 	cachyos-keyring cachyos-mirrorlist cachyos-settings \
-	linux-cachyos linux-cachyos-headers
+	linux-cachyos linux-cachyos-headers tpm2-tss
 
 # Mark as CachyOS-augmented for install-desktop.sh detection
 install -D /dev/null /etc/cachyos-release


### PR DESCRIPTION
Adds `tpm2-tss` to the pacman package list in `cachyos.sh` to satisfy dracut's module dependency.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->