### PR TITLE
fix(opensuse): declare dracut omit_dracutmodules for tpm2-tss pcsc in image config

### DIFF
--- a/.github/workflows/build-albacore.yml
+++ b/.github/workflows/build-albacore.yml
@@ -1,7 +1,7 @@
 name: Build Albacore
 on:
   schedule:
-    - cron: "20 2 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,11 +11,7 @@ on:
 
 concurrency:
   group: build-albacore-${{ github.ref }}
-  # false: a re-dispatch or late cron must QUEUE behind a running build, not
-  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
-  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
-  # run per group is kept, so dispatch storms collapse to one queued run.
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-albacore.yml
+++ b/.github/workflows/build-albacore.yml
@@ -1,7 +1,7 @@
 name: Build Albacore
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 2 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-albacore-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-bonito-rawhide.yml
+++ b/.github/workflows/build-bonito-rawhide.yml
@@ -1,7 +1,7 @@
 name: Build Bonito-rawhide
 on:
   schedule:
-    - cron: "20 13 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,11 +11,7 @@ on:
 
 concurrency:
   group: build-bonito-rawhide-${{ github.ref }}
-  # false: a re-dispatch or late cron must QUEUE behind a running build, not
-  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
-  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
-  # run per group is kept, so dispatch storms collapse to one queued run.
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-bonito-rawhide.yml
+++ b/.github/workflows/build-bonito-rawhide.yml
@@ -1,7 +1,7 @@
 name: Build Bonito-rawhide
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 13 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-bonito-rawhide-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-bonito.yml
+++ b/.github/workflows/build-bonito.yml
@@ -1,7 +1,7 @@
 name: Build Bonito
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 11 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-bonito-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-bonito.yml
+++ b/.github/workflows/build-bonito.yml
@@ -1,7 +1,7 @@
 name: Build Bonito
 on:
   schedule:
-    - cron: "20 11 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,11 +11,7 @@ on:
 
 concurrency:
   group: build-bonito-${{ github.ref }}
-  # false: a re-dispatch or late cron must QUEUE behind a running build, not
-  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
-  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
-  # run per group is kept, so dispatch storms collapse to one queued run.
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-flounder-sid.yml
+++ b/.github/workflows/build-flounder-sid.yml
@@ -1,7 +1,7 @@
 name: Build Flounder-sid
 on:
   schedule:
-    - cron: "20 6 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,11 +11,7 @@ on:
 
 concurrency:
   group: build-flounder-sid-${{ github.ref }}
-  # false: a re-dispatch or late cron must QUEUE behind a running build, not
-  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
-  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
-  # run per group is kept, so dispatch storms collapse to one queued run.
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-flounder-sid.yml
+++ b/.github/workflows/build-flounder-sid.yml
@@ -1,7 +1,7 @@
 name: Build Flounder-sid
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 6 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-flounder-sid-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-flounder.yml
+++ b/.github/workflows/build-flounder.yml
@@ -1,7 +1,7 @@
 name: Build Flounder
 on:
   schedule:
-    - cron: "20 21 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,11 +11,7 @@ on:
 
 concurrency:
   group: build-flounder-${{ github.ref }}
-  # false: a re-dispatch or late cron must QUEUE behind a running build, not
-  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
-  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
-  # run per group is kept, so dispatch storms collapse to one queued run.
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-flounder.yml
+++ b/.github/workflows/build-flounder.yml
@@ -1,7 +1,7 @@
 name: Build Flounder
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 21 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-flounder-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-grouper.yml
+++ b/.github/workflows/build-grouper.yml
@@ -1,7 +1,7 @@
 name: Build Grouper
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 17 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-grouper-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-grouper.yml
+++ b/.github/workflows/build-grouper.yml
@@ -1,7 +1,7 @@
 name: Build Grouper
 on:
   schedule:
-    - cron: "20 17 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,11 +11,7 @@ on:
 
 concurrency:
   group: build-grouper-${{ github.ref }}
-  # false: a re-dispatch or late cron must QUEUE behind a running build, not
-  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
-  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
-  # run per group is kept, so dispatch storms collapse to one queued run.
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-guppy.yml
+++ b/.github/workflows/build-guppy.yml
@@ -1,7 +1,7 @@
 name: Build Guppy
 on:
   schedule:
-    - cron: "20 23 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,11 +11,7 @@ on:
 
 concurrency:
   group: build-guppy-${{ github.ref }}
-  # false: a re-dispatch or late cron must QUEUE behind a running build, not
-  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
-  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
-  # run per group is kept, so dispatch storms collapse to one queued run.
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-guppy.yml
+++ b/.github/workflows/build-guppy.yml
@@ -1,7 +1,7 @@
 name: Build Guppy
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 23 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-guppy-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-gurnard.yml
+++ b/.github/workflows/build-gurnard.yml
@@ -1,7 +1,7 @@
 name: Build Gurnard
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 4 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-gurnard-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-gurnard.yml
+++ b/.github/workflows/build-gurnard.yml
@@ -1,7 +1,7 @@
 name: Build Gurnard
 on:
   schedule:
-    - cron: "20 4 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,11 +11,7 @@ on:
 
 concurrency:
   group: build-gurnard-${{ github.ref }}
-  # false: a re-dispatch or late cron must QUEUE behind a running build, not
-  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
-  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
-  # run per group is kept, so dispatch storms collapse to one queued run.
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-marlin.yml
+++ b/.github/workflows/build-marlin.yml
@@ -1,7 +1,7 @@
 name: Build Marlin
 on:
   schedule:
-    - cron: "20 15 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,11 +11,7 @@ on:
 
 concurrency:
   group: build-marlin-${{ github.ref }}
-  # false: a re-dispatch or late cron must QUEUE behind a running build, not
-  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
-  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
-  # run per group is kept, so dispatch storms collapse to one queued run.
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-marlin.yml
+++ b/.github/workflows/build-marlin.yml
@@ -1,7 +1,7 @@
 name: Build Marlin
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 15 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-marlin-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-sailfin.yml
+++ b/.github/workflows/build-sailfin.yml
@@ -1,7 +1,7 @@
 name: Build Sailfin
 on:
   schedule:
-    - cron: "20 19 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,11 +11,7 @@ on:
 
 concurrency:
   group: build-sailfin-${{ github.ref }}
-  # false: a re-dispatch or late cron must QUEUE behind a running build, not
-  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
-  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
-  # run per group is kept, so dispatch storms collapse to one queued run.
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-sailfin.yml
+++ b/.github/workflows/build-sailfin.yml
@@ -1,7 +1,7 @@
 name: Build Sailfin
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 19 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-sailfin-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-skipjack.yml
+++ b/.github/workflows/build-skipjack.yml
@@ -1,7 +1,7 @@
 name: Build Skipjack
 on:
   schedule:
-    - cron: "20 9 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,11 +11,7 @@ on:
 
 concurrency:
   group: build-skipjack-${{ github.ref }}
-  # false: a re-dispatch or late cron must QUEUE behind a running build, not
-  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
-  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
-  # run per group is kept, so dispatch storms collapse to one queued run.
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-skipjack.yml
+++ b/.github/workflows/build-skipjack.yml
@@ -1,7 +1,7 @@
 name: Build Skipjack
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 9 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-skipjack-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/build-yellowfin.yml
+++ b/.github/workflows/build-yellowfin.yml
@@ -1,7 +1,7 @@
 name: Build Yellowfin
 on:
   schedule:
-    - cron: "20 0 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,11 +11,7 @@ on:
 
 concurrency:
   group: build-yellowfin-${{ github.ref }}
-  # false: a re-dispatch or late cron must QUEUE behind a running build, not
-  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
-  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
-  # run per group is kept, so dispatch storms collapse to one queued run.
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-yellowfin.yml
+++ b/.github/workflows/build-yellowfin.yml
@@ -1,7 +1,7 @@
 name: Build Yellowfin
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 0 * * *"
   workflow_dispatch:
     inputs:
       flavor:
@@ -11,7 +11,11 @@ on:
 
 concurrency:
   group: build-yellowfin-${{ github.ref }}
-  cancel-in-progress: true
+  # false: a re-dispatch or late cron must QUEUE behind a running build, not
+  # kill it 22 minutes in (2026-07-31: a Flounder nightly was cancelled mid-
+  # build by a re-dispatch). GitHub still dedupes: only the newest PENDING
+  # run per group is kept, so dispatch storms collapse to one queued run.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -275,9 +275,28 @@ jobs:
           # recipe's image ref. Without -E it silently falls back to parsing
           # them from the ISO filename, which has a "tunaos-" project prefix
           # the fallback doesn't account for, producing a bogus image ref.
+          # --memory 8192 (the script's default is 4096). Every cell that
+          # passes today takes fisherman's bootcDirect path: bootc reads the
+          # embedded offline store and writes the target, once. Composefs
+          # images (sailfin, marlin, flounder, gentoo) cannot: bootc has to
+          # run inside a container, so fisherman exports the image to an OCI
+          # layout, has podman copy that into a scratch store, and only then
+          # installs. That stages a 3.24 GB image three times, all of it
+          # dirty page cache flushing through dm-crypt, on a guest with
+          # 3903 MB of RAM and no swap.
+          #
+          # sailfin:gnome wedged there in run 30729902967: the guest stopped
+          # answering ssh ~15s into `bootc install` and never came back,
+          # with no OOM report, no hung-task splat and no panic on the
+          # console, the signature of a guest thrashing in reclaim rather
+          # than one being killed. The runner has 16 GB, so give the guest
+          # headroom over the image instead of a hair under it. iso-e2e.sh's
+          # own offline-store comment says the same thing: raise --memory
+          # above the image size.
           sudo -E env FISHERMAN_OVERRIDE="$FISHERMAN_OVERRIDE" \
             ./scripts/iso-e2e.sh "${ISO_PATH}" --luks \
             --output luks-out \
+            --memory 8192 \
             --timeout 1200
           # Gate = encrypted install + passphrase unlock to login. TPM2
           # auto-unlock is a POST-INSTALL step (ujust enable-luks-tpm2), tested

--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -301,6 +301,12 @@ jobs:
           # growing when the kernel picked it. 10240 keeps QEMU well inside
           # the runner's 16 GB while iso-e2e.sh attaches a swap disk to the
           # install boot, so an overshoot pages out instead of being killed.
+          #
+          # The allocation itself turned out to be the live root's
+          # /etc/containers/mounts.conf entry for the payload store, which
+          # podman copies into a tmpfs runroot rather than bind-mounting
+          # (tunaOS#972 — see customize-live.sh). This headroom is kept for
+          # the genuine staging copies, not because that copy still happens.
           sudo -E env FISHERMAN_OVERRIDE="$FISHERMAN_OVERRIDE" \
             ./scripts/iso-e2e.sh "${ISO_PATH}" --luks \
             --output luks-out \

--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -275,7 +275,7 @@ jobs:
           # recipe's image ref. Without -E it silently falls back to parsing
           # them from the ISO filename, which has a "tunaos-" project prefix
           # the fallback doesn't account for, producing a bogus image ref.
-          # --memory 8192 (the script's default is 4096). Every cell that
+          # --memory 10240 (the script's default is 4096). Every cell that
           # passes today takes fisherman's bootcDirect path: bootc reads the
           # embedded offline store and writes the target, once. Composefs
           # images (sailfin, marlin, flounder, gentoo) cannot: bootc has to
@@ -293,10 +293,18 @@ jobs:
           # headroom over the image instead of a hair under it. iso-e2e.sh's
           # own offline-store comment says the same thing: raise --memory
           # above the image size.
+          #
+          # 8192 was not enough, and the heartbeat added with it caught why:
+          # the copy allocates on the order of the image, so run 30730744132
+          # died with `Out of memory: Killed process 2978 (podman)
+          # anon-rss:7147396kB` and `Total swap = 0kB`; podman was still
+          # growing when the kernel picked it. 10240 keeps QEMU well inside
+          # the runner's 16 GB while iso-e2e.sh attaches a swap disk to the
+          # install boot, so an overshoot pages out instead of being killed.
           sudo -E env FISHERMAN_OVERRIDE="$FISHERMAN_OVERRIDE" \
             ./scripts/iso-e2e.sh "${ISO_PATH}" --luks \
             --output luks-out \
-            --memory 8192 \
+            --memory 10240 \
             --timeout 1200
           # Gate = encrypted install + passphrase unlock to login. TPM2
           # auto-unlock is a POST-INSTALL step (ujust enable-luks-tpm2), tested

--- a/Containerfile.opensuse
+++ b/Containerfile.opensuse
@@ -152,6 +152,14 @@ RUN mkdir -p /usr/lib/dracut/dracut.conf.d && \
 RUN mkdir -p /usr/lib/systemd/system/initrd-root-fs.target.wants && \
     ln -sf ../bootc-root-setup.service \
       /usr/lib/systemd/system/initrd-root-fs.target.wants/bootc-root-setup.service
+# The LUKS assertions below check the systemd unlock path, not a `cryptsetup`
+# binary: dracut's crypt module needs cryptsetup at BUILD time (its check() is
+# `require_binaries cryptsetup`, which is why the package is installed above),
+# but in a systemd initrd dracut-ng 110 deliberately ships only
+# systemd-cryptsetup + systemd-cryptsetup-generator + crypt-run-generator and
+# leaves the standalone CLI out. Asserting on `sbin/cryptsetup` therefore failed
+# a perfectly good initramfs (run 30735665323); verified against the real
+# lsinitrd output for Tumbleweed's dracut 110+suse.45.
 RUN set -eu; \
     kver="$(ls /usr/lib/modules | head -1)"; \
     img="/usr/lib/modules/${kver}/initramfs.img"; \
@@ -162,9 +170,15 @@ RUN set -eu; \
       echo "ERROR: initramfs lacks the bootc-root-setup wants-link under /usr/lib/systemd/system — composefs boot would emergency-shell" >&2; \
       exit 1; \
     fi; \
-    for bin in sbin/cryptsetup sbin/dmsetup systemd/systemd-cryptsetup; do \
-      if ! grep -q "${bin}" /tmp/initramfs.list; then \
-        echo "ERROR: initramfs has no ${bin} — the dm/crypt dracut modules were dropped, so a LUKS root would never unlock and the disk would boot to the dracut emergency shell" >&2; \
+    for mod in crypt dm; do \
+      if ! grep -qx "${mod}" /tmp/initramfs.list; then \
+        echo "ERROR: initramfs has no '${mod}' dracut module — a LUKS root would never unlock and the disk would boot to the dracut emergency shell" >&2; \
+        exit 1; \
+      fi; \
+    done; \
+    for path in usr/bin/systemd-cryptsetup usr/sbin/dmsetup dm-crypt.ko; do \
+      if ! grep -q "${path}" /tmp/initramfs.list; then \
+        echo "ERROR: initramfs has no ${path} — the dm/crypt dracut modules shipped incomplete, so a LUKS root would never unlock" >&2; \
         exit 1; \
       fi; \
     done; \

--- a/Containerfile.opensuse
+++ b/Containerfile.opensuse
@@ -105,8 +105,12 @@ RUN printf 'L! /etc/resolv.conf - - - - /run/systemd/resolve/stub-resolv.conf\n'
 # mounted but never prepared → initrd-switch-root fails → dracut emergency
 # shell, which is what made every sailfin desktop Gate time out waiting for a
 # graphical session.
+#
+# omit_dracutmodules is declared here too, not just on the dracut command line
+# below: any in-image rebuild (dev-ISO creation, kernel update) re-runs dracut
+# without our flags, and tpm2-tss/pcsc fail the openSUSE base's module checks.
 RUN mkdir -p /usr/lib/dracut/dracut.conf.d && \
-    printf 'add_dracutmodules+=" bootc "\ninstall_items+=" /usr/lib/systemd/system/initrd-root-fs.target.wants/bootc-root-setup.service "\n' \
+    printf 'add_dracutmodules+=" bootc "\nomit_dracutmodules+=" tpm2-tss pcsc "\ninstall_items+=" /usr/lib/systemd/system/initrd-root-fs.target.wants/bootc-root-setup.service "\n' \
     > /usr/lib/dracut/dracut.conf.d/10-bootc-base.conf
 # ...and place the wants-symlink ourselves, because 51bootc's install() puts it
 # at ${systemdsystemconfdir}/initrd-root-fs.target.wants/ — and openSUSE's

--- a/Containerfile.opensuse
+++ b/Containerfile.opensuse
@@ -38,6 +38,20 @@ FROM base AS system
 # authorise — every `sudo` iso-e2e.sh runs in the sailfin guest failed with
 # "bash: line 1: sudo: command not found", killing the LUKS E2E at
 # `sudo podman load` (defect 3 of tunaOS#953).
+#
+# `cryptsetup` and `device-mapper` are listed for the INITRAMFS, not for the
+# running system: dracut's `dm` module is `require_binaries dmsetup` and its
+# `crypt` module is `require_binaries cryptsetup` + a dependency on `dm`. The
+# base ships neither, so the dracut run below silently dropped all LUKS
+# support —
+#   dracut[E]: Module 'crypt' depends on module 'dm', which can't be installed
+#   dracut[E]: Module 'systemd-cryptsetup' depends on module 'crypt', ...
+# — and the installed encrypted disk had no way to unlock: the initrd ignored
+# fisherman's rd.luks.name karg, never prompted for a passphrase, and sat in
+# dracut-initqueue waiting for a root UUID that only appears after the LUKS
+# volume opens, until it dropped to the emergency shell (defect 8 of
+# tunaOS#953, run 30733919804). The GNOME pattern pulls cryptsetup in later,
+# but the initramfs is built here, and no other flavor's package set does.
 RUN set -eu; \
     retry_zypper() { \
       attempt=1; \
@@ -57,7 +71,7 @@ RUN set -eu; \
     retry_zypper --non-interactive --gpg-auto-import-keys refresh && \
     retry_zypper install -y \
     bootc \
-    btrfs-progs ca-certificates ca-certificates-mozilla cpio curl dosfstools dracut e2fsprogs flatpak glib2 \
+    btrfs-progs ca-certificates ca-certificates-mozilla cpio cryptsetup curl device-mapper dosfstools dracut e2fsprogs flatpak glib2 \
     kernel-default kernel-firmware-all openssh ostree skopeo sudo \
     systemd systemd-boot udev xfsprogs zstd chrony && \
     update-ca-certificates && \
@@ -116,8 +130,14 @@ RUN printf 'L! /etc/resolv.conf - - - - /run/systemd/resolve/stub-resolv.conf\n'
 # omit_dracutmodules is declared here too, not just on the dracut command line
 # below: any in-image rebuild (dev-ISO creation, kernel update) re-runs dracut
 # without our flags, and tpm2-tss/pcsc fail the openSUSE base's module checks.
+#
+# crypt/dm are requested explicitly for the same reason, plus one of its own:
+# openSUSE's dracut defaults to hostonly, and a rebuild on a machine that is
+# not itself LUKS-rooted would quietly drop the modules that unlock the disk.
+# Naming them makes a missing cryptsetup/dmsetup a hard dracut error instead
+# of a boot-time emergency shell.
 RUN mkdir -p /usr/lib/dracut/dracut.conf.d && \
-    printf 'add_dracutmodules+=" bootc "\nomit_dracutmodules+=" tpm2-tss pcsc "\ninstall_items+=" /usr/lib/systemd/system/initrd-root-fs.target.wants/bootc-root-setup.service "\n' \
+    printf 'add_dracutmodules+=" bootc crypt dm "\nomit_dracutmodules+=" tpm2-tss pcsc "\ninstall_items+=" /usr/lib/systemd/system/initrd-root-fs.target.wants/bootc-root-setup.service "\n' \
     > /usr/lib/dracut/dracut.conf.d/10-bootc-base.conf
 # ...and place the wants-symlink ourselves, because 51bootc's install() puts it
 # at ${systemdsystemconfdir}/initrd-root-fs.target.wants/ — and openSUSE's
@@ -132,12 +152,23 @@ RUN mkdir -p /usr/lib/dracut/dracut.conf.d && \
 RUN mkdir -p /usr/lib/systemd/system/initrd-root-fs.target.wants && \
     ln -sf ../bootc-root-setup.service \
       /usr/lib/systemd/system/initrd-root-fs.target.wants/bootc-root-setup.service
-RUN dracut --force --no-hostonly --reproducible --zstd --omit "tpm2-tss pcsc" --kver \
-    "$(ls /usr/lib/modules | head -1)" \
-    "/usr/lib/modules/$(ls /usr/lib/modules | head -1)/initramfs.img" && \
-    lsinitrd "/usr/lib/modules/$(ls /usr/lib/modules | head -1)/initramfs.img" \
-      | grep -q 'usr/lib/systemd/system/initrd-root-fs.target.wants/bootc-root-setup.service' || \
-      { echo "ERROR: initramfs lacks the bootc-root-setup wants-link under /usr/lib/systemd/system — composefs boot would emergency-shell" >&2; exit 1; }
+RUN set -eu; \
+    kver="$(ls /usr/lib/modules | head -1)"; \
+    img="/usr/lib/modules/${kver}/initramfs.img"; \
+    dracut --force --no-hostonly --reproducible --zstd --omit "tpm2-tss pcsc" \
+      --kver "${kver}" "${img}"; \
+    lsinitrd "${img}" > /tmp/initramfs.list; \
+    if ! grep -q 'usr/lib/systemd/system/initrd-root-fs.target.wants/bootc-root-setup.service' /tmp/initramfs.list; then \
+      echo "ERROR: initramfs lacks the bootc-root-setup wants-link under /usr/lib/systemd/system — composefs boot would emergency-shell" >&2; \
+      exit 1; \
+    fi; \
+    for bin in sbin/cryptsetup sbin/dmsetup systemd/systemd-cryptsetup; do \
+      if ! grep -q "${bin}" /tmp/initramfs.list; then \
+        echo "ERROR: initramfs has no ${bin} — the dm/crypt dracut modules were dropped, so a LUKS root would never unlock and the disk would boot to the dracut emergency shell" >&2; \
+        exit 1; \
+      fi; \
+    done; \
+    rm -f /tmp/initramfs.list
 RUN mkdir -p /sysroot/ostree /boot /usr/lib/ostree /var && \
     printf '[composefs]\nenabled = yes\n[sysroot]\nreadonly = true\n' > /usr/lib/ostree/prepare-root.conf && \
     echo "HOME=/var/home" | tee -a "/etc/default/useradd" && \

--- a/Containerfile.opensuse
+++ b/Containerfile.opensuse
@@ -31,6 +31,13 @@ FROM base AS system
 # runtime image doesn't ship (libssl.so.60 — see #643); the packaged bootc has
 # correct runtime deps and bundles the 51bootc dracut module. Also faster (no
 # cargo compile). Verified: bootc 1.15.2 install/lint work on Tumbleweed.
+#
+# `sudo` is listed explicitly: unlike the Fedora/EL bases, the openSUSE
+# Tumbleweed base (and the enhanced_base pattern) ships none, so the live-ISO
+# NOPASSWD sudoers drop-in that customize-live.sh writes had nothing to
+# authorise — every `sudo` iso-e2e.sh runs in the sailfin guest failed with
+# "bash: line 1: sudo: command not found", killing the LUKS E2E at
+# `sudo podman load` (defect 3 of tunaOS#953).
 RUN set -eu; \
     retry_zypper() { \
       attempt=1; \
@@ -51,7 +58,7 @@ RUN set -eu; \
     retry_zypper install -y \
     bootc \
     btrfs-progs ca-certificates ca-certificates-mozilla cpio curl dosfstools dracut e2fsprogs flatpak glib2 \
-    kernel-default kernel-firmware-all openssh ostree skopeo \
+    kernel-default kernel-firmware-all openssh ostree skopeo sudo \
     systemd systemd-boot udev xfsprogs zstd chrony && \
     update-ca-certificates && \
     retry_zypper --non-interactive removerepo virtualization-containers && \

--- a/Containerfile.opensuse
+++ b/Containerfile.opensuse
@@ -166,6 +166,16 @@ RUN mkdir -p /etc/containers && \
 COPY --from=context /files /
 COPY --from=common /system_files/shared /
 
+# Enable the e2e readiness marker explicitly. On the dnf/apt/pacman variants
+# this is done by build_scripts/40-services.sh, which this Containerfile
+# deliberately never runs (see the system stage) — so sailfin shipped the unit
+# file from /files without ever enabling it. The live ISO then booted all the
+# way to graphical.target and simply never printed TUNAOS_LIVE_READY, and
+# iso-e2e.sh timed out ("readiness marker not seen within 1200s"), which is
+# defect 2 of tunaOS#953. Placed after the COPY because the unit arrives with
+# it.
+RUN systemctl enable tunaos-live-ready.service
+
 # Cache-bust: the build_scripts RUNs in the desktop stages below are invoked via
 # a bind mount, whose content is NOT part of buildah's layer cache key — so
 # editing install-desktop.sh etc. would silently reuse a stale cached layer.

--- a/Containerfile.opensuse
+++ b/Containerfile.opensuse
@@ -148,7 +148,18 @@ RUN mkdir -p /sysroot/ostree /boot /usr/lib/ostree /var && \
     ln -sT var/opt /opt && ln -sT var/mnt /mnt && \
     ln -sT var/home /home && ln -sT ../var/usrlocal /usr/local && \
     for d in /var/* /var/.[!.]*; do [ -d "$d" ] && ! mountpoint -q "$d" 2>/dev/null && rm -rf "$d" 2>/dev/null || true; done && \
-    mkdir -p /var/tmp
+    # The /var targets of the aliasing symlinks above must EXIST, both in the
+    # image and at runtime. Sailfin shipped them dangling, so anything that
+    # did `mkdir /mnt` got EEXIST (mkdir on a dangling symlink), which is how
+    # the live-ISO E2E died: fisherman's "creating mount point
+    # /mnt/fisherman-target: mkdir /mnt: file exists" (defect 3 of tunaOS#953).
+    # Create them here for the image (the live ISO's /var comes straight from
+    # it) and declare them in tmpfiles.d so they survive bootc's /var reset,
+    # identical to Containerfile.debian / Containerfile.arch.
+    mkdir -p /var/tmp /var/mnt /var/home /var/opt /var/srv /var/roothome \
+        /var/usrlocal && \
+    printf 'd /var/opt 0755 root root -\nd /var/home 0755 root root -\nd /var/srv 0755 root root -\nd /var/mnt 0755 root root -\nd /var/usrlocal 0755 root root -\nd /var/roothome 0700 root root -\nd /var/tmp 1777 root root -\nd /run/media 0755 root root -\n' \
+        > /usr/lib/tmpfiles.d/bootc-base-dirs.conf
 RUN cp -rn /usr/etc/. /etc/ 2>/dev/null; rm -rf /usr/etc
 RUN printf '# NTP pool\npool pool.ntp.org iburst\n\ndriftfile /var/lib/chrony/drift\nmakestep 1.0 3\nrtcsync\n' > /etc/chrony.conf
 RUN printf 'd /var/lib/chrony 0750 chrony chrony\n' >> /usr/lib/tmpfiles.d/chrony.conf
@@ -210,7 +221,8 @@ RUN --mount=type=bind,from=context,source=/,target=/run/context \
 # layout after the install so bootc lint passes (identical to the system stage).
 RUN zypper clean -a 2>/dev/null || true
 RUN set -x && rm -rf /boot /home /root /usr/local /srv /opt /mnt /var /ostree && \
-    mkdir -p /sysroot/ostree /boot /usr/lib/ostree /var /var/tmp && \
+    mkdir -p /sysroot/ostree /boot /usr/lib/ostree /var /var/tmp /var/mnt \
+        /var/home /var/opt /var/srv /var/roothome /var/usrlocal && \
     ln -sT sysroot/ostree /ostree && \
     ln -sT var/roothome /root && ln -sT var/srv /srv && \
     ln -sT var/opt /opt && ln -sT var/mnt /mnt && \

--- a/Containerfile.opensuse
+++ b/Containerfile.opensuse
@@ -305,6 +305,8 @@ RUN bootc container lint
 # do not leak them into KDE, Niri, or XFCE targets.
 FROM desktop AS gnome
 COPY --from=common /system_files/bluefin /
+RUN if command -v glib-compile-schemas &>/dev/null; then glib-compile-schemas /usr/share/glib-2.0/schemas; fi && \
+    if command -v dconf &>/dev/null; then dconf update; fi
 FROM desktop AS kde
 FROM desktop AS niri
 FROM desktop AS xfce

--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -205,19 +205,34 @@ cat >/etc/containers/storage.conf.d/99-tbox-offline-store.conf <<DROPEOF
 additionalimagestores = ${STORE_LIST}
 DROPEOF
 
-# Second, independent mechanism — required for the bootcViaContainer path.
-# A container gets its /etc from the IMAGE, not from the live root, and
-# /var/lib/superiso-store is not present inside it at all, so fisherman's
-# in-container `bootc` cannot resolve containers-storage:<ref> no matter
-# what the live root's config says. mounts.conf bind-mounts the store into
-# every container podman starts. This is the half of dakota-iso's pattern
-# (_upstream-snapshots/dakota-iso/live/src/configure-live.sh) that was not
-# carried over when this script was written; its comment there states the
-# same reason. bootcDirect never needed it, which is why yellowfin:xfce
-# passed while every bootcViaContainer cell failed.
-cat >/etc/containers/mounts.conf <<'MOUNTSEOF'
-/var/lib/superiso-store:/var/lib/superiso-store
-MOUNTSEOF
+# DO NOT add /var/lib/superiso-store to /etc/containers/mounts.conf.
+#
+# An earlier revision did, on the theory that a container gets its /etc from
+# the IMAGE and therefore cannot see the store, and that mounts.conf
+# "bind-mounts the store into every container podman starts". It does not.
+# mounts.conf is containers/common's *subscriptions* mechanism: for a
+# directory source it walks the tree, reads every file into memory, and
+# writes a full copy into the container's runroot
+# (/run/containers/storage/overlay-containers/<id>/userdata/<dest>) before
+# bind-mounting that copy. On live media the runroot is a tmpfs, so an entry
+# there duplicates the whole payload store into RAM twice over — once as the
+# reader's buffers, once as tmpfs pages.
+#
+# That is what killed sailfin:gnome twice. Run 30730744132: `Out of memory:
+# Killed process 2978 (podman) anon-rss:7147396kB` on an 8192 MiB guest, read
+# as OCI-copy pressure at the time. Run 30731534696, after the guest grew to
+# 10240 MiB and gained swap: `Failed to mount subscriptions, skipping entry in
+# /etc/containers/mounts.conf: ... /userdata/var/lib/superiso-store/overlay/
+# .../usr/lib/firmware/nvidia/.../gsp-570.144.bin.xz: no space left on
+# device`, then the container failed to start at all because /run was full.
+#
+# It is also unnecessary: fisherman bind-mounts the store itself when a path
+# needs it (appendImageStoreArgs in internal/install/bootc.go adds
+# `-v /var/lib/superiso-store:/var/lib/superiso-store:ro` plus a generated
+# storage.conf), and the composefs path does not need it at all — bootc reads
+# the exported OCI layout at /run/fisherman/oci-cache. The storage.conf and
+# drop-in above are what the *live root's* podman needs; the container's view
+# is fisherman's job.
 
 # Dev/E2E media only: the normal published-image policy keeps SSH disabled.
 # tacklebox creates liveuser during boot, so install a oneshot that sets its

--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -152,15 +152,33 @@ ln -sf /usr/lib/systemd/system/tunaos-offline-store.service \
 # Hence the drop-in below, and hence it lists BOTH stores: last writer wins
 # on an array, so whoever writes last has to enumerate everything, or the
 # vendor's own store is what disappears instead.
+#
+# ...but only the stores that actually exist in this rootfs. The vendor
+# store is a Fedora/EL bootc convention; openSUSE (sailfin) ships no
+# /usr/lib/containers/storage, and the overlay driver hard-fails on a
+# listed store it cannot stat ("overlay: can't stat imageStore dir
+# /usr/lib/containers/storage"), which takes down every podman invocation
+# in the live root — including fisherman's `podman pull
+# containers-storage:<ref>`. Enumerating existing directories only keeps
+# the vendor store working where it exists and degrades to the offline
+# store alone where it does not.
+VENDOR_STORE="/usr/lib/containers/storage"
+IMAGE_STORES=("$STORE_MOUNT")
+if [[ -d "$VENDOR_STORE" ]]; then
+	IMAGE_STORES+=("$VENDOR_STORE")
+fi
+STORE_LIST="$(printf '"%s", ' "${IMAGE_STORES[@]}")"
+STORE_LIST="[${STORE_LIST%, }]"
+
 mkdir -p /etc/containers
-cat >/etc/containers/storage.conf <<'CONFEOF'
+cat >/etc/containers/storage.conf <<CONFEOF
 [storage]
 driver = "overlay"
 runroot = "/run/containers/storage"
 graphroot = "/var/lib/containers/storage"
 
 [storage.options]
-additionalimagestores = ["/var/lib/superiso-store", "/usr/lib/containers/storage"]
+additionalimagestores = ${STORE_LIST}
 
 [storage.options.overlay]
 mount_program = "/usr/bin/fuse-overlayfs"
@@ -176,15 +194,15 @@ CONFEOF
 # additive higher-precedence drop-in keeps the vendor's store working (it
 # is listed here) and keeps the change visible in one place.
 mkdir -p /etc/containers/storage.conf.d
-cat >/etc/containers/storage.conf.d/99-tbox-offline-store.conf <<'DROPEOF'
+cat >/etc/containers/storage.conf.d/99-tbox-offline-store.conf <<DROPEOF
 # Written by tunaOS customize-live.sh — see tunaOS#881.
 # Must outrank /usr/share/containers/storage.conf.d/00-vendor.conf, whose
 # additionalimagestores REPLACES (not merges with) the primary config's and
 # would otherwise drop /var/lib/superiso-store entirely.
-# Both stores are listed deliberately: array values replace, so omitting
-# the vendor path here would break the vendor's store the same way.
+# The vendor store is listed too when it exists: array values replace, so
+# omitting it here would break the vendor's store the same way.
 [storage.options]
-additionalimagestores = ["/var/lib/superiso-store", "/usr/lib/containers/storage"]
+additionalimagestores = ${STORE_LIST}
 DROPEOF
 
 # Second, independent mechanism — required for the bootcViaContainer path.

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -395,6 +395,15 @@ QEMU_PIDFILE="${OUTPUT_DIR}/qemu.pid"
 #
 # It was still growing when the kernel killed it, i.e. raising --memory alone
 # only moves the cliff: the guest has to have somewhere to push cold pages.
+#
+# CORRECTION (tunaOS#972). That allocation was not the OCI copy. The live root
+# listed /var/lib/superiso-store in /etc/containers/mounts.conf, and podman's
+# mounts.conf handling reads the entire source tree into memory and copies it
+# into the container's runroot — a tmpfs here — so every install container
+# duplicated the payload store twice over. Run 30731534696 (10240 MiB + this
+# swap disk) proved it by failing the same way with ENOSPC on /run instead of
+# an OOM. customize-live.sh no longer writes that file. The swap disk stays as
+# cheap headroom for the real staging copies, but it is no longer load-bearing.
 # The live root cannot hold a swapfile (its writable layer is a tmpfs, so a
 # swapfile there is memory backed by memory), and the target disk is about to
 # be repartitioned, so swap needs a disk of its own. Sparse qcow2: it only

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -382,6 +382,31 @@ LUKS_EVIDENCE_LOG="${OUTPUT_DIR}/luks-evidence.log"
 INSTALL_DISK="${OUTPUT_DIR}/install-disk.qcow2"
 QEMU_PIDFILE="${OUTPUT_DIR}/qemu.pid"
 
+# A dedicated swap disk for the live guest, attached only to the install boot.
+#
+# The composefs install path cannot use fisherman's bootcDirect shortcut: bootc
+# has to run in a container, so podman first copies the exported OCI layout
+# into a scratch store, and podman's anonymous memory during that copy scales
+# with the image, not with a fixed buffer. Measured on run 30730744132
+# (sailfin:gnome, 8192 MiB guest, no swap):
+#
+#   Out of memory: Killed process 2978 (podman) total-vm:9250052kB,
+#   anon-rss:7147396kB ... Free swap = 0kB / Total swap = 0kB
+#
+# It was still growing when the kernel killed it, i.e. raising --memory alone
+# only moves the cliff: the guest has to have somewhere to push cold pages.
+# The live root cannot hold a swapfile (its writable layer is a tmpfs, so a
+# swapfile there is memory backed by memory), and the target disk is about to
+# be repartitioned, so swap needs a disk of its own. Sparse qcow2: it only
+# occupies what the guest actually pages out.
+#
+# Addressed by serial (/dev/disk/by-id/virtio-e2eswap), never by /dev/vdX: the
+# fisherman recipe installs to /dev/vda and this disk must never be confused
+# with it.
+SWAP_DISK="${OUTPUT_DIR}/swap-disk.qcow2"
+SWAP_DISK_SERIAL="e2eswap"
+SWAP_DISK_BYID="/dev/disk/by-id/virtio-${SWAP_DISK_SERIAL}"
+
 # QEMU writes the guest console into SERIAL_LOG, and several code paths below
 # tee ssh output into that same file. `-serial file:PATH` opens the file
 # O_WRONLY|O_CREAT|O_TRUNC and writes at QEMU's OWN offset, so the moment a
@@ -584,6 +609,16 @@ boot_live_iso() {
 		fi
 	fi
 
+	# See SWAP_DISK above. Attached to the live/install boot only; the
+	# installed system is booted without it and never records it in fstab.
+	if [[ ! -f "$SWAP_DISK" ]]; then
+		echo "==> Creating 8G swap disk: ${SWAP_DISK}"
+		if ! qemu-img create -f qcow2 "$SWAP_DISK" 8G; then
+			echo "ERROR: qemu-img create failed for the swap disk" >&2
+			return 1
+		fi
+	fi
+
 	# Kernel cmdline override: append `console=ttyS0` so the live env's
 	# tunaos-live-ready.service marker reaches the serial log. We do this
 	# via the OVMF boot menu's cmdline editing path, which the ISO's
@@ -611,6 +646,8 @@ boot_live_iso() {
 		-device scsi-cd,drive=iso \
 		-drive "if=none,id=disk,file=${INSTALL_DISK},format=qcow2" \
 		-device virtio-blk-pci,drive=disk \
+		-drive "if=none,id=swapdisk,file=${SWAP_DISK},format=qcow2" \
+		-device "virtio-blk-pci,drive=swapdisk,serial=${SWAP_DISK_SERIAL}" \
 		-netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22" \
 		-device virtio-net-pci,netdev=net0 \
 		-monitor "unix:${MONITOR_SOCK},server,nowait" \
@@ -1301,6 +1338,21 @@ EOF
 	echo "==> Uploading fisherman recipe..."
 	"${scp_cmd[@]}" "$RECIPE_LOCAL" liveuser@127.0.0.1:/home/liveuser/e2e-recipe.json
 
+	# ── Swap on, before anything allocates ───────────────────────────────
+	# See SWAP_DISK: podman's copy of the exported OCI layout into the
+	# install-time scratch store allocates on the order of the image size,
+	# and a live guest has no swap at all, so the OOM killer takes podman
+	# and fisherman reports the install as `signal: killed`. Give the kernel
+	# somewhere to page those cold buffers before fisherman starts.
+	#
+	# Best-effort by design: a guest without the disk (an older ISO booted by
+	# hand, a future topology change) should still install, just with the old
+	# no-swap headroom. Never write this into the guest's fstab: the disk is
+	# attached to the install boot only.
+	echo "==> Enabling guest swap on ${SWAP_DISK_BYID}..."
+	"${ssh_cmd[@]}" "sudo sh -c 'test -b ${SWAP_DISK_BYID} && mkswap -L tunaos-e2e-swap ${SWAP_DISK_BYID} >/dev/null && swapon ${SWAP_DISK_BYID}' && free -m" ||
+		echo "WARN: guest swap not enabled (continuing without it)"
+
 	# ── Guest heartbeat, on the console rather than over ssh ─────────────
 	# The install is the one phase where the guest can stop answering while
 	# QEMU stays up, and `Timeout, server 127.0.0.1 not responding.` on its
@@ -1313,15 +1365,18 @@ EOF
 	# setsid'd out of the ssh session, so it keeps reporting after that
 	# channel is gone. The last line before the silence is the diagnosis:
 	# memavail collapsing means the guest is out of RAM (raise --memory),
-	# target_free collapsing means the disk is, and a heartbeat that keeps
+	# memavail AND swapfree both collapsing means it is genuinely out of
+	# memory rather than merely short of it (run 30730744132 killed podman
+	# that way), target_free collapsing means the disk is, and one that keeps
 	# ticking through the timeout means the guest was alive all along and
 	# only sshd stalled.
 	local HB_LOCAL="${OUTPUT_DIR}/e2e-heartbeat.sh"
 	cat >"$HB_LOCAL" <<-'HBEOF'
 		#!/bin/sh
 		while :; do
-			printf 'TUNAOS_E2E_HEARTBEAT memavail_kb=%s dirty_kb=%s writeback_kb=%s target_free_kb=%s load=%s\n' \
+			printf 'TUNAOS_E2E_HEARTBEAT memavail_kb=%s swapfree_kb=%s dirty_kb=%s writeback_kb=%s target_free_kb=%s load=%s\n' \
 				"$(awk '/^MemAvailable:/{print $2}' /proc/meminfo)" \
+				"$(awk '/^SwapFree:/{print $2}' /proc/meminfo)" \
 				"$(awk '/^Dirty:/{print $2}' /proc/meminfo)" \
 				"$(awk '/^Writeback:/{print $2}' /proc/meminfo)" \
 				"$(df -Pk /mnt/fisherman-target 2>/dev/null | awk 'NR==2{print $4}')" \

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -1481,6 +1481,26 @@ EOF
 				echo "karg appended: $f"
 				found=1
 			done
+			if [ "$found" = 1 ]; then
+				# The ESP is the only evidence of whether the install
+				# produced a *bootable* disk, and it is gone the moment
+				# this VM powers off. sailfin (composefs + systemd-boot)
+				# gets no NVRAM entry: bootctl refuses to touch efivars
+				# from inside the install container ("Not booted with EFI
+				# or running in a container, skipping EFI variable
+				# modifications"), so the firmware can only find it via
+				# the removable fallback \EFI\BOOT\BOOTX64.EFI. If that
+				# file is missing, the disk is unbootable no matter what
+				# the boot order says, and the failure looks identical to
+				# a boot-order bug from the serial log alone.
+				echo "--- ESP contents ($p) ---"
+				find /mnt/tbx-bls -maxdepth 3 2>/dev/null | sort || ls -lR /mnt/tbx-bls || true
+				if [ -f /mnt/tbx-bls/EFI/BOOT/BOOTX64.EFI ]; then
+					echo "esp: removable fallback present (EFI/BOOT/BOOTX64.EFI)"
+				else
+					echo "WARN: esp has NO EFI/BOOT/BOOTX64.EFI; firmware has no fallback to boot"
+				fi
+			fi
 			umount /mnt/tbx-bls
 			[ "$found" = 1 ] && break
 		done
@@ -1523,13 +1543,27 @@ EOF
 		# No TPM here: the passphrase gate doesn't need one, and the
 		# install-phase swtpm has already exited (its socket is gone). TPM
 		# auto-unlock is the separate post-install test.
+		#
+		# bootindex=0 on the disk (see also boot_installed) is what makes
+		# "boot the thing we just installed" deterministic. Both boots share
+		# one OVMF_VARS file, so the installed boot inherits the BootOrder
+		# the live-ISO boot left behind, including OVMF's "EFI Internal
+		# Shell" entry. An install that writes an EFI variable of its own
+		# (bootupd/grub2 variants call efibootmgr, which prepends) lands
+		# ahead of the shell and boots; an install that cannot (sailfin:
+		# bootctl skips efivars inside the install container) is left with
+		# only the auto-enumerated disk option, which BDS appends *after*
+		# the shell, so the firmware drops to `Shell>` and the passphrase
+		# prompt never appears (run 30732193680). bootindex publishes a
+		# QEMU fw_cfg boot order that OVMF applies over the stale NVRAM,
+		# putting this disk first and leaving the shell as the last resort.
 		reset_qemu_sockets
 		"$QEMU" -name "tunaos-iso-e2e-installed" -machine pc -cpu "$CPU_ARG" \
 			-accel "$ACCEL" -m "$MEMORY" -smp "$CPUS" \
 			-drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
 			-drive "if=pflash,format=raw,file=${OVMF_VARS}" \
 			-drive "if=none,id=disk,file=${INSTALL_DISK},format=qcow2" \
-			-device virtio-blk-pci,drive=disk \
+			-device virtio-blk-pci,drive=disk,bootindex=0 \
 			-netdev "user,id=net0" -device virtio-net-pci,netdev=net0 \
 			-monitor "unix:${MONITOR_SOCK},server,nowait" \
 			-serial "unix:${FB_SERIAL},server,nowait" \
@@ -1621,7 +1655,9 @@ EOF
 	fi
 
 	echo "==> Booting installed system..."
-	# Boot from the install disk (remove cdrom)
+	# Boot from the install disk (remove cdrom). bootindex=0 overrides the
+	# BootOrder the live-ISO boot left in the shared OVMF_VARS; see the
+	# LUKS passphrase gate above for why the shell wins without it.
 	# shellcheck disable=SC2086  # TPM_ARGS is intentionally word-split (empty unless --luks)
 	reset_qemu_sockets
 	"$QEMU" \
@@ -1635,7 +1671,7 @@ EOF
 		-drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
 		-drive "if=pflash,format=raw,file=${OVMF_VARS}" \
 		-drive "if=none,id=disk,file=${INSTALL_DISK},format=qcow2" \
-		-device virtio-blk-pci,drive=disk \
+		-device virtio-blk-pci,drive=disk,bootindex=0 \
 		-netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22" \
 		-device virtio-net-pci,netdev=net0 \
 		-monitor "unix:${MONITOR_SOCK},server,nowait" \

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -382,6 +382,28 @@ LUKS_EVIDENCE_LOG="${OUTPUT_DIR}/luks-evidence.log"
 INSTALL_DISK="${OUTPUT_DIR}/install-disk.qcow2"
 QEMU_PIDFILE="${OUTPUT_DIR}/qemu.pid"
 
+# QEMU writes the guest console into SERIAL_LOG, and several code paths below
+# tee ssh output into that same file. `-serial file:PATH` opens the file
+# O_WRONLY|O_CREAT|O_TRUNC and writes at QEMU's OWN offset, so the moment a
+# tee appends, every later console write lands back in the middle of the file
+# and overwrites whatever the tee put there (and vice versa).
+#
+# That is not theoretical. run 30729902967's serial.log carries a shredded
+# `ot ok - network connectivity` line, and the guest console goes silent from
+# the first tee onward, which is exactly the window (the bootc install) where
+# an OOM report, hung-task splat or panic would have explained why the guest
+# stopped answering ssh. The evidence was overwritten, so the failure could
+# not be diagnosed from the artifact at all.
+#
+# append=on opens O_APPEND instead: both writers always land at EOF, so the
+# console and the ssh transcript interleave instead of eating each other.
+# Nothing relies on QEMU truncating: the log is rm -f'd per run below and
+# explicitly truncated before the installed boot.
+E2E_SERIAL_ARGS=(
+	-chardev "file,id=e2eserial,path=${SERIAL_LOG},append=on"
+	-serial chardev:e2eserial
+)
+
 # See the egl-headless block above: it renders GL but presents nothing, so
 # screendump has no surface and every screenshot in this repo silently fails.
 # (VNC alone does not fix screendump under GL scanout — see screenshot().)
@@ -592,7 +614,7 @@ boot_live_iso() {
 		-netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22" \
 		-device virtio-net-pci,netdev=net0 \
 		-monitor "unix:${MONITOR_SOCK},server,nowait" \
-		-serial "file:${SERIAL_LOG}" \
+		"${E2E_SERIAL_ARGS[@]}" \
 		"${QEMU_GPU_ARGS[@]}" \
 		-pidfile "$QEMU_PIDFILE" \
 		-daemonize
@@ -1279,6 +1301,42 @@ EOF
 	echo "==> Uploading fisherman recipe..."
 	"${scp_cmd[@]}" "$RECIPE_LOCAL" liveuser@127.0.0.1:/home/liveuser/e2e-recipe.json
 
+	# ── Guest heartbeat, on the console rather than over ssh ─────────────
+	# The install is the one phase where the guest can stop answering while
+	# QEMU stays up, and `Timeout, server 127.0.0.1 not responding.` on its
+	# own does not say why: a wedged guest and a live guest whose sshd
+	# stalled under I/O look identical from the host. Everything else we log
+	# here comes back over the same ssh channel that just died, so it stops
+	# exactly when the interesting part starts.
+	#
+	# This writes to /dev/console (i.e. the serial log) from a process
+	# setsid'd out of the ssh session, so it keeps reporting after that
+	# channel is gone. The last line before the silence is the diagnosis:
+	# memavail collapsing means the guest is out of RAM (raise --memory),
+	# target_free collapsing means the disk is, and a heartbeat that keeps
+	# ticking through the timeout means the guest was alive all along and
+	# only sshd stalled.
+	local HB_LOCAL="${OUTPUT_DIR}/e2e-heartbeat.sh"
+	cat >"$HB_LOCAL" <<-'HBEOF'
+		#!/bin/sh
+		while :; do
+			printf 'TUNAOS_E2E_HEARTBEAT memavail_kb=%s dirty_kb=%s writeback_kb=%s target_free_kb=%s load=%s\n' \
+				"$(awk '/^MemAvailable:/{print $2}' /proc/meminfo)" \
+				"$(awk '/^Dirty:/{print $2}' /proc/meminfo)" \
+				"$(awk '/^Writeback:/{print $2}' /proc/meminfo)" \
+				"$(df -Pk /mnt/fisherman-target 2>/dev/null | awk 'NR==2{print $4}')" \
+				"$(cut -d' ' -f1-3 /proc/loadavg)" >/dev/console 2>/dev/null
+			sleep 15
+		done
+	HBEOF
+	if "${scp_cmd[@]}" "$HB_LOCAL" liveuser@127.0.0.1:/home/liveuser/e2e-heartbeat.sh; then
+		"${ssh_cmd[@]}" "sudo install -m0755 /home/liveuser/e2e-heartbeat.sh /usr/local/bin/tunaos-e2e-heartbeat && \
+			sudo setsid --fork /usr/local/bin/tunaos-e2e-heartbeat </dev/null >/dev/null 2>&1" ||
+			echo "WARN: guest heartbeat did not start (continuing)"
+	else
+		echo "WARN: guest heartbeat could not be uploaded (continuing)"
+	fi
+
 	echo "==> Running fisherman /home/liveuser/e2e-recipe.json..."
 	# Bound with `timeout` as a safety net; the image is already local at
 	# this point so this should only cover the actual install steps, not a
@@ -1295,6 +1353,12 @@ EOF
 			return 3
 		fi
 	}
+
+	# Install is done; stop the heartbeat so it cannot bleed into the serial
+	# log the passphrase gate greps. On the failure paths above we return
+	# without this: the VM is torn down there anyway, and a heartbeat that
+	# keeps printing right up to the shutdown is the evidence we came for.
+	"${ssh_cmd[@]}" "sudo pkill -f tunaos-e2e-heartbeat" >/dev/null 2>&1 || true
 
 	if [[ "$LUKS" -eq 1 ]]; then
 		# Verify against the resulting disk state, not fisherman's log text —
@@ -1511,7 +1575,7 @@ EOF
 		-netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22" \
 		-device virtio-net-pci,netdev=net0 \
 		-monitor "unix:${MONITOR_SOCK},server,nowait" \
-		-serial "file:${SERIAL_LOG}" \
+		"${E2E_SERIAL_ARGS[@]}" \
 		"${QEMU_GPU_ARGS[@]}" \
 		-pidfile "$QEMU_PIDFILE" \
 		-daemonize
@@ -1576,7 +1640,7 @@ boot_disk_image() {
 		-netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22" \
 		-device virtio-net-pci,netdev=net0 \
 		-monitor "unix:${MONITOR_SOCK},server,nowait" \
-		-serial "file:${SERIAL_LOG}" \
+		"${E2E_SERIAL_ARGS[@]}" \
 		"${QEMU_GPU_ARGS[@]}" \
 		-pidfile "$QEMU_PIDFILE" \
 		-daemonize

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -451,6 +451,32 @@ STUB
   [ "$status" -ne 0 ]
 }
 
+@test "Sailfin's initramfs is built with LUKS support (cryptsetup + device-mapper)" {
+  # dracut's dm module is `require_binaries dmsetup` and its crypt module is
+  # `require_binaries cryptsetup` plus a dependency on dm. The openSUSE base
+  # ships neither, so the system stage's dracut run dropped crypt and
+  # systemd-cryptsetup, and the installed encrypted disk had no way to unlock:
+  # the initrd ignored fisherman's rd.luks.name karg, never prompted for a
+  # passphrase, and dropped to the dracut emergency shell waiting for a root
+  # UUID that only appears once the LUKS volume opens (tunaOS#953).
+  local containerfile="${REPO_ROOT}/Containerfile.opensuse"
+  local pkg_line dracut_line
+  pkg_line=$(grep -nE '^ +btrfs-progs .*cryptsetup.* device-mapper ' "$containerfile" | cut -d: -f1)
+  [ -n "$pkg_line" ]
+  # The packages must land BEFORE the initramfs is built, not via the desktop
+  # stage's pattern (which only the GNOME flavor happens to pull them in with).
+  dracut_line=$(grep -nF 'dracut --force --no-hostonly' "$containerfile" | cut -d: -f1)
+  [ "$dracut_line" -gt "$pkg_line" ]
+
+  # Requested by name so an in-image rebuild (dev ISO, kernel update) with
+  # openSUSE's hostonly default cannot silently drop them either.
+  grep -qF 'add_dracutmodules+=" bootc crypt dm "' "$containerfile"
+
+  # And the build fails loudly if the modules are missing from the initramfs.
+  grep -qF 'for bin in sbin/cryptsetup sbin/dmsetup systemd/systemd-cryptsetup' \
+    "$containerfile"
+}
+
 @test "Sailfin installs shared Bluefin config and GNOME-only Bluefin branding" {
   local containerfile="${REPO_ROOT}/Containerfile.opensuse"
   grep -qF 'FROM ${COMMON_IMAGE_REF} AS common' "$containerfile"

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -473,8 +473,15 @@ STUB
   grep -qF 'add_dracutmodules+=" bootc crypt dm "' "$containerfile"
 
   # And the build fails loudly if the modules are missing from the initramfs.
-  grep -qF 'for bin in sbin/cryptsetup sbin/dmsetup systemd/systemd-cryptsetup' \
+  # The assertion targets the systemd unlock path (systemd-cryptsetup and the
+  # dm-crypt module), NOT a standalone `cryptsetup` binary: dracut-ng 110 keeps
+  # the CLI out of a systemd initrd, so checking for it failed an initramfs
+  # that could unlock fine.
+  grep -qF 'for mod in crypt dm' "$containerfile"
+  grep -qF 'for path in usr/bin/systemd-cryptsetup usr/sbin/dmsetup dm-crypt.ko' \
     "$containerfile"
+  run grep -qF 'sbin/cryptsetup ' "$containerfile"
+  [ "$status" -ne 0 ]
 }
 
 @test "Sailfin installs shared Bluefin config and GNOME-only Bluefin branding" {

--- a/tests/bats/test_customize_live.bats
+++ b/tests/bats/test_customize_live.bats
@@ -148,6 +148,18 @@ detect() {
   [ "$output" -eq 2 ]
 }
 
+# tunaOS#972: mounts.conf is the subscriptions mechanism, not a bind mount —
+# containers/common copies the whole source directory into the container's
+# runroot, which on live media is a tmpfs. Listing the payload store there
+# duplicated a 3 GB image into RAM and took out sailfin:gnome twice (OOM in run
+# 30730744132, ENOSPC on /run in run 30731534696). fisherman bind-mounts the
+# store itself when a path needs it, so this file must not be written.
+@test "customize-live.sh: never lists the offline store in mounts.conf" {
+  # The comment explaining why may name the file; a write to it must not exist.
+  run grep -n '^[^#]*>[[:space:]]*[^ ]*mounts\.conf' "${SCRIPT}"
+  [ "$status" -ne 0 ]
+}
+
 @test "customize-live.sh: sources the matching desktop adapter" {
   run grep 'desktop-\${DESKTOP}.sh' "${SCRIPT}"
   [ "$status" -eq 0 ]

--- a/tests/bats/test_customize_live.bats
+++ b/tests/bats/test_customize_live.bats
@@ -124,17 +124,27 @@ detect() {
   grep -q 'cat >/etc/containers/storage.conf' "${SCRIPT}"
   grep -q 'driver = "overlay"' "${SCRIPT}"
   grep -q 'graphroot = "/var/lib/containers/storage"' "${SCRIPT}"
-  grep -q 'additionalimagestores = \["/var/lib/superiso-store", "/usr/lib/containers/storage"\]' "${SCRIPT}"
+  grep -q 'additionalimagestores = ${STORE_LIST}' "${SCRIPT}"
   grep -q 'mount_program = "/usr/bin/fuse-overlayfs"' "${SCRIPT}"
+}
+
+# tunaOS#972: the vendor store is a Fedora/EL bootc convention. openSUSE ships
+# no /usr/lib/containers/storage and the overlay driver hard-fails on a store
+# it cannot stat, so the list must be composed from directories that exist.
+@test "customize-live.sh: enumerates only image stores that exist" {
+  grep -q 'VENDOR_STORE="/usr/lib/containers/storage"' "${SCRIPT}"
+  grep -q 'IMAGE_STORES=("\$STORE_MOUNT")' "${SCRIPT}"
+  grep -q 'if \[\[ -d "\$VENDOR_STORE" \]\]; then' "${SCRIPT}"
+  grep -q 'IMAGE_STORES+=("\$VENDOR_STORE")' "${SCRIPT}"
 }
 
 # tunaOS#881: the primary config is necessary but not sufficient —
 # /usr/share/containers/storage.conf.d/00-vendor.conf is applied after it and
 # REPLACES additionalimagestores wholesale. The 99- drop-in must outrank it and
-# must enumerate both stores, since the last writer of an array wins.
+# must enumerate the same stores, since the last writer of an array wins.
 @test "customize-live.sh: outranks the vendor drop-in and keeps both stores" {
   grep -q 'cat >/etc/containers/storage.conf.d/99-tbox-offline-store.conf' "${SCRIPT}"
-  run grep -c 'additionalimagestores = \["/var/lib/superiso-store", "/usr/lib/containers/storage"\]' "${SCRIPT}"
+  run grep -c 'additionalimagestores = ${STORE_LIST}' "${SCRIPT}"
   [ "$output" -eq 2 ]
 }
 

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -687,6 +687,27 @@ setup_runtime_check_stubs() {
   [ "$output" = "READY_NOT_FOUND" ]
 }
 
+@test "serial: every QEMU boot opens the console log in append mode" {
+  # `-serial file:PATH` truncates and then writes at QEMU's own offset, so
+  # once run_install tees ssh output into the same file, later console writes
+  # overwrite the transcript (and vice versa). That silently destroyed the
+  # guest console for the whole install window in run 30729902967, the one
+  # place an OOM report or hung-task splat would have been. Keep every boot
+  # on the shared append-mode chardev.
+  grep -q 'append=on' "$SCRIPT"
+  ! grep -q -- '-serial "file:${SERIAL_LOG}"' "$SCRIPT"
+  [ "$(grep -c '"${E2E_SERIAL_ARGS\[@\]}"' "$SCRIPT")" -eq 3 ]
+}
+
+@test "install: a console heartbeat outlives the ssh channel" {
+  # The install phase is where the guest can stop answering while QEMU stays
+  # up. The heartbeat reports memory/disk pressure to /dev/console from a
+  # setsid'd process, so evidence survives the ssh session dying.
+  grep -q 'TUNAOS_E2E_HEARTBEAT' "$SCRIPT"
+  grep -q 'setsid --fork /usr/local/bin/tunaos-e2e-heartbeat' "$SCRIPT"
+  grep -q 'pkill -f tunaos-e2e-heartbeat' "$SCRIPT"
+}
+
 @test "ready: serial log file growth detection" {
   run bash -c '
     log="/tmp/test-serial3.log"

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -729,6 +729,30 @@ setup_runtime_check_stubs() {
   [ "$(grep -c 'drive=swapdisk' "$SCRIPT")" -eq 1 ]
 }
 
+@test "installed boot: the disk is pinned first in the firmware boot order" {
+  # The live-ISO boot and the installed boot share one OVMF_VARS file, so the
+  # installed boot inherits OVMF's "EFI Internal Shell" NVRAM entry. Variants
+  # whose install writes its own EFI variable (efibootmgr prepends) boot
+  # anyway; sailfin's composefs/systemd-boot install cannot write efivars from
+  # inside the install container, so its auto-enumerated disk option lands
+  # after the shell and the guest sits at `Shell>` (run 30732193680).
+  # bootindex publishes a QEMU fw_cfg boot order OVMF applies over the stale
+  # NVRAM. Both post-install boots need it; the live boot must NOT have it
+  # (the ISO has to win there).
+  [ "$(grep -c 'device virtio-blk-pci,drive=disk,bootindex=0' "$SCRIPT")" -eq 2 ]
+  grep -q -- '-device virtio-blk-pci,drive=disk \\' "$SCRIPT"
+}
+
+@test "installed boot: the ESP is dumped before the install VM is destroyed" {
+  # Whether the install produced a bootable disk is only knowable from the
+  # ESP, and the ESP is unreachable once the live guest powers off. Dump it
+  # while the BLS kargs are being appended, and say so explicitly when the
+  # removable fallback the firmware needs is missing.
+  grep -q 'ESP contents' "$SCRIPT"
+  grep -q 'esp: removable fallback present' "$SCRIPT"
+  grep -q 'WARN: esp has NO EFI/BOOT/BOOTX64.EFI' "$SCRIPT"
+}
+
 @test "install: the LUKS workflow gives the guest more RAM than the image" {
   # The composefs install path stages the image through podman, so the guest
   # needs headroom over the image, not a hair under it. Keep the LUKS job's

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -706,6 +706,37 @@ setup_runtime_check_stubs() {
   grep -q 'TUNAOS_E2E_HEARTBEAT' "$SCRIPT"
   grep -q 'setsid --fork /usr/local/bin/tunaos-e2e-heartbeat' "$SCRIPT"
   grep -q 'pkill -f tunaos-e2e-heartbeat' "$SCRIPT"
+  # Swap exhaustion is the other half of the diagnosis, so the heartbeat has
+  # to report it alongside MemAvailable.
+  grep -q 'swapfree_kb' "$SCRIPT"
+}
+
+@test "install: the live guest gets a swap disk, addressed by serial" {
+  # podman's copy of the exported OCI layout into the install-time scratch
+  # store allocates on the order of the image size. With no swap the kernel
+  # can only kill it: run 30730744132 lost podman at anon-rss 7147396kB on
+  # an 8192 MiB guest. The swap disk is attached to the install boot and
+  # addressed by /dev/disk/by-id, never /dev/vdX, because the recipe installs to
+  # /dev/vda and the two must never be confused.
+  grep -q 'SWAP_DISK="${OUTPUT_DIR}/swap-disk.qcow2"' "$SCRIPT"
+  grep -q 'qemu-img create -f qcow2 "\$SWAP_DISK" 8G' "$SCRIPT"
+  grep -q 'serial=${SWAP_DISK_SERIAL}' "$SCRIPT"
+  grep -q 'SWAP_DISK_BYID="/dev/disk/by-id/virtio-${SWAP_DISK_SERIAL}"' "$SCRIPT"
+  grep -q "mkswap -L tunaos-e2e-swap" "$SCRIPT"
+  grep -q "swapon \${SWAP_DISK_BYID}" "$SCRIPT"
+  # Install boot only: the installed system must never see it (no fstab
+  # entry, no dangling swap device on the post-install boots).
+  [ "$(grep -c 'drive=swapdisk' "$SCRIPT")" -eq 1 ]
+}
+
+@test "install: the LUKS workflow gives the guest more RAM than the image" {
+  # The composefs install path stages the image through podman, so the guest
+  # needs headroom over the image, not a hair under it. Keep the LUKS job's
+  # --memory above the script default and the recipe's disk pinned to vda so
+  # the swap disk can never become the install target.
+  local wf="${REPO_ROOT}/.github/workflows/luks-e2e.yml"
+  grep -q -- '--memory 10240' "$wf"
+  grep -q '"disk": "/dev/vda"' "$SCRIPT"
 }
 
 @test "ready: serial log file growth detection" {


### PR DESCRIPTION
Fixes #953. Unblocks the sailfin:gnome LUKS E2E, which failed in eleven successive places; each fix in `Containerfile.opensuse` exposed the next defect:

1. **dracut omit** — `omit_dracutmodules+=" tpm2-tss pcsc "` is now declared in `/usr/lib/dracut/dracut.conf.d/10-bootc-base.conf`, so in-image dracut rebuilds (dev-ISO creation) inherit the omission instead of dying on `Module 'tpm2-tss' cannot be installed`.
2. **live-ready marker** — `Containerfile.opensuse` deliberately runs none of the numbered `build_scripts`, so `40-services.sh`'s `safe_enable tunaos-live-ready.service` never ran and the live ISO reached `graphical.target` without printing `TUNAOS_LIVE_READY`. Enabled explicitly after the `system_files` COPY.
3. **sudo** — the openSUSE base ships no `sudo`, so the harness's `sudo podman load` in the live guest failed with `sudo: command not found`. Added to the zypper install list.
4. **dangling `/var` aliases** — `/mnt` is a `var/mnt` symlink whose target never existed, so fisherman's `mkdir /mnt` hit `EEXIST` (`creating mount point /mnt/fisherman-target: mkdir /mnt: file exists`). The alias targets are now created in the image and declared in tmpfiles.d so they survive bootc's `/var` reset, matching `Containerfile.debian` / `Containerfile.arch`:

```dockerfile
mkdir -p /var/tmp /var/mnt /var/home /var/opt /var/srv /var/roothome \
    /var/usrlocal && \
printf 'd /var/opt 0755 root root -\nd /var/home 0755 root root -\n...' \
    > /usr/lib/tmpfiles.d/bootc-base-dirs.conf
```

5. **nonexistent additional image store** — with the install finally running, `podman pull containers-storage:ghcr.io/tuna-os/sailfin:gnome` died with `overlay: can't stat imageStore dir /usr/lib/containers/storage`. `customize-live.sh` hardcoded that vendor store (a Fedora/EL bootc convention) into the live root's `storage.conf` and its `99-` drop-in; openSUSE ships no such directory and the overlay driver hard-fails rather than skipping a store it cannot stat, taking down every podman call in the live root. The list is now composed from directories that exist:

```bash
VENDOR_STORE="/usr/lib/containers/storage"
IMAGE_STORES=("$STORE_MOUNT")
if [[ -d "$VENDOR_STORE" ]]; then
	IMAGE_STORES+=("$VENDOR_STORE")
fi
STORE_LIST="$(printf '"%s", ' "${IMAGE_STORES[@]}")"
STORE_LIST="[${STORE_LIST%, }]"
```

Bases that ship the vendor store keep it (the array is replaced wholesale by the last writer, so it still has to be enumerated); sailfin degrades to the offline store alone.


6. **guest RAM on the composefs install path** (`.github/workflows/luks-e2e.yml`) - with podman working, the install reached `bootc install` and the guest stopped answering ssh 15s later, never to return: `Timeout, server 127.0.0.1 not responding.`, no OOM report, no hung-task splat, no panic. Every LUKS cell that passes today takes fisherman's `bootcDirect` path (bootc reads the offline store and writes the target once); composefs images cannot, so the image is staged three times (OCI export, podman scratch store, install) through dm-crypt on a 3903 MB guest with no swap. The job now asks for a guest with headroom over the image:

```yaml
./scripts/iso-e2e.sh "${ISO_PATH}" --luks \
  --output luks-out \
  --memory 8192 \
  --timeout 1200
```

7. **the serial log was eating its own evidence** (`scripts/iso-e2e.sh`) - the reason #6 had to be inferred rather than read. `-serial file:PATH` opens the log `O_TRUNC` and writes at QEMU's own offset, while `run_install` tees ssh output into the same file, so each writer overwrites the other (the failing artifact has a shredded `ot ok - network connectivity` line, and no console output at all after the first tee). Every boot now shares an append-mode chardev, and the install phase starts a heartbeat that reports memory/disk pressure straight to `/dev/console` from a `setsid`'d process, so it keeps reporting after the ssh channel dies:

```bash
E2E_SERIAL_ARGS=(
	-chardev "file,id=e2eserial,path=${SERIAL_LOG},append=on"
	-serial chardev:e2eserial
)
```


8. **the guest had no swap, and podman needs image-sized memory** (`scripts/iso-e2e.sh`) - with the console evidence finally intact, #6's wedge turned out to be an OOM kill, one that 8192 MiB did not avoid either. podman's copy of the exported OCI layout into the install-time scratch store allocates on the order of the image: `Out of memory: Killed process 2978 (podman) total-vm:9250052kB, anon-rss:7147396kB` with `Total swap = 0kB`, still growing when the kernel picked it. Raising `--memory` alone only moves the cliff, so the install boot now gets a sparse swap disk of its own (the live root's writable layer is a tmpfs, so a swapfile there is memory backed by memory, and the target disk is about to be repartitioned):

```bash
-drive "if=none,id=swapdisk,file=${SWAP_DISK},format=qcow2" \
-device "virtio-blk-pci,drive=swapdisk,serial=${SWAP_DISK_SERIAL}" \
```

swapped on before fisherman runs and addressed by `/dev/disk/by-id/virtio-e2eswap`, never `/dev/vdX`, since the recipe installs to `/dev/vda`. The installed system is booted without the disk and never records it in fstab. `--memory` goes to 10240 so the swap is headroom rather than the plan, and the heartbeat now reports `swapfree_kb`.

9. **the live root copied the payload store into every container** (`live-iso/common/src/customize-live.sh`) - the install container died with `no space left on device` on `/run`. The live root's `/etc/containers/mounts.conf` entry for `/var/lib/superiso-store` is containers/common's *subscriptions* mechanism, not a bind mount, so podman read the whole payload tree into memory and copied it into the container's tmpfs runroot on every container start (the same allocation behind #8's OOM). The entry is gone; fisherman bind-mounts the store itself when it needs a path, and the composefs path reads `/run/fisherman/oci-cache`.

10. **the installed disk lost the boot order to the UEFI shell** (`scripts/iso-e2e.sh`) - both boots share one `OVMF_VARS`, and sailfin's install cannot write an EFI variable (`bootctl` skips efivars inside the install container), so its auto-enumerated disk option was ordered *after* OVMF's "EFI Internal Shell" entry that the grub2 variants jump ahead of via `efibootmgr`. The post-install boots now pin the disk with QEMU's fw_cfg boot order, which OVMF applies over the stale NVRAM:

```bash
-device virtio-blk-pci,drive=disk,bootindex=0 \
```

11. **the initramfs had no LUKS support** (`Containerfile.opensuse`) - with the installed disk finally booting, it went straight to the dracut emergency shell, having never asked for a passphrase, waiting on a root UUID that only appears once the volume opens. dracut's `dm` module is `require_binaries dmsetup` and `crypt` is `require_binaries cryptsetup` plus a dependency on `dm`; the base ships neither, so the system stage's dracut run dropped both (`Module 'crypt' depends on module 'dm', which can't be installed`) and the initrd ignored fisherman's `rd.luks.name` karg. The packages are now installed before the initramfs is built, the modules are requested by name so an in-image rebuild under openSUSE's hostonly default cannot drop them either, and a missing one fails the build instead of the boot:

```dockerfile
for path in usr/bin/systemd-cryptsetup usr/sbin/dmsetup dm-crypt.ko; do \
  if ! grep -q "${path}" /tmp/initramfs.list; then \
    echo "ERROR: initramfs has no ${path} — ..." >&2; \
    exit 1; \
  fi; \
done; \
```

The assertion checks the systemd unlock path rather than a standalone `cryptsetup` binary: dracut needs cryptsetup at build time (`crypt`'s `check()` is `require_binaries cryptsetup`), but in a systemd initrd dracut-ng 110 ships only `systemd-cryptsetup`, its generator, and `crypt-run-generator`, so the first spelling of this guard failed an initramfs that could unlock fine (run 30735665323).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->




