### PR TITLE
fix(e2e): prefer the offline store over a transfer that OOMs the guest

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -1067,10 +1067,23 @@ run_install() {
 		local img_json="/var/lib/superiso-store/overlay-images/images.json"
 		if "${ssh_cmd[@]}" "sudo test -f ${img_json} && sudo jq -e --arg ref '${candidate_ref}' '.[] | select(.names != null) | select(.names | index(\$ref))' ${img_json} >/dev/null 2>&1" 2>/dev/null; then
 			echo "==> Found ${candidate_ref} in offline store images.json (podman query missed it)"
-			# The image exists but podman/bootc can't resolve it from the
-			# additional store (overlay driver mismatch). Don't set
-			# found_local here — let the code fall through to the network
-			# pull, which now uses aggressive MTU clamping + retries.
+			# This used to deliberately NOT set found_local, on the theory that
+			# podman/bootc could not resolve the image from the additional
+			# store anyway, so it was better to "fall through to the network
+			# pull". Two things were wrong with that. The else branch has not
+			# been a network pull for some time — it is an SSH copy of a
+			# multi-GB tar. And that copy cannot succeed: it lands in
+			# /home/liveuser, which is the live overlay's upperdir, which is a
+			# tmpfs (`tbox-overlay ... size=8388608k`) on a 4096M guest with no
+			# swap. Pushing a ~4.9G image into ~2.9G of real memory OOMs the
+			# guest every time. Measured, not inferred — see #941.
+			#
+			# So preferring the store is strictly better even when podman's
+			# query missed: if bootc cannot read it either we get a fast, clear
+			# failure, instead of a guaranteed dead guest ~2.5 minutes in.
+			found_local=1
+			found_ref="$candidate_ref"
+			break
 		fi
 	done
 
@@ -1086,12 +1099,35 @@ run_install() {
 			recipe_image="containers-storage:${found_ref}"
 		fi
 	else
-		# The offline store is inaccessible to the guest's containers/storage
-		# library (overlay driver / fuse-overlayfs mismatch). QEMU SLIRP NAT
-		# stalls on large blobs (PMTU blackhole). Instead, save the image
-		# from the HOST's podman (where 'just iso' built it) and transfer it
-		# over SSH. SSH port-forwarding is a TCP tunnel, immune to SLIRP NAT
-		# PMTU issues.
+		# LAST RESORT, AND IT USUALLY FAILS. Read this before relying on it.
+		#
+		# The comment here used to claim SSH port-forwarding is "a TCP tunnel,
+		# immune to SLIRP NAT PMTU issues". Both halves are wrong. Port 2222 is
+		# a QEMU `hostfwd` on `-netdev user`, so it traverses SLIRP like
+		# everything else — and SLIRP is not what breaks this anyway.
+		#
+		# What breaks it is the destination. The tar lands in /home/liveuser,
+		# i.e. the live overlay's upperdir, which is a tmpfs:
+		#
+		#   tbox-overlay /run/tbox-overlay tmpfs rw,size=8388608k
+		#   LiveOS_rootfs / overlay ... upperdir=/run/tbox-overlay/upper
+		#
+		# df reports 8.0G free on / because that is the tmpfs's ADVERTISED
+		# size. The guest has 3903M of RAM and no swap. Copying a ~4.9G image
+		# into ~2.9G of usable memory invokes the OOM killer, every time,
+		# regardless of transport or MTU:
+		#
+		#   rtkit-daemon invoked oom-killer: ... global_oom
+		#   Out of memory: Killed process 1622 (niri)
+		#
+		# Reproduced on hosted CI (2m34s, 2m35s) and on bare metal with no
+		# SLIRP pathology and a far faster link (2m54s) — the timing tracks
+		# bytes written, not network conditions. See #941.
+		#
+		# Do not "fix" this with a longer timeout, MTU clamping (already
+		# applied above) or retries. Any image larger than guest RAM cannot be
+		# delivered this way. Make the offline store resolve, or raise --memory
+		# above the image size.
 		echo "==> No local image in offline store — transferring from host via SSH"
 		local host_img="localhost/${VARIANT:-}:${FLAVOR:-}"
 		local host_tar="/tmp/luks-image-${VARIANT:-}-${FLAVOR:-}.tar"


### PR DESCRIPTION
Refs #941. The LUKS image-transfer fallback **cannot succeed** — it is not slow, unguarded or unlucky.

## Measured cause

The tar lands in `/home/liveuser`, which is the live overlay's upperdir, which is a tmpfs on a 4096M guest with no swap:

```
tbox-overlay /run/tbox-overlay tmpfs rw,size=8388608k
LiveOS_rootfs / overlay ... upperdir=/run/tbox-overlay/upper
Mem:  total 3903   available 2993     Swap: 0
```

`df` reports `8.0G` free on `/` because that is the tmpfs's **advertised** size, not memory that exists. Copying a ~4.9G image into ~2.9G of usable RAM invokes the OOM killer:

```
rtkit-daemon invoked oom-killer: ... global_oom
Out of memory: Killed process 1622 (niri)
```

## Reproduced three ways, near-identical timing

| where | what | time to failure |
|---|---|---|
| hosted CI [30653804067](https://github.com/tuna-os/tunaOS/actions/runs/30653804067) | real transfer | 2m34s |
| hosted CI [30661620271](https://github.com/tuna-os/tunaOS/actions/runs/30661620271) | real transfer | 2m35s |
| bare metal | plain 4.9G `scp` into the same live ISO — no podman, no store, far faster link | 2m54s |

The third is the discriminator: same failure with the network hypothesis removed. **Timing tracks bytes written, not network conditions.**

## Two comments were actively misleading

- `"fall through to the network pull, which now uses aggressive MTU clamping + retries"` — the else branch has not been a network pull for some time; it is the SSH copy.
- `"SSH port-forwarding is a TCP tunnel, immune to SLIRP NAT PMTU issues"` — 2222 is a QEMU `hostfwd` on `-netdev user`, so it traverses SLIRP like everything else. And SLIRP is not the cause regardless.

MTU clamping is **already applied** to every guest interface before the transfer — `mtu 1400` is visible in both failing runs — so it is neither missing nor sufficient. Between them these two comments made this path look like a solved problem.

## Changes

1. **Trust the `images.json` hit.** The probe found the image and deliberately fell through anyway. Even granting the original premise that podman/bootc might not resolve it from the additional store, the alternative it selects is a guaranteed dead guest — so preferring the store is strictly better. If bootc cannot read it either, we get a fast legible failure instead of an OOM 2.5 minutes in.
2. **Rewrite both comments** to record what was measured, and to say plainly that longer timeouts and MTU tweaks cannot fix it.

## What this does not do

Does not close #941. Whether bootc can read the offline store on a hosted runner is now the open question — this makes that answer arrive in seconds instead of hiding it behind an OOM. Complements #940 (which bounded the hang) rather than replacing it.

Verified: `bash -n`, `shellcheck -S warning` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->