### PR TITLE
Revert "fix(ci): unblock full LUKS matrix on RunsOn (#886)"

### DIFF
--- a/.github/workflows/live-iso-bootc.yml
+++ b/.github/workflows/live-iso-bootc.yml
@@ -48,14 +48,10 @@ jobs:
       - name: Maximize build space
         uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6 # main as of 2026-02-11
 
-      # crun is listed so a runtime is guaranteed present, but note it does
-      # nothing on runner images that already ship one — which crun podman
-      # picks is decided by the pinning step below, not by apt.
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y just podman crun jq rclone golang-go git systemd-boot-efi mtools squashfs-tools xorriso dosfstools gdisk e2fsprogs btrfs-progs
-          podman --version; crun --version | head -1
+          sudo apt-get install -y just podman jq rclone golang-go git systemd-boot-efi mtools squashfs-tools xorriso dosfstools gdisk e2fsprogs btrfs-progs
 
       - name: Setup rootless podman (subuid/subgid for runner)
         run: |
@@ -69,53 +65,6 @@ jobs:
           if ! grep -q "^${USER}:" /etc/subgid 2>/dev/null; then
             echo "${USER}:100000:65536" | sudo tee -a /etc/subgid
           fi
-
-      # podman does not find crun on PATH; it walks a hardcoded list that puts
-      # /usr/bin/crun ahead of /usr/local/bin/crun (containers/common
-      # pkg/config/default.go). So on a runner image that installs its own
-      # podman stack under /usr/local while dpkg still owns an older
-      # /usr/bin/crun, every `podman run` dies with:
-      #
-      #   Error: OCI runtime error: crun: unknown version specified
-      #
-      # crun <= 1.14 rejects any OCI spec version whose string does not
-      # contain "1.0" (libcrun/container.c), podman 5.x generates "1.2.0",
-      # and the image's own crun that would have accepted it sits later in
-      # the search list and is never reached. Image ubuntu24/20260726.254 is
-      # exactly that shape — podman 5.8.4 and crun 1.28 in /usr/local/bin,
-      # dpkg crun 1.14.1 in /usr/bin — so `crun --version` prints 1.28 while
-      # podman runs 1.14.1. That is what killed run 30522938645 at the
-      # chunkah `podman run`, after buildah had already built the whole
-      # image. Newer crun dropped the version check, so the newest crun on
-      # the box is safe for whichever podman ends up running.
-      - name: Pin podman to the newest crun on the runner
-        run: |
-          set -euo pipefail
-          best="" bestv=""
-          for c in /usr/bin/crun /usr/sbin/crun /usr/local/bin/crun \
-                   /usr/local/sbin/crun /sbin/crun /bin/crun; do
-            [ -x "$c" ] || continue
-            v=$("$c" --version | awk 'NR==1{print $3}')
-            echo "candidate: $c -> $v"
-            newest=$(printf '%s\n%s\n' "$bestv" "$v" | sort -V | tail -1)
-            if [ -z "$bestv" ] || [ "$newest" = "$v" ]; then
-              best="$c" bestv="$v"
-            fi
-          done
-          [ -n "$best" ] || { echo "no crun found on this runner" >&2; exit 1; }
-          echo "==> pinning crun ${bestv} (${best})"
-          sudo mkdir -p /etc/containers/containers.conf.d
-          sudo tee /etc/containers/containers.conf.d/99-crun.conf >/dev/null <<CONF
-          [engine]
-          runtime = "crun"
-
-          [engine.runtimes]
-          crun = ["${best}"]
-          CONF
-          # Both stores matter: the build runs under sudo, the ISO squashfs
-          # step runs rootless as the runner user.
-          sudo podman info --format 'root: {{.Host.OCIRuntime.Path}}'
-          podman info --format 'rootless: {{.Host.OCIRuntime.Path}}'
 
       - name: Build OS image
         run: |

--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -198,9 +198,10 @@ jobs:
       # That is crun rejecting the OCI spec version podman generated, not a
       # build error, though it surfaces as one at a random RUN step — the
       # same shape as the cgroup-manager failure documented below. It took
-      # out every cell of run 30520334279. Listing crun here only guarantees
-      # one exists; which one podman actually runs is settled by the pinning
-      # step below, since apt is a no-op on images that already ship a crun.
+      # out every cell of run 30520334279. reusable-build-image.yml dodges
+      # this by letting setup-runner install a matched podman stack
+      # (update-podman: "true"); this job installs from apt, so the pair has
+      # to be pinned together here.
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
@@ -209,47 +210,6 @@ jobs:
             qemu-system-x86 qemu-utils ovmf swtpm socat sshpass imagemagick \
             systemd-boot-efi mtools squashfs-tools xorriso dosfstools gdisk
           podman --version; crun --version | head -1
-
-      # podman does not find crun on PATH; it walks a hardcoded list that puts
-      # /usr/bin/crun ahead of /usr/local/bin/crun (containers/common
-      # pkg/config/default.go). On a runner image that installs its own podman
-      # stack under /usr/local while dpkg still owns an older /usr/bin/crun,
-      # `crun --version` prints the new one while podman silently runs the old
-      # one and every container dies with the "unknown version specified"
-      # above: crun <= 1.14 rejects any OCI spec version whose string does not
-      # contain "1.0" (libcrun/container.c) and podman 5.x generates "1.2.0".
-      # Image ubuntu24/20260726.254 is exactly that shape — podman 5.8.4 and
-      # crun 1.28 in /usr/local/bin, dpkg crun 1.14.1 in /usr/bin. Newer crun
-      # dropped the version check, so the newest crun on the box is safe for
-      # whichever podman ends up running.
-      - name: Pin podman to the newest crun on the runner
-        run: |
-          set -euo pipefail
-          best="" bestv=""
-          for c in /usr/bin/crun /usr/sbin/crun /usr/local/bin/crun \
-                   /usr/local/sbin/crun /sbin/crun /bin/crun; do
-            [ -x "$c" ] || continue
-            v=$("$c" --version | awk 'NR==1{print $3}')
-            echo "candidate: $c -> $v"
-            newest=$(printf '%s\n%s\n' "$bestv" "$v" | sort -V | tail -1)
-            if [ -z "$bestv" ] || [ "$newest" = "$v" ]; then
-              best="$c" bestv="$v"
-            fi
-          done
-          [ -n "$best" ] || { echo "no crun found on this runner" >&2; exit 1; }
-          echo "==> pinning crun ${bestv} (${best})"
-          sudo mkdir -p /etc/containers/containers.conf.d
-          sudo tee /etc/containers/containers.conf.d/99-crun.conf >/dev/null <<CONF
-          [engine]
-          runtime = "crun"
-
-          [engine.runtimes]
-          crun = ["${best}"]
-          CONF
-          # Both stores matter: the ISO build runs rootless, iso-e2e.sh and the
-          # fisherman build run under sudo.
-          podman info --format 'rootless: {{.Host.OCIRuntime.Path}}'
-          sudo podman info --format 'root: {{.Host.OCIRuntime.Path}}'
 
       # iso-e2e.sh resolves the published image ref through
       # scripts/published-image-ref.sh, which needs yq. Without it the script

--- a/Containerfile.arch
+++ b/Containerfile.arch
@@ -82,47 +82,6 @@ RUN grep "= */var" /etc/pacman.conf | sed "/= *\/var/s/.*=// ; s/ //" | \
 # will pull optimized packages automatically. We detect CachyOS by checking
 # for the cachyos repo in pacman.conf and install linux-cachyos instead of
 # stock linux.
-#
-# cryptsetup is in the list because fisherman refuses to install with
-# encryption when it is missing from the live env ("missing required host
-# tool") and because dracut's crypt module needs it to build an initramfs
-# that can unlock the installed root. Arch's `base` does not pull it in
-# (systemd only optdepends on it).
-#
-# openssh is in the list because the dev/E2E ISO path needs a real
-# sshd.service to enable (live-iso/common/src/customize-live.sh hard-fails
-# with "no SSH service is installed" otherwise — that is how LUKS
-# marlin:{kde,cosmic,niri,xfce} died, while marlin:gnome only built because
-# the GNOME manifest happened to pull openssh in transitively). Arch enables
-# nothing on install (99-default.preset disables everything), so shipping the
-# package keeps sshd closed on installed systems, matching the openSUSE and
-# Gentoo bases, which already install openssh in their base stage.
-#
-# sudo is in the list because Arch's `base` does not depend on it (verified
-# with pacman -Qi base on the stock archlinux image, which has no sudo binary
-# at all) and no desktop manifest pulls it in either. That is how
-# `LUKS marlin:gnome` died before the installer ran:
-#   ERROR: liveuser has no working passwordless sudo in the live env.
-#   (sudo is not installed on this image)
-# The live session drives the whole install through sudo, and ujust recipes
-# plus the desktop admin flows need it on installed systems too.
-#
-# fuse-overlayfs is in the list because the live env's storage.conf sets
-# overlay's mount_program to /usr/bin/fuse-overlayfs
-# (live-iso/common/src/customize-live.sh), and containers/storage stats that
-# program at startup and hard-fails the whole config when it is absent:
-#   Error: configure storage: overlay: can't stat program
-#   "/usr/bin/fuse-overlayfs": no such file or directory
-# That took every podman call in the marlin live guest down, so the
-# offline-store probe found nothing and the e2e aborted on the staging-space
-# preflight ("guest has ... writable but staging localhost/marlin:cosmic").
-# The mount_program is not optional there: the live root is itself an
-# overlayfs, and the overlay driver refuses to stack on one without it
-# ("'overlay' is not supported over overlayfs, a mount_program is required").
-# Arch's podman does not depend on fuse-overlayfs (verified with pacman -Qo on
-# a stock archlinux image, which has no fuse-overlayfs binary after installing
-# podman). The apt and dnf bases already get it from
-# build_scripts/10-base-packages.sh, which this Containerfile does not run.
 RUN KERNEL_PKG="linux"; \
     # Arch Linux ARM names its stock kernel linux-aarch64
     if [ "$(uname -m)" = "aarch64" ]; then \
@@ -140,20 +99,16 @@ RUN KERNEL_PKG="linux"; \
         linux-firmware \
         ostree \
         btrfs-progs \
-        cryptsetup \
         e2fsprogs \
         xfsprogs \
         dosfstools \
         skopeo \
         podman \
-        fuse-overlayfs \
         dbus \
         glib2 \
         shadow \
-        sudo \
         systemd \
         networkmanager \
-        openssh \
         pipewire \
         wireplumber \
         flatpak \
@@ -180,43 +135,12 @@ RUN KERNEL_PKG="linux"; \
 # Build initramfs. Live-boot modules are NOT needed here: tacklebox
 # injects its own embedded tbox-live/tbox-root dracut modules at ISO
 # build time using this image's stock dracut (tuna-os/tacklebox#90).
-#
-# filesystems= and add_drivers= are spelled out because Arch's dracut never
-# performs its own "not hostonly -> install every filesystem module" step:
-# 70kernel-modules implements it as `dracut_instmods -o -P ... '=fs'`, and
-# this dracut-install expands the `=path` form to nothing at all. Verified in
-# a container on the same base image: '=fs', '=drivers/block' and '=crypto'
-# each install 0 modules (identically on dracut 107/109/110/111), while
-# openSUSE's patched dracut installs 152 for the very same '=fs' call — which
-# is why only the Arch base is affected. Everything the initramfs did contain
-# came from modules dracut names explicitly, so xfs.ko was absent from every
-# marlin image, and xfs is what fisherman formats the root with.
-#
-# That is how `LUKS marlin:cosmic` died after a fully successful install: the
-# passphrase gate unlocked the disk and then dropped into emergency mode,
-#   Please enter passphrase for disk root   <- unlock OK
-#   [FAILED] Failed to mount /sysroot.
-#   [DEPEND] Dependency failed for bootc setup root.
-# ext4, btrfs and virtio_blk are built into Arch's kernel, which is why the
-# disk was found at all and only the xfs mount failed. erofs and loop are
-# modules too and are needed one step later, for the composefs deployment
-# ostree-prepare-root mounts on top of /sysroot; overlay is already pulled in
-# transitively and is listed to keep it that way.
 RUN mkdir -p /usr/lib/dracut/dracut.conf.d/ && \
     printf 'systemdsystemconfdir=/etc/systemd/system\nsystemdsystemunitdir=/usr/lib/systemd/system\n' \
         > /usr/lib/dracut/dracut.conf.d/30-fix-bootc-module.conf && \
-    printf 'reproducible=yes\nhostonly=no\ncompress=zstd\nadd_dracutmodules+=" bootc "\nomit_dracutmodules+=" tpm2-tss pcsc "\nfilesystems+=" xfs erofs overlay "\nadd_drivers+=" loop "\n' \
+    printf 'reproducible=yes\nhostonly=no\ncompress=zstd\nadd_dracutmodules+=" bootc "\nomit_dracutmodules+=" tpm2-tss pcsc "\n' \
         > /usr/lib/dracut/dracut.conf.d/30-bootc-container-build.conf && \
-    KVER_DIR="$(find /usr/lib/modules -maxdepth 1 -type d | grep -v '\.img' | tail -1)" && \
-    dracut --force "${KVER_DIR}/initramfs.img" && \
-    # Never ship an initramfs that cannot mount the installed root: the
-    # failure only surfaces an hour later, in a QEMU emergency shell.
-    for m in xfs erofs overlay loop; do \
-        lsinitrd "${KVER_DIR}/initramfs.img" | grep -q "/${m}\.ko" && continue; \
-        grep -q "/${m}\.ko\$" "${KVER_DIR}/modules.builtin" && continue; \
-        echo "ERROR: initramfs has no ${m} support (neither a module in the image nor built into the kernel)" >&2; \
-        exit 1; \
-    done
+    dracut --force "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v '\.img' | tail -1)/initramfs.img"
 
 # Set up bootc/ostree filesystem layout
 RUN rm -rf /boot /home /root /usr/local /srv /opt /mnt \

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -87,21 +87,6 @@ RUN apt-get update -y && \
     esac
 
 # Install base system packages
-#
-# systemd-cryptsetup provides systemd-cryptenroll, which fisherman's pre-flight
-# requires for tpm2-luks installs. Debian splits it out of the systemd package
-# (dpkg -L systemd on trixie has no cryptenroll), so `systemd` below is not
-# enough. This is the same gap that failed `LUKS grouper:niri` on Ubuntu.
-#
-# openssh-server is in the list because the dev/E2E ISO path needs a real SSH
-# unit to enable: live-iso/common/src/customize-live.sh hard-fails with
-# "dev ISO requested but no SSH service is installed" otherwise, which is how
-# `LUKS flounder:{gnome,kde}` died. `just iso dev=1` builds with ENABLE_SSHD=1
-# to cover exactly this, but that ARG is only consumed by
-# build_scripts/40-services.sh, and this Containerfile never runs it (unlike
-# Containerfile.ubuntu), so on Debian ENABLE_SSHD installed nothing. Ship the
-# package unconditionally, the way the Arch/openSUSE/Gentoo bases do, and close
-# it below.
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         btrfs-progs \
@@ -114,14 +99,12 @@ RUN apt-get update -y && \
         podman \
         systemd \
         systemd-boot \
-        systemd-cryptsetup \
         xfsprogs \
         dracut \
         dmsetup \
         squashfs-tools \
         cryptsetup \
         network-manager \
-        openssh-server \
         pipewire \
         wireplumber \
         flatpak \
@@ -132,14 +115,6 @@ RUN apt-get update -y && \
         unzip \
         git \
         ca-certificates && \
-    # Security default: sshd closed, matching the apt policy in
-    # build_scripts/40-services.sh (which this Containerfile does not run).
-    # Arch's preset enables nothing, but openssh-server's postinst links
-    # ssh.service into multi-user.target.wants and drops an /etc sshd.service
-    # compat alias, so installing the package would otherwise ship published
-    # Debian images with SSH listening. customize-live.sh re-enables the unit
-    # on dev/E2E media only.
-    systemctl disable ssh.service ssh.socket && \
     apt-get clean -y
 
 RUN --mount=type=bind,from=context,source=/,target=/run/context \

--- a/Containerfile.opensuse
+++ b/Containerfile.opensuse
@@ -31,30 +31,6 @@ FROM base AS system
 # runtime image doesn't ship (libssl.so.60 — see #643); the packaged bootc has
 # correct runtime deps and bundles the 51bootc dracut module. Also faster (no
 # cargo compile). Verified: bootc 1.15.2 install/lint work on Tumbleweed.
-#
-# cryptsetup is explicit because nothing in this list pulls it in (verified with
-# a zypper --dry-run of exactly these packages plus the enhanced_base pattern),
-# and fisherman's pre-flight refuses to install with encryption without it.
-# That is the same gate that failed the Ubuntu and Arch LUKS cells.
-# systemd-cryptenroll, the other tpm2-luks requirement, comes from `udev` on
-# Tumbleweed (not `systemd`), and that is already in the list below.
-#
-# sudo is explicit for the same reason it is on the Arch and apt bases: the
-# stock Tumbleweed image has no sudo binary and neither this list nor the
-# enhanced_base pattern pulls it in (both checked with zypper --dry-run). The
-# live session drives the entire install through sudo, and `LUKS marlin:gnome`
-# showed what its absence costs: "liveuser has no working passwordless sudo in
-# the live env".
-#
-# fuse-overlayfs is explicit for the same reason it is on the Arch base: the
-# live env's storage.conf points overlay's mount_program at
-# /usr/bin/fuse-overlayfs, and containers/storage hard-fails its whole config
-# when that program is missing, taking every podman call in the live guest with
-# it ("can't stat program \"/usr/bin/fuse-overlayfs\""). Dropping the
-# mount_program is not an option: the live root is an overlayfs and the overlay
-# driver will not stack on one without it. Neither this list nor the
-# enhanced_base pattern pulls it in (checked with zypper --dry-run on a stock
-# Tumbleweed image, which has no fuse-overlayfs binary).
 RUN set -eu; \
     retry_zypper() { \
       attempt=1; \
@@ -74,8 +50,8 @@ RUN set -eu; \
     retry_zypper --non-interactive --gpg-auto-import-keys refresh && \
     retry_zypper install -y \
     bootc \
-    btrfs-progs ca-certificates ca-certificates-mozilla cpio curl cryptsetup dosfstools dracut e2fsprogs flatpak fuse-overlayfs glib2 \
-    kernel-default kernel-firmware-all openssh ostree skopeo sudo \
+    btrfs-progs ca-certificates ca-certificates-mozilla cpio curl dosfstools dracut e2fsprogs flatpak glib2 \
+    kernel-default kernel-firmware-all openssh ostree skopeo \
     systemd systemd-boot udev xfsprogs zstd chrony && \
     update-ca-certificates && \
     retry_zypper --non-interactive removerepo virtualization-containers && \

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -111,56 +111,18 @@ COPY --from=bootc-builder /output /
 #
 # The t64 suffixes are Ubuntu's 64-bit time_t transition; the unsuffixed names
 # do not exist in resolute. All five were verified against the base image.
-#
-# network-manager is explicit (Containerfile.debian does the same) because
-# ubuntu-desktop-minimal only *recommends* it and every apt install in this
-# repo passes --no-install-recommends: grouper images shipped with no network
-# manager and no enabled systemd-networkd, so nothing ever configured a NIC.
-# The installed system had no network, and in the live ISO the missing DHCP
-# lease meant QEMU's hostfwd had nothing to forward to, which is how
-# `LUKS grouper:gnome` spent five minutes on "ERROR: SSH check failed" while
-# the guest's own sshd was up and its e2e-runtime-checks reported
-# "not ok - a network manager is active".
-#
-# cryptsetup likewise: dmsetup alone is not enough, and Ubuntu leaves it out
-# of ubuntu-desktop-minimal's hard dependencies. `LUKS grouper:niri` got all
-# the way to running the installer and died on
-#   fisherman: fatal: missing required host tool: "cryptsetup" not found
-# because the live env had no cryptsetup binary. Containerfile.debian already
-# installs it for the same reason.
-#
-# systemd-cryptsetup is the second half of that story. fisherman's pre-flight
-# also requires systemd-cryptenroll for the tpm2-luks recipes this E2E uses,
-# and it names "systemd" as the providing package, which is true on Fedora and
-# Arch but not here: Debian and Ubuntu split systemd-cryptenroll into
-# systemd-cryptsetup
-# (verified with dpkg -L on ubuntu:resolute and debian:trixie: it is not in
-# the systemd package). So `LUKS grouper:niri` cleared the cryptsetup gate and
-# died one requirement later on:
-#   fisherman: fatal: missing required host tool: "systemd-cryptenroll" not found
 RUN --mount=type=bind,from=context,source=/,target=/run/context \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
         ca-certificates curl gpg \
         ostree libostree-1-1 dracut \
         btrfs-progs dosfstools e2fsprogs xfsprogs skopeo jq \
-        systemd-boot systemd-boot-efi dmsetup network-manager \
-        cryptsetup systemd-cryptsetup \
+        systemd-boot systemd-boot-efi dmsetup \
         tpm2-tools libtss2-tcti-device0t64 libtss2-tctildr0t64 \
         libtss2-rc0t64 libtss2-esys-3.0.2-0t64 && \
     # pcsc (smart card daemon) dracut module is part of Ubuntu's default
     # module set but the pcscd package isn't needed for the initramfs.
     echo 'omit_dracutmodules+=" pcsc "' > /etc/dracut.conf.d/omit-pcsc.conf && \
-    # Installing NetworkManager is not enough on Ubuntu: its package ships
-    # /usr/lib/NetworkManager/conf.d/10-globally-managed-devices.conf with
-    #   unmanaged-devices=*,except:type:wifi,except:type:gsm,except:type:cdma
-    # so ethernet stays unmanaged unless netplan hands the device over. A
-    # same-named file under /etc shadows the vendor one outright (this is how
-    # Ubuntu Desktop globally manages devices), leaving NM to auto-configure
-    # wired links over DHCP with no netplan YAML in the image.
-    mkdir -p /etc/NetworkManager/conf.d && \
-    printf '# Intentionally sets no unmanaged-devices: this file shadows the\n# vendor one of the same name in /usr/lib/NetworkManager/conf.d, so\n# NetworkManager manages ethernet as well as wifi/wwan.\n' \
-        > /etc/NetworkManager/conf.d/10-globally-managed-devices.conf && \
     cp -a /run/context/build_scripts/bootc/sandbox/. / && \
     apt-get clean -y && rm -rf /var/lib/apt/lists/*
 

--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -23,23 +23,11 @@ if [[ "$PKG_MGR" == "apt" ]]; then
 	# Base packages common to all desktop flavors on apt-based systems.
 	# Package name mapping from RPM: gcc-c++ → g++, xhost → x11-xserver-utils,
 	# systemd-oomd-defaults → systemd-oomd, tuned-ppd → power-profiles-daemon.
-	#
-	# sudo is explicit because the stock ubuntu/debian container bases do not
-	# ship it (only the `sudo` group), nothing here pulls it as a hard
-	# dependency, and every apt install in this repo passes
-	# --no-install-recommends. `LUKS grouper:niri` ran the entire
-	# offline-store probe with every privileged command answering
-	# "bash: line 1: sudo: command not found", concluded the payload image was
-	# missing and fell back to SCP'ing a 4 GB tar. ujust recipes and the
-	# desktop's own admin flows need it on installed systems too.
-	# (The Arch and openSUSE bases turned out to be missing sudo as well; they
-	# install it from their own Containerfile package lists.)
 	pkg_install \
 		buildah \
 		podman \
 		skopeo \
 		systemd-container \
-		sudo \
 		util-linux \
 		fdisk \
 		flatpak \

--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -64,11 +64,6 @@ if [[ "${PKG_MGR:-}" == "apt" ]]; then
 	fi
 
 	# Units that exist on Ubuntu once their packages are installed.
-	# NetworkManager explicitly: the deb postinst enables it via preset, but
-	# an image whose only network manager silently failed to come up has no
-	# way to be fixed after install (grouper booted with no managed NIC at
-	# all), so state the dependency instead of inheriting it.
-	safe_enable NetworkManager.service
 	safe_enable tailscaled.service
 	safe_enable fwupd.service
 	systemctl enable podman-auto-update.timer 2>/dev/null || true

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -27,14 +27,9 @@ downloads:
   kcm_ublue: "v0.6.1"
   # renovate: datasource=github-releases depName=twpayne/chezmoi
   chezmoi: "v2.71.1"
-  # Renovate bumps `chezmoi` above but has no idea this digest map exists, so
-  # it must be updated in the same breath or every apt-based niri build dies on
-  # `sha256sum -c` (v2.71.1 shipped with v2.71.0's digests here and broke
-  # grouper:niri). Values come from the release's own
-  # chezmoi_<version>_checksums.txt.
   chezmoi_sha256:
-    amd64: "49b68f441f60fbf84a79928e35076ccd4d0d7d5c050924c27d03bda25a7024eb"
-    arm64: "feed3a214511619f7b6a167b3d7d8cee6146a44a19ea0f1705af9a84b7205ed7"
+    amd64: "a8880a1b01e877c3e5da250b9f882ce9fa39962686d75f436fa21e021fa092b1"
+    arm64: "ea9389f4efdc26d74bf9b4cc73db8f3a529e1e6effb5703e438117ea3f095439"
   # renovate: datasource=git-refs depName=tuna-os/tacklebox
   tacklebox: "320a1a459511b9d056d67e9301ec5fed02858f44"
 

--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -91,23 +91,6 @@ if systemctl list-unit-files NetworkManager.service --no-legend 2>/dev/null | gr
 	systemctl enable NetworkManager.service || true
 fi
 
-# ── 1d. Live readiness marker ────────────────────────────────────────────────
-# scripts/iso-e2e.sh waits for TUNAOS_LIVE_READY on the serial console before
-# it does anything else, and tunaos-live-ready.service is what prints it.
-# Only build_scripts/40-services.sh enables that unit, and only
-# Containerfile.{el10,ubuntu} run it — the arch, opensuse, gentoo and debian
-# bootcifications never do, so they shipped the unit (system_files) disabled.
-# `LUKS marlin:gnome` burned its whole 1200s ready timeout on a live session
-# that was up and idle at a login prompt, having never queued the marker (its
-# Wants=NetworkManager-wait-online.service never appears in that boot's
-# journal). Enable it here: the marker exists for live media, this is the live
-# squash, and it is a no-op where 40-services.sh already enabled it.
-if [[ ! -f /usr/lib/systemd/system/tunaos-live-ready.service ]]; then
-	install -Dm644 "${SCRIPT_DIR}/tunaos-live-ready.service" \
-		/usr/lib/systemd/system/tunaos-live-ready.service
-fi
-systemctl enable tunaos-live-ready.service
-
 # ── 2. Desktop adapter (autologin, screen-lock, suspend masking) ─────────────
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/desktop-${DESKTOP}.sh"
@@ -168,61 +151,6 @@ additionalimagestores = ["/var/lib/superiso-store"]
 mount_program = "/usr/bin/fuse-overlayfs"
 CONFEOF
 
-# mount_program above is mandatory, not an optimization: the live root is
-# itself an overlayfs, and the overlay driver refuses to stack on one
-# ("'overlay' is not supported over overlayfs, a mount_program is required").
-# But containers/storage also stats the program at startup and hard-fails the
-# entire config when it is missing, which takes down every podman call in the
-# live guest and surfaces far away as the staging-space preflight abort. Warn
-# loudly here, at build time, instead of leaving that to be rediscovered from
-# an e2e log. The base package lists own the fix (the apt and dnf bases get it
-# from build_scripts/10-base-packages.sh; Arch and openSUSE list it directly).
-if [[ ! -x /usr/bin/fuse-overlayfs ]]; then
-	echo "WARNING: /usr/bin/fuse-overlayfs is missing from this image." >&2
-	echo "WARNING: podman will fail in the live env with \"can't stat program\"" >&2
-	echo "WARNING: and the offline store will be unusable. Add fuse-overlayfs" >&2
-	echo "WARNING: to this base's package list." >&2
-fi
-
-# ...but the primary config is no longer the last word. containers/storage 1.60+
-# (Fedora Rawhide's container-libs rebase) reads drop-ins from
-# storage{,.rootful}.conf.d AFTER the main file, and Fedora's containers-common
-# ships /usr/share/containers/storage.rootful.conf.d/00-vendor-rootful.conf with
-#   additionalimagestores = ["/usr/lib/containers/storage"]
-# which REPLACES the list above. On rawhide the live VM therefore never saw
-# /var/lib/superiso-store: `podman image exists` missed the payload image that
-# images.json plainly listed, and iso-e2e.sh fell back to SCP'ing the ~7 GB
-# image tar into the guest, onto the RAM-backed live overlay, which thrashed
-# for an hour and then took sshd down with it.
-#
-# Drop-ins are applied in filename order across all directories, so a 99-
-# prefixed admin drop-in wins over the vendor one. Re-declare the offline store
-# there, keeping the vendor entry alongside it where that path exists (it is
-# where bootc keeps logically-bound images).
-# Older containers/storage releases have no drop-in support and simply ignore
-# this file, where the primary config above is already correct.
-#
-# The vendor path is Fedora-specific and must only be listed where it exists:
-# containers/storage stats every additionalimagestores entry at startup and
-# hard-fails the whole config if one is missing, taking podman down with it:
-#   Error: configure storage: overlay: can't stat imageStore dir
-#   /usr/lib/containers/storage: no such file or directory
-# containers-common ships that directory on Fedora, but Arch's containers
-# package does not, so listing it unconditionally broke every podman call in
-# the marlin live guest: the offline-store probe then found nothing and the
-# e2e aborted on the staging-space preflight. Keep /var/lib/superiso-store
-# unconditional: tunaos-offline-store.service mounts it during boot, so it is
-# legitimately absent here at customize time.
-mkdir -p /etc/containers/storage.conf.d
-STORE_LIST='"/var/lib/superiso-store"'
-if [[ -d /usr/lib/containers/storage ]]; then
-	STORE_LIST="${STORE_LIST}, \"/usr/lib/containers/storage\""
-fi
-cat >/etc/containers/storage.conf.d/99-tunaos-offline-store.conf <<CONFEOF
-[storage.options]
-additionalimagestores = [${STORE_LIST}]
-CONFEOF
-
 # Dev/E2E media only: the normal published-image policy keeps SSH disabled.
 # tacklebox creates liveuser during boot, so install a oneshot that sets its
 # temporary test password after livesys and before the SSH daemon starts.
@@ -239,52 +167,21 @@ if [[ -f "${SCRIPT_DIR}/.enable-sshd" ]]; then
 		echo "ERROR: dev ISO requested but no SSH service is installed" >&2
 		exit 1
 	fi
-	mkdir -p /etc/ssh/sshd_config.d /usr/lib/systemd/system /usr/libexec \
+	mkdir -p /etc/ssh/sshd_config.d /usr/lib/systemd/system \
 		/etc/systemd/system/tunaos-live-ready.service.d
 	cat >/etc/ssh/sshd_config.d/90-tunaos-live-e2e.conf <<'EOF'
 PasswordAuthentication yes
 PermitEmptyPasswords no
 EOF
-	# The account may already exist from the image build (40-services.sh's
-	# ENABLE_SSHD path runs `useradd -m`), so section 1b above skips creating
-	# it — but a home directory made at build time does not necessarily
-	# survive to the live session. grouper bootcifies with
-	# build_scripts/bootc/mount-system.sh, which wipes /var and turns /home
-	# into a bind mount of /var/home, and /var/home is (re)created empty by
-	# tmpfiles at boot. `LUKS grouper:niri` failed exactly there: sshd logged
-	# "Could not chdir to home directory /home/liveuser" on every connection
-	# and each `scp ... liveuser@...:/home/liveuser/` died with
-	# `dest open "/home/liveuser/": Failure`. Materialise the home at boot,
-	# from the account's own passwd entry, instead of trusting the build-time
-	# directory. A separate script rather than an inline ExecStart so the
-	# quoting stays readable.
-	cat >/usr/libexec/tunaos-live-ssh-credentials <<'CREDEOF'
-#!/bin/sh
-# Live/dev media only: make sure liveuser exists, owns a usable home, and
-# carries the temporary E2E password. Runs before the SSH daemon.
-set -eux
-getent passwd liveuser >/dev/null ||
-	useradd --create-home --user-group --shell /bin/bash liveuser
-live_home="$(getent passwd liveuser | cut -d: -f6)"
-[ -n "$live_home" ] || live_home=/home/liveuser
-mkdir -p "$live_home"
-chown "$(id -u liveuser):$(id -g liveuser)" "$live_home"
-chmod 0700 "$live_home"
-echo liveuser:live | chpasswd
-CREDEOF
-	chmod 0755 /usr/libexec/tunaos-live-ssh-credentials
-	# local-fs.target: home.mount (grouper's /var/home → /home bind) is
-	# ordered Before=local-fs.target, so waiting for it keeps the directory
-	# below from being created underneath the mount that then hides it.
 	cat >/usr/lib/systemd/system/tunaos-live-ssh-credentials.service <<EOF
 [Unit]
 Description=Configure temporary TunaOS live E2E SSH credentials
-After=livesys.service local-fs.target
+After=livesys.service
 Before=${SSH_UNIT}
 
 [Service]
 Type=oneshot
-ExecStart=/usr/libexec/tunaos-live-ssh-credentials
+ExecStart=/bin/sh -euxc 'getent passwd liveuser >/dev/null || useradd --create-home --user-group --shell /bin/bash liveuser; echo liveuser:live | chpasswd'
 RemainAfterExit=yes
 StandardOutput=journal+console
 StandardError=journal+console

--- a/scripts/build-image-inner.sh
+++ b/scripts/build-image-inner.sh
@@ -147,28 +147,17 @@ build_primary_image() {
 		.
 }
 
-# Runners intermittently fail a build before it starts with
-# `open out/index.json: no such file or directory` (seen on Blacksmith
-# amd64/v2), and the same inputs then succeed on a fresh invocation, so retry
-# the whole build rather than failing the flavor/manifest job.
-#
-# This deliberately does not test BUILDER. The gate used to require "buildah"
-# as a stand-in for "running in CI", but BUILDER only becomes buildah when the
-# binary is present (see above), so any runner without it was excluded from the
-# retry regardless of how transient its failure was.
-#
-# Retrying in-process cannot rescue a broken runtime stack on the host, and it
-# is not meant to: crun's `unknown version specified` reproduced on all three
-# attempts of `LUKS flounder:kde`, because the workflow was installing a podman
-# that did not match the runner image's crun. That belongs in the workflow (see
-# .github/workflows/luks-e2e.yml), not here.
+# Blacksmith's amd64/v2 runners intermittently fail before a Buildah build
+# starts with `open out/index.json: no such file or directory`. The same
+# inputs reliably succeed on a fresh invocation, so retry the whole build
+# rather than making a transient storage race fail the flavor/manifest job.
 build_attempt=1
 until build_primary_image; do
-	if [[ "${build_attempt}" -ge 3 ]]; then
+	if [[ "${BUILDER}" != "buildah" || "${build_attempt}" -ge 3 ]]; then
 		echo "ERROR: image build failed after ${build_attempt} attempt(s)" >&2
 		exit 1
 	fi
-	echo "Build attempt ${build_attempt} failed; retrying in $((build_attempt * 10))s..." >&2
+	echo "Buildah build attempt ${build_attempt} failed; retrying in $((build_attempt * 10))s..." >&2
 	sleep "$((build_attempt * 10))"
 	build_attempt=$((build_attempt + 1))
 done

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -405,58 +405,14 @@ start_swtpm() {
 
 # Fresh OVMF NVRAM each run — UEFI writes state during install (boot order,
 # secure-boot vars). Reusing a stale one masks regressions.
-mint_ovmf_vars() {
-	local dest="$1"
-	# Always start from nothing: `truncate` only extends an existing file, so
-	# reusing one would carry its old contents into the "fresh" varstore.
-	rm -f "$dest"
-	if [[ -n "$OVMF_VARS_SRC" ]]; then
-		cp -f "$OVMF_VARS_SRC" "$dest"
-	else
-		# Some packaging only ships a combined OVMF.fd; create empty vars file
-		# as a fallback (UEFI will populate it).
-		truncate -s 4M "$dest"
-	fi
-}
-mint_ovmf_vars "$OVMF_VARS"
+if [[ -n "$OVMF_VARS_SRC" ]]; then
+	cp -f "$OVMF_VARS_SRC" "$OVMF_VARS"
+else
+	# Some packaging only ships a combined OVMF.fd; create empty vars file
+	# as a fallback (UEFI will populate it).
+	truncate -s 4M "$OVMF_VARS"
+fi
 rm -f "$MONITOR_SOCK" "$SERIAL_LOG" "$QEMU_PIDFILE"
-
-# Which NVRAM the installed-disk boot should use. OVMF persists its enumerated
-# boot options and BootOrder into the varstore, and the live boot is what fills
-# it in: at that point the only bootable device is the ISO's virtio-scsi
-# CD-ROM, because the install disk is still a blank qcow2 with no ESP to
-# enumerate. Handing that same varstore to the installed boot, which attaches
-# neither the CD-ROM nor its controller, leaves the firmware walking stale
-# entries for hardware that is gone and then giving up into the shell:
-#   BdsDxe: starting Boot0007 "EFI Internal Shell"
-#   !!! passphrase prompt never appeared
-# That is how `LUKS flounder-sid:gnome` died with exit 4 after a completely
-# successful install (LUKS partition confirmed, "Installation complete!").
-#
-# The GRUB/bootupd path hides this because its install writes an NVRAM entry
-# into the shared varstore, so a valid entry is always waiting. bootc's
-# composefs-native systemd-boot path does not: it installs with
-# `--no-variables` and writes no boot variable at all, leaving the firmware to
-# discover the default loader by enumeration. `bootctl install` does always
-# place that loader at \EFI\BOOT\BOOTX64.EFI (in systemd 261 the copy is
-# guarded only by the architecture suffix, not by --no-variables), so a
-# pristine varstore boots it the same way this media boots off a USB stick on
-# real hardware.
-#
-# Only the systemd-boot images change behaviour here; GRUB images keep using
-# the varstore their bootupd install just wrote to.
-installed_boot_ovmf_vars() {
-	local bootloader="$1"
-	if [[ "$bootloader" != "systemd" ]]; then
-		printf '%s' "$OVMF_VARS"
-		return 0
-	fi
-	local fresh="${OUTPUT_DIR}/OVMF_VARS.installed.fd"
-	mint_ovmf_vars "$fresh"
-	echo "==> systemd-boot image: booting the installed disk with a pristine" \
-		"UEFI varstore so the firmware enumerates its default loader" >&2
-	printf '%s' "$fresh"
-}
 
 # ── Cleanup on exit ─────────────────────────────────────────────────────────
 
@@ -852,15 +808,6 @@ run_install() {
 	done
 	check_ssh || {
 		echo "ERROR: SSH not available"
-		# Every attempt above goes through QEMU's hostfwd, which needs the
-		# guest to hold a DHCP lease. An image shipping no network manager
-		# therefore fails all 30 tries while its own sshd is perfectly
-		# healthy, which is indistinguishable from a broken sshd unless the
-		# live TAP checks are surfaced. That was `LUKS grouper:*`: 30 opaque
-		# "SSH check failed" lines, with the answer ("not ok - a network
-		# manager is active") sitting in the serial log the whole time.
-		echo "--- live-env TAP failures from the serial console ---" >&2
-		grep -a "not ok -" "$SERIAL_LOG" 2>/dev/null | tr -d '\r' >&2 || true
 		return 5
 	}
 
@@ -870,26 +817,6 @@ run_install() {
 	local -a COMMON_SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
 	local ssh_cmd=(sshpass -p live ssh "${COMMON_SSH_OPTS[@]}" -p "$SSH_PORT" liveuser@127.0.0.1)
 	local scp_cmd=(sshpass -p live scp "${COMMON_SSH_OPTS[@]}" -P "$SSH_PORT")
-
-	# Everything below runs privileged commands over non-interactive SSH and
-	# stages files in liveuser's home. Both preconditions failed silently on
-	# `LUKS grouper:niri`: the Ubuntu image shipped no sudo package, so every
-	# probe in the offline-store dump answered "sudo: command not found" and
-	# degraded to "(empty or error)" — the harness concluded the payload image
-	# was absent and tried to SCP a 4 GB tar into /home/liveuser, which did
-	# not exist either. Assert them up front so the ISO's actual defect is
-	# the error message.
-	if ! "${ssh_cmd[@]}" "sudo -n true" 2>/dev/null; then
-		echo "ERROR: liveuser has no working passwordless sudo in the live env." >&2
-		"${ssh_cmd[@]}" "command -v sudo || echo '(sudo is not installed on this image)'" >&2 || true
-		return 3
-	fi
-	if ! "${ssh_cmd[@]}" "test -w /home/liveuser" 2>/dev/null; then
-		echo "ERROR: /home/liveuser is missing or not writable in the live env;" >&2
-		echo "ERROR: the install path stages the recipe and image tar there." >&2
-		"${ssh_cmd[@]}" "ls -ld /home /home/liveuser 2>&1; getent passwd liveuser" >&2 || true
-		return 3
-	fi
 
 	# Bug #20: fisherman's network pull stalled indefinitely mid-blob (layer
 	# 42/65, no error, no further output) after dozens of smaller layers
@@ -976,33 +903,10 @@ run_install() {
 	local local_ref="localhost/${VARIANT:-}:${FLAVOR:-}" # dev=1 ISO
 	local prod_ref="$published_ref"                      # production ISO
 	local recipe_image=""                                # set below after probing the VM
-	# Mirror bootc's own bootloader decision rather than naming variants.
-	# install.rs (PostFetchState::new) picks GRUB only when
-	# bootloader::supports_bootupd() holds, i.e. bootupctl is on PATH AND the
-	# image contains the update payload dir usr/lib/bootupd/updates; otherwise
-	# it falls back to systemd-boot. Its ostree-based install path then refuses
-	# systemd-boot outright:
-	#   error: Installing to filesystem: bootupd is required for ostree-based installs
-	# which is how `LUKS flounder-sid:gnome` died after deploying all 4.2 GB.
-	#
-	# The Debian, Arch and openSUSE bases build bootupd from source, and
-	# bootupd's `make install` ships only the binary plus the bootupctl
-	# symlink. Nothing ever runs `bootupctl backend generate-update-metadata`,
-	# so bootupctl exists while the payload never does. Those bases install
-	# systemd-boot and set composefs enabled = yes precisely so bootc's
-	# composefs-native backend performs the install, exactly like grouper
-	# (Ubuntu), which was the only variant this check used to cover.
-	#
-	# Probing the image keeps the harness from ever disagreeing with bootc:
-	# the dev ISO's live squash is the image being installed, and Fedora/EL10,
-	# which do ship the payload, still resolve to GRUB. These two combinations
-	# are the only ones the recipe supports, so deriving both flags from the
-	# one signal cannot produce an untested mix.
 	local composefs_backend="false" bootloader="grub2"
-	if "${ssh_cmd[@]}" "test -d /usr/lib/bootupd/updates" &>/dev/null; then
-		echo "==> Image ships the bootupd update payload: installing via GRUB/bootupd"
-	else
-		echo "==> No bootupd update payload in the image: using bootc's composefs-native backend with systemd-boot"
+	# grouper (Ubuntu) has no bootupd package available via apt, so it ships
+	# systemd-boot instead and installs via bootc's composefs-native backend.
+	if [[ "${VARIANT:-}" == "grouper" ]]; then
 		composefs_backend="true"
 		bootloader="systemd"
 	fi
@@ -1044,16 +948,9 @@ run_install() {
 	# image store (driver mismatch, unreadable lock, version skew); images.json
 	# is ~1 KB and states the names actually recorded, which distinguishes
 	# "store ignored" from "image recorded under a name we never probe".
-	#
-	# Keep 'config' in the filter: containers-storage logs `Read config file
-	# "<path>"` for every main file and drop-in it merges, in merge order. That
-	# list is what distinguishes "our config is wrong" from "our config was
-	# overridden by a later drop-in" — the actual bonito-rawhide failure, where
-	# the effective additionalimagestores was the vendor drop-in's value and the
-	# printed /etc/containers/storage.conf was a red herring.
 	echo "--- why podman does or does not see the additional store ---"
 	"${ssh_cmd[@]}" "sudo podman --log-level=debug images 2>&1 \
-		| grep -iE 'additional|superiso|store|driver|config file' | head -40 \
+		| grep -iE 'additional|superiso|store|driver' | head -40 \
 		|| echo '(no matching debug lines)'" || true
 	echo "--- names recorded in the offline store ---"
 	"${ssh_cmd[@]}" "sudo cat /var/lib/superiso-store/overlay-images/images.json 2>&1 \
@@ -1077,24 +974,10 @@ run_install() {
 		local img_json="/var/lib/superiso-store/overlay-images/images.json"
 		if "${ssh_cmd[@]}" "sudo test -f ${img_json} && sudo jq -e --arg ref '${candidate_ref}' '.[] | select(.names != null) | select(.names | index(\$ref))' ${img_json} >/dev/null 2>&1" 2>/dev/null; then
 			echo "==> Found ${candidate_ref} in offline store images.json (podman query missed it)"
-			# The store holds the image but this podman does not have
-			# /var/lib/superiso-store in its additional-store list. On
-			# Rawhide because containers-common's
-			# storage.rootful.conf.d/00-vendor-rootful.conf drop-in replaces
-			# the list our /etc/containers/storage.conf sets (fixed in
-			# customize-live.sh with a 99- admin drop-in; kept here so an
-			# ISO built before that fix still installs). Re-assert the store
-			# and re-probe: bootc reads the same config, so if podman sees
-			# the image after this, so will the install.
-			"${ssh_cmd[@]}" "sudo mkdir -p /etc/containers/storage.conf.d && \
-				printf '[storage.options]\nadditionalimagestores = [\"/var/lib/superiso-store\", \"/usr/lib/containers/storage\"]\n' \
-				| sudo tee /etc/containers/storage.conf.d/99-tunaos-offline-store.conf >/dev/null" || true
-			if "${ssh_cmd[@]}" "sudo podman image exists '${candidate_ref}'" 2>/dev/null; then
-				echo "==> Store re-registered: ${candidate_ref} is now visible to podman"
-				found_local=1
-				found_ref="$candidate_ref"
-				break
-			fi
+			# The image exists but podman/bootc can't resolve it from the
+			# additional store (overlay driver mismatch). Don't set
+			# found_local here — let the code fall through to the network
+			# pull, which now uses aggressive MTU clamping + retries.
 		fi
 	done
 
@@ -1122,25 +1005,6 @@ run_install() {
 		if podman image exists "$host_img" 2>/dev/null; then
 			echo "==> Saving $host_img on host..."
 			podman save "$host_img" -o "$host_tar"
-			# The live root is a RAM-backed overlay, so the tar plus the
-			# loaded copy have to fit in what little the guest can write.
-			# Without this check an oversized transfer does not fail, it
-			# thrashes until the kernel kills sshd, which is how
-			# bonito-rawhide:cosmic burned 61 minutes before reporting
-			# "Connection closed by remote host" with no visible cause.
-			local tar_kb avail_kb need_kb
-			tar_kb=$(du -k "$host_tar" | cut -f1)
-			avail_kb=$("${ssh_cmd[@]}" "df -Pk /home/liveuser | awk 'NR==2 {print \$4}'" 2>/dev/null | tr -dc '0-9')
-			need_kb=$((tar_kb * 9 / 4)) # tar + podman load's unpacked copy
-			echo "==> Guest writable space: ${avail_kb:-unknown} KiB, image tar: ${tar_kb} KiB"
-			if [[ -n "$avail_kb" && "$avail_kb" -lt "$need_kb" ]]; then
-				echo "ERROR: guest has ${avail_kb} KiB writable but staging ${host_img}" >&2
-				echo "ERROR: needs ~${need_kb} KiB. The offline store on the ISO is the" >&2
-				echo "ERROR: only viable source for an image this size. Check that" >&2
-				echo "ERROR: /var/lib/superiso-store is registered in the guest's" >&2
-				echo "ERROR: containers-storage config (storage.conf.d drop-ins win)." >&2
-				return 3
-			fi
 			echo "==> Transferring image to guest (this may take a few minutes)..."
 			"${scp_cmd[@]}" "$host_tar" "liveuser@127.0.0.1:/home/liveuser/"
 			echo "==> Loading image into guest podman..."
@@ -1267,13 +1131,6 @@ EOF
 				echo "karg appended: $f"
 				found=1
 			done
-			# Evidence for the installed boot: the firmware can only find the
-			# installed system by enumerating the default loader, so record
-			# whether it is actually on the ESP before we hand over to QEMU.
-			if [ -d /mnt/tbx-bls/EFI ]; then
-				echo "ESP EFI binaries on ${p}:"
-				find /mnt/tbx-bls/EFI -iname '*.efi' -printf '  %p\n' 2>/dev/null | sed 's|/mnt/tbx-bls||'
-			fi
 			umount /mnt/tbx-bls
 			[ "$found" = 1 ] && break
 		done
@@ -1313,15 +1170,13 @@ EOF
 		echo "==> LUKS passphrase gate: booting installed disk, injecting passphrase, expecting login..."
 		local FB_SERIAL="${OUTPUT_DIR}/installed-serial.sock"
 		rm -f "$FB_SERIAL"
-		local FB_VARS
-		FB_VARS="$(installed_boot_ovmf_vars "$bootloader")"
 		# No TPM here: the passphrase gate doesn't need one, and the
 		# install-phase swtpm has already exited (its socket is gone). TPM
 		# auto-unlock is the separate post-install test.
 		"$QEMU" -name "tunaos-iso-e2e-installed" -machine pc -cpu "$CPU_ARG" \
 			-accel "$ACCEL" -m "$MEMORY" -smp "$CPUS" \
 			-drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
-			-drive "if=pflash,format=raw,file=${FB_VARS}" \
+			-drive "if=pflash,format=raw,file=${OVMF_VARS}" \
 			-drive "if=none,id=disk,file=${INSTALL_DISK},format=qcow2" \
 			-device virtio-blk-pci,drive=disk \
 			-netdev "user,id=net0" -device virtio-net-pci,netdev=net0 \
@@ -1342,8 +1197,6 @@ EOF
 	fi
 
 	echo "==> Booting installed system..."
-	local INSTALLED_VARS
-	INSTALLED_VARS="$(installed_boot_ovmf_vars "$bootloader")"
 	# Boot from the install disk (remove cdrom)
 	# shellcheck disable=SC2086  # TPM_ARGS is intentionally word-split (empty unless --luks)
 	"$QEMU" \
@@ -1355,7 +1208,7 @@ EOF
 		-smp "$CPUS" \
 		${TPM_ARGS} \
 		-drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
-		-drive "if=pflash,format=raw,file=${INSTALLED_VARS}" \
+		-drive "if=pflash,format=raw,file=${OVMF_VARS}" \
 		-drive "if=none,id=disk,file=${INSTALL_DISK},format=qcow2" \
 		-device virtio-blk-pci,drive=disk \
 		-netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22" \

--- a/system_files/etc/systemd/system/systemd-firstboot.service
+++ b/system_files/etc/systemd/system/systemd-firstboot.service
@@ -1,1 +1,0 @@
-/dev/null

--- a/tests/bats/test_customize_live.bats
+++ b/tests/bats/test_customize_live.bats
@@ -126,38 +126,8 @@ detect() {
   grep -q 'graphroot = "/var/lib/containers/storage"' "${SCRIPT}"
   grep -q 'additionalimagestores = \["/var/lib/superiso-store"\]' "${SCRIPT}"
   grep -q 'mount_program = "/usr/bin/fuse-overlayfs"' "${SCRIPT}"
-}
-
-# The primary config above is necessary but no longer sufficient:
-# containers/storage 1.60+ (Rawhide) applies storage{,.rootful}.conf.d drop-ins
-# after it, and containers-common's vendor drop-in replaces
-# additionalimagestores with just /usr/lib/containers/storage. A 99- admin
-# drop-in is applied last (drop-ins run in filename order), so it must re-list
-# the offline store while keeping the vendor path bootc uses for bound images.
-@test "customize-live.sh: re-asserts the offline store in a late drop-in" {
-  grep -q 'storage.conf.d/99-tunaos-offline-store.conf' "${SCRIPT}"
-  grep -q 'additionalimagestores = \[\${STORE_LIST}\]' "${SCRIPT}"
-  grep -q "STORE_LIST='\"/var/lib/superiso-store\"'" "${SCRIPT}"
-}
-
-# ...but the vendor path only gets listed where it exists. containers/storage
-# stats every additionalimagestores entry and fails the entire config when one
-# is missing, so hardcoding Fedora's /usr/lib/containers/storage took podman
-# down on Arch ("can't stat imageStore dir"). The offline store itself stays
-# unconditional: it is mounted during boot, so it is absent at customize time.
-@test "customize-live.sh: gates the vendor image store on it existing" {
-  grep -q 'if \[\[ -d /usr/lib/containers/storage \]\]; then' "${SCRIPT}"
-  # the heredoc delimiter must stay unquoted or STORE_LIST won't expand
-  grep -q "cat >/etc/containers/storage.conf.d/99-tunaos-offline-store.conf <<CONFEOF" "${SCRIPT}"
-}
-
-# Only Containerfile.{el10,ubuntu} run build_scripts/40-services.sh, which is
-# the sole place tunaos-live-ready.service gets enabled — the arch, opensuse,
-# gentoo and debian bases shipped it disabled, so the e2e harness waited out
-# its full ready timeout on a live session that was already up.
-@test "customize-live.sh: enables the readiness marker in the live squash" {
-  grep -q 'systemctl enable tunaos-live-ready.service' "${SCRIPT}"
-  grep -q 'install -Dm644 "${SCRIPT_DIR}/tunaos-live-ready.service"' "${SCRIPT}"
+  run grep 'storage.conf.d/99-tunaos-offline-store.conf' "${SCRIPT}"
+  [ "$status" -ne 0 ]
 }
 
 @test "customize-live.sh: sources the matching desktop adapter" {


### PR DESCRIPTION
Reverts #886 — it regressed the **Build dev ISO** step, which sits upstream of every LUKS cell.

## Evidence

`yellowfin:gnome` was green on LUKS E2E before #886 and fails after it, at *Build dev ISO*:

| | run 30594079979 (pass) | run 30605643466 (fail) |
|---|---|---|
| tacklebox | `e7d76b2a` | `e7d76b2a` (same) |
| podman / crun | 4.9.3 / 1.14.1 | 4.9.3 / 1.14.1 (same) |
| published image | `yellowfin:gnome` 2026-07-27 | same tag, unchanged |
| result | `TUNAOS_LUKS_E2E_PASS` | `prepare initramfs ... failed` |

Only two commits landed on main between those runs — #886 and #909 — and #909 only deletes two workflows that cannot run. #886 is the cause by elimination.

## Blast radius

This is upstream of the whole axis: 16 LUKS cells were verified green on main before #886 (yellowfin 4/4, albacore and bonito across gnome/kde/cosmic/niri/xfce). Left in place, they would all turn red for a reason unrelated to LUKS or to the images themselves. `skipjack:gnome` fails identically.

## Not a rejection of the fix

#886 contains work that is still wanted — notably `customize-live.sh` installing and enabling `tunaos-live-ready.service` when the image lacks it, which is exactly the gap that blocks `sailfin` (its published image ships no `tunaos-live-ready.service`, so `iso-e2e.sh` waits 1200s for a marker that can never arrive). Please re-land with the dev-ISO regression fixed.

## Diagnostic note for whoever re-lands it

The failure surfaces as:

```
Error: prepare initramfs for yellowfin-gnome: initramfs preparation for
localhost/tbox-live-custom:... failed (does the image ship dracut?): podman run ...
```

That message is misleading twice over: the image **does** ship dracut, and the podman invocation dies **1.5s** after it starts, i.e. the container never comes up. tacklebox also swallows podman's stderr, so the real error is never printed. Worth fixing in tacklebox independently — it cost most of the time spent diagnosing this.

The most likely suspect in the diff is the new `/etc/containers/storage.conf.d/99-tunaos-offline-store.conf` written by `customize-live.sh` (`additionalimagestores`), since it changes container storage config in the image that is then committed and immediately run. Unconfirmed — stated as a lead, not a diagnosis.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788068122&installation_model_id=429180&pr_number=926&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F926&signature=a1e76f0a111ed3d9bf86ff31e14f1c0301aecf7e31c56cb515134a2ff93b87ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->