### PR TITLE
fix(e2e): make the installed-desktop screenshot capturable at all (#946)

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -445,7 +445,6 @@ rm -f "$MONITOR_SOCK" "$SERIAL_LOG" "$QEMU_PIDFILE"
 
 # ── Cleanup on exit ─────────────────────────────────────────────────────────
 
-# shellcheck disable=SC2329  # invoked via `trap cleanup_vm EXIT`
 # Clear the unix sockets a previous QEMU left behind, immediately before
 # launching the next one. This is bug 1 of #946.
 #
@@ -462,6 +461,7 @@ reset_qemu_sockets() {
 	rm -f "${OUTPUT_DIR}/vnc.sock" "$MONITOR_SOCK"
 }
 
+# shellcheck disable=SC2329  # invoked via `trap cleanup_vm EXIT`
 cleanup_vm() {
 	# `|| true` is load-bearing under `set -e`: once the watchdog has FIRED it
 	# has already exited, so this kill fails, and without the guard the
@@ -651,15 +651,29 @@ screenshot() {
 		# peer". One capture is one connection, so `fork` bought nothing.
 		VNC_BRIDGE_PORT=$((${VNC_BRIDGE_PORT:-${TBOX_E2E_VNC_PORT:-5999}} + 1))
 		local port="$VNC_BRIDGE_PORT"
-		socat "TCP-LISTEN:${port},reuseaddr" "UNIX-CONNECT:${vnc_sock}" >>"$cap_log" 2>&1 &
+		# bind=127.0.0.1: vncdo connects to loopback, so there is no reason to
+		# expose the guest console on every host interface, however briefly —
+		# these runs happen on bare-metal hosts on a real LAN.
+		socat "TCP-LISTEN:${port},bind=127.0.0.1,reuseaddr" "UNIX-CONNECT:${vnc_sock}" >>"$cap_log" 2>&1 &
 		local bridge=$!
 		# Wait for the listener instead of sleeping at it: on a loaded host
 		# 1s was sometimes short, and the failure was indistinguishable from
 		# a real capture failure.
+		#
+		# Liveness of *this* socat is checked first: a listening port alone
+		# proves nothing, since a leftover bridge or an unrelated service can
+		# hold it while our socat failed to bind and exited. And the port match
+		# is anchored on whitespace/end-of-line — `\b` is not a word boundary
+		# in grep's default BRE, so ":5999\b" never matched `ss` output as
+		# intended (and a bare ":5999" would also match ":59990").
 		local ready=0
 		for _ in $(seq 1 20); do
+			if ! kill -0 "$bridge" 2>/dev/null; then
+				echo "==> VNC bridge exited before listening on ${port}" >>"$cap_log"
+				break
+			fi
 			if command -v ss &>/dev/null; then
-				ss -ltn 2>/dev/null | grep -q ":${port}\b" && { ready=1; break; }
+				ss -ltn 2>/dev/null | grep -Eq "127\.0\.0\.1:${port}([[:space:]]|$)" && { ready=1; break; }
 			else
 				sleep 1
 				ready=1

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -446,6 +446,22 @@ rm -f "$MONITOR_SOCK" "$SERIAL_LOG" "$QEMU_PIDFILE"
 # ── Cleanup on exit ─────────────────────────────────────────────────────────
 
 # shellcheck disable=SC2329  # invoked via `trap cleanup_vm EXIT`
+# Clear the unix sockets a previous QEMU left behind, immediately before
+# launching the next one. This is bug 1 of #946.
+#
+# QEMU does not unlink a stale unix socket before binding, and — critically —
+# it does not fail either: it logs nothing and boots on with no VNC server.
+# So the installed-boot VM silently had no VNC at all, socat got "Connection
+# refused", the capture fell back to screendump, and screendump cannot read a
+# GL scanout — hence `rendered=absent` on the only host configuration where
+# the render path can work at all.
+#
+# Called from every launcher rather than from cleanup_vm: cleanup runs on the
+# way out, and the run that matters is the one that starts next.
+reset_qemu_sockets() {
+	rm -f "${OUTPUT_DIR}/vnc.sock" "$MONITOR_SOCK"
+}
+
 cleanup_vm() {
 	# `|| true` is load-bearing under `set -e`: once the watchdog has FIRED it
 	# has already exited, so this kill fails, and without the guard the
@@ -557,6 +573,7 @@ boot_live_iso() {
 	echo "==> Accel: ${ACCEL}, CPU: ${CPU_ARG}, MEM: ${MEMORY}M, CPUS: ${CPUS}"
 
 	# shellcheck disable=SC2086  # TPM_ARGS is intentionally word-split (empty unless --luks)
+	reset_qemu_sockets
 	"$QEMU" \
 		-name "tunaos-iso-e2e" \
 		-machine pc \
@@ -618,19 +635,50 @@ screenshot() {
 	local png="${OUTPUT_DIR}/${label}.png"
 	local vnc_sock="${OUTPUT_DIR}/vnc.sock"
 
+	local cap_log="${OUTPUT_DIR}/vnc-capture-${label}.log"
+
 	if [[ -S "$vnc_sock" ]] && command -v vncdo &>/dev/null && command -v socat &>/dev/null; then
 		# vncdo speaks TCP, so bridge the unix socket for the moment of capture.
-		local port="${TBOX_E2E_VNC_PORT:-5999}"
-		socat "TCP-LISTEN:${port},reuseaddr,fork" "UNIX-CONNECT:${vnc_sock}" &
+		#
+		# A FRESH PORT PER CAPTURE, and no `fork` — this is bug 2 of #946.
+		# The old bridge was `TCP-LISTEN:...,fork`, which forks a child per
+		# connection; `kill $bridge` reaps only the listener, so children
+		# bridging to a socket whose QEMU has since been killed survive and
+		# keep the port warm. The next capture then connects to one of those
+		# corpses and vncdo reads ECONNRESET — which is exactly the reported
+		# signature: the live capture (first use of the port) succeeds, the
+		# installed capture (always second) fails with "Connection reset by
+		# peer". One capture is one connection, so `fork` bought nothing.
+		VNC_BRIDGE_PORT=$((${VNC_BRIDGE_PORT:-${TBOX_E2E_VNC_PORT:-5999}} + 1))
+		local port="$VNC_BRIDGE_PORT"
+		socat "TCP-LISTEN:${port},reuseaddr" "UNIX-CONNECT:${vnc_sock}" >>"$cap_log" 2>&1 &
 		local bridge=$!
-		sleep 1
-		vncdo -s "127.0.0.1::${port}" capture "$png" >/dev/null 2>&1 || true
+		# Wait for the listener instead of sleeping at it: on a loaded host
+		# 1s was sometimes short, and the failure was indistinguishable from
+		# a real capture failure.
+		local ready=0
+		for _ in $(seq 1 20); do
+			if command -v ss &>/dev/null; then
+				ss -ltn 2>/dev/null | grep -q ":${port}\b" && { ready=1; break; }
+			else
+				sleep 1
+				ready=1
+				break
+			fi
+			sleep 0.25
+		done
+		[[ "$ready" == 1 ]] || echo "==> VNC bridge never listened on ${port}" >>"$cap_log"
+		# Errors go to a per-label log, not /dev/null. #946 bug 2 sat
+		# undiagnosed because this line discarded both vncdo's and socat's
+		# output, so a failed capture said only "rendered=absent".
+		vncdo -s "127.0.0.1::${port}" capture "$png" >>"$cap_log" 2>&1 || true
 		kill "$bridge" 2>/dev/null || true
+		wait "$bridge" 2>/dev/null || true
 		if [[ -s "$png" ]]; then
 			echo "==> Screenshot saved: ${png} (vnc)"
 			return 0
 		fi
-		echo "==> VNC capture failed; falling back to screendump" >&2
+		echo "==> VNC capture failed; falling back to screendump (see ${cap_log})" >&2
 	fi
 
 	if [[ -S "$MONITOR_SOCK" ]] && command -v socat &>/dev/null; then
@@ -1333,6 +1381,7 @@ EOF
 		# No TPM here: the passphrase gate doesn't need one, and the
 		# install-phase swtpm has already exited (its socket is gone). TPM
 		# auto-unlock is the separate post-install test.
+		reset_qemu_sockets
 		"$QEMU" -name "tunaos-iso-e2e-installed" -machine pc -cpu "$CPU_ARG" \
 			-accel "$ACCEL" -m "$MEMORY" -smp "$CPUS" \
 			-drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
@@ -1432,6 +1481,7 @@ EOF
 	echo "==> Booting installed system..."
 	# Boot from the install disk (remove cdrom)
 	# shellcheck disable=SC2086  # TPM_ARGS is intentionally word-split (empty unless --luks)
+	reset_qemu_sockets
 	"$QEMU" \
 		-name "tunaos-iso-e2e-installed" \
 		-machine pc \
@@ -1497,6 +1547,7 @@ boot_disk_image() {
 	echo "==> Booting disk image: ${ISO_PATH} (${fmt})"
 	echo "==> Accel: ${ACCEL}, CPU: ${CPU_ARG}, MEM: ${MEMORY}M, CPUS: ${CPUS}"
 
+	reset_qemu_sockets
 	"$QEMU" \
 		-name "tunaos-disk-e2e" \
 		-machine pc \


### PR DESCRIPTION
Both bugs from #946. **Do not close #946 on this PR** — the bar is a named run reporting `TUNAOS_LUKS_E2E_INSTALLED_SCREENSHOT rendered=` something other than `absent`, on a host with a render node (himachal, not hosted CI).

## Bug 1 — stale VNC socket (confirmed by the reporter)

QEMU does not unlink a stale unix socket before binding, and **does not fail either** — it logs nothing and boots on with no VNC server. The live QEMU bound `vnc.sock` and was killed; the installed-boot QEMU could not bind over the leftover file, so it had no VNC at all. `socat` got `Connection refused`, capture fell back to `screendump`, and screendump cannot read a GL scanout — hence `rendered=absent` on the one host configuration where the render path can work.

`reset_qemu_sockets()` clears `vnc.sock` and the monitor socket immediately before each of the four QEMU launches. Deliberately **not** in `cleanup_vm`: cleanup runs on the way out, and the run that matters is the one starting next — a crashed or timed-out run leaves exactly the mess that breaks the following boot.

## Bug 2 — the bridge outliving its VM (hypothesis, fits the evidence)

The bridge was `socat TCP-LISTEN:${port},reuseaddr,fork`. `fork` forks a child per connection, so `kill $bridge` reaps **only the listener**. Children still bridging to a socket whose QEMU is gone survive and keep the port warm; the next capture connects to one of those corpses and vncdo reads **ECONNRESET**.

That matches the reported signature exactly: the live capture — first use of the port — succeeds, and the installed capture — always second — fails with `Connection reset by peer`. It also explains why removing the stale socket *changed* the error rather than fixing it.

One capture is one connection, so `fork` bought nothing. Dropped it, and used a fresh port per capture so a survivor cannot be reached even if one exists.

## The reason bug 2 was undiagnosable

`vncdo` and `socat` output both went to `/dev/null`, so a failed capture said only `rendered=absent`. Now logged per label to `vnc-capture-<label>.log`, and the fallback message names the file. The blind `sleep 1` is now a poll for the listener, so a slow host is distinguishable from a real capture failure.

## Honest status

Bug 1 is confirmed — the reporter showed `rm -f` changing the error. Bug 2's mechanism is a hypothesis that fits every observation, but nothing has proven it. If the next run still fails, `vnc-capture-*.log` will say why, which it could not before.

`bash -n` and `shellcheck -S warning` clean. #916 is next and depends on this landing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->