### PR TITLE
ci: fit the pipeline inside the 20-concurrent-job org limit

### DIFF
--- a/.github/workflows/archive/build.yml
+++ b/.github/workflows/archive/build.yml
@@ -208,11 +208,18 @@ jobs:
               esac
             fi
 
+            # reusable-build-image.yml drives its build matrix from
+            # platforms-json (it no longer runs its own generate_matrix job),
+            # so every call site below must pass this alongside platforms.
+            PLATFORMS_JSON="$(printf '%s' "${PLATFORMS}" | jq -Rc 'split(",")
+              | map({platform: ., safeplatform: (gsub("/"; "-"))}) | tostring')"
+
             MATRIX="$(echo "${MATRIX}" | jq ".include += [{
               \"image_variant\": \"${image_variant}\",
               \"image_name\": \"${IMAGE_NAME}\",
               \"default_tag\": \"${TAG}\",
               \"platforms\": \"${PLATFORMS}\",
+              \"platforms_json\": ${PLATFORMS_JSON},
               \"description\": \"${DESCRIPTION}\",
               \"run_hwe_gdx\": ${RUN_HWE_GDX},
               \"run_kde\": ${RUN_KDE},
@@ -249,6 +256,7 @@ jobs:
       image-variant: ${{ matrix.image_variant }}
       flavor: base
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       major-version: ${{ matrix.major_version }}
       default-tag: ${{ github.event_name == 'pull_request' && format('pr-{0}-base', github.event.pull_request.number) || 'base' }}
       rechunk: ${{ matrix.rechunk }}
@@ -276,6 +284,7 @@ jobs:
       image-variant: ${{ matrix.image_variant }}
       flavor: hwe-base
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ github.event_name == 'pull_request' && format('pr-{0}-hwe-base', github.event.pull_request.number) || 'hwe-base' }}
       rechunk: ${{ matrix.rechunk }}
       sbom: ${{ matrix.sbom }}
@@ -306,6 +315,7 @@ jobs:
       image-variant: ${{ matrix.image_variant }}
       flavor: gdx-base
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ github.event_name == 'pull_request' && format('pr-{0}-gdx-base', github.event.pull_request.number) || 'gdx-base' }}
       rechunk: ${{ matrix.rechunk }}
       sbom: ${{ matrix.sbom }}
@@ -338,6 +348,7 @@ jobs:
       image-variant: ${{ matrix.image_variant }}
       flavor: gnome
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ github.event_name == 'pull_request' && format('pr-{0}-gnome', github.event.pull_request.number) || 'gnome' }}
       rechunk: ${{ matrix.rechunk }}
       sbom: ${{ matrix.sbom }}
@@ -369,6 +380,7 @@ jobs:
       image-variant: ${{ matrix.image_variant }}
       flavor: kde
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ github.event_name == 'pull_request' && format('pr-{0}-kde', github.event.pull_request.number) || 'kde' }}
       rechunk: ${{ matrix.rechunk }}
       sbom: ${{ matrix.sbom }}
@@ -400,6 +412,7 @@ jobs:
       image-variant: ${{ matrix.image_variant }}
       flavor: niri
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ github.event_name == 'pull_request' && format('pr-{0}-niri', github.event.pull_request.number) || 'niri' }}
       rechunk: ${{ matrix.rechunk }}
       sbom: ${{ matrix.sbom }}
@@ -430,6 +443,7 @@ jobs:
       image-variant: ${{ matrix.image_variant }}
       flavor: gnome-hwe
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ github.event_name == 'pull_request' && format('pr-{0}-gnome-hwe', github.event.pull_request.number) || 'gnome-hwe' }}
       rechunk: ${{ matrix.rechunk }}
       sbom: ${{ matrix.sbom }}
@@ -460,6 +474,7 @@ jobs:
       image-variant: ${{ matrix.image_variant }}
       flavor: gnome-gdx
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ github.event_name == 'pull_request' && format('pr-{0}-gnome-gdx', github.event.pull_request.number) || 'gnome-gdx' }}
       rechunk: ${{ matrix.rechunk }}
       sbom: ${{ matrix.sbom }}
@@ -491,6 +506,7 @@ jobs:
       image-variant: ${{ matrix.image_variant }}
       flavor: kde-hwe
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ github.event_name == 'pull_request' && format('pr-{0}-kde-hwe', github.event.pull_request.number) || 'kde-hwe' }}
       rechunk: ${{ matrix.rechunk }}
       sbom: ${{ matrix.sbom }}
@@ -521,6 +537,7 @@ jobs:
       image-variant: ${{ matrix.image_variant }}
       flavor: kde-gdx
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ github.event_name == 'pull_request' && format('pr-{0}-kde-gdx', github.event.pull_request.number) || 'kde-gdx' }}
       rechunk: ${{ matrix.rechunk }}
       sbom: ${{ matrix.sbom }}
@@ -552,6 +569,7 @@ jobs:
       image-variant: ${{ matrix.image_variant }}
       flavor: niri-hwe
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ github.event_name == 'pull_request' && format('pr-{0}-niri-hwe', github.event.pull_request.number) || 'niri-hwe' }}
       rechunk: ${{ matrix.rechunk }}
       sbom: ${{ matrix.sbom }}
@@ -582,6 +600,7 @@ jobs:
       image-variant: ${{ matrix.image_variant }}
       flavor: niri-gdx
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ github.event_name == 'pull_request' && format('pr-{0}-niri-gdx', github.event.pull_request.number) || 'niri-gdx' }}
       rechunk: ${{ matrix.rechunk }}
       sbom: ${{ matrix.sbom }}

--- a/.github/workflows/build-albacore.yml
+++ b/.github/workflows/build-albacore.yml
@@ -1,7 +1,7 @@
 name: Build Albacore
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 2 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-albacore-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-bonito-rawhide.yml
+++ b/.github/workflows/build-bonito-rawhide.yml
@@ -1,7 +1,7 @@
 name: Build Bonito-rawhide
 on:
   schedule:
-    - cron: "30 1 * * *"
+    - cron: "20 13 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-bonito-rawhide-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-bonito.yml
+++ b/.github/workflows/build-bonito.yml
@@ -1,7 +1,7 @@
 name: Build Bonito
 on:
   schedule:
-    - cron: "15 1 * * *"
+    - cron: "20 11 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-bonito-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-flavor.yml
+++ b/.github/workflows/build-flavor.yml
@@ -1,7 +1,10 @@
 name: Build Flavor
+# Dispatch-only. The weekly Sunday "all flavors x all variants" schedule was
+# removed 2026-08-01: every nightly variant build already runs flavor=all, so
+# the weekly sweep rebuilt the exact same ~137 images a 12th time — as one
+# ~600-job wave against a 20-concurrent-job org limit. Zero coverage lost;
+# use workflow_dispatch to rebuild one flavor across all variants.
 on:
-  schedule:
-    - cron: "0 6 * * 0"  # weekly Sunday 6am UTC — build all flavors across all variants
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-flounder-sid.yml
+++ b/.github/workflows/build-flounder-sid.yml
@@ -1,7 +1,7 @@
 name: Build Flounder-sid
 on:
   schedule:
-    - cron: "0 2 * * *"
+    - cron: "20 6 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-flounder-sid-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-flounder.yml
+++ b/.github/workflows/build-flounder.yml
@@ -1,7 +1,7 @@
 name: Build Flounder
 on:
   schedule:
-    - cron: "45 1 * * *"
+    - cron: "20 21 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-flounder-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-grouper.yml
+++ b/.github/workflows/build-grouper.yml
@@ -1,7 +1,7 @@
 name: Build Grouper
 on:
   schedule:
-    - cron: "15 2 * * *"
+    - cron: "20 17 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-grouper-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-guppy.yml
+++ b/.github/workflows/build-guppy.yml
@@ -1,7 +1,7 @@
 name: Build Guppy
 on:
   schedule:
-    - cron: "30 2 * * *"
+    - cron: "20 23 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-guppy-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-gurnard.yml
+++ b/.github/workflows/build-gurnard.yml
@@ -1,7 +1,7 @@
 name: Build Gurnard
 on:
   schedule:
-    - cron: "45 2 * * *"
+    - cron: "20 4 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-gurnard-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-marlin.yml
+++ b/.github/workflows/build-marlin.yml
@@ -1,7 +1,7 @@
 name: Build Marlin
 on:
   schedule:
-    - cron: "45 2 * * *"
+    - cron: "20 15 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-marlin-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-sailfin.yml
+++ b/.github/workflows/build-sailfin.yml
@@ -1,7 +1,7 @@
 name: Build Sailfin
 on:
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "20 19 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-sailfin-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-skipjack.yml
+++ b/.github/workflows/build-skipjack.yml
@@ -1,7 +1,7 @@
 name: Build Skipjack
 on:
   schedule:
-    - cron: "15 3 * * *"
+    - cron: "20 9 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-skipjack-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -1,4 +1,18 @@
 name: Unified Build
+# ── Nightly schedule registry ────────────────────────────────────────────────
+# The org has a 20-concurrent-job ceiling. One variant's full build alone
+# demands more than that, so the per-variant nightlies (in build-<variant>.yml)
+# are staggered ~2h apart instead of the old 01:00–03:30 cluster, which put
+# ~8 variants (~500 job demand) in flight at once and starved the proving
+# workflows (0 running / 28 queued / 102-min waits on 2026-07-31).
+# Biggest variants overnight; only the two smallest inside the 04:00–09:00
+# proving window (daily-verify 04:00, verify-asahi 05:40, matrix-status &
+# catalog-facts 06:00, desktop-contract-sweep 08:00).
+#   00:20 yellowfin(20fl)  02:20 albacore(20)   04:20 gurnard(2)
+#   06:20 flounder-sid(5)  09:20 skipjack(18)   11:20 bonito(15)
+#   13:20 bonito-rawhide(14) 15:20 marlin(9)    17:20 grouper(7)
+#   19:20 sailfin(7)       21:20 flounder(6)    23:20 guppy(4)
+# If you add a variant or move a cron, keep this table true.
 on:
   workflow_call:
     inputs:
@@ -96,6 +110,8 @@ jobs:
                 variant_emoji: ($v.emoji // "❓"),
                 base_image:    $v.base_image,
                 platforms:     (if $event == "pull_request" then "linux/amd64" else ((.platforms // $v.platforms) | join(",")) end),
+                platforms_json: ((if $event == "pull_request" then ["linux/amd64"] else (.platforms // $v.platforms) end)
+                                 | map({platform: ., safeplatform: (gsub("/"; "-"))}) | tostring),
                 flavor:        .id,
                 stage:         (if $event == "pull_request" then 1 else .stage end),
                 build_iso:     (.build_iso  // false),
@@ -115,6 +131,7 @@ jobs:
                 variant_emoji: .variant_emoji,
                 flavor:        .flavor,
                 platforms:     .platforms,
+                platforms_json: .platforms_json,
                 base_image:    .base_image
               })
             }'
@@ -181,6 +198,7 @@ jobs:
       image-variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ matrix.published_tag }}
       publish: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
@@ -216,6 +234,7 @@ jobs:
       image-variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ matrix.published_tag }}
       publish: true
       sbom: true
@@ -251,6 +270,7 @@ jobs:
       image-variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ matrix.published_tag }}
       publish: true
       sbom: true
@@ -280,6 +300,7 @@ jobs:
       image-variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
       platforms: ${{ matrix.platforms }}
+      platforms-json: ${{ matrix.platforms_json }}
       default-tag: ${{ matrix.published_tag }}
       publish: true
       sbom: true

--- a/.github/workflows/build-yellowfin.yml
+++ b/.github/workflows/build-yellowfin.yml
@@ -1,7 +1,7 @@
 name: Build Yellowfin
 on:
   schedule:
-    - cron: "30 3 * * *"
+    - cron: "20 0 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-yellowfin-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -31,6 +31,17 @@ on:
         required: false
         type: string
         default: "linux/amd64,linux/arm64"
+      platforms-json:
+        description: >-
+          The same platform list as a JSON matrix include —
+          [{"platform":"linux/amd64","safeplatform":"linux-amd64"},...].
+          Must stay in sync with `platforms`. Passed pre-computed by the
+          caller so this workflow needs no matrix-generation job: at a
+          20-concurrent-job org limit, a 5-second generate_matrix job per
+          flavor was measurably starving real builds of slots.
+        required: false
+        type: string
+        default: '[{"platform":"linux/amd64","safeplatform":"linux-amd64"},{"platform":"linux/arm64","safeplatform":"linux-arm64"}]'
       major-version:
         description: "The version of CentOS to build the image on"
         required: false
@@ -78,27 +89,6 @@ on:
 
 
 jobs:
-  generate_matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Set matrix
-        id: set-matrix
-        env:
-          PLATFORMS: "${{ inputs.platforms }}"
-        run: |
-          # turn the comma separated string into a list
-          platforms=()
-          IFS=',' read -r -a platforms <<< "${PLATFORMS}"
-
-          MATRIX="{\"include\":[]}"
-          for platform in "${platforms[@]}"; do
-            safeplatform="${platform//\//-}" # Replace all / with -
-            MATRIX="$(echo "${MATRIX}" | jq ".include += [{\"platform\": \"${platform}\", \"safeplatform\": \"${safeplatform}\"}]")"
-          done
-          echo "matrix=$(echo "${MATRIX}" | jq -c '.')" >> $GITHUB_OUTPUT
-
   build_push:
     name: ${{ matrix.safeplatform }}
     runs-on: ${{ contains(matrix.platform, 'amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
@@ -106,10 +96,10 @@ jobs:
     # guppy (Gentoo) still compiles bootc from git even with the binhost (#644).
     # A max, not a fixed duration: RPM variants finish in ~20-40m unaffected.
     timeout-minutes: 180
-    needs: generate_matrix
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.generate_matrix.outputs.matrix)}}
+      matrix:
+        include: ${{ fromJson(inputs.platforms-json) }}
     permissions:
       contents: read
       packages: write
@@ -551,7 +541,6 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
-      - generate_matrix
       - build_push
     container:
       image: cgr.dev/chainguard/wolfi-base@sha256:d2ad9a742d38e1ab550fbb20911056339632a5ca2f01777a32422a4c944fcb99  # :latest linux/amd64 as of 2026-06-13
@@ -800,28 +789,11 @@ jobs:
           echo "DIGEST=$DIGEST" >> $GITHUB_OUTPUT
           echo "IMAGE=$IMAGE_REGISTRY/$IMAGE_NAME" >> $GITHUB_OUTPUT
 
-  # Cosign throws errors when ran inside the Fedora container for one reason or another
-  # so we move this to another step in order to run on Ubuntu
-  sign:
-    name: Sign
-    needs: manifest
-    if: ${{ inputs.publish && github.event_name != 'pull_request' }}
-    # Temporarily off RunsOn: the tuna-os AWS account is capped to Free Tier,
-    # so CreateFleet rejects every 8-vCPU type it tries and the job dies in
-    # "Set up runner" before a single step executes. This is registry and
-    # signing work with no special hardware needs, so a GitHub runner does it
-    # fine. Restore the RunsOn label once AWS credits are back.
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    steps:
-      # TODO: reinstate sign-and-publish for manifest when key propagation
-      # through composite actions is resolved. Same issue as per-arch signing.
-      - run: |
-          echo "Manifest signing skipped"
+  # NOTE: the former `sign` job is gone. It had been reduced to a single
+  # `echo "Manifest signing skipped"` while cosign key propagation is broken
+  # (see the TODO above Promote), yet still spun up a runner per flavor —
+  # at a 20-concurrent-job org limit that slot starves real builds. When
+  # signing is reinstated, add it back between manifest and tag-image.
   # ── Boot gate ───────────────────────────────────────────────────────────────
   # Pull the just-pushed :<tag>-testing manifest, install it to a qcow2 with
   # bootc, boot it in QEMU, and require a graphical session (serial marker or

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -39,9 +39,11 @@ on:
           caller so this workflow needs no matrix-generation job: at a
           20-concurrent-job org limit, a 5-second generate_matrix job per
           flavor was measurably starving real builds of slots.
-        required: false
+          Required, deliberately with no default: this input alone drives the
+          build matrix, so a caller that forgot it would silently build a
+          different platform set than the one it asked for in `platforms`.
+        required: true
         type: string
-        default: '[{"platform":"linux/amd64","safeplatform":"linux-amd64"},{"platform":"linux/arm64","safeplatform":"linux-arm64"}]'
       major-version:
         description: "The version of CentOS to build the image on"
         required: false

--- a/.github/workflows/weekly-qcow2-screenshots.yml
+++ b/.github/workflows/weekly-qcow2-screenshots.yml
@@ -2,7 +2,10 @@ name: Weekly QCOW2 Boot Screenshots
 
 on:
   schedule:
-    - cron: "0 23 * * 0" # Every Sunday at 23:00 UTC (ready for Monday report)
+    # Sunday 20:00 UTC — still ready for the Monday 10:00 boot report, but no
+    # longer double-booked with publish-iso-groups at Sunday 23:00 (both
+    # contending for the same 20-job org concurrency budget).
+    - cron: "0 20 * * 0"
   workflow_dispatch:
     inputs:
       variant:


### PR DESCRIPTION
## Problem (measured 2026-07-31/08-01)

The org has a **20-concurrent-job ceiling**. The fleet hit **0 running jobs with a double-digit queue three times** (oldest wait 102 min); at 06:57 today it was 1 running / 25 queued, oldest since 04:17. What starved was the proving work (LUKS, installer, contract sweeps) — the deliverable itself.

Root causes, from real run data:
- **Coordination jobs held slots**: every flavor spawned a 5-second `generate_matrix` job and a `Sign` job that has been a bare `echo` since signing was disabled. In yellowfin's last full nightly (run 30518425454): 105 jobs, 62 executed, **28 of the 62 ran under 2 minutes**.
- **Cron clustering**: 11 nightly variant builds fired between 01:00–03:30 — ~500 jobs of demand in 2.5 h against a 20-job ceiling.
- **Duplicate + wasted work**: the weekly Sunday `build-flavor` all×all sweep rebuilt the exact images the nightlies already build daily (~600-job wave); `cancel-in-progress: true` killed a Flounder nightly 22 min in on a re-dispatch; two weekly workflows shared the Sunday 23:00 slot.

## Changes

1. **`reusable-build-image.yml`**: platform matrix now arrives pre-computed (`platforms-json`) from `build-variant.yml`'s existing variant-level generate_matrix — the per-flavor `generate_matrix` job is gone. The no-op `Sign` job is deleted (comment marks where to reinstate it).
2. **Nightly crons staggered ~2 h apart around the clock** (registry documented in `build-variant.yml`), biggest variants overnight, only the two smallest (gurnard, flounder-sid) inside the 04:00–09:00 proving window.
3. **`cancel-in-progress: false`** on all 12 variant wrappers — re-dispatches queue instead of killing running builds; GitHub still collapses pending duplicates.
4. **`build-flavor.yml` schedule removed** (dispatch kept). Zero coverage lost — the nightlies build every one of these images daily; this was a 12th rebuild of the same ~137 images in one wave.
5. **`weekly-qcow2-screenshots`** moved Sunday 23:00 → 20:00, off `publish-iso-groups`' slot.

## Measured before/after

Canary: `build-grouper.yml` dispatched from this branch — [run 30688732984](https://github.com/tuna-os/tunaOS/actions/runs/30688732984) vs the same variant's main nightly this morning ([run 30684297227](https://github.com/tuna-os/tunaOS/actions/runs/30684297227)):

| | before (main) | after (branch) |
|---|---|---|
| grouper jobs scheduled | 20 | **16** |
| grouper jobs executed | 10 | **7** |
| base chain | published | published (build → Manifest → Promote green) |
| gnome-asahi | failed (pre-existing `gnome-keyring-daemon` image bug) | same failure, unchanged |

Savings scale at **2 jobs per flavor** (~137 flavors fleet-wide ≈ **270+ fewer jobs/day**). Projected per big variant: yellowfin ~146 → ~106 scheduled jobs (−27%). Peak scheduled demand drops from ~500 jobs in the 01:00–03:30 band to at most ~2 variants in flight at any hour, plus zero Sunday all×all wave (~600 jobs/week gone with no image built less often).

**No coverage removed**: every variant still builds every flavor daily; Gates, ISOs, and proving workflows untouched.

## What to watch after merge

- Tonight's staggered nightlies: queue depth at the old 05:00 collision point, and time-to-first-job for the proving workflows.
- `verify-asahi` (05:40) may now verify an image promoted up to 24 h earlier depending on the variant's slot — cadence unchanged, phase shifted.
- Status/report workflows (matrix-status 06:00, update-build-status 13:30) now snapshot a rolling-rebuild fleet rather than a post-nightly one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->