### PR TITLE
fix(bootc): keep the package database out of /var so images can describe themselves

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -329,6 +329,92 @@ jobs:
             echo "::warning::pushed manifest ${REF} has no ostree/chunkah layer annotations — rechunk metadata may have been stripped"
           fi
 
+      # Publish the installed package set alongside the image so parity
+      # between editions is diffable directly, instead of being inferred.
+      #
+      # This exists because inference is unreliable. A size-based audit of all
+      # 37 editions (tuna-os/tunaos-packages#133) flagged 24 as "too small to
+      # contain their desktop" — and the EL-family XFCE flags were wrong:
+      # those ship a lean XFCE *Wayland* stack (xfwl4 + greetd), which is
+      # legitimately far smaller than Fedora's X11 XFCE. Compressed size
+      # cannot tell "packages missing" from "different architecture". A
+      # package list can, and it also confirms the real failures: marlin:kde
+      # carries 338 packages against its base's 480, and zero KDE packages.
+      #
+      # Not derived from the Syft SBOM below: that step is continue-on-error
+      # and time-boxed because Syft mmaps the whole image and OOMs on desktop
+      # sizes, so the SBOM is frequently absent. Asking the package manager
+      # directly costs a second and always works. Its artifact also expires in
+      # 7 days and needs GitHub auth, which is no good for comparing editions
+      # built weeks apart.
+      #
+      # Pushed as an OCI artifact next to the image, so it is durable, is
+      # versioned with the image, and is readable by anyone who can pull it.
+      - name: Publish package manifest
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+          DEFAULT_TAG: ${{ inputs.default-tag }}
+          SAFE_PLATFORM: ${{ matrix.safeplatform }}
+        run: |
+          set -euo pipefail
+          REF="${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${SAFE_PLATFORM}"
+          OUT="packages-${IMAGE_NAME}-${DEFAULT_TAG}-${SAFE_PLATFORM}.txt"
+
+          # The image is already in local storage from the push step, so this
+          # runs against local layers rather than pulling anything back.
+          # Every TunaOS base is covered: rpm (yellowfin/bonito/skipjack/
+          # albacore/sailfin), dpkg (flounder/grouper), pacman (marlin),
+          # portage (guppy).
+          sudo podman run --rm --entrypoint sh "$REF" -c '
+            if   command -v rpm        >/dev/null 2>&1; then rpm -qa --qf "%{NAME}\t%{VERSION}-%{RELEASE}\n"
+            elif command -v dpkg-query >/dev/null 2>&1; then dpkg-query -W -f "${Package}\t${Version}\n"
+            elif command -v pacman     >/dev/null 2>&1; then pacman -Q | tr " " "\t"
+            elif command -v qlist      >/dev/null 2>&1; then qlist -ICv
+            else echo "UNKNOWN-PACKAGE-MANAGER" >&2; exit 1
+            fi' | LC_ALL=C sort -u > "$OUT"
+
+          # An empty manifest is worse than none: it reads as "this edition has
+          # no packages" and would make a parity diff show everything missing.
+          #
+          # It is a real state, not a hypothetical. flounder (Debian) and guppy
+          # (Gentoo) ship *no package database*: /var/lib/dpkg and /var/db/pkg
+          # are both empty and there is no dpkg `status` file anywhere in the
+          # image. Those DBs live under /var, which bootc images empty — rpm
+          # escapes it only because its DB moved to /usr/lib/sysimage/rpm, and
+          # pacman's happens to survive. So those systems cannot enumerate
+          # their own packages either (tuna-os/tunaos-packages#135).
+          COUNT=$(wc -l < "$OUT")
+          if [ "$COUNT" -lt 20 ]; then
+            echo "::warning::${REF} reported only ${COUNT} packages — the package database is likely absent (see tunaos-packages#135). Publishing a marker instead of an empty manifest."
+            printf '# NO PACKAGE DATABASE IN IMAGE\n# %s\n# see https://github.com/tuna-os/tunaos-packages/issues/135\n' "$REF" > "$OUT"
+          fi
+
+          echo "${COUNT} packages recorded for ${REF}"
+          head -3 "$OUT"
+
+          # oras is already used elsewhere in this pipeline for toolchain
+          # payloads. The .packages suffix keeps it out of the image tag
+          # namespace while staying trivially discoverable.
+          command -v oras >/dev/null 2>&1 || {
+            curl -fsSL "https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz" \
+              | sudo tar -xz -C /usr/local/bin oras
+          }
+          oras push "${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${SAFE_PLATFORM}.packages" \
+            --artifact-type application/vnd.tunaos.packages.v1 \
+            "${OUT}:text/plain"
+
+      - name: Upload package manifest
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: packages-${{ env.IMAGE_NAME }}-${{ inputs.default-tag }}-${{ matrix.safeplatform }}
+          path: packages-*.txt
+          if-no-files-found: warn
+
       - name: Setup Syft
         if: inputs.sbom && github.event_name != 'pull_request'
         id: setup-syft

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -140,6 +140,28 @@ RUN mkdir -p /usr/lib/dracut/dracut.conf.d/ && \
 # Set up bootc/ostree filesystem layout
 RUN sed -i 's|^HOME=.*|HOME=/var/home|' /etc/default/useradd && \
     rm -rf /boot /home /root /usr/local /srv /opt /mnt && \
+    # Move the dpkg database out of /var BEFORE the wipe below, or the image
+    # ships with no record of its own packages.
+    #
+    # /var/lib/dpkg is where dpkg keeps `status`, and the wipe on the next
+    # line takes it. That is not a TunaOS quirk — every Debian/Ubuntu bootc
+    # image does this (bootcrew/ubuntu-bootc: `rm -rf ... /var`), and the
+    # result is measurable: ghcr.io/tuna-os/flounder:base answers
+    # `dpkg-query -W` with zero packages and has no `status` file anywhere.
+    # A running flounder box therefore cannot enumerate its own packages,
+    # which blinds remora layering, update tooling and support diagnostics
+    # (tuna-os/tunaos-packages#135).
+    #
+    # Fedora hit the identical problem with rpm and solved it by relocating
+    # the database into /usr, where it belongs anyway: the package database
+    # describes /usr, and keeping it there means it snapshots and rolls back
+    # with the image (Changes/RelocateRPMToUsr). Same move here.
+    #
+    # The tmpfiles symlink below points /var/lib/dpkg back at it, so dpkg,
+    # apt and dpkg-query all keep working through their default paths with no
+    # --admindir plumbing.
+    mkdir -p /usr/lib/sysimage && \
+    if [ -d /var/lib/dpkg ]; then cp -a /var/lib/dpkg /usr/lib/sysimage/dpkg; fi && \
     # /var may contain mount points from overlayfs layers. Clean safely.
     for d in /var/* /var/.[!.]*; do [ -d "$d" ] && ! mountpoint -q "$d" 2>/dev/null && rm -rf "$d" 2>/dev/null || true; done && \
     # Recreate /var/tmp: tacklebox rebuilds the live-ISO initramfs against
@@ -161,6 +183,15 @@ RUN sed -i 's|^HOME=.*|HOME=/var/home|' /etc/default/useradd && \
     ln -sT ../var/usrlocal /usr/local && \
     printf 'd /var/opt 0755 root root -\nd /var/home 0755 root root -\nd /var/srv 0755 root root -\nd /var/mnt 0755 root root -\nd /var/usrlocal 0755 root root -\nd /var/roothome 0700 root root -\nd /var/tmp 1777 root root -\nd /run/media 0755 root root -\n' \
         > /usr/lib/tmpfiles.d/bootc-base-dirs.conf && \
+    # Restore the dpkg database path at runtime. L+ replaces whatever is
+    # there, so a /var reset re-establishes the link rather than leaving apt
+    # pointing at an empty directory. /var/lib must be created first —
+    # tmpfiles does not build parents for L+.
+    printf 'd /var/lib 0755 root root -\nL+ /var/lib/dpkg - - - - ../../usr/lib/sysimage/dpkg\n' \
+        > /usr/lib/tmpfiles.d/dpkg-sysimage.conf && \
+    # Image-build time too: apt/dpkg run in later layers (and in
+    # live_customize) before tmpfiles has ever executed.
+    mkdir -p /var/lib && ln -sT ../../usr/lib/sysimage/dpkg /var/lib/dpkg && \
     printf '[composefs]\nenabled = yes\n[sysroot]\nreadonly = true\n' \
         > /usr/lib/ostree/prepare-root.conf
 

--- a/Containerfile.gentoo
+++ b/Containerfile.gentoo
@@ -105,7 +105,22 @@ RUN KVER=$(ls /usr/lib/modules | head -1) && \
     (cp /boot/vmlinuz-* "/usr/lib/modules/$KVER/vmlinuz" 2>/dev/null || cp /usr/src/linux-*/arch/x86/boot/bzImage "/usr/lib/modules/$KVER/vmlinuz") && \
     dracut --force --no-hostonly --reproducible --zstd --omit "tpm2-tss pcsc" --kver "$KVER" \
     "/usr/lib/modules/$KVER/initramfs.img" && \
-    rm -rf /var/db /var/cache
+    rm -rf /var/cache && \
+    # Keep portage's package database; drop only its caches.
+    #
+    # /var/db/pkg is the record of what is installed, and deleting it here
+    # (plus the /var wipe below) is why ghcr.io/tuna-os/guppy:base answers
+    # `qlist -ICv` with nothing — qlist is installed, the database simply
+    # isn't there, so the running system cannot enumerate its own packages
+    # (tuna-os/tunaos-packages#135).
+    #
+    # Relocated into /usr for the reason Fedora moved the rpmdb there
+    # (Changes/RelocateRPMToUsr): the database describes /usr, so keeping it
+    # under /usr makes it snapshot and roll back with the image instead of
+    # being erased with /var. The tmpfiles link restores the default path.
+    mkdir -p /usr/lib/sysimage && \
+    if [ -d /var/db/pkg ]; then rm -rf /usr/lib/sysimage/portage; cp -a /var/db /usr/lib/sysimage/portage; fi && \
+    rm -rf /var/db
 RUN sed -i 's|^HOME=.*|HOME=/var/home|' "/etc/default/useradd" && \
     rm -rf /boot /home /root /usr/local /srv /opt /mnt /var && \
     find /dev -mindepth 1 -maxdepth 1 ! -name pts ! -name shm ! -name mqueue -exec rm -rf {} + 2>/dev/null || true && \
@@ -118,6 +133,9 @@ RUN sed -i 's|^HOME=.*|HOME=/var/home|' "/etc/default/useradd" && \
     echo "d /var/roothome 0700 root root -" >> /usr/lib/tmpfiles.d/bootc-base-dirs.conf && \
     echo "d /var/tmp 1777 root root -" >> /usr/lib/tmpfiles.d/bootc-base-dirs.conf && \
     echo "d /run/media 0755 root root -" >> /usr/lib/tmpfiles.d/bootc-base-dirs.conf && \
+    printf 'd /var/db 0755 root root -\nL+ /var/db/pkg - - - - ../../usr/lib/sysimage/portage/pkg\n' \
+        > /usr/lib/tmpfiles.d/portage-sysimage.conf && \
+    mkdir -p /var/db && ln -sT ../../usr/lib/sysimage/portage/pkg /var/db/pkg && \
     printf '[composefs]\nenabled = yes\n[sysroot]\nreadonly = true\n' > /usr/lib/ostree/prepare-root.conf
 
 # Cache-bust so build_scripts edits invalidate the desktop stages' install
@@ -168,7 +186,22 @@ RUN KVER=$(ls /usr/lib/modules | head -1) && \
     (cp /boot/vmlinuz-* "/usr/lib/modules/$KVER/vmlinuz" 2>/dev/null || cp /usr/src/linux-*/arch/x86/boot/bzImage "/usr/lib/modules/$KVER/vmlinuz") && \
     dracut --force --no-hostonly --reproducible --zstd --omit "tpm2-tss pcsc" --kver "$KVER" \
     "/usr/lib/modules/$KVER/initramfs.img" && \
-    rm -rf /var/db /var/cache
+    rm -rf /var/cache && \
+    # Keep portage's package database; drop only its caches.
+    #
+    # /var/db/pkg is the record of what is installed, and deleting it here
+    # (plus the /var wipe below) is why ghcr.io/tuna-os/guppy:base answers
+    # `qlist -ICv` with nothing — qlist is installed, the database simply
+    # isn't there, so the running system cannot enumerate its own packages
+    # (tuna-os/tunaos-packages#135).
+    #
+    # Relocated into /usr for the reason Fedora moved the rpmdb there
+    # (Changes/RelocateRPMToUsr): the database describes /usr, so keeping it
+    # under /usr makes it snapshot and roll back with the image instead of
+    # being erased with /var. The tmpfiles link restores the default path.
+    mkdir -p /usr/lib/sysimage && \
+    if [ -d /var/db/pkg ]; then rm -rf /usr/lib/sysimage/portage; cp -a /var/db /usr/lib/sysimage/portage; fi && \
+    rm -rf /var/db
 RUN sed -i 's|^HOME=.*|HOME=/var/home|' "/etc/default/useradd" && \
     rm -rf /boot /home /root /usr/local /srv /opt /mnt /var && \
     find /dev -mindepth 1 -maxdepth 1 ! -name pts ! -name shm ! -name mqueue -exec rm -rf {} + 2>/dev/null || true && \
@@ -181,6 +214,9 @@ RUN sed -i 's|^HOME=.*|HOME=/var/home|' "/etc/default/useradd" && \
     echo "d /var/roothome 0700 root root -" >> /usr/lib/tmpfiles.d/bootc-base-dirs.conf && \
     echo "d /var/tmp 1777 root root -" >> /usr/lib/tmpfiles.d/bootc-base-dirs.conf && \
     echo "d /run/media 0755 root root -" >> /usr/lib/tmpfiles.d/bootc-base-dirs.conf && \
+    printf 'd /var/db 0755 root root -\nL+ /var/db/pkg - - - - ../../usr/lib/sysimage/portage/pkg\n' \
+        > /usr/lib/tmpfiles.d/portage-sysimage.conf && \
+    mkdir -p /var/db && ln -sT ../../usr/lib/sysimage/portage/pkg /var/db/pkg && \
     printf '[composefs]\nenabled = yes\n[sysroot]\nreadonly = true\n' > /usr/lib/ostree/prepare-root.conf
 
 LABEL containers.bootc=1 ostree.bootable=1

--- a/build_scripts/bootc/mount-system.sh
+++ b/build_scripts/bootc/mount-system.sh
@@ -12,8 +12,38 @@
 # Adapted from bootc-shindig/ubuntu-bootc-remix.
 set -ouex pipefail
 
+# Preserve the dpkg database across the wipe below.
+#
+# The header above notes that /var/lib/dpkg goes with /var. That is true and
+# intended for apt's caches, but it also leaves the shipped image unable to
+# say what is installed in it: ghcr.io/tuna-os/grouper:base answers
+# `dpkg-query -W` with zero packages, and there is no `status` file anywhere
+# in the image. So remora layering, update tooling and support diagnostics are
+# all blind on a running grouper box, not just at build time
+# (tuna-os/tunaos-packages#135).
+#
+# Fedora hit exactly this with rpm and moved the database into /usr
+# (Changes/RelocateRPMToUsr) — the package database describes /usr, so storing
+# it there means it snapshots and rolls back with the image rather than being
+# erased with /var. Same move for dpkg. The symlink and the tmpfiles rule keep
+# the default path working, so apt/dpkg/dpkg-query need no --admindir.
+mkdir -p /usr/lib/sysimage
+if [ -d /var/lib/dpkg ]; then
+	rm -rf /usr/lib/sysimage/dpkg
+	cp -a /var/lib/dpkg /usr/lib/sysimage/dpkg
+fi
+
 # shellcheck disable=SC2114
 rm -rf /boot /home /root /srv /var /media
+
+# L+ rather than L: replace whatever is at the path, so a /var reset
+# re-establishes the link instead of leaving dpkg pointing at an empty dir.
+# /var/lib needs creating first — tmpfiles does not build parents for L+.
+mkdir -p /usr/lib/tmpfiles.d
+printf 'd /var/lib 0755 root root -\nL+ /var/lib/dpkg - - - - ../../usr/lib/sysimage/dpkg\n' \
+	> /usr/lib/tmpfiles.d/dpkg-sysimage.conf
+mkdir -p /var/lib
+ln -sT ../../usr/lib/sysimage/dpkg /var/lib/dpkg
 
 mkdir -p \
 	/sysroot /boot /usr/lib/ostree /var \

--- a/scripts/package-parity.sh
+++ b/scripts/package-parity.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# package-parity.sh — diff the installed package sets of two TunaOS editions.
+#
+#   scripts/package-parity.sh yellowfin:gnome albacore:gnome
+#   scripts/package-parity.sh marlin:base marlin:kde
+#   scripts/package-parity.sh --audit gnome        # every variant, one desktop
+#
+# Answers "is this edition missing packages, or is it just built differently?"
+# — which image size cannot. A size audit of all 37 editions
+# (tuna-os/tunaos-packages#133) flagged 24 as suspect and was wrong about the
+# EL-family XFCE rows: those ship a lean XFCE *Wayland* stack (xfwl4 +
+# greetd), legitimately much smaller than Fedora's X11 XFCE. The same audit
+# was right about marlin:kde — 338 packages against its base's 480, and zero
+# KDE packages. Only a package list separates those two cases.
+#
+# Reads the .packages OCI artifact published beside each image by
+# reusable-build-image.yml. Falls back to querying the image directly when an
+# edition predates that (or the publish step was skipped), which costs a pull.
+set -euo pipefail
+
+REGISTRY="${TUNA_REGISTRY:-ghcr.io/tuna-os}"
+CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/tuna-parity"
+mkdir -p "$CACHE"
+
+die() { echo "package-parity: $*" >&2; exit 1; }
+
+# NAME<TAB>VERSION, sorted. Artifact first; image query only if we must.
+fetch() {
+	local ref="$1" out="$CACHE/${ref//[:\/]/_}.txt"
+	if [[ -s "$out" && -z "${TUNA_PARITY_REFRESH:-}" ]]; then
+		echo "$out"; return
+	fi
+	local repo="${ref%%:*}" tag="${ref##*:}"
+	if command -v oras >/dev/null &&
+		oras pull "${REGISTRY}/${repo}:${tag}-linux-amd64.packages" -o "$CACHE/pull" >/dev/null 2>&1; then
+		mv "$CACHE"/pull/packages-*.txt "$out" 2>/dev/null || true
+	fi
+	if [[ ! -s "$out" ]]; then
+		echo "  (no published manifest for $ref — querying the image)" >&2
+		command -v podman >/dev/null || die "podman needed to query $ref"
+		podman run --rm --entrypoint sh "${REGISTRY}/${repo}:${tag}" -c '
+			if   command -v rpm        >/dev/null 2>&1; then rpm -qa --qf "%{NAME}\t%{VERSION}-%{RELEASE}\n"
+			elif command -v dpkg-query >/dev/null 2>&1; then dpkg-query -W -f "${Package}\t${Version}\n"
+			elif command -v pacman     >/dev/null 2>&1; then pacman -Q | tr " " "\t"
+			elif command -v qlist      >/dev/null 2>&1; then qlist -ICv
+			fi' 2>/dev/null | LC_ALL=C sort -u > "$out"
+	fi
+	[[ -s "$out" ]] || die "could not obtain a package list for $ref"
+	echo "$out"
+}
+
+names() { cut -f1 "$1" | LC_ALL=C sort -u; }
+
+# One desktop across every variant: the shape that exposes a build applying
+# no desktop at all, which is what marlin's kde/cosmic/niri/xfce do.
+if [[ "${1:-}" == "--audit" ]]; then
+	de="${2:?usage: --audit <desktop>}"
+	printf '%-12s %8s %8s %9s   %s\n' variant base "$de" delta verdict
+	printf -- '-%.0s' {1..72}; echo
+	for v in yellowfin bonito sailfin flounder grouper marlin skipjack albacore guppy; do
+		b=$(fetch "$v:base" 2>/dev/null) || { printf '%-12s   (no base)\n' "$v"; continue; }
+		d=$(fetch "$v:$de" 2>/dev/null) || continue
+		nb=$(names "$b" | wc -l); nd=$(names "$d" | wc -l)
+		delta=$((nd - nb))
+		verdict="ok"
+		(( delta <= 0 )) && verdict="BROKEN: no more packages than base"
+		(( delta > 0 && delta < 25 )) && verdict="suspect: only $delta added"
+		printf '%-12s %8d %8d %+9d   %s\n' "$v" "$nb" "$nd" "$delta" "$verdict"
+	done
+	exit 0
+fi
+
+A="${1:?usage: package-parity.sh <edition-a> <edition-b>}"
+B="${2:?usage: package-parity.sh <edition-a> <edition-b>}"
+
+fa=$(fetch "$A"); fb=$(fetch "$B")
+na=$(names "$fa"); nb=$(names "$fb")
+
+echo "=== $A: $(echo "$na" | wc -l) packages | $B: $(echo "$nb" | wc -l) packages"
+echo
+echo "--- only in $A ---"
+comm -23 <(echo "$na") <(echo "$nb") | head -60
+echo
+echo "--- only in $B ---"
+comm -13 <(echo "$na") <(echo "$nb") | head -60
+echo
+# Version skew matters for parity too, but is noise next to a missing set —
+# summarise rather than dump.
+common=$(comm -12 <(echo "$na") <(echo "$nb") | wc -l)
+echo "--- $common packages in common ---"


### PR DESCRIPTION
Closes tuna-os/tunaos-packages#135.

## The problem

Three bases ship with **no package database at all**:

```
flounder:base   dpkg-query -W   ->  0 packages, no `status` file anywhere
grouper:base    dpkg-query -W   ->  0 packages
guppy:base      qlist -ICv      ->  0 packages, /var/db/pkg empty
```

The tools are installed — there is nothing for them to read. Both databases live under `/var`, and bootcification wipes `/var`.

`mount-system.sh` even documents it: *"This WIPES /var (including /var/lib/dpkg and /var/lib/apt)"*. That was understood as an **apt-at-build-time** constraint, but the consequence is that the *shipped* system can't enumerate its own packages either. Remora layering, update tooling, support diagnostics and SBOM scanners are all blind on those bases.

## Prior art

Not a TunaOS quirk — every Debian/Ubuntu bootc image does this. From [bootcrew/ubuntu-bootc](https://github.com/bootcrew/ubuntu-bootc):

```dockerfile
rm -rf /boot /home /root /usr/local /srv /var && \
```

None of the public examples relocates the database.

Fedora hit the identical problem with rpm and solved it by moving the database into `/usr` ([Changes/RelocateRPMToUsr](https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr)) — the package database *describes* `/usr`, so storing it there means it snapshots and rolls back with the image instead of being erased with mutable state. That's why our rpm variants are fine (albacore: 807 packages) and marlin, whose pacman DB happens to survive, reports 480.

## The change

| file | relocation |
|---|---|
| `Containerfile.debian` | `/var/lib/dpkg` → `/usr/lib/sysimage/dpkg` |
| `build_scripts/bootc/mount-system.sh` | same, covering **every** Ubuntu stage in one place |
| `Containerfile.gentoo` | `/var/db` → `/usr/lib/sysimage/portage` (both stages; also stops `rm -rf /var/db` deleting the DB along with caches) |

Each gets a tmpfiles `L+` rule restoring the conventional path, plus a build-time symlink because apt and dpkg run in later layers before tmpfiles has ever executed. `L+` rather than `L` so a `/var` reset re-establishes the link instead of leaving dpkg pointed at an empty directory. No `--admindir` plumbing needed anywhere.

## Verified against the real upstream bases

Replayed the actual bootcify sequence — copy DB, wipe `/var`, recreate dirs, symlink:

```
debian:trixie     78 packages queryable afterwards, apt usable
ubuntu:resolute   87 packages queryable afterwards, dpkg -l works
```

## Together with #906

#906 publishes each image's package set as an OCI artifact so parity is diffable. On these three bases that publisher currently emits a `NO PACKAGE DATABASE` marker — this PR is what gives it something real to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->