### PR TITLE
fix(build): stop building niri on Debian/Ubuntu — there is no compositor to ship

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -811,9 +811,13 @@ variants:
       - id: cosmic
         stage: 2
         build_image: true
-      - id: niri
-        stage: 2
-        build_image: true
+      # No niri: it is not packaged for apt in Debian trixie, Debian sid or
+      # Ubuntu 26.04 (all three checked), and manifests/desktops/niri.yaml
+      # has no apt section as a result. Building it produced a PUBLISHED,
+      # installable image with no compositor at all — `command -v niri` was
+      # empty in ghcr.io/tuna-os/flounder:niri. See tunaOS#915; packaging it
+      # ourselves is tracked in tunaos-packages#136 and needs a whole deb
+      # toolchain this org does not have yet. Do not re-add without one.
       - id: xfce
         stage: 2
         build_image: true
@@ -839,9 +843,7 @@ variants:
       - id: cosmic
         stage: 2
         build_image: true
-      - id: niri
-        stage: 2
-        build_image: true
+      # No niri — same reason as flounder above (absent from Debian sid too).
       - id: xfce
         stage: 2
         build_image: true

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -42,27 +42,25 @@ green on 2026-07-23, while the installer GUI had never once been observed.
 
 ## LUKS E2E
 
-**15 of 50** cells green (50 tested, 0 never tested).
+**5 of 48** cells green (12 tested, 36 never tested).
 
 Measured against the set `luks-e2e.yml` schedules: every published desktop image (`build_image`), not only the ones that ship an ISO. That is wider than the ISO matrix below on purpose — the browser ISO builder can make an ISO from any image, so image-only variants (`sailfin`, `guppy`, `flounder-sid`) need boot and install coverage too.
 
 | Variant | gnome | kde | cosmic | niri | xfce |
 |---|:--:|:--:|:--:|:--:|:--:|
-| **albacore** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **bonito** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **bonito-rawhide** | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **flounder** | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **flounder-sid** | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **grouper** | ❌ | ❌ | — | ❌ | ❌ |
-| **guppy** | ❌ | ❌ | — | — | — |
-| **marlin** | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **sailfin** | ❌ | ❌ | — | ❌ | ❌ |
-| **skipjack** | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **yellowfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **albacore** | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **bonito** | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **bonito-rawhide** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **flounder** | ❌ | ✅ | ⬜ | — | ⬜ |
+| **flounder-sid** | ❌ | ⬜ | ⬜ | — | ⬜ |
+| **grouper** | ❌ | ⬜ | — | ⬜ | ⬜ |
+| **guppy** | ❌ | ⬜ | — | — | — |
+| **marlin** | ❌ | ⬜ | ✅ | ⬜ | ❌ |
+| **sailfin** | ❌ | ⬜ | — | ⬜ | ⬜ |
+| **skipjack** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **yellowfin** | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 
-NVIDIA cells are **out of scope** for this workflow — `luks-e2e.yml` excludes them deliberately, because `-nvidia` takes the identical LUKS path in headless QEMU. 24 stale pre-exclusion result(s) remain from before that change; they are not a gap and will age out.
-
-Newest result 2026-07-27, oldest still-authoritative result 2026-07-23. Results older than the most recent round of fixes are the best available data, not current data.
+Newest result 2026-07-30, oldest still-authoritative result 2026-07-29. Results older than the most recent round of fixes are the best available data, not current data.
 
 ## Installer smoke
 
@@ -85,7 +83,7 @@ cosmic, niri, xfwl4 and kde all need a DRM render node; a ❌ for those on hoste
 
 ## Live overlay
 
-**38** tags published.
+**39** tags published.
 
 Missing for 1 ISO cell(s): `marlin-kde`
 
@@ -93,10 +91,12 @@ Missing for 1 ISO cell(s): `marlin-kde`
 
 | Date | Run | Cells |
 |---|---|---|
-| 2026-07-27 | [30249218614](https://github.com/tuna-os/tunaOS/actions/runs/30249218614) | 50 |
-| 2026-07-27 | [30234237855](https://github.com/tuna-os/tunaOS/actions/runs/30234237855) | 2 |
-| 2026-07-23 | [29978067348](https://github.com/tuna-os/tunaOS/actions/runs/29978067348) | 24 |
-| 2026-07-22 | [29914643652](https://github.com/tuna-os/tunaOS/actions/runs/29914643652) | 2 |
+| 2026-07-30 | [30524767610](https://github.com/tuna-os/tunaOS/actions/runs/30524767610) | 1 |
+| 2026-07-30 | [30522159277](https://github.com/tuna-os/tunaOS/actions/runs/30522159277) | 8 |
+| 2026-07-29 | [30484849112](https://github.com/tuna-os/tunaOS/actions/runs/30484849112) | 1 |
+| 2026-07-29 | [30472017143](https://github.com/tuna-os/tunaOS/actions/runs/30472017143) | 1 |
+| 2026-07-29 | [30467796102](https://github.com/tuna-os/tunaOS/actions/runs/30467796102) | 1 |
+| 2026-07-29 | [30447516312](https://github.com/tuna-os/tunaOS/actions/runs/30447516312) | 4 |
 
 <!-- END GENERATED -->
 


### PR DESCRIPTION
Closes #915. Resolves the scope question in tuna-os/tunaos-packages#136 as "decline for now".

## The problem

`ghcr.io/tuna-os/flounder:niri` is **published and installable with no niri binary at all**:

```
$ podman run --rm --entrypoint /bin/sh ghcr.io/tuna-os/flounder:niri -c "command -v niri || echo NO-NIRI"
NO-NIRI
```

`flounder-sid:niri` ships from the same manifest and is identical.

## Why it happened

`manifests/desktops/niri.yaml` declares `fedora`, `el10`, `zypper` and `emerge` lists and **no `apt` section**. `install-desktop.sh` guards its install on a non-empty list, so on a Debian base it installs nothing and continues.

That is not a missing translation — **niri is not packaged for apt anywhere we consume**:

| suite | `niri` | `xwayland-satellite` |
|---|---|---|
| Debian 13 trixie | absent | absent |
| Debian sid | absent | absent |
| Ubuntu 26.04 | absent | — |

Everything *else* a niri session needs is in trixie: `greetd` 0.10.3, `waybar`, `fuzzel`, `alacritty`, `swaylock`, `swayidle`, `mako-notifier`, `xdg-desktop-portal-gnome`/`-gtk`. The compositor is the only gap, and it is the one that matters.

## Why it shipped anyway

The contract gate **does** catch this:

```
flounder:niri -> exit=1  missing required command: niri
```

But the published tag dates to **2026-07-13** and predates enforcement. `Containerfile.debian:230-232` runs the gate today, so a rebuild would fail the build rather than publish. The broken artifact has simply been sitting there.

Related, and worth doing separately: the comment at `build_scripts/desktop/install-desktop.sh:100-102` records that this class already happened once — *"every apt flavor shipped a desktop-less image that still passed CI."*

## The change

Remove the `niri` flavor from `flounder` and `flounder-sid` in `.github/build-config.yml`, with an inline comment recording why so it is not re-added blind.

niri remains available on the five families that package it: **Fedora, EL10, openSUSE, Arch, Gentoo.**

## Why not package it instead

tunaos-packages#136 scoped that: it needs a **second packaging toolchain** — Debian source packaging for a large Rust dependency tree (dh-cargo or vendored crates), sbuild in CI, and an apt repo on R2 with pool/dists layout, `Release`/`InRelease` signing, and the key shipped into the images. That is a lot of infrastructure for one package when the alternative — not offering the flavor on two of nine variants — costs nothing and fixes the user-facing problem today.

If the apt toolchain is ever built for other reasons, this is trivially reversible.

## Still to do

The published `flounder:niri` and `flounder-sid:niri` tags need **de-publishing**. That is a destructive, irreversible action on the registry and is deliberately not part of this PR — until it happens, users can still pull a desktop-less image.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->