### PR TITLE
fix(luks-e2e): install crun with podman so the dev ISO build can start

### DIFF
--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -186,13 +186,30 @@ jobs:
           sudo udevadm trigger --name-match=kvm || true
           ls -la /dev/kvm 2>/dev/null && echo "KVM available" || echo "Warning: no /dev/kvm — TCG (slow)"
 
+      # crun is installed explicitly and in the same transaction as podman.
+      # Without it, podman comes from Ubuntu while crun comes from whatever
+      # the runner image happens to ship, and a mismatched pair fails every
+      # build at the first RUN with:
+      #
+      #   error running container: from /usr/bin/crun creating container for
+      #   [/bin/sh -c echo "${BUILD_SCRIPTS_HASH}" > /dev/null]:
+      #   unknown version specified
+      #
+      # That is crun rejecting the OCI spec version podman generated, not a
+      # build error, though it surfaces as one at a random RUN step — the
+      # same shape as the cgroup-manager failure documented below. It took
+      # out every cell of run 30520334279. reusable-build-image.yml dodges
+      # this by letting setup-runner install a matched podman stack
+      # (update-podman: "true"); this job installs from apt, so the pair has
+      # to be pinned together here.
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            just podman jq \
+            just podman crun jq \
             qemu-system-x86 qemu-utils ovmf swtpm socat sshpass imagemagick \
             systemd-boot-efi mtools squashfs-tools xorriso dosfstools gdisk
+          podman --version; crun --version | head -1
 
       # iso-e2e.sh resolves the published image ref through
       # scripts/published-image-ref.sh, which needs yq. Without it the script


### PR DESCRIPTION
## The failure

Every cell of run [30520334279](https://github.com/tuna-os/tunaOS/actions/runs/30520334279) died in **Build dev ISO**, before LUKS was ever exercised:

```
error running container: from /usr/bin/crun creating container for
[/bin/sh -c echo "${BUILD_SCRIPTS_HASH}" > /dev/null]:
unknown version specified
```

That's crun refusing the OCI spec version podman generated — a mismatched pair, not a build error, though it surfaces at a random `RUN` step. Exactly the same misleading shape as the cgroup-manager failure already documented in this file.

## Why it started now

The job apt-installs `podman` but never `crun`. So podman comes from Ubuntu and crun comes from whatever the runner image ships, with nothing pinning them to each other. That works until either side moves.

Evidence it's a drift, not a code change:

- single cells passed **yesterday** (runs 30484849112, 30472017143, 30470717735)
- **identical** runner image `20260707.563` and runner `2.336.0` in both the passing and failing jobs
- today's log shows apt fetching `podman_4.9.3+ds1-1ubuntu0.2` — i.e. it *upgraded* the preinstalled podman, leaving crun behind

`reusable-build-image.yml` doesn't hit this because it lets `projectbluefin/actions/bootc-build/setup-runner` install a matched stack (`update-podman: "true"`). This job installs from apt, so the pair gets pinned together here instead.

Both versions are now echoed, so the next mismatch is visible in the log rather than inferred from a crun error.

## Validation

Dispatching a single cell rather than the full matrix — running 11 cells to learn one bit is what the previous run already did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->