### PR TITLE
fix(iso-e2e): don't pass an ISO the serial log says failed to boot

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -625,6 +625,40 @@ screenshot_compare() {
 	fi
 }
 
+# Did the serial log say, in so many words, that the boot failed?
+#
+# The screenshot fallback below exists because bootc base kernels ship
+# CONFIG_SERIAL_8250=m and a healthy live session often cannot get
+# TUNAOS_LIVE_READY onto the serial console. What it cannot distinguish is a
+# healthy session from a dracut emergency shell: that renders text too, so
+# the framebuffer is "sane" and the run passes.
+#
+# That is not hypothetical. marlin:kde-cachyos sat in `Dracut Emergency
+# Shell` after `/run/tacklebox-live-done does not exist` / `Could not boot`,
+# and this script still exited 0. A gate that green-lights an ISO in an
+# emergency shell is worse than no gate, especially as the input to a LUKS
+# matrix where every cell would inherit the same false pass.
+#
+# So: absence of the marker stays recoverable, but *evidence of failure* does
+# not. These signatures are unambiguous — no healthy boot prints them.
+boot_failed_on_serial() {
+	[[ -f "$SERIAL_LOG" ]] || return 1
+	local sig
+	for sig in \
+		"Entering emergency mode" \
+		"Dracut Emergency Shell" \
+		"Warning: Could not boot" \
+		"Kernel panic" \
+		"You are in emergency mode"; do
+		if grep -qF "$sig" "$SERIAL_LOG" 2>/dev/null; then
+			echo "ERROR: serial log shows a failed boot: ${sig}" >&2
+			echo "       refusing to pass on the screenshot fallback." >&2
+			return 0
+		fi
+	done
+	return 1
+}
+
 # Sanity-check a captured screenshot: it must exist and show actual content
 # (not a black/blank framebuffer). Used as the readiness fallback when the
 # serial marker never arrives — the bootc base kernels ship
@@ -1311,7 +1345,7 @@ ready)
 	# console support; fall back to verifying the framebuffer actually
 	# rendered a screen. Hard failures (blank/absent screenshot) stay fatal
 	# so this exit code can gate publishing.
-	if [[ "$rc" -ne 0 ]] && screenshot_sane "10-ready"; then
+	if [[ "$rc" -ne 0 ]] && ! boot_failed_on_serial && screenshot_sane "10-ready"; then
 		echo "::warning::readiness marker not seen on serial console; screenshot sanity check passed — treating as ready"
 		rc=0
 	fi


### PR DESCRIPTION
## The bug

`scripts/iso-e2e.sh` exits **0** for an ISO sitting in a dracut emergency shell. `marlin:kde-cachyos` did exactly that today:

```
Warning: /run/tacklebox-live-done does not exist
Warning: Could not boot.
Entering emergency mode.
...
::warning::readiness marker not seen on serial console;
           screenshot sanity check passed — treating as ready
HARNESS_EXIT=0
```

## Why the fallback isn't itself wrong

bootc base kernels ship `CONFIG_SERIAL_8250=m`, so a healthy live session frequently *cannot* get `TUNAOS_LIVE_READY` onto the serial console. Without the screenshot fallback those images could never pass, so removing it isn't the fix.

What it can't do is tell a healthy session from an emergency shell — that renders text too, so the framebuffer is "sane" and the run passes.

## The change

Absence of the marker stays recoverable; **evidence of failure does not**. `boot_failed_on_serial` greps for signatures no healthy boot ever prints and blocks the fallback when it finds one:

- `Entering emergency mode`
- `Dracut Emergency Shell`
- `Warning: Could not boot`
- `Kernel panic`
- `You are in emergency mode`

## Verified against real logs, not in principle

Both serial logs captured today were run through the new guard:

| ISO | actual state | before | after |
|---|---|---|---|
| `marlin:kde-cachyos` | dracut emergency shell | pass ❌ | **fail** ✅ |
| `sailfin:base` | real boot to systemd, rootfs loop-mounted, no marker | pass | **pass** ✅ |

So the false pass is closed and the legitimate serial-less path is preserved.

## Why now

This gate is the input to the LUKS matrix (#763). Every cell inherits it, so a false pass here turns the whole matrix green while proving nothing — the same failure mode as `@full` never having run in iso-builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->