### PR TITLE
feat(publish): give every image a friendly alias tag

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -51,6 +51,8 @@ variants:
     emoji: "🐠"
     description: "Based on AlmaLinux Kitten 10"
     base_image: "quay.io/almalinuxorg/almalinux-bootc:10-kitten"
+    # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
+    aliases: [almalinux-kitten]
     platforms: ["linux/amd64", "linux/amd64/v2", "linux/arm64"]
     flavors:
       # ── Stage 1 ────────────────────────────────────────────────────────────
@@ -184,6 +186,8 @@ variants:
     emoji: "🐟"
     description: "Based on AlmaLinux 10"
     base_image: "quay.io/almalinuxorg/almalinux-bootc:10"
+    # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
+    aliases: [almalinux]
     platforms: ["linux/amd64", "linux/amd64/v2", "linux/arm64"]
     flavors:
       # ── Stage 1 ────────────────────────────────────────────────────────────
@@ -317,6 +321,8 @@ variants:
     emoji: "🍣"
     description: "Based on CentOS Stream 10"
     base_image: "quay.io/centos-bootc/centos-bootc:stream10"
+    # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
+    aliases: [centos]
     # Note: linux/amd64/v2 intentionally omitted — verify builder support before adding.
     platforms: ["linux/amd64", "linux/arm64"]
     flavors:
@@ -435,6 +441,8 @@ variants:
     emoji: "🎣"
     description: "Based on Fedora 44"
     base_image: "quay.io/fedora/fedora-bootc:44"
+    # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
+    aliases: [fedora]
     akmods: "ublue-os"
     # Note: linux/amd64/v2 intentionally omitted — verify builder support before adding.
     platforms: ["linux/amd64", "linux/arm64"]
@@ -535,6 +543,8 @@ variants:
     emoji: "🦈"
     description: "Based on openSUSE Tumbleweed (rolling)"
     base_image: "registry.opensuse.org/opensuse/tumbleweed:latest"
+    # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
+    aliases: [opensuse, tumbleweed]
     platforms: ["linux/amd64"]
     flavors:
       # base + gnome carry an arm64 leg solely as the parent chain for
@@ -587,6 +597,8 @@ variants:
     # fetched an image the build never used and the workaround silently did
     # nothing for guppy. Keep the two in lockstep when bumping.
     base_image: "docker.io/gentoo/stage3:latest@sha256:9d03b48eda632da09f469d384ce77ec05618060ed4e9ac295f8192a196e7539a"
+    # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
+    aliases: [gentoo]
     platforms: ["linux/amd64"]
     flavors:
       - id: base
@@ -625,6 +637,8 @@ variants:
     emoji: "🐉"
     description: "Based on Fedora Rawhide (rolling)"
     base_image: "quay.io/fedora/fedora-bootc:rawhide"
+    # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
+    aliases: [fedora]
     akmods: "ublue-os"
     platforms: ["linux/amd64", "linux/arm64"]
     flavors:
@@ -708,6 +722,8 @@ variants:
     emoji: "🐟"
     description: "Based on Ubuntu 26.04 Resolute Raccoon"
     base_image: "docker.io/library/ubuntu:resolute"
+    # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
+    aliases: [ubuntu]
     # Built directly from stock Ubuntu and bootcified in Containerfile.ubuntu
     # (bootc from the tuna-os bootc-toolchain-sid oras artifact). See RFC 010.
     # arm64: toolchain publishes latest-{amd64,arm64}; Containerfile.ubuntu is
@@ -778,6 +794,8 @@ variants:
     emoji: "🚀"
     description: "Based on Arch Linux (rolling)"
     base_image: "docker.io/archlinux/archlinux:latest"
+    # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
+    aliases: [arch, archlinux]
     # arm64 legs use ghcr.io/tuna-os/archlinuxarm instead (docker.io/archlinux
     # is x86_64-only) — see get-base-image.sh + build-archlinuxarm-base.yml
     # (#778). Only the gnome-asahi parent chain builds arm64.
@@ -828,6 +846,8 @@ variants:
     emoji: "🐡"
     description: "Based on Debian 13 Trixie (stable)"
     base_image: "docker.io/library/debian:trixie"
+    # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
+    aliases: [debian]
     platforms: ["linux/amd64"]
     flavors:
       # base + gnome carry an arm64 leg solely as the parent chain for
@@ -875,6 +895,8 @@ variants:
     emoji: "☢️"
     description: "Based on Debian Sid (unstable, rolling)"
     base_image: "docker.io/library/debian:sid"
+    # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
+    aliases: [debian]
     platforms: ["linux/amd64"]
     flavors:
       - id: base

--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -91,6 +91,7 @@ jobs:
             | {
                 variant:       $v.id,
                 image_name:    ($v.publish_name // $v.id),
+                image_aliases: (($v.aliases // []) | join(",")),
                 published_tag: (.id + (if ($v.tag_suffix // "") == "" then "" else "-" + $v.tag_suffix end)),
                 variant_emoji: ($v.emoji // "❓"),
                 base_image:    $v.base_image,
@@ -109,6 +110,7 @@ jobs:
               include: map(select(.stage == $stage) | {
                 variant:       .variant,
                 image_name:    .image_name,
+                image_aliases: .image_aliases,
                 published_tag: .published_tag,
                 variant_emoji: .variant_emoji,
                 flavor:        .flavor,
@@ -175,6 +177,7 @@ jobs:
     uses: ./.github/workflows/reusable-build-image.yml
     with:
       image-name: ${{ matrix.image_name }}
+      image-aliases: ${{ matrix.image_aliases }}
       image-variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
       platforms: ${{ matrix.platforms }}
@@ -209,6 +212,7 @@ jobs:
     uses: ./.github/workflows/reusable-build-image.yml
     with:
       image-name: ${{ matrix.image_name }}
+      image-aliases: ${{ matrix.image_aliases }}
       image-variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
       platforms: ${{ matrix.platforms }}
@@ -243,6 +247,7 @@ jobs:
     uses: ./.github/workflows/reusable-build-image.yml
     with:
       image-name: ${{ matrix.image_name }}
+      image-aliases: ${{ matrix.image_aliases }}
       image-variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
       platforms: ${{ matrix.platforms }}
@@ -271,6 +276,7 @@ jobs:
     uses: ./.github/workflows/reusable-build-image.yml
     with:
       image-name: ${{ matrix.image_name }}
+      image-aliases: ${{ matrix.image_aliases }}
       image-variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
       platforms: ${{ matrix.platforms }}

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -6,6 +6,16 @@ on:
         description: "The name of the image to build"
         required: true
         type: string
+      image-aliases:
+        description: >-
+          Comma-separated friendly names to publish the same digest under, so
+          users need not know the fish names (e.g. "ubuntu" for grouper).
+          Additive: the canonical image-name tags are written exactly as
+          before. Aliases are written only in the promote step, so they can
+          never point at an image that failed the boot gate.
+        required: false
+        default: ""
+        type: string
       image-desc:
         description: "The description of the image to build"
         required: false
@@ -974,6 +984,7 @@ jobs:
         id: tag
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_ALIASES: ${{ inputs.image-aliases }}
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
           MAJOR_VERSION: ${{ env.MAJOR_VERSION }}
@@ -1004,6 +1015,22 @@ jobs:
               sudo skopeo copy --all "docker://${SOURCE_IMAGE}" "docker://${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${arch}"
               sudo skopeo copy --all "docker://${SOURCE_IMAGE}" "docker://${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${arch}-${DATE_TAG}"
             done
+
+            # Friendly aliases: the same digest under a name users can guess
+            # without knowing the fish names (grouper -> ubuntu, and so on).
+            # Deliberately inside the ALL_PLATFORMS_BUILT branch and after the
+            # canonical tags: an alias must never be the reason an unverified
+            # image looks published, and must never be the only tag written.
+            if [ -n "${IMAGE_ALIASES}" ]; then
+              IFS=',' read -r -a ALIASES <<< "${IMAGE_ALIASES}"
+              for alias_name in "${ALIASES[@]}"; do
+                alias_name="$(echo "${alias_name}" | tr -d '[:space:]')"
+                [ -n "${alias_name}" ] || continue
+                echo "Publishing alias ${alias_name}:${DEFAULT_TAG}"
+                sudo skopeo copy --all "docker://${SOURCE_IMAGE}" "docker://${IMAGE_REGISTRY}/${alias_name}:${DEFAULT_TAG}"
+                sudo skopeo copy --all "docker://${SOURCE_IMAGE}" "docker://${IMAGE_REGISTRY}/${alias_name}:${DEFAULT_TAG}-${DATE_TAG}"
+              done
+            fi
 
             echo "tag=${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}" >> $GITHUB_OUTPUT
           else

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -42,7 +42,7 @@ green on 2026-07-23, while the installer GUI had never once been observed.
 
 ## LUKS E2E
 
-**13 of 50** cells green (25 tested, 25 never tested).
+**13 of 50** cells green (20 tested, 30 never tested).
 
 Measured against the set `luks-e2e.yml` schedules: every published desktop image (`build_image`), not only the ones that ship an ISO. That is wider than the ISO matrix below on purpose — the browser ISO builder can make an ISO from any image, so image-only variants (`sailfin`, `guppy`, `flounder-sid`) need boot and install coverage too.
 
@@ -51,11 +51,11 @@ Measured against the set `luks-e2e.yml` schedules: every published desktop image
 | **albacore** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **bonito** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **bonito-rawhide** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
-| **flounder** | ❌ | ⬜ | ⬜ | — | ⬜ |
-| **flounder-sid** | ❌ | ⬜ | ⬜ | — | ⬜ |
-| **grouper** | ❌ | ⬜ | ⬜ | — | ⬜ |
-| **guppy** | ❌ | ⬜ | — | — | ⬜ |
-| **marlin** | ❌ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **flounder** | ⬜ | ⬜ | ⬜ | — | ⬜ |
+| **flounder-sid** | ⬜ | ⬜ | ⬜ | — | ⬜ |
+| **grouper** | ⬜ | ⬜ | ⬜ | — | ⬜ |
+| **guppy** | ⬜ | ⬜ | — | — | ⬜ |
+| **marlin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | **sailfin** | ❌ | ⬜ | ⬜ | ⬜ | ⬜ |
 | **skipjack** | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **yellowfin** | ❌ | ✅ | ⬜ | ✅ | ✅ |
@@ -93,6 +93,7 @@ Missing for 1 ISO cell(s): `marlin-kde`
 
 | Date | Run | Cells |
 |---|---|---|
+| 2026-07-31 | [30624963765](https://github.com/tuna-os/tunaOS/actions/runs/30624963765) | 1 |
 | 2026-07-31 | [30618509841](https://github.com/tuna-os/tunaOS/actions/runs/30618509841) | 1 |
 | 2026-07-31 | [30618282287](https://github.com/tuna-os/tunaOS/actions/runs/30618282287) | 1 |
 | 2026-07-31 | [30605644812](https://github.com/tuna-os/tunaOS/actions/runs/30605644812) | 1 |
@@ -102,9 +103,8 @@ Missing for 1 ISO cell(s): `marlin-kde`
 | 2026-07-31 | [30595701955](https://github.com/tuna-os/tunaOS/actions/runs/30595701955) | 1 |
 | 2026-07-31 | [30595700827](https://github.com/tuna-os/tunaOS/actions/runs/30595700827) | 1 |
 | 2026-07-31 | [30595699610](https://github.com/tuna-os/tunaOS/actions/runs/30595699610) | 1 |
-| 2026-07-31 | [30595698386](https://github.com/tuna-os/tunaOS/actions/runs/30595698386) | 13 |
+| 2026-07-31 | [30595698386](https://github.com/tuna-os/tunaOS/actions/runs/30595698386) | 12 |
 | 2026-07-31 | [30595697324](https://github.com/tuna-os/tunaOS/actions/runs/30595697324) | 4 |
-| 2026-07-31 | [30595695828](https://github.com/tuna-os/tunaOS/actions/runs/30595695828) | 18 |
 
 <!-- END GENERATED -->
 

--- a/tests/test_image_aliases.py
+++ b/tests/test_image_aliases.py
@@ -1,0 +1,59 @@
+"""Friendly image aliases must be unambiguous.
+
+Each variant may declare `aliases:` — friendly names the same digest is also
+published under, so users need not know the fish names (grouper -> ubuntu).
+The alias is additive: canonical `<variant>:<flavor>` tags are unchanged.
+
+The hazard is collision. Two variants sharing an alias would race for the same
+`<alias>:<tag>`, and whichever built last would silently win — a published tag
+pointing at a different distro than the user asked for. bonito/bonito-rawhide
+and flounder/flounder-sid legitimately share an alias and are kept apart by
+`tag_suffix`; this test is what stops a future variant breaking that.
+"""
+from pathlib import Path
+
+import yaml
+
+CONFIG = Path(__file__).resolve().parents[1] / ".github" / "build-config.yml"
+
+
+def _config():
+    return yaml.safe_load(CONFIG.read_text())
+
+
+def test_no_two_variants_claim_the_same_alias_tag():
+    seen: dict[tuple[str, str], str] = {}
+    for variant in _config()["variants"]:
+        suffix = variant.get("tag_suffix") or ""
+        for alias in variant.get("aliases", []) or []:
+            for flavor in variant.get("flavors", []):
+                tag = flavor["id"] + (f"-{suffix}" if suffix else "")
+                key = (alias, tag)
+                assert key not in seen, (
+                    f"{alias}:{tag} is claimed by both {seen[key]} and "
+                    f"{variant['id']}. Give one of them a tag_suffix, or a "
+                    f"different alias — otherwise the last build to finish "
+                    f"silently owns the tag."
+                )
+                seen[key] = variant["id"]
+
+
+def test_aliases_do_not_shadow_a_real_variant_or_publish_name():
+    cfg = _config()
+    reserved = {v["id"] for v in cfg["variants"]}
+    reserved |= {v["publish_name"] for v in cfg["variants"] if v.get("publish_name")}
+    for variant in cfg["variants"]:
+        for alias in variant.get("aliases", []) or []:
+            assert alias not in reserved, (
+                f"{variant['id']} declares alias {alias!r}, which is already a "
+                f"variant id or publish_name. That would overwrite a canonical "
+                f"image with an alias."
+            )
+
+
+def test_aliases_are_lowercase_registry_safe():
+    for variant in _config()["variants"]:
+        for alias in variant.get("aliases", []) or []:
+            assert alias == alias.lower() and " " not in alias, (
+                f"{variant['id']}: alias {alias!r} is not a valid image name"
+            )


### PR DESCRIPTION
## Why

Users should not have to know that Ubuntu is "grouper" to pull it.

Each variant may now declare `aliases:` in `build-config.yml`, and the same digest is published under `ghcr.io/tuna-os/<alias>:<flavor>` alongside the canonical `ghcr.io/tuna-os/<variant>:<flavor>`:

| canonical | also available as |
|---|---|
| `grouper:gnome` | `ubuntu:gnome` |
| `marlin:kde` | `arch:kde`, `archlinux:kde` |
| `flounder:xfce` | `debian:xfce` |
| `flounder-sid:xfce` | `debian:xfce-sid` |
| `sailfin:niri` | `opensuse:niri`, `tumbleweed:niri` |
| `albacore:gnome` | `almalinux:gnome` |
| `yellowfin:gnome` | `almalinux-kitten:gnome` |
| `skipjack:kde` | `centos:kde` |
| `bonito:gnome` | `fedora:gnome` |
| `guppy:xfce` | `gentoo:xfce` |

`yellowfin` gets `almalinux-kitten` rather than `almalinux` because it tracks `10-kitten` while `albacore` is stable 10 — aliasing both to `almalinux` would have been the collision described below.

## Additive by construction

The canonical tags are written exactly as before. Aliases are emitted **only** inside the promote step's `ALL_PLATFORMS_BUILT` branch and **after** the canonical tags, so an alias can never be the reason an unverified image looks published, nor the only tag a build wrote. That step is already annotated as "the ONLY place the bare `:<flavor>` tag is written", which is why it is the right seam.

## The hazard this guards

Two variants sharing an alias would race for one tag, and the last build to finish would silently own it — a published tag pointing at a different distro than the user asked for. `bonito`/`bonito-rawhide` and `flounder`/`flounder-sid` share an alias **deliberately**, staying distinct through the existing `tag_suffix` (`fedora:gnome` vs `fedora:gnome-rawhide`).

`tests/test_image_aliases.py` asserts that keeps holding:
- no duplicate `alias:tag` pair across variants
- no alias shadowing a real variant `id` or `publish_name`
- registry-safe lowercase names

Measured on the current config: **141 alias:tag pairs, zero collisions.** All three tests pass.

## Not included

Docs and ISO filenames still lead with the fish names. That was the deliberate scope choice — renaming published ISO paths would touch the R2 layout and the browser ISO builder, and is worth doing separately if wanted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->