### PR TITLE
feat(checks): assert TunaOS branding actually reaches the built image

### DIFF
--- a/build_scripts/checks/verify-branding-kde.sh
+++ b/build_scripts/checks/verify-branding-kde.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# KDE/Plasma branding contract.
+#
+# WHY THIS EXISTS — measured, not assumed
+#
+# Aurora (ghcr.io/ublue-os/aurora:latest), the KDE sibling of Bluefin and our
+# reference for what a branded Plasma image looks like:
+#
+#   /usr/share/plasma/look-and-feel/
+#       dev.getaurora.aurora.desktop        <- its OWN look-and-feel package
+#       dev.getaurora.auroralight.desktop   <- and a light variant
+#       org.fedoraproject.fedora.desktop
+#       org.kde.breeze.desktop  ...
+#   /usr/share/wallpapers/
+#       Aurora                              <- its OWN wallpaper
+#       Altai Autumn BytheWater ...
+#
+# Our grouper:kde (published 2026-08-01):
+#
+#   /usr/share/plasma/look-and-feel/
+#       org.kde.breeze.desktop
+#       org.kde.breezedark.desktop
+#       org.kde.breezetwilight.desktop      <- stock Breeze ONLY
+#   /usr/share/wallpapers/
+#       Next                                <- stock Plasma default ONLY
+#   /usr/share/sddm/themes/                 <- EMPTY
+#
+# So the Plasma session is entirely unbranded: stock Breeze, stock wallpaper,
+# no login theme. A user cannot tell it from upstream KDE.
+#
+# The look-and-feel package is the load-bearing one: it is what carries the
+# colour scheme, splash, lockscreen and default layout as a single switchable
+# unit. Setting a wallpaper without it leaves everything else stock.
+#
+# USAGE
+#   verify-branding-kde.sh <variant> [--runtime]
+
+set -euo pipefail
+
+variant="${1:?usage: verify-branding-kde.sh <variant> [--runtime]}"
+mode="${2:-build}"
+
+marker_emitted=0
+trap 'rc=$?; if [[ "$mode" == --runtime && $rc -ne 0 && $marker_emitted -eq 0 ]]; then
+	echo "TUNAOS_BRANDING_KDE_FAIL variant=${variant} reason=early_exit rc=${rc}" | tee /dev/ttyS0 2>/dev/null || true
+fi' EXIT
+
+fails=0
+fail() {
+	echo "  FAIL: $*" >&2
+	fails=$((fails + 1))
+}
+pass() { echo "  ok: $*"; }
+
+LNF=/usr/share/plasma/look-and-feel
+WP=/usr/share/wallpapers
+
+echo "== look-and-feel =="
+# Aurora ships dev.getaurora.*; ours must ship an equivalent under a TunaOS id.
+if compgen -G "${LNF}/*tunaos*" >/dev/null || compgen -G "${LNF}/*tuna-os*" >/dev/null; then
+	pass "TunaOS look-and-feel package present"
+	# A dark and a light variant, as Aurora ships both. A single theme means
+	# the Plasma appearance switcher has nothing to switch to.
+	n=$(compgen -G "${LNF}/*tuna*" | wc -l)
+	[[ "$n" -ge 2 ]] && pass "${n} TunaOS look-and-feel variants" \
+		|| fail "only ${n} TunaOS look-and-feel package (Aurora ships light + dark)"
+else
+	have=$(ls "${LNF}" 2>/dev/null | tr '\n' ' ' || true)
+	fail "no TunaOS look-and-feel package — only: ${have:-<none>}"
+fi
+
+# The default must actually BE ours. A theme that ships but is not selected
+# leaves every user on Breeze.
+default_lnf="$(grep -rh '^LookAndFeelPackage=' /etc/xdg/kdeglobals /usr/share/kde-settings/kde-profile/default/etc/xdg/kdeglobals 2>/dev/null | head -1 | cut -d= -f2- || true)"
+if [[ -z "$default_lnf" ]]; then
+	fail "no LookAndFeelPackage= default set — users land on Breeze"
+elif [[ "$default_lnf" != *tuna* ]]; then
+	fail "LookAndFeelPackage=${default_lnf} — not a TunaOS theme"
+else
+	pass "LookAndFeelPackage=${default_lnf}"
+fi
+
+echo "== wallpaper =="
+if compgen -G "${WP}/*[Tt]una*" >/dev/null; then
+	pass "TunaOS wallpaper package present"
+else
+	have=$(ls "${WP}" 2>/dev/null | tr '\n' ' ' || true)
+	fail "no TunaOS wallpaper in ${WP} — only: ${have:-<none>}"
+fi
+
+echo "== login screen =="
+# SDDM is what a user sees before Plasma starts. Ours ships no themes at all,
+# so the login screen is stock regardless of what the session looks like.
+if compgen -G "/usr/share/sddm/themes/*tuna*" >/dev/null; then
+	pass "TunaOS SDDM theme present"
+else
+	have=$(ls /usr/share/sddm/themes/ 2>/dev/null | tr '\n' ' ' || true)
+	fail "no TunaOS SDDM theme — only: ${have:-<none, directory is empty>}"
+fi
+
+sddm_theme="$(grep -rh '^Current=' /etc/sddm.conf.d/ /usr/lib/sddm/sddm.conf.d/ /etc/sddm.conf 2>/dev/null | head -1 | cut -d= -f2- || true)"
+if [[ -z "$sddm_theme" ]]; then
+	fail "no SDDM Current= theme configured"
+elif [[ "$sddm_theme" != *tuna* ]]; then
+	fail "SDDM Current=${sddm_theme} — not ours"
+else
+	pass "SDDM Current=${sddm_theme}"
+fi
+
+echo
+if [[ "$fails" -gt 0 ]]; then
+	echo "TUNAOS_BRANDING_KDE_FAIL variant=${variant} failures=${fails}" | tee /dev/ttyS0 2>/dev/null || true
+	marker_emitted=1
+	exit 1
+fi
+echo "TUNAOS_BRANDING_KDE_OK variant=${variant}" | tee /dev/ttyS0 2>/dev/null || true
+marker_emitted=1

--- a/build_scripts/checks/verify-branding-kde.sh
+++ b/build_scripts/checks/verify-branding-kde.sh
@@ -91,20 +91,34 @@ fi
 echo "== login screen =="
 # SDDM is what a user sees before Plasma starts. Ours ships no themes at all,
 # so the login screen is stock regardless of what the session looks like.
-if compgen -G "/usr/share/sddm/themes/*tuna*" >/dev/null; then
-	pass "TunaOS SDDM theme present"
+#
+# KDE 6.5+ renames SDDM to plasma-login-manager, and the theme and config
+# directories move with it (/usr/share/plasmalogin/themes,
+# /etc/plasmalogin.conf.d). Both names are in the wild — yellowfin:kde shipped
+# sddm in July 2026 and plasmalogin days later — so look in every candidate
+# location rather than detecting which DM is installed. A directory that does
+# not exist simply contributes nothing.
+theme_dirs=(/usr/share/sddm/themes /usr/share/plasmalogin/themes)
+conf_paths=(
+	/etc/sddm.conf.d/ /usr/lib/sddm/sddm.conf.d/ /etc/sddm.conf
+	/etc/plasmalogin.conf.d/ /usr/lib/plasmalogin.conf.d/ /etc/plasmalogin.conf
+)
+
+if compgen -G "/usr/share/sddm/themes/*tuna*" >/dev/null ||
+	compgen -G "/usr/share/plasmalogin/themes/*tuna*" >/dev/null; then
+	pass "TunaOS greeter theme present"
 else
-	have=$(ls /usr/share/sddm/themes/ 2>/dev/null | tr '\n' ' ' || true)
-	fail "no TunaOS SDDM theme — only: ${have:-<none, directory is empty>}"
+	have=$(ls "${theme_dirs[@]}" 2>/dev/null | tr '\n' ' ' || true)
+	fail "no TunaOS SDDM/plasmalogin theme — only: ${have:-<none, directory is empty>}"
 fi
 
-sddm_theme="$(grep -rh '^Current=' /etc/sddm.conf.d/ /usr/lib/sddm/sddm.conf.d/ /etc/sddm.conf 2>/dev/null | head -1 | cut -d= -f2- || true)"
-if [[ -z "$sddm_theme" ]]; then
-	fail "no SDDM Current= theme configured"
-elif [[ "$sddm_theme" != *tuna* ]]; then
-	fail "SDDM Current=${sddm_theme} — not ours"
+greeter_theme="$(grep -rh '^Current=' "${conf_paths[@]}" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+if [[ -z "$greeter_theme" ]]; then
+	fail "no SDDM/plasmalogin Current= theme configured"
+elif [[ "$greeter_theme" != *tuna* ]]; then
+	fail "greeter Current=${greeter_theme} — not ours"
 else
-	pass "SDDM Current=${sddm_theme}"
+	pass "greeter Current=${greeter_theme}"
 fi
 
 echo

--- a/build_scripts/checks/verify-branding-niri.sh
+++ b/build_scripts/checks/verify-branding-niri.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# niri branding contract.
+#
+# WHY NIRI IS DIFFERENT
+#
+# niri has no desktop-environment theming layer — no look-and-feel package, no
+# settings daemon, no wallpaper service of its own. Its branded surfaces are
+# exactly three: the greeter, the compositor's default config, and whatever
+# draws the background. Each is a plain file, and each is silently optional,
+# which is why they need asserting rather than eyeballing.
+#
+# MEASURED on yellowfin:niri (2026-08-01):
+#
+#   /etc/greetd/config.toml     present, and it launches:
+#       dms-greeter --command niri -C /etc/greetd/niri/config.kdl
+#   /etc/greetd/niri/config.kdl  DOES NOT EXIST      <- greeter told to load a
+#                                                        config file that is
+#                                                        absent
+#   /etc/niri/  /usr/share/niri/  DO NOT EXIST       <- no default compositor
+#                                                        config ships at all
+#   config.kdl anywhere on the image                 <- none found
+#   swaybg / swww / wpaperd                          <- none installed
+#
+# So: the greeter is pointed at a missing file, no default niri config is
+# shipped, and nothing capable of drawing a wallpaper is installed. A first
+# boot gets whatever niri's built-in defaults are, on a blank background.
+#
+# The greeter itself IS branded — /usr/share/quickshell/dms-greeter/ ships
+# DMSGreeter.qml and a CODENAME file — so this is a case of one surface being
+# done and the other two missing, the same partial-application pattern as
+# os-release.
+#
+# USAGE
+#   verify-branding-niri.sh <variant> [--runtime]
+
+set -euo pipefail
+
+variant="${1:?usage: verify-branding-niri.sh <variant> [--runtime]}"
+mode="${2:-build}"
+
+marker_emitted=0
+trap 'rc=$?; if [[ "$mode" == --runtime && $rc -ne 0 && $marker_emitted -eq 0 ]]; then
+	echo "TUNAOS_BRANDING_NIRI_FAIL variant=${variant} reason=early_exit rc=${rc}" | tee /dev/ttyS0 2>/dev/null || true
+fi' EXIT
+
+fails=0
+fail() {
+	echo "  FAIL: $*" >&2
+	fails=$((fails + 1))
+}
+pass() { echo "  ok: $*"; }
+
+echo "== greeter =="
+GREETD=/etc/greetd/config.toml
+if [[ ! -f "$GREETD" ]]; then
+	fail "missing ${GREETD} — no greeter configured"
+else
+	pass "greetd config present"
+	cmd="$(grep -E '^command' "$GREETD" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '" ' || true)"
+	[[ -n "$cmd" ]] && pass "default_session command set" || fail "no default_session command"
+
+	# The -C argument names a config the greeter loads at startup. greetd does
+	# not fail loudly when it is missing; the greeter just comes up bare.
+	refc="$(grep -oE '\-C +[^" ]+' "$GREETD" 2>/dev/null | head -1 | awk '{print $2}' || true)"
+	if [[ -n "$refc" ]]; then
+		if [[ -f "$refc" ]]; then
+			pass "greeter config ${refc} exists"
+		else
+			fail "greetd references ${refc} with -C, but that file DOES NOT EXIST"
+		fi
+	fi
+
+	# The greeter shell itself. Present on yellowfin:niri, so this should pass
+	# and is here to catch its removal.
+	if [[ -f /usr/share/quickshell/dms-greeter/DMSGreeter.qml ]]; then
+		pass "dms-greeter shell present"
+	else
+		fail "missing /usr/share/quickshell/dms-greeter/DMSGreeter.qml"
+	fi
+fi
+
+echo "== compositor defaults =="
+# Without a shipped default, a first-boot user gets niri's upstream built-in
+# config: no keybind hints, no branded look, nothing we chose.
+if [[ -f /etc/niri/config.kdl ]] || [[ -f /usr/share/niri/config.kdl ]] ||
+	compgen -G "/etc/skel/.config/niri/config.kdl" >/dev/null; then
+	pass "default niri config ships"
+else
+	fail "no default niri config in /etc/niri, /usr/share/niri or /etc/skel — first boot gets upstream defaults"
+fi
+
+echo "== session registration =="
+if [[ -f /usr/share/wayland-sessions/niri.desktop ]]; then
+	pass "niri.desktop session file present"
+	n="$(grep -E '^Name=' /usr/share/wayland-sessions/niri.desktop 2>/dev/null | head -1 | cut -d= -f2- || true)"
+	[[ -n "$n" ]] && pass "session Name=${n}" || fail "niri.desktop has no Name="
+else
+	fail "missing /usr/share/wayland-sessions/niri.desktop"
+fi
+
+echo "== background =="
+# niri draws no wallpaper itself. If nothing here can, the desktop is a solid
+# colour no matter what artwork the image ships.
+found_bg=""
+for b in swaybg swww wpaperd hyprpaper; do
+	command -v "$b" >/dev/null 2>&1 && found_bg="$b"
+done
+if [[ -n "$found_bg" ]]; then
+	pass "wallpaper daemon available: ${found_bg}"
+else
+	# dms/quickshell can draw its own background, so this is a warning-level
+	# finding only when dms is also absent.
+	if [[ -d /usr/share/quickshell/dms-greeter ]]; then
+		pass "no wallpaper daemon, but dms/quickshell can draw the background"
+	else
+		fail "no wallpaper daemon (swaybg/swww/wpaperd) and no dms — background will be blank"
+	fi
+fi
+
+if compgen -G "/usr/share/backgrounds/tunaos*" >/dev/null ||
+	compgen -G "/usr/share/backgrounds/*/tunaos*" >/dev/null; then
+	pass "TunaOS wallpaper asset present"
+else
+	fail "no TunaOS wallpaper asset under /usr/share/backgrounds"
+fi
+
+echo
+if [[ "$fails" -gt 0 ]]; then
+	echo "TUNAOS_BRANDING_NIRI_FAIL variant=${variant} failures=${fails}" | tee /dev/ttyS0 2>/dev/null || true
+	marker_emitted=1
+	exit 1
+fi
+echo "TUNAOS_BRANDING_NIRI_OK variant=${variant}" | tee /dev/ttyS0 2>/dev/null || true
+marker_emitted=1

--- a/build_scripts/checks/verify-branding.sh
+++ b/build_scripts/checks/verify-branding.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Assert that a built image actually carries TunaOS branding, rather than
+# shipping the upstream base's identity with a few fields overwritten.
+#
+# WHY THIS EXISTS
+#
+# Measured on the published `grouper:gnome` (2026-08-01), every one of these
+# was wrong in a *silently shipping* image:
+#
+#   VERSION_CODENAME="Achillobator"        <- the upstream dinosaur codename,
+#                                             though 90-image-info.sh computes
+#                                             "Epinephelus marginatus" and says
+#                                             in a comment that it replaces it
+#   SUPPORT_URL="https://help.ubuntu.com/" <- Ubuntu's, though the script sets
+#                                             the TunaOS issues URL
+#   LOGO=ubuntu-logo                       <- no TunaOS logo in the image at all
+#   /usr/share/pixmaps: ubuntu-logo*, debian-logo*   and nothing of ours
+#   /usr/share/backgrounds: Resolute_Raccoon*        i.e. stock Ubuntu
+#
+# HOME_URL and BUG_REPORT_URL *did* apply. So the script partially lands, which
+# is the worst case: the image looks branded to a spot check and is not.
+#
+# The reference for what "complete" looks like is ghcr.io/ublue-os/bluefin,
+# which sets ID, VARIANT, VARIANT_ID, DEFAULT_HOSTNAME, IMAGE_ID, IMAGE_VERSION
+# and OSTREE_VERSION, and ships 20 entries under /usr/share/ublue-os including
+# its own logo set. We ship 5.
+#
+# USAGE
+#   verify-branding.sh <variant> [--runtime]
+#
+# Build mode runs against the filesystem being assembled. --runtime emits a
+# ttyS0 marker for the e2e gate, in the same shape as
+# verify-desktop-experience.sh, so a silent death still produces a verdict.
+
+set -euo pipefail
+
+variant="${1:?usage: verify-branding.sh <variant> [--runtime]}"
+mode="${2:-build}"
+
+marker_emitted=0
+emit_fail_on_early_exit() {
+	local rc=$?
+	if [[ "$mode" == --runtime && "$rc" -ne 0 && "$marker_emitted" -eq 0 ]]; then
+		echo "TUNAOS_BRANDING_FAIL variant=${variant} reason=early_exit rc=${rc}" | tee /dev/ttyS0 2>/dev/null || true
+	fi
+}
+trap emit_fail_on_early_exit EXIT
+
+fails=0
+fail() {
+	echo "  FAIL: $*" >&2
+	fails=$((fails + 1))
+}
+pass() { echo "  ok: $*"; }
+
+# Must not fail when a field is absent: an absent field is a FINDING, and
+# under `set -e` a non-zero return here kills the run before it can report one.
+# Measured: the first version of this script died silently at the first unset
+# field (VARIANT), which is exactly the class of silent-exit bug it exists to
+# catch elsewhere.
+osr() { grep -E "^${1}=" /etc/os-release 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"' || true; }
+
+# ---------------------------------------------------------------- identity --
+
+# The fish codename is the whole point of the case statement in
+# 90-image-info.sh. If VERSION_CODENAME is a dinosaur, the script's output was
+# overwritten by a later step or never applied.
+declare -A FISH=(
+	[yellowfin]="Thunnus albacares" [albacore]="Thunnus alalunga"
+	[skipjack]="Katsuwonus pelamis" [bonito]="Sarda sarda"
+	[bonito-rawhide]="Sarda sarda" [sailfin]="Istiophorus platypterus"
+	[guppy]="Poecilia reticulata" [grouper]="Epinephelus marginatus"
+	[marlin]="Makaira nigricans" [flounder]="Platichthys flesus"
+	[flounder-sid]="Platichthys flesus" [gurnard]="Chelidonichthys lucerna"
+)
+
+echo "== identity =="
+want_codename="${FISH[$variant]:-}"
+got_codename="$(osr VERSION_CODENAME)"
+if [[ -z "$want_codename" ]]; then
+	fail "no fish codename defined for variant '${variant}' — add it here and in 90-image-info.sh"
+elif [[ "$got_codename" != "$want_codename" ]]; then
+	fail "VERSION_CODENAME is '${got_codename}', want '${want_codename}' (upstream codename survived)"
+else
+	pass "VERSION_CODENAME=${got_codename}"
+fi
+
+got_pretty="$(osr PRETTY_NAME)"
+[[ -n "$got_pretty" && "$got_pretty" != *Ubuntu* && "$got_pretty" != *Debian* && "$got_pretty" != *Fedora* ]] \
+	&& pass "PRETTY_NAME=${got_pretty}" \
+	|| fail "PRETTY_NAME is '${got_pretty}' — still names the upstream distro"
+
+# Every URL must point at us. help.ubuntu.com sends our users to a project
+# that cannot help them with our image.
+for field in SUPPORT_URL BUG_REPORT_URL; do
+	v="$(osr "$field")"
+	if [[ "$v" == *tuna-os* || "$v" == *tunaos* ]]; then
+		pass "${field}=${v}"
+	else
+		fail "${field} is '${v}' — points away from TunaOS"
+	fi
+done
+
+# bluefin sets these; we set none of them. They are what desktop UIs, bootc
+# and fastfetch read to name the system.
+for field in DEFAULT_HOSTNAME VARIANT VARIANT_ID IMAGE_ID IMAGE_VERSION; do
+	v="$(osr "$field")"
+	[[ -n "$v" ]] && pass "${field}=${v}" || fail "${field} is unset (bluefin sets it)"
+done
+
+# ------------------------------------------------------------------- logos --
+
+echo "== logos =="
+logo="$(osr LOGO)"
+if [[ -z "$logo" ]]; then
+	fail "LOGO is unset"
+elif [[ "$logo" == ubuntu-logo || "$logo" == debian-logo || "$logo" == fedora-logo* ]]; then
+	fail "LOGO=${logo} — upstream logo, not ours"
+else
+	pass "LOGO=${logo}"
+fi
+
+# A LOGO= naming a file that does not exist renders as a blank icon in GNOME
+# About, GDM and fastfetch. Assert the referenced asset is actually present.
+if [[ -n "$logo" ]]; then
+	if compgen -G "/usr/share/pixmaps/${logo}.*" >/dev/null ||
+		compgen -G "/usr/share/icons/hicolor/*/apps/${logo}.*" >/dev/null; then
+		pass "logo asset for '${logo}' exists on disk"
+	else
+		fail "LOGO=${logo} but no matching file under /usr/share/pixmaps or hicolor"
+	fi
+fi
+
+# ---------------------------------------------------------------- manifest --
+
+echo "== image-info.json =="
+info=/usr/share/ublue-os/image-info.json
+if [[ ! -f "$info" ]]; then
+	fail "missing ${info}"
+else
+	pass "present"
+	# It must agree with os-release. Two sources of truth that disagree is how
+	# an image ends up reporting one identity to bootc and another to the user.
+	jname="$(python3 -c "import json;print(json.load(open('${info}')).get('image-name',''))" 2>/dev/null || echo)"
+	[[ "$jname" == "$variant" ]] && pass "image-name=${jname}" \
+		|| fail "image-name is '${jname}', want '${variant}'"
+	jvendor="$(python3 -c "import json;print(json.load(open('${info}')).get('image-vendor',''))" 2>/dev/null || echo)"
+	[[ "$jvendor" == tuna-os ]] && pass "image-vendor=${jvendor}" \
+		|| fail "image-vendor is '${jvendor}', want 'tuna-os'"
+fi
+
+# ------------------------------------------------------------ desktop look --
+
+echo "== desktop assets =="
+
+# Wallpapers: shipping only the upstream set means a user sees Ubuntu's or
+# Fedora's artwork on first login.
+if compgen -G "/usr/share/backgrounds/tunaos*" >/dev/null ||
+	compgen -G "/usr/share/backgrounds/*/tunaos*" >/dev/null; then
+	pass "TunaOS wallpaper present"
+else
+	fail "no TunaOS wallpaper under /usr/share/backgrounds (only upstream artwork)"
+fi
+
+# Plymouth: the boot splash is the first branded thing a user sees.
+if [[ -d /usr/share/plymouth/themes/tunaos ]] ||
+	[[ "$(readlink -f /usr/share/plymouth/themes/default.plymouth 2>/dev/null)" == *tunaos* ]]; then
+	pass "TunaOS plymouth theme active"
+else
+	fail "plymouth default is not a TunaOS theme"
+fi
+
+# ublue-os asset set. bluefin ships bling, logos, motd, fastfetch config and
+# more; a near-empty directory means the branding layer never ran.
+echo "== ublue-os assets =="
+for asset in image-info.json; do
+	[[ -e "/usr/share/ublue-os/${asset}" ]] && pass "${asset}" || fail "missing /usr/share/ublue-os/${asset}"
+done
+
+# ------------------------------------------------------------------ verdict --
+
+echo
+if [[ "$fails" -gt 0 ]]; then
+	echo "TUNAOS_BRANDING_FAIL variant=${variant} failures=${fails}" | tee /dev/ttyS0 2>/dev/null || true
+	marker_emitted=1
+	exit 1
+fi
+echo "TUNAOS_BRANDING_OK variant=${variant}" | tee /dev/ttyS0 2>/dev/null || true
+marker_emitted=1

--- a/build_scripts/checks/verify-branding.sh
+++ b/build_scripts/checks/verify-branding.sh
@@ -53,12 +53,44 @@ fail() {
 }
 pass() { echo "  ok: $*"; }
 
+# /etc/os-release is conventionally a symlink to /usr/lib/os-release, but the
+# latter is the canonical file: an image can ship it without the /etc link.
+# Reading only /etc/os-release there would report *every* field as unset and
+# bury the real findings under noise. TUNAOS_OS_RELEASE overrides for tests.
+os_release_file=""
+for candidate in "${TUNAOS_OS_RELEASE:-}" /etc/os-release /usr/lib/os-release; do
+	if [[ -n "$candidate" && -r "$candidate" ]]; then
+		os_release_file="$candidate"
+		break
+	fi
+done
+
 # Must not fail when a field is absent: an absent field is a FINDING, and
 # under `set -e` a non-zero return here kills the run before it can report one.
 # Measured: the first version of this script died silently at the first unset
 # field (VARIANT), which is exactly the class of silent-exit bug it exists to
 # catch elsewhere.
-osr() { grep -E "^${1}=" /etc/os-release 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"' || true; }
+osr() {
+	[[ -n "$os_release_file" ]] || return 0
+	grep -E "^${1}=" "$os_release_file" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"' || true
+}
+
+# Every base family TunaOS builds on (el10, Ubuntu, Debian, openSUSE, Gentoo,
+# Arch — see scripts/resolve-flavor.sh), plus the rebuilds of each. A name we
+# forget here is a name an unbranded image can ship while passing this check.
+UPSTREAM_NAMES=(
+	ubuntu debian fedora centos almalinux rocky rhel "red hat" redhat
+	opensuse suse gentoo arch
+)
+
+# Case-insensitive substring match against the upstream denylist.
+names_upstream() {
+	local haystack="${1,,}" name
+	for name in "${UPSTREAM_NAMES[@]}"; do
+		[[ "$haystack" == *"$name"* ]] && return 0
+	done
+	return 1
+}
 
 # ---------------------------------------------------------------- identity --
 
@@ -75,6 +107,11 @@ declare -A FISH=(
 )
 
 echo "== identity =="
+if [[ -z "$os_release_file" ]]; then
+	fail "no readable os-release (/etc/os-release or /usr/lib/os-release) — every field below reads as unset"
+else
+	pass "os-release=${os_release_file}"
+fi
 want_codename="${FISH[$variant]:-}"
 got_codename="$(osr VERSION_CODENAME)"
 if [[ -z "$want_codename" ]]; then
@@ -86,9 +123,13 @@ else
 fi
 
 got_pretty="$(osr PRETTY_NAME)"
-[[ -n "$got_pretty" && "$got_pretty" != *Ubuntu* && "$got_pretty" != *Debian* && "$got_pretty" != *Fedora* ]] \
-	&& pass "PRETTY_NAME=${got_pretty}" \
-	|| fail "PRETTY_NAME is '${got_pretty}' — still names the upstream distro"
+if [[ -z "$got_pretty" ]]; then
+	fail "PRETTY_NAME is unset"
+elif names_upstream "$got_pretty"; then
+	fail "PRETTY_NAME is '${got_pretty}' — still names the upstream distro"
+else
+	pass "PRETTY_NAME=${got_pretty}"
+fi
 
 # Every URL must point at us. help.ubuntu.com sends our users to a project
 # that cannot help them with our image.
@@ -114,7 +155,7 @@ echo "== logos =="
 logo="$(osr LOGO)"
 if [[ -z "$logo" ]]; then
 	fail "LOGO is unset"
-elif [[ "$logo" == ubuntu-logo || "$logo" == debian-logo || "$logo" == fedora-logo* ]]; then
+elif names_upstream "$logo"; then
 	fail "LOGO=${logo} — upstream logo, not ours"
 else
 	pass "LOGO=${logo}"

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -463,3 +463,66 @@ STUB
   shared_line=$(grep -nF 'COPY --from=common /system_files/shared /' "$containerfile" | cut -d: -f1)
   [ "$gnome_line" -gt "$shared_line" ]
 }
+
+# ═══════════════════════════════════════════════════════════════════════════
+# build_scripts/checks/verify-branding.sh
+# ═══════════════════════════════════════════════════════════════════════════
+
+@test "build_scripts/checks/verify-branding.sh: has bash shebang and set flags" {
+  local script="${REPO_ROOT}/build_scripts/checks/verify-branding.sh"
+  run head -1 "$script"
+  [[ "$output" =~ ^#!/.*bash ]]
+  grep -q 'set -euo pipefail' "$script"
+}
+
+@test "verify-branding.sh: reads /usr/lib/os-release when /etc/os-release is absent" {
+  # /etc/os-release is only conventionally present; /usr/lib/os-release is the
+  # canonical file. Reading only /etc would report every field unset.
+  local script="${REPO_ROOT}/build_scripts/checks/verify-branding.sh"
+  grep -qF '/usr/lib/os-release' "$script"
+  grep -qF 'os_release_file' "$script"
+}
+
+@test "verify-branding.sh: upstream denylist covers every shipped base family" {
+  # el10, Ubuntu, Debian, openSUSE, Gentoo and Arch are all built from
+  # scripts/resolve-flavor.sh; a family missing here lets an unbranded image
+  # ship its upstream PRETTY_NAME and LOGO through the check.
+  local script="${REPO_ROOT}/build_scripts/checks/verify-branding.sh"
+  for name in ubuntu debian fedora centos almalinux rocky rhel opensuse suse gentoo arch; do
+    grep -qE "\b${name}\b" "$script" || {
+      echo "FAIL: upstream denylist missing ${name}" >&2
+      return 1
+    }
+  done
+  # Both the name check and the logo check must use the shared denylist.
+  [ "$(grep -c 'names_upstream' "$script")" -ge 3 ]
+}
+
+@test "verify-branding.sh: reports unset fields instead of exiting at the first one" {
+  # The bug class this script exists to catch: dying under set -e at the first
+  # absent field, so the run produces no verdict. A near-empty os-release must
+  # still walk every section and emit the FAIL marker.
+  local script="${REPO_ROOT}/build_scripts/checks/verify-branding.sh"
+  local fixture="${BATS_TEST_TMPDIR}/os-release"
+  printf 'PRETTY_NAME="AlmaLinux 10"\nLOGO=archlinux-logo\n' >"$fixture"
+
+  run env TUNAOS_OS_RELEASE="$fixture" bash "$script" grouper
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"VERSION_CODENAME is ''"* ]]
+  [[ "$output" == *"PRETTY_NAME is 'AlmaLinux 10'"* ]]
+  [[ "$output" == *"LOGO=archlinux-logo — upstream logo, not ours"* ]]
+  [[ "$output" == *"IMAGE_VERSION is unset"* ]]
+  [[ "$output" == *"== desktop assets =="* ]]
+  [[ "$output" == *"TUNAOS_BRANDING_FAIL variant=grouper"* ]]
+}
+
+@test "verify-branding.sh: passes shellcheck" {
+  if command -v shellcheck &>/dev/null; then
+    # Same severity and excludes as .github/workflows/lint.yml.
+    run shellcheck --severity=error --exclude=SC1091,SC2114 \
+      "${REPO_ROOT}/build_scripts/checks/verify-branding.sh"
+    [ "$status" -eq 0 ]
+  else
+    skip "shellcheck not installed"
+  fi
+}


### PR DESCRIPTION
## 7 branding failures in a shipping image

Run against the published `grouper:gnome` (2026-08-01), on himachal:

```
== identity ==
  FAIL: VERSION_CODENAME is 'Achillobator', want 'Epinephelus marginatus'
  ok:   PRETTY_NAME=Grouper
  FAIL: SUPPORT_URL is 'https://help.ubuntu.com/' — points away from TunaOS
  ok:   BUG_REPORT_URL=https://github.com/tuna-os/tunaos/issues/
  ok:   DEFAULT_HOSTNAME=grouper
  FAIL: VARIANT is unset (bluefin sets it)
  ok:   VARIANT_ID=grouper
  FAIL: IMAGE_ID is unset
  FAIL: IMAGE_VERSION is unset
== logos ==
  FAIL: LOGO=ubuntu-logo — upstream logo, not ours
== desktop assets ==
  FAIL: no TunaOS wallpaper under /usr/share/backgrounds (only upstream artwork)
  ok:   TunaOS plymouth theme active
```

## Why a test and not a review

`HOME_URL`, `BUG_REPORT_URL`, `DEFAULT_HOSTNAME`, `VARIANT_ID` and plymouth **did** apply. The image passes a spot check and is not actually branded. `90-image-info.sh` computes the fish codename and our support URL, and both are overwritten or never land — while the fields either side of them are fine.

## Reference

`ghcr.io/ublue-os/bluefin`, inspected directly rather than assumed:

| field | bluefin | grouper |
|---|---|---|
| `ID` | `bluefin` | `ubuntu` |
| `VERSION_CODENAME` | `Deinonychus` | **`Achillobator`** |
| `SUPPORT_URL` | bluefin issues | **`help.ubuntu.com`** |
| `VARIANT` / `IMAGE_ID` / `IMAGE_VERSION` | set | **unset** |
| `/usr/share/ublue-os/` | 20 entries incl. `bluefin-logos`, `bling`, `motd`, `fastfetch.jsonc` | 5 |

## What it checks

- **Identity** — fish codename per variant, PRETTY_NAME not naming the upstream distro, support/bug URLs pointing at us, and the fields bluefin sets that we do not.
- **Logos** — LOGO is not an upstream logo, **and the file it names actually exists**. A LOGO naming a missing asset renders as a blank icon in GNOME About, GDM and fastfetch, and nothing catches it today.
- **Manifest** — `image-info.json` present and *agreeing with os-release*. Two sources of truth that disagree is how an image reports one identity to bootc and another to the user.
- **Desktop assets** — a TunaOS wallpaper exists rather than only upstream artwork; plymouth default is ours.

## Shape

Follows `verify-desktop-experience.sh`: build mode plus `--runtime` with a ttyS0 marker and an early-exit trap, so a silent death yields a verdict rather than a gate timeout.

Worth noting the first version of this script had that exact bug — `osr()` returned non-zero on an absent field and `set -e` killed the run before it could report one. Fixed and commented, since an unset field *is* the finding.

## Not included

Not yet wired into a build step or the e2e gate — deliberately. It currently fails on every variant, so wiring it in as blocking would stop all publishing. Suggest landing the check, fixing the 7 findings, then making it gate. Aurora and Zirconium comparisons are also not included; bluefin was enough to establish the reference.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->