### PR TITLE
fix(build): install remora on the non-dnf bases, the contract requires it

### DIFF
--- a/Containerfile.arch
+++ b/Containerfile.arch
@@ -168,6 +168,20 @@ COPY --from=context /files /
 COPY --from=common /system_files/shared /
 RUN bootc container lint
 
+# remora — the desktop experience contract requires it, and this base runs
+# none of the numbered build_scripts that install it. 26-packages-post.sh
+# provides remora on the dnf variants only; Containerfile.opensuse already hit
+# this and calls install-remora.sh directly for the same reason (see the
+# comment there). Without it every Gate on this base fails with
+#
+#   TUNAOS_DESKTOP_CONTRACT_FAIL reason=remora_contract_missing
+#
+# which reads as a broken desktop when the desktop booted fine — grouper gnome,
+# kde, xfce and gnome-zfs all died this way in run 30692866756. The binary is
+# static Go, so there is nothing distro-specific to guard.
+RUN --mount=type=bind,from=context,source=/,target=/run/context \
+    /run/context/build_scripts/install-remora.sh
+
 # Cache-bust so build_scripts edits invalidate the desktop stages' install
 # layers (bind-mounted scripts aren't in the cache key). Inherited by children.
 ARG BUILD_SCRIPTS_HASH

--- a/Containerfile.arch
+++ b/Containerfile.arch
@@ -166,13 +166,12 @@ RUN rm -rf /boot /home /root /usr/local /srv /opt /mnt \
 LABEL containers.bootc 1
 COPY --from=context /files /
 COPY --from=common /system_files/shared /
-RUN bootc container lint
 
-# remora — the desktop experience contract requires it, and this base runs
-# none of the numbered build_scripts that install it. 26-packages-post.sh
-# provides remora on the dnf variants only; Containerfile.opensuse already hit
-# this and calls install-remora.sh directly for the same reason (see the
-# comment there). Without it every Gate on this base fails with
+# remora — the desktop experience contract requires it, and this base does
+# not run 26-packages-post.sh, which is what installs remora on the dnf
+# variants. Containerfile.opensuse already hit this and calls
+# install-remora.sh directly for the same reason (see the comment there).
+# Without it every Gate on this base fails with
 #
 #   TUNAOS_DESKTOP_CONTRACT_FAIL reason=remora_contract_missing
 #
@@ -181,6 +180,8 @@ RUN bootc container lint
 # static Go, so there is nothing distro-specific to guard.
 RUN --mount=type=bind,from=context,source=/,target=/run/context \
     /run/context/build_scripts/install-remora.sh
+
+RUN bootc container lint
 
 # Cache-bust so build_scripts edits invalidate the desktop stages' install
 # layers (bind-mounted scripts aren't in the cache key). Inherited by children.

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -123,11 +123,11 @@ RUN --mount=type=bind,from=context,source=/,target=/run/context \
 RUN --mount=type=bind,from=context,source=/,target=/run/context \
     /run/context/build_scripts/20-packages.sh
 
-# remora — the desktop experience contract requires it, and this base runs
-# none of the numbered build_scripts that install it. 26-packages-post.sh
-# provides remora on the dnf variants only; Containerfile.opensuse already hit
-# this and calls install-remora.sh directly for the same reason (see the
-# comment there). Without it every Gate on this base fails with
+# remora — the desktop experience contract requires it, and this base does
+# not run 26-packages-post.sh, which is what installs remora on the dnf
+# variants. Containerfile.opensuse already hit this and calls
+# install-remora.sh directly for the same reason (see the comment there).
+# Without it every Gate on this base fails with
 #
 #   TUNAOS_DESKTOP_CONTRACT_FAIL reason=remora_contract_missing
 #

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -123,6 +123,20 @@ RUN --mount=type=bind,from=context,source=/,target=/run/context \
 RUN --mount=type=bind,from=context,source=/,target=/run/context \
     /run/context/build_scripts/20-packages.sh
 
+# remora — the desktop experience contract requires it, and this base runs
+# none of the numbered build_scripts that install it. 26-packages-post.sh
+# provides remora on the dnf variants only; Containerfile.opensuse already hit
+# this and calls install-remora.sh directly for the same reason (see the
+# comment there). Without it every Gate on this base fails with
+#
+#   TUNAOS_DESKTOP_CONTRACT_FAIL reason=remora_contract_missing
+#
+# which reads as a broken desktop when the desktop booted fine — grouper gnome,
+# kde, xfce and gnome-zfs all died this way in run 30692866756. The binary is
+# static Go, so there is nothing distro-specific to guard.
+RUN --mount=type=bind,from=context,source=/,target=/run/context \
+    /run/context/build_scripts/install-remora.sh
+
 # Copy kernel to modules directory (Debian puts it in /boot)
 RUN cp /boot/vmlinuz-* "$(find /usr/lib/modules -maxdepth 1 -type d | tail -1)/vmlinuz"
 

--- a/Containerfile.gentoo
+++ b/Containerfile.gentoo
@@ -224,6 +224,20 @@ COPY --from=context /files /
 COPY --from=common /system_files/shared /
 RUN bootc container lint
 
+# remora — the desktop experience contract requires it, and this base runs
+# none of the numbered build_scripts that install it. 26-packages-post.sh
+# provides remora on the dnf variants only; Containerfile.opensuse already hit
+# this and calls install-remora.sh directly for the same reason (see the
+# comment there). Without it every Gate on this base fails with
+#
+#   TUNAOS_DESKTOP_CONTRACT_FAIL reason=remora_contract_missing
+#
+# which reads as a broken desktop when the desktop booted fine — grouper gnome,
+# kde, xfce and gnome-zfs all died this way in run 30692866756. The binary is
+# static Go, so there is nothing distro-specific to guard.
+RUN --mount=type=bind,from=context,source=/,target=/run/context \
+    /run/context/build_scripts/install-remora.sh
+
 # Per-flavor target aliases so the build's `--target=<flavor>` resolves. Each
 # resolves to the desktop stage above, specialized by the DESKTOP_FLAVOR
 # build-arg (target and build-arg always agree — see resolve-flavor.sh).

--- a/Containerfile.gentoo
+++ b/Containerfile.gentoo
@@ -222,13 +222,12 @@ RUN sed -i 's|^HOME=.*|HOME=/var/home|' "/etc/default/useradd" && \
 LABEL containers.bootc=1 ostree.bootable=1
 COPY --from=context /files /
 COPY --from=common /system_files/shared /
-RUN bootc container lint
 
-# remora — the desktop experience contract requires it, and this base runs
-# none of the numbered build_scripts that install it. 26-packages-post.sh
-# provides remora on the dnf variants only; Containerfile.opensuse already hit
-# this and calls install-remora.sh directly for the same reason (see the
-# comment there). Without it every Gate on this base fails with
+# remora — the desktop experience contract requires it, and this base does
+# not run 26-packages-post.sh, which is what installs remora on the dnf
+# variants. Containerfile.opensuse already hit this and calls
+# install-remora.sh directly for the same reason (see the comment there).
+# Without it every Gate on this base fails with
 #
 #   TUNAOS_DESKTOP_CONTRACT_FAIL reason=remora_contract_missing
 #
@@ -237,6 +236,8 @@ RUN bootc container lint
 # static Go, so there is nothing distro-specific to guard.
 RUN --mount=type=bind,from=context,source=/,target=/run/context \
     /run/context/build_scripts/install-remora.sh
+
+RUN bootc container lint
 
 # Per-flavor target aliases so the build's `--target=<flavor>` resolves. Each
 # resolves to the desktop stage above, specialized by the DESKTOP_FLAVOR

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -176,11 +176,11 @@ RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=bind,from=context,source=/,target=/run/context \
    /run/context/build_scripts/20-packages.sh
 
-# remora — the desktop experience contract requires it, and this base runs
-# none of the numbered build_scripts that install it. 26-packages-post.sh
-# provides remora on the dnf variants only; Containerfile.opensuse already hit
-# this and calls install-remora.sh directly for the same reason (see the
-# comment there). Without it every Gate on this base fails with
+# remora — the desktop experience contract requires it, and this base does
+# not run 26-packages-post.sh, which is what installs remora on the dnf
+# variants. Containerfile.opensuse already hit this and calls
+# install-remora.sh directly for the same reason (see the comment there).
+# Without it every Gate on this base fails with
 #
 #   TUNAOS_DESKTOP_CONTRACT_FAIL reason=remora_contract_missing
 #

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -176,6 +176,20 @@ RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=bind,from=context,source=/,target=/run/context \
    /run/context/build_scripts/20-packages.sh
 
+# remora — the desktop experience contract requires it, and this base runs
+# none of the numbered build_scripts that install it. 26-packages-post.sh
+# provides remora on the dnf variants only; Containerfile.opensuse already hit
+# this and calls install-remora.sh directly for the same reason (see the
+# comment there). Without it every Gate on this base fails with
+#
+#   TUNAOS_DESKTOP_CONTRACT_FAIL reason=remora_contract_missing
+#
+# which reads as a broken desktop when the desktop booted fine — grouper gnome,
+# kde, xfce and gnome-zfs all died this way in run 30692866756. The binary is
+# static Go, so there is nothing distro-specific to guard.
+RUN --mount=type=bind,from=context,source=/,target=/run/context \
+    /run/context/build_scripts/install-remora.sh
+
 # Enable systemd units (safe_enable/safe_disable).
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -405,12 +405,13 @@ STUB
 @test "every base that ships images installs Remora" {
   # sailfin shipped with no remora at all and every sailfin Gate failed on
   # reason=remora_not_found — a desktop that booted fine reported as broken.
-  # The dnf/apt/pacman bases get it via 26-packages-post.sh; openSUSE cannot
-  # run that script (it would rebuild the initramfs with Fedora kernel naming
-  # and clobber the composefs/bootc one) so it calls the split-out script
-  # directly. Both routes must stay wired up.
+  # The dnf bases get it via 26-packages-post.sh; every base that does not run
+  # that script (openSUSE, Ubuntu, Debian, Arch, Gentoo) must call the
+  # split-out script directly. Every route must stay wired up.
   grep -q 'install-remora.sh' "${REPO_ROOT}/build_scripts/26-packages-post.sh"
-  grep -q 'install-remora.sh' "${REPO_ROOT}/Containerfile.opensuse"
+  for base in opensuse ubuntu debian arch gentoo; do
+    grep -q 'install-remora.sh' "${REPO_ROOT}/Containerfile.${base}"
+  done
   [ -x "${REPO_ROOT}/build_scripts/install-remora.sh" ]
 }
 


### PR DESCRIPTION
## The marker is emitted. The contract fails.

grouper gnome, kde, xfce and gnome-zfs all died in run `30692866756` with:

```
TUNAOS_DESKTOP_CONTRACT_FAIL reason=remora_contract_missing
[   10.623357] verify-desktop-experience[853]: TUNAOS_DESKTOP_CONTRACT_FAIL reason=remora_contract_missing
```

**This is not the flounder-sid "marker was not emitted" failure #959 fixed.** The unit is installed, enabled, started, and reached ttyS0 at 10.6s. It returned a verdict. The verdict is that remora is absent.

## Who installs remora

`26-packages-post.sh` — which only the dnf bases run:

| base | 26-packages-post | remora |
|---|---|---|
| el10 | yes | present |
| opensuse | yes | + explicit `install-remora.sh` |
| ubuntu | **no** | **MISSING** |
| debian | **no** | **MISSING** |
| arch | **no** | **MISSING** |
| gentoo | **no** | **MISSING** |

Confirmed on the published images: `yellowfin:gnome` has the binary and `/usr/share/tunaos/experience-contracts/remora`; `grouper:gnome-testing` has neither.

## This is the third recurrence of the same shape

`Containerfile.opensuse` already hit this and fixed it identically. Its comment: *"sailfin shipped without remora, and every sailfin Gate failed on reason=remora_not_found — flagging a desktop that had actually booted fine as broken."*

That is now three times a solved problem has recurred on a base running a different subset of `build_scripts`, after the apt/pacman `exit 0` and the 40-services split. **The per-Containerfile script subsets are the underlying defect**; each of these is a symptom.

## Placement

Checked against each stage graph rather than pattern-matched: ubuntu and debian after `20-packages.sh` in the base stage, arch inside `base-no-de` before the desktop stages fork, gentoo inside `desktop` (which every flavour derives from). The build-time contract check is the static path and does not test remora, so ordering only has to land the file in the final image.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->