### PR TITLE
fix(e2e): bound the guest image transfer so a hung LUKS cell fails instead of idling

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -758,7 +758,16 @@ check_ssh() {
 run_smoke_checks() {
 	local script_dir
 	script_dir="$(dirname "${BASH_SOURCE[0]}")"
-	local -a COMMON_SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
+	# ConnectTimeout bounds the handshake; ServerAlive* bounds an already-open
+	# connection to a guest that stopped answering. Without the latter, ssh/scp
+	# block on a dead socket forever — three LUKS runs on 07-31 each burned
+	# 2h14m-2h42m of a runner inside one scp and had to be cancelled by hand
+	# (#939). check_ssh() a few lines up already set ConnectTimeout=10; these
+	# two arrays did not, which is why the same file behaved both ways.
+	local -a COMMON_SSH_OPTS=(
+		-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+		-o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=8
+	)
 	local ssh_cmd=(sshpass -p live ssh "${COMMON_SSH_OPTS[@]}" -p "$SSH_PORT" liveuser@127.0.0.1)
 	local scp_cmd=(sshpass -p live scp "${COMMON_SSH_OPTS[@]}" -P "$SSH_PORT")
 
@@ -831,7 +840,13 @@ run_install() {
 	# scp uses -P (capital) for the port flag; ssh uses -p. Sharing one array
 	# with the wrong flag silently makes scp treat the port number as a
 	# source-file argument ("stat local 2222: No such file or directory").
-	local -a COMMON_SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
+	# Keepalives: see run_smoke_checks() for why these are not optional. This
+	# is the array the multi-GB image transfer below uses, so it is the one
+	# that actually hung the runners in #939.
+	local -a COMMON_SSH_OPTS=(
+		-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+		-o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=8
+	)
 	local ssh_cmd=(sshpass -p live ssh "${COMMON_SSH_OPTS[@]}" -p "$SSH_PORT" liveuser@127.0.0.1)
 	local scp_cmd=(sshpass -p live scp "${COMMON_SSH_OPTS[@]}" -P "$SSH_PORT")
 
@@ -1022,10 +1037,22 @@ run_install() {
 		if podman image exists "$host_img" 2>/dev/null; then
 			echo "==> Saving $host_img on host..."
 			podman save "$host_img" -o "$host_tar"
+			# Bounded, like the fisherman call below. This is a multi-GB copy
+			# over a QEMU SLIRP hostfwd, so it is legitimately slow — but the
+			# failure mode it had was not slowness, it was silence: no output
+			# between the line above and the runner being killed hours later.
+			# The workflow's --timeout does not cover this; that is a PER-PHASE
+			# timeout (see the usage text above) consulted only by the
+			# readiness wait and the installed-boot wait.
 			echo "==> Transferring image to guest (this may take a few minutes)..."
-			"${scp_cmd[@]}" "$host_tar" "liveuser@127.0.0.1:/home/liveuser/"
+			if ! timeout 1800 "${scp_cmd[@]}" "$host_tar" \
+				"liveuser@127.0.0.1:/home/liveuser/"; then
+				echo "ERROR: image transfer to guest timed out or failed" >&2
+				rm -f "$host_tar" || true
+				return 3
+			fi
 			echo "==> Loading image into guest podman..."
-			if "${ssh_cmd[@]}" "sudo podman load -i /home/liveuser/${host_tar##*/} 2>&1" 2>&1 | tee -a "${SERIAL_LOG}"; then
+			if timeout 1800 "${ssh_cmd[@]}" "sudo podman load -i /home/liveuser/${host_tar##*/} 2>&1" 2>&1 | tee -a "${SERIAL_LOG}"; then
 				echo "==> Image loaded, using local containers-storage ref"
 				recipe_image="containers-storage:${host_img}"
 			else


### PR DESCRIPTION
Closes #939.

Three LUKS E2E runs on 07-31 each sat inside one `scp` for over two hours and had to be cancelled by hand — [30626383520](https://github.com/tuna-os/tunaOS/actions/runs/30626383520) `yellowfin:gnome` 2h38m, [30626395621](https://github.com/tuna-os/tunaOS/actions/runs/30626395621) `yellowfin:niri` 2h42m, [30627886736](https://github.com/tuna-os/tunaOS/actions/runs/30627886736) `yellowfin:niri` on `main` 2h14m. Two branches, two flavours, byte-identical final lines.

## Why this is worse than a red

A cancelled job is neither `success` nor `failure`, so `gen-matrix-status.py` scores nothing (it filters on those two at `:119`) and the cell stays ⬜. The axis reads *never tested* while it is in fact *fully blocked*. That is precisely the confusion `MATRIX-STATUS.md` exists to prevent, and it is why LUKS has not moved all day.

## The three guards

| site | was | now |
|---|---|---|
| image-transfer `scp` | unbounded | `timeout 1800`, returns 3 |
| `podman load` after it | unbounded | `timeout 1800` |
| both `COMMON_SSH_OPTS` arrays | no `ConnectTimeout`, no keepalive | `ConnectTimeout=10`, `ServerAliveInterval=15`, `ServerAliveCountMax=8` (dead guest detected in ~2 min) |

The file was already inconsistent about this: `check_ssh()` sets `ConnectTimeout=10`, the two arrays did not — so the same script handled a dead socket both ways depending on which path you were on. `fisherman` is `timeout 1800` and its comment calls itself a safety net; the `scp` next to it had nothing.

The workflow's `--timeout 1200` does not bound any of this — it is a **per-phase** timeout, consulted only by the readiness wait and the installed-boot wait.

## What this does not fix

The fallback should not have run at all. Passing cells resolve the image from the offline store and take Fisherman `bootcDirect` with no copy ([30595701955](https://github.com/tuna-os/tunaOS/actions/runs/30595701955) `yellowfin:xfce`, [30624963765](https://github.com/tuna-os/tunaOS/actions/runs/30624963765) `bonito:gnome`). The transfer is what happens when the guest's podman cannot see the offline store, and today every LUKS cell fell into it. This change makes that fail loudly in 30 minutes instead of silently in four hours; it does not stop it happening. Worth its own issue.

Verified: `bash -n`, `shellcheck -S warning` clean, `shfmt` shows no diff in the changed regions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->