### PR TITLE
chore(deps): bump tacklebox pin to 4fa6041 (live-boot fix)

### DIFF
--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -32,10 +32,23 @@ downloads:
     arm64: "ea9389f4efdc26d74bf9b4cc73db8f3a529e1e6effb5703e438117ea3f095439"
   # renovate: datasource=git-refs depName=tuna-os/tacklebox
   # This is the fallback every caller that does not set TACKLEBOX_SHA gets
-  # (scripts/lib/common.sh:229) — installer-smoke.yml among them. Held below
-  # fd95174 it bakes in `--omit "tpm2-tss pcsc"`, which aborts the dracut
-  # rebuild on any EL image that force-adds clevis. See luks-e2e.yml.
-  tacklebox: "fd95174432b854a6135600b6c321b3ef01b4bc2d"
+  # (scripts/lib/common.sh:229) — installer-smoke.yml among them.
+  #
+  # FLOOR, not a ceiling: below fd95174, tacklebox bakes `--omit "tpm2-tss
+  # pcsc"` into the dracut command line, which aborts the rebuild on any EL
+  # image that force-adds clevis (see luks-e2e.yml). fd95174 is the commit
+  # that replaced it with a per-image probe, and initramfs_test.go pins the
+  # baked-in form gone. So never move this pin below fd95174 — moving it
+  # ABOVE has always been fine, and a Renovate bump to an older-but-clean
+  # digest is the thing to watch (tuna-os/iso-builder#43).
+  #
+  # At 4fa6041 for the live-boot fix: below it, the embedded initrd overlay
+  # cannot mount the live root at all. $hookdir is on the image's read-only
+  # /usr, so the queue directories cannot be created, tbox-live-root never
+  # runs, and the boot dies in emergency on `overlayfs: failed to resolve
+  # '/run/rootfsbase'`. Proven both ways by named runs: broken at
+  # tacklebox 30629145076, booting to login at 30630284339.
+  tacklebox: "4fa604115dfa2e6356c68bde85a191c6620ebea1"
 
   # Bootc toolchain built from source (see toolchain/) and published to
   # ghcr.io/tuna-os/bootc-toolchain-<base> as OCI artifacts via ORAS.


### PR DESCRIPTION
**Deliberate manual pin — do not let Renovate move this backwards.** The `renovate: datasource=git-refs` annotation stays, so a forward bump is fine; an older-but-clean digest is not (tuna-os/iso-builder#43 was exactly that).

## Why bump

Below `4fa6041` the embedded initrd overlay cannot mount the live root at all. `$hookdir` is `/lib/dracut/hooks`, on the image's read-only `/usr`, so the dracut queue directories cannot be created, `tbox-live-root` never runs, and the boot dies in emergency on `overlayfs: failed to resolve '/run/rootfsbase'`.

Proven both ways by named runs on `yellowfin:niri` under QEMU/OVMF:

| | run |
|---|---|
| emergency mode | [30629145076](https://github.com/tuna-os/tacklebox/actions/runs/30629145076) |
| `localhost login:` | [30630284339](https://github.com/tuna-os/tacklebox/actions/runs/30630284339) |

tacklebox#166 has the full write-up. Production path regression-gated: `iso-smoke` green on tacklebox main both before (`ee9e9ed`) and after (`4fa6041`).

## The comment above the pin

It was being read as a ceiling. It is a **floor**, and it is accurate — I checked before changing it:

- `45e99f8`, the commit immediately before `fd95174`, does carry a baked-in `--omit "tpm2-tss pcsc"` on the dracut command line.
- `fd95174` is exactly where the per-image probe replaced it.
- `internal/install/initramfs.go` is **byte-identical** from `fd95174` to tacklebox main, and `initramfs_test.go:52` pins the baked-in form gone.

So the old comment described a real hazard at a real boundary and was never what kept `4fa6041` out — it just read ambiguously. Rewritten to say floor explicitly, keep the tpm2-tss/clevis reasoning, and name the direction actually worth watching.

## Scope note

`image-versions.yaml` is outside my usual boundary (browser ISO engine); done at the orchestrator's request.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->