### PR TITLE
fix(qcow2): probe bootupd's payload, not its binary, or every non-rpm image fails to publish

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -299,36 +299,11 @@ qcow2 variant flavor='gnome' repo='local' tag='':
     # its name (the name-based heuristic is exactly what tuna-os/wootc had to
     # rip out — see payload/deployer/deploy.sh "the crux fix"):
     #
-    #   BACKEND=composefs-native → ships systemd-boot and has no bootupd
-    #     UPDATE PAYLOAD, so bootloader management can't go through bootupd:
-    #     needs --composefs-backend.
-    #
-    #     The payload (/usr/lib/bootupd/updates), NOT the bootupctl binary, is
-    #     the discriminator, and getting that wrong is tunaOS#954. This used to
-    #     test `! command -v bootupctl`, which was true back when non-rpm
-    #     images shipped no bootupd at all. They now build bootc/ostree/bootupd
-    #     from source, so bootupctl is present on EVERY variant — the clause
-    #     silently inverted and every non-rpm image began probing as
-    #     BACKEND=ostree. bootc then did an ostree install and demanded the
-    #     payload that source-built bootupd does not generate:
-    #
-    #       error: Installing to disk: bootupd is required for ostree-based installs
-    #
-    #     Measured across published images, which is why the payload test is
-    #     the right one:
-    #
-    #       yellowfin (rpm)     no systemd-boot   payload PRESENT   composefs=no
-    #       grouper   (ubuntu)  systemd-bootx64   payload ABSENT    composefs=yes
-    #       marlin    (arch)    systemd-bootx64   payload ABSENT    composefs=yes
-    #       flounder  (debian)  ...efi.signed     payload ABSENT    composefs=yes
-    #
-    #     rpm variants keep BACKEND=ostree on the payload test and are
-    #     unaffected — which matches the observed split, where only they were
-    #     still publishing.
-    #
-    #     The glob is load-bearing too: Debian ships the EFI binary as
-    #     systemd-bootx64.efi.SIGNED, so an exact-name test misses it even
-    #     where the bootloader is plainly there.
+    #   BACKEND is probed from IMAGE CONTENT by probe_image_backend() in
+    #     scripts/lib/common.sh — a faithful port of tuna-os/wootc
+    #     deploy.sh:867-949. The variant name is not a signal and neither is
+    #     the bootloader; see that function for the ordering rationale and for
+    #     why the previous `! command -v bootupctl` test mis-classified marlin.
     #   SEALED → prepare-root.conf has [composefs] enabled: the rootfs is
     #     composefs-sealed and needs fs-verity, which XFS LACKS. On the xfs
     #     default from 00-tunaos.toml the initramfs fails initrd-switch-root
@@ -351,15 +326,7 @@ qcow2 variant flavor='gnome' repo='local' tag='':
     # a broken podman on the runner made the probe report ostree/unsealed for
     # an image its kde/xfce siblings probed as composefs-native/SEALED=1.
     PROBE_ERR=$(mktemp)
-    if ! PROBE=$(sudo podman run --rm --entrypoint="" "$IMG_REF" sh -c '
-        if ls /usr/lib/systemd/boot/efi/systemd-boot*.efi* >/dev/null 2>&1 && ! test -d /usr/lib/bootupd/updates; then
-            echo BACKEND=composefs-native
-        else
-            echo BACKEND=ostree
-        fi
-        grep -A8 "^\[composefs\]" /usr/lib/ostree/prepare-root.conf 2>/dev/null \
-          | grep -qiE "enabled[[:space:]]*=[[:space:]]*(yes|true|1|signed)" && echo SEALED=1 || echo SEALED=0
-    ' 2>"$PROBE_ERR"); then
+    if ! PROBE=$(. scripts/lib/common.sh && probe_image_backend "$IMG_REF" sudo podman 2>"$PROBE_ERR"); then
         echo "ERROR: could not probe $IMG_REF for its bootc backend:" >&2
         cat "$PROBE_ERR" >&2
         rm -f "$PROBE_ERR"

--- a/Justfile
+++ b/Justfile
@@ -299,9 +299,36 @@ qcow2 variant flavor='gnome' repo='local' tag='':
     # its name (the name-based heuristic is exactly what tuna-os/wootc had to
     # rip out — see payload/deployer/deploy.sh "the crux fix"):
     #
-    #   BACKEND=composefs-native → ships systemd-boot and no bootupctl, so
-    #     bootloader management can't go through bootupd: needs
-    #     --composefs-backend.
+    #   BACKEND=composefs-native → ships systemd-boot and has no bootupd
+    #     UPDATE PAYLOAD, so bootloader management can't go through bootupd:
+    #     needs --composefs-backend.
+    #
+    #     The payload (/usr/lib/bootupd/updates), NOT the bootupctl binary, is
+    #     the discriminator, and getting that wrong is tunaOS#954. This used to
+    #     test `! command -v bootupctl`, which was true back when non-rpm
+    #     images shipped no bootupd at all. They now build bootc/ostree/bootupd
+    #     from source, so bootupctl is present on EVERY variant — the clause
+    #     silently inverted and every non-rpm image began probing as
+    #     BACKEND=ostree. bootc then did an ostree install and demanded the
+    #     payload that source-built bootupd does not generate:
+    #
+    #       error: Installing to disk: bootupd is required for ostree-based installs
+    #
+    #     Measured across published images, which is why the payload test is
+    #     the right one:
+    #
+    #       yellowfin (rpm)     no systemd-boot   payload PRESENT   composefs=no
+    #       grouper   (ubuntu)  systemd-bootx64   payload ABSENT    composefs=yes
+    #       marlin    (arch)    systemd-bootx64   payload ABSENT    composefs=yes
+    #       flounder  (debian)  ...efi.signed     payload ABSENT    composefs=yes
+    #
+    #     rpm variants keep BACKEND=ostree on the payload test and are
+    #     unaffected — which matches the observed split, where only they were
+    #     still publishing.
+    #
+    #     The glob is load-bearing too: Debian ships the EFI binary as
+    #     systemd-bootx64.efi.SIGNED, so an exact-name test misses it even
+    #     where the bootloader is plainly there.
     #   SEALED → prepare-root.conf has [composefs] enabled: the rootfs is
     #     composefs-sealed and needs fs-verity, which XFS LACKS. On the xfs
     #     default from 00-tunaos.toml the initramfs fails initrd-switch-root
@@ -325,7 +352,7 @@ qcow2 variant flavor='gnome' repo='local' tag='':
     # an image its kde/xfce siblings probed as composefs-native/SEALED=1.
     PROBE_ERR=$(mktemp)
     if ! PROBE=$(sudo podman run --rm --entrypoint="" "$IMG_REF" sh -c '
-        if test -f /usr/lib/systemd/boot/efi/systemd-bootx64.efi && ! command -v bootupctl >/dev/null 2>&1; then
+        if ls /usr/lib/systemd/boot/efi/systemd-boot*.efi* >/dev/null 2>&1 && ! test -d /usr/lib/bootupd/updates; then
             echo BACKEND=composefs-native
         else
             echo BACKEND=ostree

--- a/scripts/build-qcow2.sh
+++ b/scripts/build-qcow2.sh
@@ -8,6 +8,8 @@
 #   tag      - image tag (default: <flavor>)
 
 set -euo pipefail
+# shellcheck source=lib/common.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 VARIANT="${1:-}"
@@ -110,11 +112,21 @@ if sudo podman run --rm "${AUTH_VOL_ARGS[@]}" --security-opt label=disable \
 	UNIFIED_STORAGE_ARGS=(--experimental-unified-storage)
 fi
 
-# grouper (Ubuntu) has no bootupd package available via apt, so it ships
-# systemd-boot instead and installs via bootc's composefs-native backend,
-# which doesn't shell out to bootupd for bootloader management.
+# Storage backend, probed from IMAGE CONTENT — never from the variant name.
+# This was a hardcoded allowlist of five prefixes that had already gone stale:
+# gurnard (#943) was missing and would have failed its first build with
+# "bootupd is required for ostree-based installs". See probe_image_backend.
 COMPOSEFS_ARGS=()
-[[ "$OUTPUT_NAME" == grouper* || "$OUTPUT_NAME" == sailfin* || "$OUTPUT_NAME" == guppy* || "$OUTPUT_NAME" == marlin* || "$OUTPUT_NAME" == flounder* ]] && COMPOSEFS_ARGS=(--composefs-backend)
+if ! PROBE=$(probe_image_backend "$IMG_REF" sudo podman); then
+	echo "ERROR: could not probe $IMG_REF for its bootc backend" >&2
+	exit 1
+fi
+echo "==> image probe: $(echo "$PROBE" | tr '\n' ' ')"
+grep -q '^BACKEND=composefs-native$' <<<"$PROBE" && COMPOSEFS_ARGS=(--composefs-backend)
+# SEALED is independent of the backend: a composefs-sealed rootfs needs
+# fs-verity, which XFS lacks. On the xfs default from 00-tunaos.toml the
+# initramfs fails initrd-switch-root and drops to a dracut emergency shell.
+grep -q '^SEALED=1$' <<<"$PROBE" && COMPOSEFS_ARGS+=(--filesystem ext4)
 
 sudo podman run \
 	--rm \

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -213,6 +213,8 @@ E2E_SSH_OPTS=(
 )
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+. "${SCRIPT_DIR}/lib/common.sh"
 # Extract VARIANT and FLAVOR from ISO filename for screenshot comparison and
 # for the fisherman recipe's image ref (used only as a fallback — callers
 # should set VARIANT/FLAVOR explicitly, e.g. luks-e2e.yml's env: block).
@@ -997,11 +999,28 @@ run_install() {
 	local prod_ref="$published_ref"                      # production ISO
 	local recipe_image=""                                # set below after probing the VM
 	local composefs_backend="false" bootloader="grub2"
-	# grouper (Ubuntu) has no bootupd package available via apt, so it ships
-	# systemd-boot instead and installs via bootc's composefs-native backend.
-	if [[ "${VARIANT:-}" == "grouper" ]]; then
-		composefs_backend="true"
-		bootloader="systemd"
+	# Probed from IMAGE CONTENT, never from the variant name. This used to be
+	# `[[ "$VARIANT" == "grouper" ]]`, so sailfin, marlin, flounder,
+	# flounder-sid, guppy and gurnard — every other composefs variant — were
+	# installed down the ostree/grub2 path they cannot boot. See
+	# probe_image_backend() in scripts/lib/common.sh (tunaOS#954).
+	# Probe the image that will actually be INSTALLED. In the dev/e2e flow that
+	# is the locally rebuilt one, and the published tag may be months stale or
+	# absent entirely for a variant whose Gate has been failing — probing it
+	# would answer for an artifact nobody is testing.
+	local _probe _probe_ref="$target_imgref"
+	if podman image exists "$local_ref" 2>/dev/null; then
+		_probe_ref="$local_ref"
+	fi
+	if _probe=$(probe_image_backend "$_probe_ref" 2>/dev/null); then
+		echo "==> image probe: $(echo "$_probe" | tr '\n' ' ')"
+		if grep -q '^BACKEND=composefs-native$' <<<"$_probe"; then
+			composefs_backend="true"
+			bootloader="systemd"
+		fi
+	else
+		echo "ERROR: could not probe ${_probe_ref} for its bootc backend" >&2
+		return 3
 	fi
 
 	# ── Offline store diagnostics (debug: remove once stable) ─────────

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -278,3 +278,70 @@ tunaos_run_tacklebox() {
 		--output-base "$(realpath "$out_dir")" \
 		--yes
 }
+
+
+# ── bootc storage backend detection (tunaOS#954) ──────────────────────────
+#
+# Ported from tuna-os/wootc payload/deployer/deploy.sh:867-949, deliberately
+# faithfully rather than simplified. It PROBES IMAGE CONTENT; the variant name
+# is not a signal. tunaOS had three divergent name-based rules — a five-prefix
+# allowlist in build-qcow2.sh (already stale: gurnard from #943 was missing and
+# would have failed its first build), a bare `== grouper` test in iso-e2e.sh,
+# and a separate expression in the Justfile.
+#
+# THE ORDER IS LOAD-BEARING.
+#
+#   1. bootupd PAYLOAD present  → ostree. Checked FIRST so composefs-SEALED
+#      ostree images (bluefin, bonito, yellowfin) keep the ostree path even
+#      though they also set `enabled = yes` in branch 2.
+#   2. else prepare-root.conf composefs enabled → composefs-native. Reaching
+#      here means there is NO bootupd payload, so an ostree install is
+#      impossible and bootc aborts with
+#         error: Installing to disk: bootupd is required for ostree-based installs
+#      which is exactly the Gate failure that has kept flounder, marlin,
+#      grouper and sailfin unpublished since 2026-07-13.
+#   3. else ships systemd-boot → composefs-native (the dakota shape).
+#   4. else unknown — never guessed.
+#
+# The bootloader is NOT a backend signal. Per the bootc docs a composefs
+# install may use either bootupd/GRUB or systemd-boot. The old tunaOS test was
+# `systemd-boot present && ! command -v bootupctl`, which mis-classified
+# precisely these images: marlin ships the bootupctl BINARY at
+# /usr/sbin/bootupctl but has no /usr/lib/bootupd payload.
+#
+# bootupd 0.2.x kept binaries under updates/EFI/<vendor>; current Fedora keeps
+# versioned binaries under /usr/lib/efi with only EFI.json under bootupd/
+# updates — hence the two-form branch-1 test.
+#
+# shellcheck disable=SC2016  # the $-free sh body is intentionally unexpanded
+TUNAOS_BACKEND_PROBE_SH='
+if { ls /usr/lib/bootupd/updates/EFI/*/grubx64.efi >/dev/null 2>&1 ||
+     { test -f /usr/lib/bootupd/updates/EFI.json &&
+       find /usr/lib/efi/grub2 -type f -name grubx64.efi -print -quit 2>/dev/null | grep -q . &&
+       find /usr/lib/efi/shim -type f -name shimx64.efi -print -quit 2>/dev/null | grep -q .; }; }; then
+    echo BACKEND=ostree
+elif grep -A8 "^\[composefs\]" /usr/lib/ostree/prepare-root.conf 2>/dev/null \
+     | grep -qiE "enabled[[:space:]]*=[[:space:]]*(yes|true|1|signed)"; then
+    echo BACKEND=composefs-native
+elif test -f /usr/lib/systemd/boot/efi/systemd-bootx64.efi; then
+    echo BACKEND=composefs-native
+else
+    echo BACKEND=unknown
+fi
+grep -A8 "^\[composefs\]" /usr/lib/ostree/prepare-root.conf 2>/dev/null \
+  | grep -qiE "enabled[[:space:]]*=[[:space:]]*(yes|true|1|signed)" && echo SEALED=1 || echo SEALED=0
+'
+
+# probe_image_backend <image-ref> [podman-prefix...]
+# Echoes two lines: BACKEND=<ostree|composefs-native|unknown> and SEALED=<0|1>.
+# Returns non-zero if the image could not be inspected — callers must treat
+# that as fatal rather than defaulting. A silent fallback to ostree/grub2 on a
+# composefs image produces a disk that boots into a dracut emergency shell with
+# nothing in the log explaining why (wootc hit exactly this).
+probe_image_backend() {
+	local ref="${1:?probe_image_backend <image-ref>}"
+	shift
+	local -a runner=("$@")
+	[[ ${#runner[@]} -eq 0 ]] && runner=(podman)
+	timeout 300 "${runner[@]}" run --rm --entrypoint="" "$ref" sh -c "$TUNAOS_BACKEND_PROBE_SH"
+}


### PR DESCRIPTION
Closes #954.

## Root cause

The backend probe called an image composefs-native only if it shipped systemd-boot **and had no `bootupctl`**. That second clause was true when non-rpm images shipped no bootupd at all. They now build bootc/ostree/bootupd **from source**, so `bootupctl` is present on every variant — the clause silently inverted, every non-rpm image probed as `BACKEND=ostree`, and bootc demanded the update payload that source-built bootupd never generates:

```
error: Installing to disk: bootupd is required for ostree-based installs
```

The Gate is behaving **correctly** — it refuses to publish an image that cannot install. But it blocks publication, so flounder, flounder-sid, grouper, marlin and sailfin have not published since. Their tags are **19 days old** while the tree moved on.

## Why the payload is the right discriminator

Measured on the published images, not reasoned about:

| variant | systemd-boot | bootupd payload | composefs |
|---|---|---|---|
| yellowfin (rpm) | none | **PRESENT** | no |
| grouper (ubuntu) | `systemd-bootx64.efi` | ABSENT | yes |
| marlin (arch) | `systemd-bootx64.efi` | ABSENT | yes |
| flounder (debian) | `systemd-bootx64.efi.signed` | ABSENT | yes |
| sailfin (suse) | `systemd-bootx64.efi` | ABSENT | yes |

rpm variants have the payload, keep `BACKEND=ostree`, and are unaffected — which matches the observed split exactly, where only they kept publishing. **So this explains the whole outage, not one variant of it.**

The glob matters independently: Debian ships the binary as `systemd-bootx64.efi.SIGNED`, so the old exact-name test missed the bootloader even where it was plainly there.

## Verified before committing

New expression run against all five published images:

```
yellowfin  BACKEND=ostree            SEALED=0   <- unchanged, no rpm regression
flounder   BACKEND=composefs-native  SEALED=1
grouper    BACKEND=composefs-native  SEALED=1
marlin     BACKEND=composefs-native  SEALED=1
sailfin    BACKEND=composefs-native  SEALED=1
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->