### PR TITLE
ci(asahi): sweep every flavor on a schedule, and grade the asahi kernel

### DIFF
--- a/.github/workflows/verify-asahi-one.yml
+++ b/.github/workflows/verify-asahi-one.yml
@@ -1,0 +1,64 @@
+name: Verify Asahi image (one)
+
+# Reusable single-image leg of the Asahi golden-manifest harness. Called by
+# verify-asahi.yml, once per flavor in sweep mode and once for an explicit ref
+# in triage mode. Not meant to be dispatched directly — use "Verify Asahi
+# image", which drives this.
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: "Asahi image ref to verify"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install lsinitrd
+        # dracut-core provides lsinitrd; without it the harness skips the
+        # initramfs-content checks with a warning instead of verifying them.
+        run: sudo apt-get update -y && sudo apt-get install -y --no-install-recommends dracut-core
+
+      - name: Login to GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GH_TOKEN" | podman login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Verify image against Asahi golden manifest
+        id: verify
+        run: |
+          set -o pipefail
+          ./scripts/verify-asahi-image.sh "${{ inputs.image }}" 2>&1 | tee /tmp/verify.log
+
+      - name: Summarize
+        # Always runs, so a red leg reports its score and failing checks in the
+        # run summary rather than only in the raw log. This step must not mask
+        # the failure — the verify step's own exit code decides the leg.
+        if: always()
+        run: |
+          {
+            echo "### \`${{ inputs.image }}\`"
+            echo
+            if result=$(grep -oE 'RESULT: .*' /tmp/verify.log 2>/dev/null); then
+              echo "**${result}**"
+            else
+              echo "**harness did not report a result — it failed before scoring**"
+            fi
+            echo
+            if grep -qE '^\s+(FAIL|WARN)' /tmp/verify.log 2>/dev/null; then
+              echo '```'
+              grep -E '^\s+(FAIL|WARN)' /tmp/verify.log
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verify-asahi.yml
+++ b/.github/workflows/verify-asahi.yml
@@ -38,7 +38,11 @@ jobs:
   # Sweep mode: every flavor that publishes a :gnome-asahi tag.
   # guppy is intentionally absent — its asahi overlay is stubbed, not broken.
   sweep:
-    if: inputs.image == ''
+    # Explicit on the schedule path: a `schedule` event has no `inputs` context
+    # at all, and relying on null == '' to pick the sweep is exactly how you get
+    # a daily run where BOTH jobs skip and the workflow reports success with
+    # zero legs executed — coverage that looks green and checks nothing.
+    if: github.event_name == 'schedule' || inputs.image == ''
     strategy:
       fail-fast: false
       matrix:
@@ -57,7 +61,7 @@ jobs:
 
   # Triage mode: one explicit ref.
   single:
-    if: inputs.image != ''
+    if: github.event_name == 'workflow_dispatch' && inputs.image != ''
     uses: ./.github/workflows/verify-asahi-one.yml
     with:
       image: ${{ inputs.image }}

--- a/.github/workflows/verify-asahi.yml
+++ b/.github/workflows/verify-asahi.yml
@@ -5,13 +5,29 @@ name: Verify Asahi image
 # kernel, the 12 hardware-critical modules, Apple DTBs, m1n1/U-Boot payloads,
 # the dracut ESP-firmware flow, and the audio stack (speakers stay disabled if
 # any piece is missing). No Mac needed; catches regressions before hardware.
+#
+# Two modes:
+#   - Sweep (schedule, or dispatch with no image): every promoted asahi flavor,
+#     one matrix leg each. This is the mode that matters. A tag existing in
+#     ghcr only means some build promoted it once; when all eight promoted tags
+#     were swept on 2026-07-30, six were unbootable (#776). Green decays
+#     silently unless something re-checks it on a timer.
+#   - Triage (dispatch with an explicit image): one arbitrary ref, for
+#     iterating on a single variant or on a -testing tag before promotion.
+#
+# fail-fast is off so one red flavor cannot hide the other seven, and the legs
+# are deliberately NOT continue-on-error: a leg that fails must fail the run,
+# or the conclusion lies about the fleet's state.
 
 on:
+  schedule:
+    # 05:40 UTC daily — after the nightly image builds have promoted.
+    - cron: "40 5 * * *"
   workflow_dispatch:
     inputs:
       image:
-        description: "Asahi image ref to verify"
-        default: "ghcr.io/tuna-os/bonito:gnome-asahi-testing"
+        description: "Single asahi image ref to verify (leave empty to sweep every flavor)"
+        default: ""
         type: string
 
 permissions:
@@ -19,22 +35,29 @@ permissions:
   packages: read
 
 jobs:
-  verify:
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+  # Sweep mode: every flavor that publishes a :gnome-asahi tag.
+  # guppy is intentionally absent — its asahi overlay is stubbed, not broken.
+  sweep:
+    if: inputs.image == ''
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor:
+          - bonito
+          - grouper
+          - albacore
+          - yellowfin
+          - sailfin
+          - flounder
+          - marlin
+          - skipjack
+    uses: ./.github/workflows/verify-asahi-one.yml
+    with:
+      image: ghcr.io/tuna-os/${{ matrix.flavor }}:gnome-asahi
 
-      - name: Install lsinitrd
-        # dracut-core provides lsinitrd; without it the harness skips the
-        # initramfs-content checks with a warning instead of verifying them.
-        run: sudo apt-get update -y && sudo apt-get install -y --no-install-recommends dracut-core
-
-      - name: Login to GHCR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "$GH_TOKEN" | podman login ghcr.io --username "${{ github.actor }}" --password-stdin
-
-      - name: Verify image against Asahi golden manifest
-        run: ./scripts/verify-asahi-image.sh "${{ inputs.image }}"
+  # Triage mode: one explicit ref.
+  single:
+    if: inputs.image != ''
+    uses: ./.github/workflows/verify-asahi-one.yml
+    with:
+      image: ${{ inputs.image }}

--- a/scripts/verify-asahi-image.sh
+++ b/scripts/verify-asahi-image.sh
@@ -37,7 +37,17 @@ echo "== kernel =="
 mapfile -t kvers < <(ls "$mnt/usr/lib/modules/" 2>/dev/null)
 if [[ ${#kvers[@]} -eq 1 ]]; then ok "exactly one kernel: ${kvers[0]}"
 else bad "expected exactly 1 kernel in /usr/lib/modules, found ${#kvers[@]}: ${kvers[*]:-none}"; fi
+# Grade the asahi kernel where one exists, not simply the first entry `ls`
+# returns. Shipping two kernels stays a hard failure above — it is a real
+# ambiguous-boot defect — but it must not also decide WHICH kernel the rest of
+# the checks grade. albacore shipped a correct asahi kernel alongside an
+# unremoved stock one; `6.12.0-…el10_2` sorts before `6.16.4-…asahi…+16k`, so
+# every subsequent check graded the stock kernel and 24 cascading failures
+# buried the single real defect (#776).
 kver="${kvers[0]:-}"
+for k in "${kvers[@]}"; do
+    if [[ "$k" == *asahi* ]]; then kver="$k"; break; fi
+done
 M="$mnt/usr/lib/modules/$kver"
 # 16K pages are a hard requirement of Apple Silicon's DART IOMMU, not a
 # distro naming convention — Fedora encodes it in the version (+16k),


### PR DESCRIPTION
The Asahi harness was dispatch-only. Nothing re-checked a promoted image, so "green" decayed silently — the last run before today was **2026-07-24**, six days of `main` ago.

I swept all eight promoted `:gnome-asahi` tags. **Six of the eight are unbootable** — full matrix and root-cause breakdown in #776. A tag existing in ghcr only means some build promoted it once; it is not evidence the image is correct.

### What this changes

- Splits the single-image job into a reusable `verify-asahi-one.yml`, driven two ways:
  - **sweep** — daily schedule (or dispatch with an empty image), one matrix leg per flavor across all eight
  - **triage** — dispatch with an explicit ref, as before, for iterating on one variant or a `-testing` tag
- `fail-fast: false`, so one red flavor cannot hide the other seven.
- The legs are deliberately **not** `continue-on-error`. A red leg has to fail the run — job-level `continue-on-error` makes run conclusions lie, which is a landmine this repo has already paid for once.
- Each leg writes its score and failing checks to `$GITHUB_STEP_SUMMARY`, so the red/green matrix is readable without opening raw logs.
- `guppy` is deliberately absent from the matrix — its overlay is stubbed, not broken.

### Harness bug the sweep exposed

Grading used `kvers[0]` — the first entry `ls` returns — not the asahi kernel. albacore ships a correct asahi kernel (`6.16.4-0.hs100.hs+asahi.el10.aarch64+16k`) alongside an unremoved stock one, and `6.12.0-…el10_2` sorts first. So every subsequent check graded the *stock* kernel, and 24 cascading failures buried the single real defect. albacore's honest score is one failure — "two kernels installed" — not 25.

Two kernels stays a hard failure (ambiguous boot is a real defect); it just no longer decides which kernel the rest of the harness reads.

Verified: `bash -n` on the harness, YAML parses, and the selection loop unit-checked against the two-kernel, single-asahi, single-non-asahi, and empty cases.

This also delivers RFC [bootc-installer-asahi#6](https://github.com/tuna-os/bootc-installer-asahi/issues/6) §4 (published red/green matrix).

Refs #776, #777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvyH2muGbDWLmmmtrPNkwG

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->