### PR TITLE
fix(live): create /usr/local/bin through the symlink, not into it

### DIFF
--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -385,7 +385,22 @@ ensure_dbus_daemon() {
 	FISHERMAN_BIN=$(find "/var/lib/flatpak/app/${INSTALLER_APP}" \
 		-path '*/files/bin/fisherman' -type f 2>/dev/null | head -1 || true)
 	if [[ -n "${FISHERMAN_BIN}" ]]; then
-		mkdir -p /usr/local/bin
+		# `mkdir -p /usr/local/bin` is not safe here. On the ostree/bootc layout
+		# /usr/local is a symlink to ../var/usrlocal, and /var/usrlocal does not
+		# exist in the image — mkdir -p refuses to create *through* a dangling
+		# symlink and dies with the confusing:
+		#
+		#   mkdir: cannot create directory ‘/usr/local’: File exists
+		#
+		# which killed the whole ISO build for sailfin:gnome in LUKS run
+		# 30522159277. Not every variant has it: sailfin:base and yellowfin:base
+		# ship a real /usr/local directory, so this only bites the flavors built
+		# on the symlinked layout.
+		#
+		# readlink -m canonicalises without requiring the path to exist, so this
+		# creates /var/usrlocal/bin on the symlinked layout and /usr/local/bin on
+		# the plain one. The ln below then resolves through the symlink either way.
+		mkdir -p "$(readlink -m /usr/local/bin)"
 		ln -sf "${FISHERMAN_BIN}" /usr/local/bin/fisherman
 	else
 		echo "WARNING: fisherman not found inside ${INSTALLER_APP}" >&2


### PR DESCRIPTION
## The failure

`sailfin:gnome`'s ISO build dies here:

```
+ mkdir -p /usr/local/bin
mkdir: cannot create directory ‘/usr/local’: File exists
error: Recipe `iso` failed with exit code 1
```

The message is misleading. `/usr/local` is not a file — on the ostree/bootc layout it's a **symlink to `../var/usrlocal`**, and `/var/usrlocal` doesn't exist in the image. `mkdir -p` refuses to create *through* a dangling symlink and reports the symlink it stopped at as already existing.

## Why it looked image-specific

Not every variant ships that layout:

| image | `/usr/local` |
|---|---|
| `sailfin:gnome` | `-> ../var/usrlocal` (dangling) |
| `sailfin:base` | real directory |
| `yellowfin:base` | real directory |

I initially checked `:base` and concluded the symlink theory was wrong — it's the `:gnome` flavor that has it.

## The fix

`readlink -m` canonicalises without requiring the path to exist, so the `mkdir` creates `/var/usrlocal/bin` on the symlinked layout and `/usr/local/bin` on the plain one. The existing `ln -sf … /usr/local/bin/fisherman` resolves through the symlink either way and is untouched.

## Verified

Ran the new expression inside both real images — mkdir, then ln, then `test -e` on the result:

```
tuna-os/sailfin:gnome      OK
tuna-os/sailfin:base       OK
```

## Context

This is the **only** cell in LUKS run [30522159277](https://github.com/tuna-os/tunaOS/actions/runs/30522159277) that failed for an image reason. The other four failures were the crun/sudo runtime bug (#903, fixed in #904).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->