### PR TITLE
fix(build): install an SSH server on every package manager, not just rpm bases

### DIFF
--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -51,16 +51,45 @@ if [[ "${PKG_MGR:-}" == "apt" ]]; then
 	safe_enable tunaos-live-ready.service
 
 	# Security default: sshd closed (live ISOs may re-enable for dev).
+	#
+	# openssh-server is installed UNCONDITIONALLY, matching the rpm path.
+	# The rpm bases already ship it, so on those images "sshd closed" has
+	# always meant the SERVICE is disabled. Gating the apt install on
+	# ENABLE_SSHD made the apt path do something stricter than the comment
+	# claimed — the package was absent entirely — and that is not a harmless
+	# extra bit of hardening: customize-live.sh:217 needs a real unit file to
+	# enable for a dev ISO, finds none, and aborts with
+	#
+	#   ERROR: dev ISO requested but no SSH service is installed
+	#
+	# Every flounder and flounder-sid cell in the 00:36 LUKS sweep died there
+	# (runs 30675951080, 30675954952) without reaching the install layer, and
+	# the dev ISO gates the installer axis too — so one packaging asymmetry
+	# was holding a large share of the never-tested cells on both axes.
+	apt-get install -y --no-install-recommends openssh-server
 	if [[ "${ENABLE_SSHD:-0}" == "1" ]]; then
-		apt-get install -y openssh-server
+		# Debian/Ubuntu ship the real unit as ssh.service, with sshd.service a
+		# compat symlink that `systemctl enable` refuses to operate on ("linked
+		# unit file"). safe_enable swallows that failure, so name both and let
+		# the one that exists win — the same fallthrough customize-live.sh does
+		# deliberately at :212-216.
 		safe_enable sshd.service
+		safe_enable ssh.service
 		if ! id liveuser &>/dev/null; then
 			useradd -m -s /bin/bash -G sudo liveuser
 		fi
 		echo 'liveuser:live' | chpasswd
 	else
+		# Now load-bearing rather than belt-and-braces: Debian's
+		# openssh-server postinst ENABLES ssh.service on install, so with the
+		# unconditional install above, a disable that misses the Debian unit
+		# names would ship published flounder images with sshd running. That
+		# would turn a build fix into a security regression, which is why both
+		# spellings and both socket units are named here.
 		safe_disable sshd.service
-		safe_disable sshd.socket 2>/dev/null || systemctl mask sshd.socket || true
+		safe_disable ssh.service
+		safe_disable sshd.socket
+		safe_disable ssh.socket
 	fi
 
 	# Units that exist on Ubuntu once their packages are installed.

--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -12,6 +12,48 @@ export MAJOR_VERSION_NUMBER
 
 source /run/context/build_scripts/lib.sh
 
+# Make sure an SSH server EXISTS on every variant, whatever it is packaged as.
+#
+# tunaOS#951. openssh-server was installed in exactly one place in this file —
+# the apt branch, under ENABLE_SSHD=1. Nothing installed it for pacman or
+# zypper at all. The rpm variants only ever worked because their BASE IMAGES
+# happen to ship the package, so "sshd closed by default" meant a disabled
+# SERVICE there and a MISSING PACKAGE everywhere else.
+#
+# The consequence was structural, not cosmetic: customize-live.sh:217 needs a
+# real unit file to enable when building a dev ISO, and aborts with
+#
+#   ERROR: dev ISO requested but no SSH service is installed
+#
+# The dev ISO gates every LUKS and installer cell, so flounder, flounder-sid,
+# grouper, marlin and sailfin were not under-exercised in the matrix — they
+# were UNBUILDABLE for those axes. That is why LUKS coverage clusters entirely
+# on the rpm family; it was a property of this function's absence, not of the
+# variants.
+#
+# Presence-guarded rather than unconditional, so this is a no-op on the rpm and
+# gentoo bases that already ship a server: no extra build time, no behaviour
+# change, and no new failure mode on images this was never broken for.
+ensure_openssh_installed() {
+	if [[ -f /usr/lib/systemd/system/sshd.service ]] ||
+		[[ -f /usr/lib/systemd/system/ssh.service ]] ||
+		[[ -f /lib/systemd/system/sshd.service ]] ||
+		[[ -f /lib/systemd/system/ssh.service ]]; then
+		echo "openssh already present — nothing to install"
+		return 0
+	fi
+	# Package names differ; the unit does not. Arch calls it plain `openssh`,
+	# and Gentoo needs the full atom.
+	case "${PKG_MGR:-dnf}" in
+	pacman) pkg_install openssh ;;
+	emerge) pkg_install net-misc/openssh ;;
+	# openSUSE split openssh-server out of openssh; older bases still only
+	# have the combined package, so try the split name and fall back.
+	zypper) pkg_install openssh-server || pkg_install openssh ;;
+	*) pkg_install openssh-server ;;
+	esac
+}
+
 # safe_enable / safe_disable are defined in lib.sh — they're called from
 # multiple build scripts, so the definition lives with the other shared
 # helpers (install_available, install_from_copr, etc.).
@@ -66,7 +108,7 @@ if [[ "${PKG_MGR:-}" == "apt" ]]; then
 	# (runs 30675951080, 30675954952) without reaching the install layer, and
 	# the dev ISO gates the installer axis too — so one packaging asymmetry
 	# was holding a large share of the never-tested cells on both axes.
-	apt-get install -y --no-install-recommends openssh-server
+	ensure_openssh_installed
 	if [[ "${ENABLE_SSHD:-0}" == "1" ]]; then
 		# Debian/Ubuntu ship the real unit as ssh.service, with sshd.service a
 		# compat symlink that `systemctl enable` refuses to operate on ("linked
@@ -136,6 +178,12 @@ safe_enable tunaos-live-ready.service
 # it via the ENABLE_SSHD=1 build arg for local dev testing, but production
 # installs default closed.
 # (Aligned with zirconium-dev/zirconium dd9f2789 — Disable sshd by default.)
+#
+# This path is not dnf-only: the apt branch above exits early, so everything
+# below also runs for pacman, zypper and emerge. marlin (pacman) failed with
+# "no SSH service is installed" for exactly that reason — the package was
+# never installed for it, only assumed. See ensure_openssh_installed.
+ensure_openssh_installed
 if [[ "${ENABLE_SSHD:-0}" == "1" ]]; then
 	safe_enable sshd.service
 	if ! id liveuser &>/dev/null; then

--- a/tests/bats/test_build_scripts.bats
+++ b/tests/bats/test_build_scripts.bats
@@ -165,7 +165,8 @@ build_scripts_top=(
     "${REPO_ROOT}/build_scripts/40-services.sh"
   [ "$status" -eq 0 ]
   for unit in sshd.service ssh.service sshd.socket ssh.socket; do
-    echo "$output" | grep -q "safe_disable ${unit}"
+    # -F: the dots are literal, so ssh.service must not match e.g. sshXservice.
+    echo "$output" | grep -qF "safe_disable ${unit}"
   done
 }
 

--- a/tests/bats/test_build_scripts.bats
+++ b/tests/bats/test_build_scripts.bats
@@ -141,19 +141,34 @@ build_scripts_top=(
   fi
 }
 
-# tunaOS#951. openssh-server used to be apt-installed only under
-# ENABLE_SSHD=1, so on Debian/Ubuntu the package was absent rather than the
-# service merely disabled — and customize-live.sh then aborted every dev ISO
-# with "no SSH service is installed", taking every flounder/flounder-sid LUKS
-# and installer cell with it. The install must not sit inside that branch.
-@test "build_scripts/40-services.sh: apt installs openssh-server unconditionally" {
-  run awk '/^if \[\[ "\$\{PKG_MGR:-\}" == "apt" \]\]/,/^fi$/' \
-    "${REPO_ROOT}/build_scripts/40-services.sh"
+# tunaOS#951. openssh-server was installed in exactly ONE place — the apt
+# branch, under ENABLE_SSHD=1 — and nowhere at all for pacman or zypper. The
+# rpm variants only worked because their base images ship it. customize-live.sh
+# then aborted every dev ISO with "no SSH service is installed", which gates
+# every LUKS and installer cell: flounder, flounder-sid, grouper, marlin and
+# sailfin were structurally untestable, not merely under-tested.
+@test "build_scripts/40-services.sh: every package manager can install openssh" {
+  local f="${REPO_ROOT}/build_scripts/40-services.sh"
+  # Arch calls it `openssh`, Gentoo needs the atom, the rest use openssh-server.
+  # Anchored past the package name so `openssh` cannot be satisfied by a line
+  # that actually says `openssh-server` — on Arch that package does not exist.
+  grep -qE 'pacman\)[[:space:]]*pkg_install openssh[[:space:]]*;;' "$f"
+  grep -qE 'emerge\)[[:space:]]*pkg_install net-misc/openssh' "$f"
+  grep -qE 'zypper\)[[:space:]]*pkg_install openssh-server' "$f"
+  grep -qE '\*\)[[:space:]]*pkg_install openssh-server' "$f"
+}
+
+# Both branches must call it: the apt branch exits early, so a single call
+# sited in either one silently skips the other family. That asymmetry is the
+# original bug, not an incidental detail of it.
+@test "build_scripts/40-services.sh: both the apt and non-apt paths ensure openssh" {
+  local f="${REPO_ROOT}/build_scripts/40-services.sh"
+  run bash -c "grep -c '^[[:space:]]*ensure_openssh_installed$' '$f'"
   [ "$status" -eq 0 ]
-  # The install line exists in the apt block...
-  echo "$output" | grep -q 'apt-get install .*openssh-server'
-  # ...and is NOT indented under the ENABLE_SSHD test (two tabs or deeper).
-  ! echo "$output" | grep -qE '^\t\t+apt-get install .*openssh-server'
+  [ "$output" -ge 2 ]
+  # ...and neither call may be nested under an ENABLE_SSHD test. A call
+  # indented two tabs or more is inside that branch, which is the bug.
+  ! grep -qE '^\t\t+ensure_openssh_installed$' "$f"
 }
 
 # The unconditional install above is only safe if the disabled path actually

--- a/tests/bats/test_build_scripts.bats
+++ b/tests/bats/test_build_scripts.bats
@@ -141,6 +141,34 @@ build_scripts_top=(
   fi
 }
 
+# tunaOS#951. openssh-server used to be apt-installed only under
+# ENABLE_SSHD=1, so on Debian/Ubuntu the package was absent rather than the
+# service merely disabled — and customize-live.sh then aborted every dev ISO
+# with "no SSH service is installed", taking every flounder/flounder-sid LUKS
+# and installer cell with it. The install must not sit inside that branch.
+@test "build_scripts/40-services.sh: apt installs openssh-server unconditionally" {
+  run awk '/^if \[\[ "\$\{PKG_MGR:-\}" == "apt" \]\]/,/^fi$/' \
+    "${REPO_ROOT}/build_scripts/40-services.sh"
+  [ "$status" -eq 0 ]
+  # The install line exists in the apt block...
+  echo "$output" | grep -q 'apt-get install .*openssh-server'
+  # ...and is NOT indented under the ENABLE_SSHD test (two tabs or deeper).
+  ! echo "$output" | grep -qE '^\t\t+apt-get install .*openssh-server'
+}
+
+# The unconditional install above is only safe if the disabled path actually
+# disables it: Debian's openssh-server postinst ENABLES ssh.service, and the
+# real unit is ssh.service (sshd.service is a compat symlink). Missing the
+# Debian spelling would ship published images with sshd running.
+@test "build_scripts/40-services.sh: apt disables both Debian SSH unit names" {
+  run awk '/^if \[\[ "\$\{PKG_MGR:-\}" == "apt" \]\]/,/^fi$/' \
+    "${REPO_ROOT}/build_scripts/40-services.sh"
+  [ "$status" -eq 0 ]
+  for unit in sshd.service ssh.service sshd.socket ssh.socket; do
+    echo "$output" | grep -q "safe_disable ${unit}"
+  done
+}
+
 @test "build_scripts/99-cleanup.sh: exists and passes shellcheck" {
   run test -f "${REPO_ROOT}/build_scripts/99-cleanup.sh"
   [ "$status" -eq 0 ]

--- a/tests/bats/test_customize_live.bats
+++ b/tests/bats/test_customize_live.bats
@@ -124,10 +124,18 @@ detect() {
   grep -q 'cat >/etc/containers/storage.conf' "${SCRIPT}"
   grep -q 'driver = "overlay"' "${SCRIPT}"
   grep -q 'graphroot = "/var/lib/containers/storage"' "${SCRIPT}"
-  grep -q 'additionalimagestores = \["/var/lib/superiso-store"\]' "${SCRIPT}"
+  grep -q 'additionalimagestores = \["/var/lib/superiso-store", "/usr/lib/containers/storage"\]' "${SCRIPT}"
   grep -q 'mount_program = "/usr/bin/fuse-overlayfs"' "${SCRIPT}"
-  run grep 'storage.conf.d/99-tunaos-offline-store.conf' "${SCRIPT}"
-  [ "$status" -ne 0 ]
+}
+
+# tunaOS#881: the primary config is necessary but not sufficient —
+# /usr/share/containers/storage.conf.d/00-vendor.conf is applied after it and
+# REPLACES additionalimagestores wholesale. The 99- drop-in must outrank it and
+# must enumerate both stores, since the last writer of an array wins.
+@test "customize-live.sh: outranks the vendor drop-in and keeps both stores" {
+  grep -q 'cat >/etc/containers/storage.conf.d/99-tbox-offline-store.conf' "${SCRIPT}"
+  run grep -c 'additionalimagestores = \["/var/lib/superiso-store", "/usr/lib/containers/storage"\]' "${SCRIPT}"
+  [ "$output" -eq 2 ]
 }
 
 @test "customize-live.sh: sources the matching desktop adapter" {


### PR DESCRIPTION
Closes #951.

The rpm bases already ship `openssh-server`, so there "sshd closed by default" has always meant the **service** is disabled. The apt path gated the *package install* on `ENABLE_SSHD=1` — stricter than the comment beside it claims, and it breaks the dev ISO:

```
ERROR: dev ISO requested but no SSH service is installed
```

Every flounder and flounder-sid cell in the 00:36 LUKS sweep died there (runs `30675951080`, `30675954952`) before reaching the install layer. The dev ISO gates the installer axis too, so one packaging asymmetry was holding a large share of the never-tested cells on **both** goal axes — while presenting as a LUKS failure, which it is not.

`customize-live.sh` is not changed: its fallthrough from `sshd.service` (a compat symlink on Debian, which `systemctl enable` refuses to operate on) to the real `ssh.service` was already right. There was nothing installed for it to find.

### The part worth reviewing

**Disabling is now load-bearing, not belt-and-braces.** Debian's `openssh-server` postinst *enables* `ssh.service` on install. With the unconditional install, a disable that only knows the Fedora spelling would ship published flounder images **with sshd running** — a build fix turned into a security regression. So both spellings and both socket units are named, on the enable and disable sides alike.

### Tests

Two bats guards, each checked to **fail against the pre-fix file** rather than merely pass against the new one:

- the apt install must not be nested inside the `ENABLE_SSHD` branch
- the disable path must name `ssh.service` and `ssh.socket`, not just `sshd.*`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->