### PR TITLE
fix(branding): replace os-release keys instead of appending duplicates

### DIFF
--- a/build_scripts/90-image-info.sh
+++ b/build_scripts/90-image-info.sh
@@ -131,11 +131,51 @@ if ! grep -q "^VARIANT_ID=" /usr/lib/os-release; then
 	echo "VARIANT_ID=${IMAGE_NAME}" >>/usr/lib/os-release
 fi
 
-tee -a /usr/lib/os-release <<EOF
-DOCUMENTATION_URL="${DOCUMENTATION_URL}"
-SUPPORT_URL="${SUPPORT_URL}"
-DEFAULT_HOSTNAME="${IMAGE_NAME}"
-BUILD_ID="${SHA_HEAD_SHORT:-testing}"
-EOF
+# Replace-or-append, never blind append.
+#
+# These four used to be written with `tee -a`, which is only correct when the
+# base does not already define the key. Ubuntu DOES define SUPPORT_URL, so
+# grouper shipped os-release containing BOTH
+#
+#   SUPPORT_URL="https://help.ubuntu.com/"          <- upstream, line 1
+#   SUPPORT_URL="https://github.com/tuna-os/..."    <- ours, appended
+#
+# and which one wins depends entirely on the reader. Shell sourcing takes the
+# last; every `grep ... | head -1` parser — including
+# build_scripts/checks/verify-branding.sh:74 — takes the FIRST, i.e. Ubuntu's.
+# So the field was never "lost": it was set correctly and then out-voted by the
+# copy already there. A duplicate key is worse than a missing one, because both
+# readings are defensible and the file looks right to whoever greps it the way
+# that agrees with them.
+osr_set() {
+	local key="$1" value="$2"
+	if grep -q "^${key}=" /usr/lib/os-release; then
+		# `|` delimiter: every value here is a URL.
+		sed -i "s|^${key}=.*|${key}=\"${value}\"|" /usr/lib/os-release
+	else
+		echo "${key}=\"${value}\"" >>/usr/lib/os-release
+	fi
+}
+
+osr_set DOCUMENTATION_URL "${DOCUMENTATION_URL}"
+osr_set SUPPORT_URL "${SUPPORT_URL}"
+osr_set DEFAULT_HOSTNAME "${IMAGE_NAME}"
+osr_set BUILD_ID "${SHA_HEAD_SHORT:-testing}"
+
+# Set by bluefin and read by desktop UIs, bootc and fastfetch to name the
+# system; we set none of them, so those surfaces fell back to the upstream
+# identity. IMAGE_VERSION carries the flavor as well as the build, because a
+# grouper:kde and a grouper:gnome from the same commit are not interchangeable
+# and "which image is this" is the question the field exists to answer.
+osr_set VARIANT "${IMAGE_PRETTY_NAME} ${IMAGE_FLAVOR}"
+osr_set IMAGE_ID "${IMAGE_NAME}"
+osr_set IMAGE_VERSION "${IMAGE_FLAVOR}-${SHA_HEAD_SHORT:-testing}"
+
+# LOGO is deliberately NOT set here. verify-branding.sh also asserts the
+# referenced asset exists under /usr/share/pixmaps or hicolor, and this repo
+# ships no logo file at all — so naming one would swap "LOGO is upstream" for
+# "LOGO names a file that does not exist", which renders as a blank icon in
+# GNOME About, GDM and fastfetch. That needs an actual asset, not an
+# os-release line.
 
 printf "::endgroup::\n"

--- a/build_scripts/90-image-info.sh
+++ b/build_scripts/90-image-info.sh
@@ -150,7 +150,7 @@ fi
 osr_set() {
 	local key="$1" value="$2"
 	if grep -q "^${key}=" /usr/lib/os-release; then
-		# `|` delimiter: every value here is a URL.
+		# `|` delimiter rather than `/`: values may contain slashes (URLs).
 		sed -i "s|^${key}=.*|${key}=\"${value}\"|" /usr/lib/os-release
 	else
 		echo "${key}=\"${value}\"" >>/usr/lib/os-release


### PR DESCRIPTION
Part of #966 — the os-release half.

## SUPPORT_URL was not lost. It was out-voted.

`DOCUMENTATION_URL`, `SUPPORT_URL`, `DEFAULT_HOSTNAME` and `BUILD_ID` were written with `tee -a`, which is only correct when the base does not already define the key. **Ubuntu defines `SUPPORT_URL`**, so `grouper:gnome-testing` ships both:

```
SUPPORT_URL="https://help.ubuntu.com/"                <- upstream, FIRST
SUPPORT_URL="https://github.com/tuna-os/tunaos/..."   <- ours, appended
```

Which wins depends on the reader. Shell sourcing takes the **last**; every `grep | head -1` parser takes the **first** — including `verify-branding.sh:74`. That is why the check reports Ubuntu's.

**A duplicate key is worse than a missing one.** Both readings are defensible, and the file looks correct to whoever greps it the way that agrees with them.

`osr_set()` now replaces in place when the key exists and appends only when it does not. `VARIANT`, `IMAGE_ID` and `IMAGE_VERSION` go through the same helper.

Verified against grouper's real os-release content — tuna-os `SUPPORT_URL` replaces Ubuntu's in place, four new keys append once each, **no key appears twice**.

## Two baseline findings deliberately not addressed

**`VERSION_CODENAME` does not reproduce.** The baseline records `Achillobator`, but `grouper:gnome-testing` built today carries `VERSION_CODENAME="Epinephelus marginatus"`. The sed works. The baseline appears to have measured the 07-14 published image — from before the desktop flavours could build at all. Worth re-measuring the whole baseline against fresh images before treating the other 14 as current.

**`LOGO` is left alone on purpose.** `verify-branding.sh` also asserts the referenced asset exists under `/usr/share/pixmaps` or hicolor, and **this repo ships no logo file anywhere**. Naming one would trade *"LOGO is upstream"* for *"LOGO names a file that does not exist"* — a blank icon in GNOME About, GDM and fastfetch. That needs an actual asset, not an os-release line.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->