### PR TITLE
feat(ci): publish each image's package set so parity is diffable

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -329,6 +329,92 @@ jobs:
             echo "::warning::pushed manifest ${REF} has no ostree/chunkah layer annotations — rechunk metadata may have been stripped"
           fi
 
+      # Publish the installed package set alongside the image so parity
+      # between editions is diffable directly, instead of being inferred.
+      #
+      # This exists because inference is unreliable. A size-based audit of all
+      # 37 editions (tuna-os/tunaos-packages#133) flagged 24 as "too small to
+      # contain their desktop" — and the EL-family XFCE flags were wrong:
+      # those ship a lean XFCE *Wayland* stack (xfwl4 + greetd), which is
+      # legitimately far smaller than Fedora's X11 XFCE. Compressed size
+      # cannot tell "packages missing" from "different architecture". A
+      # package list can, and it also confirms the real failures: marlin:kde
+      # carries 338 packages against its base's 480, and zero KDE packages.
+      #
+      # Not derived from the Syft SBOM below: that step is continue-on-error
+      # and time-boxed because Syft mmaps the whole image and OOMs on desktop
+      # sizes, so the SBOM is frequently absent. Asking the package manager
+      # directly costs a second and always works. Its artifact also expires in
+      # 7 days and needs GitHub auth, which is no good for comparing editions
+      # built weeks apart.
+      #
+      # Pushed as an OCI artifact next to the image, so it is durable, is
+      # versioned with the image, and is readable by anyone who can pull it.
+      - name: Publish package manifest
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+          DEFAULT_TAG: ${{ inputs.default-tag }}
+          SAFE_PLATFORM: ${{ matrix.safeplatform }}
+        run: |
+          set -euo pipefail
+          REF="${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${SAFE_PLATFORM}"
+          OUT="packages-${IMAGE_NAME}-${DEFAULT_TAG}-${SAFE_PLATFORM}.txt"
+
+          # The image is already in local storage from the push step, so this
+          # runs against local layers rather than pulling anything back.
+          # Every TunaOS base is covered: rpm (yellowfin/bonito/skipjack/
+          # albacore/sailfin), dpkg (flounder/grouper), pacman (marlin),
+          # portage (guppy).
+          sudo podman run --rm --entrypoint sh "$REF" -c '
+            if   command -v rpm        >/dev/null 2>&1; then rpm -qa --qf "%{NAME}\t%{VERSION}-%{RELEASE}\n"
+            elif command -v dpkg-query >/dev/null 2>&1; then dpkg-query -W -f "${Package}\t${Version}\n"
+            elif command -v pacman     >/dev/null 2>&1; then pacman -Q | tr " " "\t"
+            elif command -v qlist      >/dev/null 2>&1; then qlist -ICv
+            else echo "UNKNOWN-PACKAGE-MANAGER" >&2; exit 1
+            fi' | LC_ALL=C sort -u > "$OUT"
+
+          # An empty manifest is worse than none: it reads as "this edition has
+          # no packages" and would make a parity diff show everything missing.
+          #
+          # It is a real state, not a hypothetical. flounder (Debian) and guppy
+          # (Gentoo) ship *no package database*: /var/lib/dpkg and /var/db/pkg
+          # are both empty and there is no dpkg `status` file anywhere in the
+          # image. Those DBs live under /var, which bootc images empty — rpm
+          # escapes it only because its DB moved to /usr/lib/sysimage/rpm, and
+          # pacman's happens to survive. So those systems cannot enumerate
+          # their own packages either (tuna-os/tunaos-packages#135).
+          COUNT=$(wc -l < "$OUT")
+          if [ "$COUNT" -lt 20 ]; then
+            echo "::warning::${REF} reported only ${COUNT} packages — the package database is likely absent (see tunaos-packages#135). Publishing a marker instead of an empty manifest."
+            printf '# NO PACKAGE DATABASE IN IMAGE\n# %s\n# see https://github.com/tuna-os/tunaos-packages/issues/135\n' "$REF" > "$OUT"
+          fi
+
+          echo "${COUNT} packages recorded for ${REF}"
+          head -3 "$OUT"
+
+          # oras is already used elsewhere in this pipeline for toolchain
+          # payloads. The .packages suffix keeps it out of the image tag
+          # namespace while staying trivially discoverable.
+          command -v oras >/dev/null 2>&1 || {
+            curl -fsSL "https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz" \
+              | sudo tar -xz -C /usr/local/bin oras
+          }
+          oras push "${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${SAFE_PLATFORM}.packages" \
+            --artifact-type application/vnd.tunaos.packages.v1 \
+            "${OUT}:text/plain"
+
+      - name: Upload package manifest
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: packages-${{ env.IMAGE_NAME }}-${{ inputs.default-tag }}-${{ matrix.safeplatform }}
+          path: packages-*.txt
+          if-no-files-found: warn
+
       - name: Setup Syft
         if: inputs.sbom && github.event_name != 'pull_request'
         id: setup-syft

--- a/scripts/package-parity.sh
+++ b/scripts/package-parity.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# package-parity.sh — diff the installed package sets of two TunaOS editions.
+#
+#   scripts/package-parity.sh yellowfin:gnome albacore:gnome
+#   scripts/package-parity.sh marlin:base marlin:kde
+#   scripts/package-parity.sh --audit gnome        # every variant, one desktop
+#
+# Answers "is this edition missing packages, or is it just built differently?"
+# — which image size cannot. A size audit of all 37 editions
+# (tuna-os/tunaos-packages#133) flagged 24 as suspect and was wrong about the
+# EL-family XFCE rows: those ship a lean XFCE *Wayland* stack (xfwl4 +
+# greetd), legitimately much smaller than Fedora's X11 XFCE. The same audit
+# was right about marlin:kde — 338 packages against its base's 480, and zero
+# KDE packages. Only a package list separates those two cases.
+#
+# Reads the .packages OCI artifact published beside each image by
+# reusable-build-image.yml. Falls back to querying the image directly when an
+# edition predates that (or the publish step was skipped), which costs a pull.
+set -euo pipefail
+
+REGISTRY="${TUNA_REGISTRY:-ghcr.io/tuna-os}"
+CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/tuna-parity"
+mkdir -p "$CACHE"
+
+die() { echo "package-parity: $*" >&2; exit 1; }
+
+# NAME<TAB>VERSION, sorted. Artifact first; image query only if we must.
+fetch() {
+	local ref="$1" out="$CACHE/${ref//[:\/]/_}.txt"
+	if [[ -s "$out" && -z "${TUNA_PARITY_REFRESH:-}" ]]; then
+		echo "$out"; return
+	fi
+	local repo="${ref%%:*}" tag="${ref##*:}"
+	if command -v oras >/dev/null &&
+		oras pull "${REGISTRY}/${repo}:${tag}-linux-amd64.packages" -o "$CACHE/pull" >/dev/null 2>&1; then
+		mv "$CACHE"/pull/packages-*.txt "$out" 2>/dev/null || true
+	fi
+	if [[ ! -s "$out" ]]; then
+		echo "  (no published manifest for $ref — querying the image)" >&2
+		command -v podman >/dev/null || die "podman needed to query $ref"
+		podman run --rm --entrypoint sh "${REGISTRY}/${repo}:${tag}" -c '
+			if   command -v rpm        >/dev/null 2>&1; then rpm -qa --qf "%{NAME}\t%{VERSION}-%{RELEASE}\n"
+			elif command -v dpkg-query >/dev/null 2>&1; then dpkg-query -W -f "${Package}\t${Version}\n"
+			elif command -v pacman     >/dev/null 2>&1; then pacman -Q | tr " " "\t"
+			elif command -v qlist      >/dev/null 2>&1; then qlist -ICv
+			fi' 2>/dev/null | LC_ALL=C sort -u > "$out"
+	fi
+	[[ -s "$out" ]] || die "could not obtain a package list for $ref"
+	echo "$out"
+}
+
+names() { cut -f1 "$1" | LC_ALL=C sort -u; }
+
+# One desktop across every variant: the shape that exposes a build applying
+# no desktop at all, which is what marlin's kde/cosmic/niri/xfce do.
+if [[ "${1:-}" == "--audit" ]]; then
+	de="${2:?usage: --audit <desktop>}"
+	printf '%-12s %8s %8s %9s   %s\n' variant base "$de" delta verdict
+	printf -- '-%.0s' {1..72}; echo
+	for v in yellowfin bonito sailfin flounder grouper marlin skipjack albacore guppy; do
+		b=$(fetch "$v:base" 2>/dev/null) || { printf '%-12s   (no base)\n' "$v"; continue; }
+		d=$(fetch "$v:$de" 2>/dev/null) || continue
+		nb=$(names "$b" | wc -l); nd=$(names "$d" | wc -l)
+		delta=$((nd - nb))
+		verdict="ok"
+		(( delta <= 0 )) && verdict="BROKEN: no more packages than base"
+		(( delta > 0 && delta < 25 )) && verdict="suspect: only $delta added"
+		printf '%-12s %8d %8d %+9d   %s\n' "$v" "$nb" "$nd" "$delta" "$verdict"
+	done
+	exit 0
+fi
+
+A="${1:?usage: package-parity.sh <edition-a> <edition-b>}"
+B="${2:?usage: package-parity.sh <edition-a> <edition-b>}"
+
+fa=$(fetch "$A"); fb=$(fetch "$B")
+na=$(names "$fa"); nb=$(names "$fb")
+
+echo "=== $A: $(echo "$na" | wc -l) packages | $B: $(echo "$nb" | wc -l) packages"
+echo
+echo "--- only in $A ---"
+comm -23 <(echo "$na") <(echo "$nb") | head -60
+echo
+echo "--- only in $B ---"
+comm -13 <(echo "$na") <(echo "$nb") | head -60
+echo
+# Version skew matters for parity too, but is noise next to a missing set —
+# summarise rather than dump.
+common=$(comm -12 <(echo "$na") <(echo "$nb") | wc -l)
+echo "--- $common packages in common ---"


### PR DESCRIPTION
Resolves tuna-os/tunaos-packages#133.

## Why inference wasn't enough

A size-based parity audit of all 37 editions flagged **24** as "too small to contain their desktop" — and was wrong about a whole class of them. The EL-family XFCE images ship a lean XFCE **Wayland** stack (`xfwl4` + greetd), legitimately far smaller than Fedora's X11 XFCE. I filed a build request for a "missing" `xfwm4` off that inference and had to withdraw it.

**Compressed size cannot separate "packages missing" from "different architecture."** A package list can — and the same audit is unambiguous where it matters: `marlin:kde` carries **338 packages against its own base's 480**, with **zero** KDE packages and no session file.

## What this adds

**1. Publish step** — each build writes its installed package set and pushes it as an OCI artifact at `<image>:<tag>-<platform>.packages`. Durable, versioned with the image, readable by anyone who can pull it.

Deliberately **not** derived from the Syft SBOM this repo already generates: that step is `continue-on-error` and time-boxed because Syft mmaps the whole image and OOMs on desktop sizes, so it frequently produces nothing. Its artifact also expires in **7 days** and needs GitHub auth — no good for comparing editions built weeks apart. Asking the package manager directly takes a second and always works.

**2. `scripts/package-parity.sh`**

```bash
package-parity.sh marlin:base marlin:kde    # pairwise diff
package-parity.sh --audit gnome             # one desktop, every variant
```

`--audit` flags `delta <= 0` as **BROKEN** — exactly the `marlin:kde` signature, caught automatically instead of by squinting at sizes.

## Tested across all four package-manager families

Not assumed — run against one image of each:

| base | family | result |
|---|---|---|
| `albacore:base` | rpm | 807 packages ✅ |
| `marlin:base` | pacman | 480 packages ✅ |
| `flounder:base` | dpkg | **0** ❌ |
| `guppy:base` | portage | **0** ❌ |

That testing found something worth its own report: **flounder and guppy have no package database at all.** `/var/lib/dpkg` and `/var/db/pkg` are empty, and flounder has no dpkg `status` file anywhere. Both live under `/var`, which bootc empties; rpm escapes it only because its DB moved to `/usr/lib/sysimage/rpm`. Filed as tuna-os/tunaos-packages#135 — those systems can't introspect their own packages either.

Rather than emit an empty list for them — which reads as "this edition has no packages" and makes a diff show everything missing — the step publishes an explicit `NO PACKAGE DATABASE` marker and warns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->