### PR TITLE
fix(gnome): give openSUSE an actual desktop, and make the contract prove usability

### DIFF
--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -59,6 +59,30 @@ gnome)
 	require_glob '/usr/share/wayland-sessions/*gnome*.desktop'
 	require_any_unit gdm gdm3
 	dm_pattern='^(gdm|gdm3)\.service$'
+	# Session-can-start is not the same as desktop-is-usable, and the gap
+	# between them is exactly how sailfin:gnome shipped. openSUSE's
+	# patterns-gnome-gnome provides gnome-shell, a wayland session and gdm
+	# — every check above — while providing no file manager, no portal
+	# backend, no keyring and no gvfs. It passed this gate with 192
+	# packages against yellowfin:gnome's 576 (tunaos-packages#132).
+	#
+	# These four are required because without them the desktop is not
+	# merely sparse, it is broken in ways a user hits immediately: no way
+	# to browse files, Flatpak file dialogs and screenshots fail (portal),
+	# saved credentials fail (keyring), removable media and network shares
+	# do not mount (gvfs).
+	#
+	# Deliberately scoped to GNOME. Every one was verified present in
+	# yellowfin:gnome and albacore:gnome before being made mandatory — a
+	# requirement that has not been checked against a known-good image
+	# turns working builds red instead of catching broken ones. Extend to
+	# kde/xfce/niri/cosmic the same way: measure a healthy image first.
+	require_command nautilus
+	require_any_glob '/usr/libexec/gvfsd' '/usr/lib/gvfs/gvfsd' '/usr/lib/*/gvfs/gvfsd'
+	require_any_glob '/usr/libexec/xdg-desktop-portal-gnome' \
+		'/usr/lib/xdg-desktop-portal-gnome' \
+		'/usr/lib/*/xdg-desktop-portal-gnome'
+	require_any_glob '/usr/bin/gnome-keyring-daemon' '/usr/libexec/gnome-keyring-daemon'
 	;;
 kde)
 	experience="ublue-os/aurora"

--- a/manifests/desktops/gnome.yaml
+++ b/manifests/desktops/gnome.yaml
@@ -147,10 +147,96 @@ packages:
       - PackageKit-command-not-found
       - gnome-software-fedora-langpacks
 
+  # ── Zypper (openSUSE Tumbleweed) ───────────────────────────────────
+  # The patterns alone are a session skeleton, NOT a desktop. Measured on
+  # Tumbleweed, patterns-gnome-gnome resolves to gdm, gnome-shell and
+  # mutter plus dependencies — it contains no nautilus, no gvfs, no
+  # gnome-keyring and no xdg-desktop-portal-gnome. That is why
+  # sailfin:gnome shipped +192 packages against yellowfin:gnome's +576,
+  # with no file manager and no portals (tunaos-packages#132).
+  #
+  # Note this is NOT a --no-recommends artifact: the pattern resolves to
+  # the same 475 packages with and without recommends. The list was simply
+  # incomplete, so the packages below are explicit.
+  #
+  # Every name here was verified to resolve with `zypper se -x -t package`
+  # against Tumbleweed. Do not add unverified names — an unresolvable name
+  # is what silently shipped a desktop-less image in the first place, and
+  # several obvious guesses are wrong on openSUSE:
+  #   NetworkManager-openvpn-gnome → NetworkManager-openvpn (no -gnome)
+  #   gnome-shell-extensions       → gnome-shell-extensions-common
+  #   tracker / tracker-miners     → tinysparql / localsearch
+  #   librsvg                      → librsvg-2-2
   zypper:
     - patterns-gnome-gnome
     - patterns-gnome-gnome_basis
     - gdm
+    # Session and control surface
+    - gnome-session
+    - gnome-settings-daemon
+    - gnome-control-center
+    - gnome-shell-extensions-common
+    - gnome-browser-connector
+    - gnome-menus
+    - gnome-backgrounds
+    # Files, mounting and secrets — the actual gap
+    - nautilus
+    - gvfs
+    - gvfs-backends
+    - gvfs-fuse
+    - gnome-keyring
+    - gnome-keyring-pam
+    - xdg-desktop-portal-gnome
+    - xdg-desktop-portal-gtk
+    - xdg-user-dirs-gtk
+    # Hardware, network and power integration
+    - ModemManager
+    - NetworkManager-openvpn
+    - NetworkManager-openconnect
+    - NetworkManager-vpnc
+    - gnome-bluetooth
+    - power-profiles-daemon
+    - switcheroo-control
+    - fwupd
+    - fprintd-pam
+    - gnome-color-manager
+    - gnome-disk-utility
+    - simple-scan
+    # Core apps and first-run
+    - gnome-initial-setup
+    - gnome-software
+    - gnome-system-monitor
+    - gnome-console
+    - gnome-text-editor
+    - gnome-calculator
+    - gnome-font-viewer
+    - gnome-characters
+    - gnome-logs
+    - loupe
+    - evince
+    - file-roller
+    - baobab
+    - seahorse
+    - gnome-online-accounts
+    - gnome-remote-desktop
+    - gnome-user-share
+    # Search indexing (tracker's successors)
+    - localsearch
+    - tinysparql
+    # Accessibility and help
+    - orca
+    - yelp
+    - gnome-user-docs
+    # Graphics and rendering
+    - Mesa-dri
+    - Mesa-libEGL1
+    - Mesa-vulkan-device-select
+    - librsvg-2-2
+    - glib-networking
+    - avahi
+    - dconf
+    - polkit
+    - pinentry-gnome3
 
   # ── Emerge (Gentoo) ────────────────────────────────────────────────
   # gnome-light, NOT gnome-base/gnome: the full meta pulls


### PR DESCRIPTION
Closes part of tuna-os/tunaos-packages#132. Related: #916.

## The problem

`sailfin:gnome` adds **192 packages** over its base where `yellowfin:gnome` adds **576** — and it ships with **no file manager and no portal backend**.

| image | packages | delta |
|---|---|---|
| sailfin:base | 681 | |
| sailfin:gnome | 866 | **+185** |
| yellowfin:base | 801 | |
| yellowfin:gnome | 1377 | **+576** |

## The cause — measured, not assumed

`patterns-gnome-gnome` on Tumbleweed resolves to **475 packages**: `gdm`, `gnome-shell`, `mutter` and dependencies. It contains **none** of nautilus, gvfs, gnome-keyring, xdg-desktop-portal-gnome, gnome-bluetooth, gnome-online-accounts, gnome-initial-setup, gnome-disk-utility, fwupd, yelp, orca, tracker, gnome-color-manager, gnome-remote-desktop or gnome-user-docs.

The pattern is a **session skeleton**. Nothing was failing — the three-entry list never asked for a desktop.

### Two theories tested and rejected first

- **"`--no-recommends` guts the pattern"** — false. Same 475 packages either way.
- **"apt has the same bug"** — false. Debian `gnome-core` pulls **903** packages under `--no-install-recommends` (1253 with), and `flounder:gnome` reports 971 installed.

Recorded inline so they are not re-derived. The issue's own hypothesis (dnf names partially translated, failing soft) was wrong for sailfin.

## Changes

**1. openSUSE GNOME list: 3 → 62 packages.**

Every name verified with `zypper se -x -t package` against Tumbleweed, because an unresolvable name fails soft — which is how a desktop-less image shipped in the first place. Several obvious guesses are wrong on openSUSE and are documented inline:

```
NetworkManager-openvpn-gnome → NetworkManager-openvpn (no -gnome)
gnome-shell-extensions       → gnome-shell-extensions-common
tracker / tracker-miners     → tinysparql / localsearch
librsvg                      → librsvg-2-2
```

The full list dry-runs on Tumbleweed as **724 new packages, no unresolved names, no conflicts**, with all fifteen previously-absent components present.

**2. The contract gate now proves GNOME is usable, not merely startable.**

Requires nautilus, gvfs, a portal backend and a keyring. Verified to discriminate rather than to be strict:

```
yellowfin:gnome -> exit=0  desktop experience contract passed
sailfin:gnome   -> exit=1  missing required command: nautilus
```

GNOME-only **on purpose**: each requirement was confirmed present in a known-good image before being made mandatory. A requirement not measured against a healthy build turns working images red instead of catching broken ones. Extending to kde/xfce/niri/cosmic should follow the same discipline — see #916.

Globs cover `/usr/libexec` vs `/usr/lib` vs `/usr/lib/<triplet>` so this is not a Fedora-only assertion.

## Why not a size or package-count gate

**guppy ships 2 emerge entries and gets the largest desktop of any variant** (+1.77 GB) because Gentoo metapackages pull their trees. Any count- or size-based rule either fails guppy or passes sailfin. Component presence is the only thing that discriminates.

## Verification

- `bats tests/bats/test_build_scripts_remaining.bats` — all pass, including the existing contract tests.
- `shellcheck build_scripts/checks/verify-desktop-experience.sh` — clean.
- Contract run against real published images, exit codes captured directly (`| tail` masks them).

## Still open, not in this PR

- sailfin `kde`/`niri`/`xfce` zypper lists are 3/2/3 — same skeleton shape, unfixed.
- el10 `kde`/`niri`/`xfce`/`cosmic` and bonito `xfce` unverified against the contract.
- grouper (Ubuntu) unverified; the apt evidence suggests it may be fine and the size metric misled.
- `flounder:niri` ships with no compositor at all — tunaOS#915, separate cause.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->