### PR TITLE
fix(marlin): mask systemd-firstboot, it blocks the boot on a timezone prompt

### DIFF
--- a/Containerfile.arch
+++ b/Containerfile.arch
@@ -162,6 +162,31 @@ RUN rm -rf /boot /home /root /usr/local /srv /opt /mnt \
     printf '[composefs]\nenabled = yes\n[sysroot]\nreadonly = true\n' \
         > /usr/lib/ostree/prepare-root.conf
 
+# systemd-firstboot asks the CONSOLE for a timezone and blocks there forever.
+#
+# Arch ships systemd-firstboot.service enabled, and a bootc image has an
+# uninitialized machine-id by design, which is exactly its trigger condition.
+# So every marlin desktop booted into
+#
+#   Starting Initial Setup...
+#   Please enter the new timezone name or number ("list" to list options...)
+#
+# and never reached graphical.target. tunaos-desktop-contract.service is
+# WantedBy=graphical.target, so it never ran and emitted nothing — the Gate
+# reported "desktop experience contract marker was not emitted" for all five
+# desktops in run 30707799065 while the image itself was complete and
+# correctly wired.
+#
+# Confirmed from the Gate's own serial.log: the last thing marlin does is
+# print the timezone prompt, and "Reached target Graphical Interface" never
+# appears. Nothing was broken about the desktop; the boot was waiting for a
+# human.
+#
+# Containerfile.opensuse already masks this for the same reason. Masking
+# rather than disabling: the unit is pulled in by sysinit.target on Arch, and
+# a disabled unit that something Wants= still starts.
+RUN systemctl mask systemd-firstboot.service
+
 # Validate
 LABEL containers.bootc 1
 COPY --from=context /files /


### PR DESCRIPTION
## The image is fine. The boot never gets there.

Inspected `marlin:gnome-testing` first, as suggested — everything is present and correctly wired:

```
FILE: PRESENT      (/usr/libexec/tunaos/verify-desktop-experience)
UNIT: PRESENT      (tunaos-desktop-contract.service)
ENABLED: yes       (symlinked into graphical.target.wants)
remora: present    (#965 landed)
```

So neither of the two candidates. The Gate's own `serial.log` gives the answer:

```
Starting Initial Setup...
(systemd-firstboot); servicename=systemd-firstboot.service
🕗 Please enter the new timezone name or number ("list" to list options, empty to skip):
```

And `Reached target Graphical Interface` **never appears in the log at all**.

Arch ships `systemd-firstboot.service` enabled, and a bootc image has an uninitialized machine-id *by design* — exactly its trigger. The boot stops at an interactive console prompt waiting for a human CI does not have. `tunaos-desktop-contract.service` is `WantedBy=graphical.target`, so it never ran.

`Containerfile.opensuse` already masks this unit for the same reason.

## Three causes, one Gate message

| variant | cause | fix |
|---|---|---|
| flounder-sid | check never installed (`exit 0`) | #959 |
| grouper | installed, ran, real FAIL verdict (remora) | #965 |
| marlin | installed correctly, target never reached | this PR |

Worth noting about that message: **"marker was not emitted" cannot distinguish "not installed" from "never ran" from "ran and could not write."** Three investigations have now started from the same string and ended somewhere different.

Masked rather than disabled: the unit is pulled in by `sysinit.target`, and a merely-disabled unit that something `Wants=` still starts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->