### PR TITLE
fix(desktop): stop the apt path exiting before the contract is installed

### DIFF
--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -172,7 +172,27 @@ if [[ "${_TD_OS}" == "apt" ]]; then
 		systemctl enable "${_TD_DM}" || true
 	fi
 	printf "::endgroup::\n"
-	exit 0
+	# Deliberately NO `exit 0` here, for the same reason the pacman branch
+	# below says so. This branch DID return early, and everything after it was
+	# silently skipped on every apt image: disable_desktop_files, post_install
+	# hooks, post_install_inline, the curated experiences/<desktop>/files
+	# overlay, and — the one that surfaced — the desktop-experience contract.
+	#
+	# So verify-desktop-experience.sh was never installed to
+	# /usr/libexec/tunaos and tunaos-desktop-contract.service was never
+	# written, which is why the Gate reported
+	#
+	#   ERROR: desktop experience contract marker was not emitted
+	#
+	# for flounder-sid gnome, kde and xfce (run 30685667161). NEITHER
+	# TUNAOS_DESKTOP_CONTRACT_OK nor _FAIL appeared because nothing was there
+	# to emit one — silence rather than a verdict, which reads as a hung check
+	# instead of a missing one. That blocked every desktop flavor on the apt
+	# variants from publishing while base promoted fine, base having no
+	# desktop and so never running this check.
+	#
+	# Confirmed by inspecting the built image: no /usr/libexec/tunaos at all,
+	# and by the build log ending at `systemctl enable gdm3` -> `exit 0`.
 fi
 
 # ── Pacman path (Arch Linux / CachyOS) ───────────────────────────────────────

--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -173,26 +173,10 @@ if [[ "${_TD_OS}" == "apt" ]]; then
 	fi
 	printf "::endgroup::\n"
 	# Deliberately NO `exit 0` here, for the same reason the pacman branch
-	# below says so. This branch DID return early, and everything after it was
-	# silently skipped on every apt image: disable_desktop_files, post_install
-	# hooks, post_install_inline, the curated experiences/<desktop>/files
-	# overlay, and — the one that surfaced — the desktop-experience contract.
-	#
-	# So verify-desktop-experience.sh was never installed to
-	# /usr/libexec/tunaos and tunaos-desktop-contract.service was never
-	# written, which is why the Gate reported
-	#
-	#   ERROR: desktop experience contract marker was not emitted
-	#
-	# for flounder-sid gnome, kde and xfce (run 30685667161). NEITHER
-	# TUNAOS_DESKTOP_CONTRACT_OK nor _FAIL appeared because nothing was there
-	# to emit one — silence rather than a verdict, which reads as a hung check
-	# instead of a missing one. That blocked every desktop flavor on the apt
-	# variants from publishing while base promoted fine, base having no
-	# desktop and so never running this check.
-	#
-	# Confirmed by inspecting the built image: no /usr/libexec/tunaos at all,
-	# and by the build log ending at `systemctl enable gdm3` -> `exit 0`.
+	# below says so. Returning early skips everything shared that follows:
+	# disable_desktop_files, post_install hooks, post_install_inline, the
+	# curated experiences/<desktop>/files overlay, and the installation of the
+	# desktop-experience contract (tunaOS#959).
 fi
 
 # ── Pacman path (Arch Linux / CachyOS) ───────────────────────────────────────


### PR DESCRIPTION
Top of the chain for #956 — this is what blocks every desktop flavour on the apt variants from publishing.

## The check never ran, because it was never installed

`install-desktop.sh`'s apt branch ended with `exit 0` right after enabling the display manager. Everything below was silently skipped on every apt image:

- `disable_desktop_files`
- `post_install` hooks and `post_install_inline`
- the curated `experiences/<desktop>/files` overlay
- **the desktop-experience contract** — `verify-desktop-experience.sh` -> `/usr/libexec/tunaos`, plus `tunaos-desktop-contract.service`

So "marker was not emitted" is literal: nothing was there to emit one.

**The pacman branch a few lines below already carries this exact fix**, with the comment *"Deliberately NO `exit 0` here. The pacman branch used to return early, skipping the desktop-experience contract check below."* Arch was fixed; apt was left behind.

## Confirmed, not inferred

| image | contract | unit |
|---|---|---|
| `yellowfin:gnome` (el10) | INSTALLED | present |
| `sailfin:gnome` (opensuse) | INSTALLED | present |
| `flounder-sid:gnome-testing` (debian, built today) | **ABSENT** | **absent** |

No `/usr/libexec/tunaos` directory at all. And the build log for run `30680374962` ends that step at `systemctl enable gdm3` -> `printf ::endgroup::` -> `exit 0`, with `verify-desktop-experience` never mentioned.

Base promoted normally throughout, because base has no desktop and never runs this check — which is why the split looked mysterious.

## The shape is the recurring one

This presented as **silence rather than a verdict**. A missing check and a hung check are indistinguishable at the Gate, and silence reads as the latter. Same shape as the greetd-active contract and the absent installed-desktop screenshot.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->