### PR TITLE
fix(grouper): move gnome-asahi off stage 1, it was gating every desktop

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -769,8 +769,21 @@ variants:
       # Apple Silicon (M1/M2, Asahi Linux) — full build with ENABLE_ASAHI=1
       # (the kernel decision lives in Containerfile.ubuntu's base stage, so
       # this is not an overlay). aarch64 only; no ISO (asahi-installer path).
+      #
+      # stage 3, NOT stage 1, and the distinction matters: `stage` is build
+      # ORDER, not parentage. This flavor has no PARENT_FLAVOR, so it still
+      # builds straight from base wherever it is placed — but at stage 1 it
+      # shared a matrix with base, and a stage does not advance until every
+      # cell in it passes. One arm64-only Apple Silicon flavor therefore gated
+      # gnome, kde, gnome-zfs, cosmic and xfce, which all live in stage 2:
+      # run 30688732984 promoted base and then never started them.
+      #
+      # Every other variant already places gnome-asahi at stage 3; grouper was
+      # the lone exception, because there asahi is a full build rather than an
+      # overlay and the stage number was read as "has no parent" rather than
+      # "runs first".
       - id: gnome-asahi
-        stage: 1
+        stage: 3
         platforms: ["linux/arm64"]
         build_image: true
         build_iso: false

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -42,27 +42,25 @@ green on 2026-07-23, while the installer GUI had never once been observed.
 
 ## LUKS E2E
 
-**13 of 50** cells green (20 tested, 30 never tested).
+**2 of 50** cells green (25 tested, 25 never tested).
 
 Measured against the set `luks-e2e.yml` schedules: every published desktop image (`build_image`), not only the ones that ship an ISO. That is wider than the ISO matrix below on purpose — the browser ISO builder can make an ISO from any image, so image-only variants (`sailfin`, `guppy`, `flounder-sid`) need boot and install coverage too.
 
 | Variant | gnome | kde | cosmic | niri | xfce |
 |---|:--:|:--:|:--:|:--:|:--:|
-| **albacore** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **bonito** | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **albacore** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **bonito** | ✅ | ⬜ | ⬜ | ⬜ | ⬜ |
 | **bonito-rawhide** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
-| **flounder** | ⬜ | ⬜ | ⬜ | — | ⬜ |
-| **flounder-sid** | ⬜ | ⬜ | ⬜ | — | ⬜ |
-| **grouper** | ⬜ | ⬜ | ⬜ | — | ⬜ |
+| **flounder** | ❌ | ❌ | ❌ | — | ❌ |
+| **flounder-sid** | ❌ | ❌ | ❌ | — | ❌ |
+| **grouper** | ❌ | ❌ | ❌ | — | ❌ |
 | **guppy** | ⬜ | ⬜ | — | — | ⬜ |
-| **marlin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
-| **sailfin** | ❌ | ⬜ | ⬜ | ⬜ | ⬜ |
-| **skipjack** | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **yellowfin** | ❌ | ✅ | ⬜ | ✅ | ✅ |
+| **marlin** | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **sailfin** | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **skipjack** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **yellowfin** | ❌ | ⬜ | ⬜ | ✅ | ⬜ |
 
-NVIDIA cells are **out of scope** for this workflow — `luks-e2e.yml` excludes them deliberately, because `-nvidia` takes the identical LUKS path in headless QEMU. 13 stale pre-exclusion result(s) remain from before that change; they are not a gap and will age out.
-
-Newest result 2026-07-31, oldest still-authoritative result 2026-07-30. Results older than the most recent round of fixes are the best available data, not current data.
+Newest result 2026-08-01, oldest still-authoritative result 2026-07-31. Results older than the most recent round of fixes are the best available data, not current data.
 
 ## Installer smoke
 
@@ -94,18 +92,18 @@ Missing for 2 ISO cell(s): `gurnard-pantheon`, `marlin-kde`
 
 | Date | Run | Cells |
 |---|---|---|
+| 2026-08-01 | [30680381500](https://github.com/tuna-os/tunaOS/actions/runs/30680381500) | 5 |
+| 2026-08-01 | [30680379297](https://github.com/tuna-os/tunaOS/actions/runs/30680379297) | 7 |
+| 2026-08-01 | [30680376995](https://github.com/tuna-os/tunaOS/actions/runs/30680376995) | 5 |
+| 2026-08-01 | [30680374962](https://github.com/tuna-os/tunaOS/actions/runs/30680374962) | 4 |
+| 2026-08-01 | [30680372927](https://github.com/tuna-os/tunaOS/actions/runs/30680372927) | 4 |
+| 2026-08-01 | [30674606103](https://github.com/tuna-os/tunaOS/actions/runs/30674606103) | 1 |
 | 2026-07-31 | [30624963765](https://github.com/tuna-os/tunaOS/actions/runs/30624963765) | 1 |
 | 2026-07-31 | [30618509841](https://github.com/tuna-os/tunaOS/actions/runs/30618509841) | 1 |
 | 2026-07-31 | [30618282287](https://github.com/tuna-os/tunaOS/actions/runs/30618282287) | 1 |
-| 2026-07-31 | [30605644812](https://github.com/tuna-os/tunaOS/actions/runs/30605644812) | 1 |
 | 2026-07-31 | [30601507789](https://github.com/tuna-os/tunaOS/actions/runs/30601507789) | 5 |
 | 2026-07-31 | [30601506679](https://github.com/tuna-os/tunaOS/actions/runs/30601506679) | 5 |
 | 2026-07-31 | [30601505643](https://github.com/tuna-os/tunaOS/actions/runs/30601505643) | 1 |
-| 2026-07-31 | [30595701955](https://github.com/tuna-os/tunaOS/actions/runs/30595701955) | 1 |
-| 2026-07-31 | [30595700827](https://github.com/tuna-os/tunaOS/actions/runs/30595700827) | 1 |
-| 2026-07-31 | [30595699610](https://github.com/tuna-os/tunaOS/actions/runs/30595699610) | 1 |
-| 2026-07-31 | [30595698386](https://github.com/tuna-os/tunaOS/actions/runs/30595698386) | 12 |
-| 2026-07-31 | [30595697324](https://github.com/tuna-os/tunaOS/actions/runs/30595697324) | 4 |
 
 <!-- END GENERATED -->
 


### PR DESCRIPTION
Run `30688732984` promoted grouper base and then never started gnome, kde, gnome-zfs, cosmic or xfce. Stage ordering, not a desktop bug.

## `stage` is build ORDER, not parentage

grouper's `gnome-asahi` carried `stage: 1`, so it shared a matrix with base — and a stage does not advance until every cell in it passes. One arm64-only Apple Silicon flavour gated all five desktop flavours, which live in stage 2.

**Every other variant already places `gnome-asahi` at stage 3.** grouper was the lone exception:

```
$ grep -A2 "id: gnome-asahi" .github/build-config.yml | grep stage:
stage: 3   stage: 3   stage: 3   stage: 3   stage: 3   stage: 1  <- grouper   stage: 3   stage: 3
```

The reason is visible in the comment above it: on grouper, asahi is a **full build** with `ENABLE_ASAHI=1` rather than an overlay on gnome, so the stage number looks to have been read as *"has no parent"* rather than *"runs first"*. It has no `PARENT_FLAVOR` either way, so it still builds straight from base at stage 3 — only the ordering changes, and nothing downstream depends on it.

This is the cheapest of the three options **and** the correct end state rather than a workaround, since it aligns grouper with the other seven variants.

## On option 3

The arm64 failure itself is already fixed in #958 — `gnome-keyring` is only an apt **recommend**, so `--no-install-recommends` drops it and the contract fails on `/usr/bin/gnome-keyring-daemon`. That is a real fix, not a deferral. But desktops should not wait on it, which is what this PR ensures.

Verified no variant now shares a stage between `base` and `gnome-asahi`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->