### PR TITLE
fix(ci): stop Just Fix installing Homebrew from scratch — this is why Renovate PRs never automerge

### DIFF
--- a/.github/workflows/just-fix.yml
+++ b/.github/workflows/just-fix.yml
@@ -31,12 +31,20 @@ jobs:
             echo "last_commit_is_bot=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Install Homebrew
+      # Use the runner's preinstalled Homebrew, as lint.yml does. Installing
+      # Homebrew from scratch on every run made this job depend on a large
+      # download that fails often enough to matter:
+      #
+      #   Error: Failed to download
+      #   https://formulae.brew.sh/api/internal/packages.x86_64_linux.jws.json!
+      #
+      # Every such failure turned this check red, which left the pull request
+      # UNSTABLE, which stopped Renovate automerging it. Renovate PRs then sat
+      # open for days — #835 merged within minutes once queued by hand, after
+      # five days of waiting.
+      - name: Setup Homebrew
         if: steps.check-bot.outputs.last_commit_is_bot != 'true'
-        run: |
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
-          echo "/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+        uses: Homebrew/actions/setup-homebrew@2ebcf16054461267868620b1414507f3ccc765c1 # main as of 2026-06-09
 
       - name: Install just
         if: steps.check-bot.outputs.last_commit_is_bot != 'true'


### PR DESCRIPTION
## The symptom

Renovate pull requests do not automerge. They accumulate: #895, #841, #840, #920 have all been open for days.

## It is not the Renovate config

`renovate.json` already has everything it needs — `automerge: true`, `platformAutomerge: true`, `automergeType: pr`, `automergeStrategy: squash`, plus a `packageRules` entry automerging every update type. That config is fine.

## The actual cause

Every stuck PR carries exactly one red check, and it is the same one:

```
#895  fail fix        #841  fail fix
#840  fail fix        #920  fail fix
```

`Just Fix` bootstraps the entire Homebrew installation on every run, to obtain one binary:

```yaml
/bin/bash -c "$(curl -fsSL .../Homebrew/install/HEAD/install.sh)"
```

That download fails often enough to matter:

```
Error: Failed to download
https://formulae.brew.sh/api/internal/packages.x86_64_linux.jws.json!
```

Each failure turns the `fix` check red → the PR goes `UNSTABLE` → **Renovate will not automerge a branch it sees as failing.** So the PR sits until a human deals with it, which is precisely what automerge exists to avoid.

The control case proves it: **#835** was the one renovate PR whose `fix` check had gone green. It was `CLEAN` — and still sat for five days because Renovate had stopped touching it by then. Queued by hand, it merged **within minutes**.

## The fix

`lint.yml` already solved this, using `Homebrew/actions/setup-homebrew` — the Homebrew the runner already has, no download. This adopts the same action at the same pin, so the two workflows behave identically.

## Ruled out on the way, so nobody re-investigates

- **The merge queue works.** It looked like the obvious suspect — 0 of 47 workflows trigger on `merge_group`, which stalls a queue configured `ALLGREEN`. But #835 merged through the queue normally once queued, which disproves it. The `main` ruleset requires no status checks, so the queue has nothing to wait for.
- **`allow_auto_merge` is enabled** on the repository.
- **Renovate is running** — #920 was updated today.

## Not addressed here

`just-fix.yml` carries two pre-existing `SC2086` shellcheck findings at the `check-bot` step. They are on `main` already (verified) and are unrelated to this change, so they are left alone rather than bundled in.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->