### PR TITLE
fix(ci): pin tacklebox past the baked-in tpm2-tss omit that aborts EL builds

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -295,7 +295,18 @@ jobs:
     permissions:
       contents: write
     steps:
+      # This job commits to main, so it must start FROM main — not from the
+      # dispatched ref. Checking out a feature branch made `git pull --rebase
+      # origin main` replay that branch's commits onto main: it conflicted
+      # (run 30618282287, add/add on luks-e2e.yml + image-versions.yaml, since
+      # the shallow clone has no merge base) and, had it succeeded, would have
+      # pushed unreviewed PR commits straight to main. fetch-depth: 0 gives the
+      # rebase real history so a concurrent push to main is handled instead of
+      # degenerating into add/add conflicts again.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Download walkthrough artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -233,7 +233,14 @@ jobs:
         env:
           VARIANT: ${{ matrix.variant }}
           FLAVOR: ${{ matrix.flavor }}
-          TACKLEBOX_SHA: e7d76b2a56cf99f2f353847fbcd0e3d487e5b8d2
+          # fd95174 probes for tpm2-tss/pcsc inside the image instead of
+          # omitting them unconditionally. e7d76b2a baked in
+          # `--omit "tpm2-tss pcsc"` to fix Gentoo (which ships neither
+          # module); on EL images, which ship both and force-add clevis on
+          # top, that omit turns clevis into "cannot be installed" and
+          # dracut exits 1 — every EL LUKS cell died at Build dev ISO.
+          # Do not pin this back below fd95174 without re-reading that.
+          TACKLEBOX_SHA: fd95174432b854a6135600b6c321b3ef01b4bc2d
         run: |
           export TACKLEBOX_FROM_SOURCE=1
           just iso "${VARIANT}" "${FLAVOR}" ghcr "" 1

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -31,7 +31,11 @@ downloads:
     amd64: "a8880a1b01e877c3e5da250b9f882ce9fa39962686d75f436fa21e021fa092b1"
     arm64: "ea9389f4efdc26d74bf9b4cc73db8f3a529e1e6effb5703e438117ea3f095439"
   # renovate: datasource=git-refs depName=tuna-os/tacklebox
-  tacklebox: "320a1a459511b9d056d67e9301ec5fed02858f44"
+  # This is the fallback every caller that does not set TACKLEBOX_SHA gets
+  # (scripts/lib/common.sh:229) — installer-smoke.yml among them. Held below
+  # fd95174 it bakes in `--omit "tpm2-tss pcsc"`, which aborts the dracut
+  # rebuild on any EL image that force-adds clevis. See luks-e2e.yml.
+  tacklebox: "fd95174432b854a6135600b6c321b3ef01b4bc2d"
 
   # Bootc toolchain built from source (see toolchain/) and published to
   # ghcr.io/tuna-os/bootc-toolchain-<base> as OCI artifacts via ORAS.


### PR DESCRIPTION
## What

Bumps the tacklebox pin to `fd95174` in the two places tunaOS resolves it independently.

## Why

Every EL-family LUKS cell has failed at **Build dev ISO** since the 07-28 pin bump:

```
dracut[E]: Module 'clevis' depends on module 'systemd-cryptsetup', which can't be installed
dracut[E]: Module 'clevis' cannot be installed.
```

`cb77943d` bumped `TACKLEBOX_SHA` to `e7d76b2a` *"to include pcsc omit fix"*. That fix makes tacklebox run `dracut ... --omit "tpm2-tss pcsc"` **unconditionally** — correct for Gentoo (guppy ships neither module, and dracut aborts when they are force-added), fatal for EL, which ships both and force-adds `clevis` / `systemd-cryptsetup` / `systemd-pcrphase` on top.

tacklebox `fd95174` replaces the blanket omit with a per-image probe, so both directions work. `TestInitramfsScriptOmitsOnlyMissingModules` pins it.

## Evidence

| run | clevis in dracut output | result |
|---|---|---|
| [30594079979](https://github.com/tuna-os/tunaOS/actions/runs/30594079979) `yellowfin:gnome` 00:37 | absent (0 lines) | ✅ rebuilt, added: tbox-live tbox-root |
| [30607222863](https://github.com/tuna-os/tunaOS/actions/runs/30607222863) `yellowfin:gnome` 06:09 | present (14 lines) | ❌ `Module 'clevis' cannot be installed` |

Same `TACKLEBOX_SHA`, same engine built from source, same image name.

## Two pins, not one

- `luks-e2e.yml` sets `TACKLEBOX_SHA` explicitly.
- `image-versions.yaml` is the fallback for callers that don't (`scripts/lib/common.sh:229`). **`installer-smoke.yml` is one of them** — so the installer axis was hitting the identical abort and it would read as an installer failure.

## Not a revert of #886

#926 reverted the offline-store `storage.conf` on a lead this evidence disproves. Harmless, but it was not the cause and should not stand as the fix.

## Known, deliberately not fixed here

- `publish-iso-groups.yml` pins a third, older SHA (`a105d6d3`) and has the same bug. Left alone — it governs publishing, not these two axes.
- **Where clevis came from is not yet established.** The floating-base hypothesis is contradicted by tag history: `quay.io/centos-bootc/centos-bootc:c10s` last moved 30 Jul 20:44 UTC and both runs are after it. The pin bump is correct regardless — the engine must not blanket-omit `tpm2-tss` on an image that force-adds clevis.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->