### PR TITLE
fix(gnome): install gnome-keyring explicitly on apt, it is only a recommend

### DIFF
--- a/build_scripts/desktop/gnome.sh
+++ b/build_scripts/desktop/gnome.sh
@@ -15,8 +15,27 @@ case "${1:-}" in
 		# recommends, and without them /usr/share/wayland-sessions has no
 		# *gnome*.desktop — configure-desktop-runtime.sh hard-fails
 		# (grouper gnome red since 2026-07-21).
+		# gnome-keyring is the next casualty of the same --no-install-recommends
+		# rule as gnome-session above: apt lists it only as a RECOMMEND of
+		# ubuntu-desktop-minimal, so it is silently dropped and
+		# verify-desktop-experience.sh's gnome branch fails its
+		# `/usr/bin/gnome-keyring-daemon` requirement:
+		#
+		#   missing required path: none of [/usr/bin/gnome-keyring-daemon] exist
+		#
+		# That is what kills grouper gnome-asahi (run 30684297227). It is NOT
+		# an asahi or arm64 problem — measured on the PUBLISHED images,
+		# grouper:gnome (amd64) is missing it too while flounder:gnome
+		# (Debian) has it, because only Ubuntu demotes it to a recommend.
+		# gnome-asahi merely surfaced it first, since base and asahi build in
+		# the same workflow while the amd64 desktop flavors are a later stage.
+		#
+		# libpam-gnome-keyring comes too, matching niri.sh and cosmic.sh: the
+		# daemon alone satisfies the contract check but leaves the keyring
+		# locked at login, which is the user-visible half of the feature.
 		pkg_install ubuntu-desktop-minimal gnome-shell-extension-manager \
-			gnome-session ubuntu-session
+			gnome-session ubuntu-session \
+			gnome-keyring libpam-gnome-keyring
 
 		# Additional GNOME utilities (mirrors the RPM set where possible)
 		pkg_install \

--- a/build_scripts/desktop/gnome.sh
+++ b/build_scripts/desktop/gnome.sh
@@ -15,24 +15,12 @@ case "${1:-}" in
 		# recommends, and without them /usr/share/wayland-sessions has no
 		# *gnome*.desktop — configure-desktop-runtime.sh hard-fails
 		# (grouper gnome red since 2026-07-21).
-		# gnome-keyring is the next casualty of the same --no-install-recommends
-		# rule as gnome-session above: apt lists it only as a RECOMMEND of
-		# ubuntu-desktop-minimal, so it is silently dropped and
-		# verify-desktop-experience.sh's gnome branch fails its
-		# `/usr/bin/gnome-keyring-daemon` requirement:
-		#
-		#   missing required path: none of [/usr/bin/gnome-keyring-daemon] exist
-		#
-		# That is what kills grouper gnome-asahi (run 30684297227). It is NOT
-		# an asahi or arm64 problem — measured on the PUBLISHED images,
-		# grouper:gnome (amd64) is missing it too while flounder:gnome
-		# (Debian) has it, because only Ubuntu demotes it to a recommend.
-		# gnome-asahi merely surfaced it first, since base and asahi build in
-		# the same workflow while the amd64 desktop flavors are a later stage.
-		#
-		# libpam-gnome-keyring comes too, matching niri.sh and cosmic.sh: the
-		# daemon alone satisfies the contract check but leaves the keyring
-		# locked at login, which is the user-visible half of the feature.
+		# gnome-keyring falls to the same --no-install-recommends rule: Ubuntu
+		# lists it only as a recommend of ubuntu-desktop-minimal, so it is
+		# dropped and verify-desktop-experience.sh fails its
+		# /usr/bin/gnome-keyring-daemon requirement. libpam-gnome-keyring comes
+		# too (matching niri.sh and cosmic.sh) so the keyring unlocks at login.
+		# Full investigation: tuna-os/tunaOS#956.
 		pkg_install ubuntu-desktop-minimal gnome-shell-extension-manager \
 			gnome-session ubuntu-session \
 			gnome-keyring libpam-gnome-keyring


### PR DESCRIPTION
Part of #956 — the grouper half.

grouper `gnome-asahi` fails its desktop contract at:

```
missing required path: none of [/usr/bin/gnome-keyring-daemon] exist
```

apt lists `gnome-keyring` only as a **recommend** of `ubuntu-desktop-minimal`, and `pkg_install` uses `--no-install-recommends`, so it is silently dropped. This is the same failure the comment directly above it already records for `gnome-session`/`ubuntu-session`, which had to be made explicit when resolute's GNOME 50.1 update stopped dragging them in.

### It is not an asahi bug

#956 pairs this with #914 (sailfin asahi missing Apple DTBs), which invites a shared-cause reading. Measured on the published images rather than inferred:

| image | | 
|---|---|
| `grouper:gnome` (Ubuntu, **amd64**) | KEYRING-**MISSING** |
| `flounder:gnome` (Debian, amd64) | KEYRING-PRESENT |

amd64 Ubuntu is equally broken; Debian is fine, because only Ubuntu demotes the package to a recommend. `gnome-asahi` surfaced it first because base and asahi build in the **same workflow** while the amd64 desktop flavors run in a later stage. **The two asahi failures are unrelated bugs sharing a lightly-exercised path** — worth fixing that path's exposure, but not as one cause.

### Why libpam-gnome-keyring too

Matching `niri.sh` and `cosmic.sh`. The daemon alone satisfies the contract check but leaves the keyring **locked at login** — a fix that satisfies the gate without delivering the behaviour the gate exists to protect is not a fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->