### PR TITLE
fix(e2e): say WHY the SSH check failed, instead of 30 identical lines

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -901,7 +901,15 @@ check_ssh() {
 	# what the client saw, so the same wall has now been hit three times and
 	# three separate hypotheses were proposed against zero client-side
 	# evidence.
-	echo "ERROR: SSH check failed: $(tr -d '\r' <"$err" | grep -v '^Warning: Permanently added' | tr '\n' ' ' | sed 's/  */ /g')" >&2
+	#
+	# The filter can legitimately match nothing (empty stderr, or nothing but
+	# the known-hosts warning), and under `pipefail` that grep exits 1. Keep
+	# the status off the caller's path with `|| true`, and never emit the bare
+	# "SSH check failed:" this whole change exists to eliminate.
+	local why=""
+	why=$(tr -d '\r' <"$err" | grep -v '^Warning: Permanently added' | tr '\n' ' ' | sed 's/  */ /g') || true
+	[[ -n "${why// /}" ]] || why="(no ssh stderr beyond the known-hosts warning)"
+	echo "ERROR: SSH check failed: $why" >&2
 	rm -f "$err"
 	return 5
 }

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -877,12 +877,32 @@ check_ssh() {
 		return 77
 	fi
 	local opts="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+	local err
+	err=$(mktemp)
 	# shellcheck disable=SC2086
-	if sshpass -p live ssh $opts liveuser@127.0.0.1 -p "$SSH_PORT" true 2>/dev/null; then
+	if sshpass -p live ssh $opts liveuser@127.0.0.1 -p "$SSH_PORT" true 2>"$err"; then
+		rm -f "$err"
 		echo "==> SSH OK"
 		return 0
 	fi
-	echo "ERROR: SSH check failed" >&2
+	# Say WHY. This used to be `2>/dev/null` with a bare "SSH check failed",
+	# repeated up to 30 times — 30 identical lines carrying no more
+	# information than one, and none of it the reason.
+	#
+	# The distinction the discarded stderr carries is the whole diagnosis:
+	#   Connection refused   -> nothing listening: port-forward or sshd down
+	#   Connection reset     -> sshd is there and rejected the connection
+	#   Permission denied    -> reached sshd, auth failed (user/password)
+	#   Operation timed out  -> the guest is wedged, not the daemon
+	#
+	# Measured need: grouper LUKS cells fail here while the guest serial shows
+	# "Started ssh.service - OpenBSD Secure Shell server" and the host keys
+	# generated (run 30692913767). The daemon is UP and we still cannot say
+	# what the client saw, so the same wall has now been hit three times and
+	# three separate hypotheses were proposed against zero client-side
+	# evidence.
+	echo "ERROR: SSH check failed: $(tr -d '\r' <"$err" | grep -v '^Warning: Permanently added' | tr '\n' ' ' | sed 's/  */ /g')" >&2
+	rm -f "$err"
 	return 5
 }
 
@@ -961,7 +981,18 @@ run_install() {
 		sleep 2
 	done
 	check_ssh || {
-		echo "ERROR: SSH not available"
+		echo "ERROR: SSH not available" >&2
+		# One shot with full verbosity before giving up. The retry loop above
+		# is deliberately quiet-ish; this is the frame that gets read when the
+		# cell is triaged, and it costs one connection attempt.
+		echo "--- ssh -vvv (final attempt, for diagnosis) ---" >&2
+		sshpass -p live ssh -vvv \
+			-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+			-o ConnectTimeout=10 liveuser@127.0.0.1 -p "$SSH_PORT" true 2>&1 |
+			tail -30 >&2 || true
+		echo "--- guest-side sshd evidence from serial ---" >&2
+		grep -aiE "ssh\.service|sshd|host keys" "$SERIAL_LOG" 2>/dev/null |
+			tr -d '\r' | tail -10 >&2 || true
 		return 5
 	}
 


### PR DESCRIPTION
`check_ssh()` sent ssh's stderr to `/dev/null` and printed a bare `ERROR: SSH check failed` — up to 30 times per cell. Thirty copies of a message carrying no more information than one, and none of it the reason.

The discarded stderr **is** the diagnosis:

| ssh says | means |
|---|---|
| `Connection refused` | nothing listening — port-forward or sshd down |
| `Connection reset` | sshd is there and rejected the connection |
| `Permission denied` | reached sshd, auth failed |
| `Operation timed out` | the guest is wedged, not the daemon |

Not hypothetical tidying. grouper LUKS cells fail here while the guest's own serial shows:

```
OK  Started ssh.service - OpenBSD Secure Shell server.
ok - SSH host keys were generated
```

The daemon is **up** and we still cannot say what the client saw. Three investigations have now stalled at this exact fork — grouper:xfce, grouper:gnome, and the flounder work — and three different hypotheses were proposed against zero client-side evidence.

On final give-up it also runs one `ssh -vvv` attempt and dumps the guest-side sshd lines from the serial. **That pair is what separates a host-side connectivity problem from a guest-side daemon problem** — the fork every one of those investigations stopped at.

The `Warning: Permanently added ...` line is filtered; it appears on successful and failed connections alike and would otherwise be the only thing most readers see.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->