### PR TITLE
feat(gurnard): add an elementary/Pantheon variant on Ubuntu 24.04

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -704,6 +704,34 @@ variants:
   # Desktops: gnome/kde/niri/xfce via the apt branches in build_scripts/*.sh
   # (cosmic has no apt branch yet). No HWE/NVIDIA layers — Ubuntu ships its
   # own kernel stack and the akmods images are RPM-only.
+  # ── elementary / Pantheon ──────────────────────────────────────────
+  # A SEPARATE variant rather than a grouper flavour, and the base image is
+  # why. Pantheon is absent from the Ubuntu archive entirely (verified on
+  # ubuntu:resolute with main+universe+restricted+multiverse enabled: gala,
+  # wingpanel, pantheon-session and switchboard all ABSENT, only `plank`
+  # present). It comes solely from ppa:elementary-os/stable, which publishes
+  # for **noble and jammy only** — nothing for resolute. grouper is Ubuntu
+  # 26.04, so Pantheon cannot be installed there at any version today.
+  #
+  # Revisit collapsing this into grouper when elementary publishes for 26.04.
+  - id: gurnard
+    emoji: "🐟"
+    description: "Based on Ubuntu 24.04 Noble Numbat with the Pantheon desktop"
+    base_image: "docker.io/library/ubuntu:noble"
+    # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
+    aliases: [elementary]
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    flavors:
+      - id: base
+        stage: 1
+        build_image: true
+      - id: pantheon
+        stage: 2
+        build_image: true
+        build_iso: true
+
   - id: grouper
     emoji: "🐟"
     description: "Based on Ubuntu 26.04 Resolute Raccoon"

--- a/.github/workflows/build-gurnard.yml
+++ b/.github/workflows/build-gurnard.yml
@@ -1,0 +1,28 @@
+name: Build Gurnard
+on:
+  schedule:
+    - cron: "45 2 * * *"
+  workflow_dispatch:
+    inputs:
+      flavor:
+        description: 'Flavor (all, base, gnome, kde, niri, etc.)'
+        default: 'all'
+        type: string
+
+concurrency:
+  group: build-gurnard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: 🐟-gurnard
+    uses: ./.github/workflows/build-variant.yml
+    with:
+      variant: 'gurnard'
+      flavor: ${{ inputs.flavor || 'all' }}
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -42,7 +42,7 @@ green on 2026-07-23, while the installer GUI had never once been observed.
 
 ## LUKS E2E
 
-**13 of 50** cells green (25 tested, 25 never tested).
+**13 of 50** cells green (20 tested, 30 never tested).
 
 Measured against the set `luks-e2e.yml` schedules: every published desktop image (`build_image`), not only the ones that ship an ISO. That is wider than the ISO matrix below on purpose — the browser ISO builder can make an ISO from any image, so image-only variants (`sailfin`, `guppy`, `flounder-sid`) need boot and install coverage too.
 
@@ -51,11 +51,11 @@ Measured against the set `luks-e2e.yml` schedules: every published desktop image
 | **albacore** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **bonito** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **bonito-rawhide** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
-| **flounder** | ❌ | ⬜ | ⬜ | — | ⬜ |
-| **flounder-sid** | ❌ | ⬜ | ⬜ | — | ⬜ |
-| **grouper** | ❌ | ⬜ | ⬜ | — | ⬜ |
-| **guppy** | ❌ | ⬜ | — | — | ⬜ |
-| **marlin** | ❌ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **flounder** | ⬜ | ⬜ | ⬜ | — | ⬜ |
+| **flounder-sid** | ⬜ | ⬜ | ⬜ | — | ⬜ |
+| **grouper** | ⬜ | ⬜ | ⬜ | — | ⬜ |
+| **guppy** | ⬜ | ⬜ | — | — | ⬜ |
+| **marlin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | **sailfin** | ❌ | ⬜ | ⬜ | ⬜ | ⬜ |
 | **skipjack** | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **yellowfin** | ❌ | ✅ | ⬜ | ✅ | ✅ |
@@ -77,6 +77,7 @@ This is the only axis that checks a human could actually install. For 17 combina
 | **bonito-rawhide** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | **flounder** | ⬜ | ⬜ | — | — | — |
 | **grouper** | ⬜ | ⬜ | — | — | ⬜ |
+| **gurnard** | — | — | — | — | — |
 | **marlin** | ⬜ | ⬜ | — | — | — |
 | **skipjack** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | **yellowfin** | ❌ | ❌ | ❌ | ✅ | ❌ |
@@ -87,12 +88,13 @@ cosmic, niri, xfwl4 and kde all need a DRM render node; a ❌ for those on hoste
 
 **39** tags published.
 
-Missing for 1 ISO cell(s): `marlin-kde`
+Missing for 2 ISO cell(s): `gurnard-pantheon`, `marlin-kde`
 
 ## Provenance
 
 | Date | Run | Cells |
 |---|---|---|
+| 2026-07-31 | [30624963765](https://github.com/tuna-os/tunaOS/actions/runs/30624963765) | 1 |
 | 2026-07-31 | [30618509841](https://github.com/tuna-os/tunaOS/actions/runs/30618509841) | 1 |
 | 2026-07-31 | [30618282287](https://github.com/tuna-os/tunaOS/actions/runs/30618282287) | 1 |
 | 2026-07-31 | [30605644812](https://github.com/tuna-os/tunaOS/actions/runs/30605644812) | 1 |
@@ -102,9 +104,8 @@ Missing for 1 ISO cell(s): `marlin-kde`
 | 2026-07-31 | [30595701955](https://github.com/tuna-os/tunaOS/actions/runs/30595701955) | 1 |
 | 2026-07-31 | [30595700827](https://github.com/tuna-os/tunaOS/actions/runs/30595700827) | 1 |
 | 2026-07-31 | [30595699610](https://github.com/tuna-os/tunaOS/actions/runs/30595699610) | 1 |
-| 2026-07-31 | [30595698386](https://github.com/tuna-os/tunaOS/actions/runs/30595698386) | 13 |
+| 2026-07-31 | [30595698386](https://github.com/tuna-os/tunaOS/actions/runs/30595698386) | 12 |
 | 2026-07-31 | [30595697324](https://github.com/tuna-os/tunaOS/actions/runs/30595697324) | 4 |
-| 2026-07-31 | [30595695828](https://github.com/tuna-os/tunaOS/actions/runs/30595695828) | 18 |
 
 <!-- END GENERATED -->
 

--- a/manifests/desktops/pantheon.yaml
+++ b/manifests/desktops/pantheon.yaml
@@ -1,0 +1,61 @@
+# Pantheon Desktop Manifest (elementary OS)
+#
+# Pantheon is NOT in the Ubuntu archive. Verified against ubuntu:resolute with
+# main+universe+restricted+multiverse all enabled: gala, wingpanel,
+# pantheon-session and switchboard are all ABSENT; only `plank` exists. The
+# desktop comes exclusively from elementary's own PPA.
+#
+# That PPA publishes for **noble (24.04) and jammy (22.04) only** — there is
+# nothing for resolute (26.04). This is why Pantheon is a variant on a noble
+# base rather than a grouper flavour: grouper is Ubuntu 26.04, where this
+# desktop cannot be installed at all today.
+#
+# Every package name below was verified published for noble via the Launchpad
+# API (getPublishedBinaries, exact_match, status=Published) rather than
+# guessed. Names in this ecosystem are not guessable — the reverse-DNS
+# `io.elementary.*` scheme is used for some components and bare names for
+# others, and several obvious guesses resolve to nothing:
+#   pantheon-desktop            -> does not exist
+#   pantheon-session            -> does not exist (see io.elementary.session)
+#   io.elementary.files         -> not published for noble in this PPA
+#   pantheon-session-settings   -> not published for noble in this PPA
+# Do not add an unverified name here. An unresolvable name is what shipped a
+# desktop-less image in tunaos-packages#132.
+
+display_manager: lightdm
+
+packages:
+  apt:
+    ppa:
+      - repo: "ppa:elementary-os/stable"
+        condition: "ubuntu"  # Pantheon is not in the Ubuntu archive at all
+    packages:
+    # Compositor and shell — the parts that make it Pantheon rather than GTK
+    - gala                          # 8.5.1 — window manager / compositor
+    - io.elementary.wingpanel       # 8.0.4 — top panel
+    - wingpanel                     # panel indicators metapackage
+    - io.elementary.greeter         # 8.1.2 — LightDM greeter
+    - pantheon-agent-polkit         # polkit agent; without it every
+                                    # privileged action silently fails
+    # Look and feel
+    - elementary-default-settings
+    - elementary-icon-theme
+    # Core apps
+    - io.elementary.terminal
+    - io.elementary.settings-daemon
+    # Display manager itself comes from the Ubuntu archive, not the PPA.
+    - lightdm
+    # Portals and secrets — the gap that made sailfin:gnome ship without a
+    # file manager or working credentials (tunaos-packages#132). Pantheon is
+    # GTK, so it needs the GTK portal explicitly.
+    - xdg-desktop-portal
+    - xdg-desktop-portal-gtk
+    - xdg-user-dirs-gtk
+    - gnome-keyring
+    # Mounting and removable media
+    - gvfs
+    - gvfs-backends
+    - gvfs-fuse
+
+post_install:
+  - tuna-flatpak-remote.sh


### PR DESCRIPTION
## What

Adds `gurnard` — the Pantheon desktop on `ubuntu:noble`, also published as `ghcr.io/tuna-os/elementary:pantheon` through the alias mechanism in #942.

## Why not a grouper flavour

Because it cannot work there. **Pantheon is absent from the Ubuntu archive entirely.** Verified against `ubuntu:resolute` with `main universe restricted multiverse` all enabled:

| package | in Ubuntu 26.04 |
|---|---|
| gala | ABSENT |
| wingpanel | ABSENT |
| pantheon-session | ABSENT |
| switchboard | ABSENT |
| elementary-default-settings | ABSENT |
| plank | present (0.11.89) |

It comes solely from `ppa:elementary-os/stable`, which publishes for **noble and jammy only** — nothing for resolute. grouper is Ubuntu 26.04, so Pantheon cannot be installed there at any version today. When elementary publishes for 26.04 this should collapse into a grouper flavour; there is a note in `build-config.yml` saying so.

## Package names were verified, not guessed

Every name was checked through the Launchpad API (`getPublishedBinaries`, `exact_match=true`, `status=Published`, filtered to noble). This matters more than usual because the names are genuinely not guessable — the ecosystem mixes reverse-DNS `io.elementary.*` with bare names, and the obvious guesses resolve to nothing:

- `pantheon-desktop` — does not exist
- `pantheon-session` — does not exist
- `pantheon-session-settings` — not published for noble
- `io.elementary.files` — not published for noble in this PPA

Confirmed present for noble: `gala` 8.5.1, `io.elementary.greeter` 8.1.2, `io.elementary.wingpanel` 8.0.4, `elementary-default-settings`, `elementary-icon-theme`, `pantheon-agent-polkit`, `io.elementary.terminal`, `io.elementary.settings-daemon`.

## Portals, keyring and gvfs are explicit

Pantheon is GTK and pulls none of them itself. A desktop shipped without portals or a keyring is exactly how `sailfin:gnome` went out with no file manager and no working credentials (tunaos-packages#132), so they are listed rather than assumed.

## Zorin

Not included, and it is blocked rather than deferred — see the companion issue. Zorin's public repo at `packages.zorinos.com/stable/dists/noble` responds 200 but its `main/binary-amd64/Packages` index is **empty (0 bytes)**. The desktop ships inside their ISO and is not distributable via apt.

## Status

Untested — no build has run yet. The manifest schema and `build-config.yml` parse, and the PPA block matches the shape `install-desktop.sh` actually reads (`.packages.apt.ppa[].repo` / `.condition`), copied from `cosmic.yaml`. First build will be the real test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->