### PR TITLE
fix(gnome): install gnome-keyring on Ubuntu, not just in the manifest

### DIFF
--- a/build_scripts/desktop/gnome.sh
+++ b/build_scripts/desktop/gnome.sh
@@ -19,7 +19,15 @@ case "${1:-}" in
 			gnome-session ubuntu-session
 
 		# Additional GNOME utilities (mirrors the RPM set where possible)
+		# gnome-keyring is explicit: ubuntu-desktop-minimal only recommends
+		# it and pkg_install runs --no-install-recommends, so without it the
+		# image ships no /usr/bin/gnome-keyring-daemon and
+		# verify-desktop-experience.sh fails the gnome case (grouper
+		# gnome/gnome-asahi red since the check landed). This is the same
+		# omission manifests/desktops/gnome.yaml documents; Ubuntu builds
+		# take this script path, not the manifest, so both must list it.
 		pkg_install \
+			gnome-keyring \
 			gnome-browser-connector \
 			gnome-disk-utility \
 			gnome-system-monitor \


### PR DESCRIPTION
Every grouper GNOME build (both `gnome` and `gnome-asahi`) dies with `missing required path: none of [/usr/bin/gnome-keyring-daemon] exist` after three buildah retries. It reproduces on main (nightly run 30686132465) and on any branch, so it is not a flake.

d8ebdf6 added the keyring to `manifests/desktops/gnome.yaml`, but Ubuntu bases never read that manifest: `Containerfile.ubuntu` runs `build_scripts/desktop/gnome.sh base`, whose hardcoded apt list never gained the package. `ubuntu-desktop-minimal` only *Recommends* `gnome-keyring` and `pkg_install` passes `--no-install-recommends`, so it is dropped, and `verify-desktop-experience.sh`'s gnome case (`require_any_glob '/usr/bin/gnome-keyring-daemon'`) fails the build.

```sh
# Additional GNOME utilities (mirrors the RPM set where possible)
# gnome-keyring is explicit: ubuntu-desktop-minimal only recommends
# it and pkg_install runs --no-install-recommends, ...
pkg_install \
	gnome-keyring \
	gnome-browser-connector \
	...
```

Debian is unaffected (`gnome-core` depends on `gnome-keyring`) and the RPM paths already satisfy the check, so this touches only the Ubuntu branch of the script.

Split out of #962 deliberately: that PR is CI-orchestration only and documents this failure as pre-existing, so the image-content fix belongs on its own against main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->