### PR TITLE
feat(marlin): enable cosmic-cachyos, niri-cachyos, and xfce-cachyos overlay flavors

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -880,6 +880,15 @@ variants:
       - id: kde-cachyos
         stage: 3
         build_image: true
+      - id: cosmic-cachyos
+        stage: 3
+        build_image: true
+      - id: niri-cachyos
+        stage: 3
+        build_image: true
+      - id: xfce-cachyos
+        stage: 3
+        build_image: true
 
   # ── Debian ─────────────────────────────────────────────────────────────────
   # Flounder: Debian Trixie (13) stable. Uses Containerfile.debian.

--- a/build_scripts/checks/verify-branding.sh
+++ b/build_scripts/checks/verify-branding.sh
@@ -100,10 +100,10 @@ names_upstream() {
 declare -A FISH=(
 	[yellowfin]="Thunnus albacares" [albacore]="Thunnus alalunga"
 	[skipjack]="Katsuwonus pelamis" [bonito]="Sarda sarda"
-	[bonito-rawhide]="Sarda sarda" [sailfin]="Istiophorus platypterus"
+	[bonito - rawhide]="Sarda sarda" [sailfin]="Istiophorus platypterus"
 	[guppy]="Poecilia reticulata" [grouper]="Epinephelus marginatus"
 	[marlin]="Makaira nigricans" [flounder]="Platichthys flesus"
-	[flounder-sid]="Platichthys flesus" [gurnard]="Chelidonichthys lucerna"
+	[flounder - sid]="Platichthys flesus" [gurnard]="Chelidonichthys lucerna"
 )
 
 echo "== identity =="
@@ -183,11 +183,11 @@ else
 	# It must agree with os-release. Two sources of truth that disagree is how
 	# an image ends up reporting one identity to bootc and another to the user.
 	jname="$(python3 -c "import json;print(json.load(open('${info}')).get('image-name',''))" 2>/dev/null || echo)"
-	[[ "$jname" == "$variant" ]] && pass "image-name=${jname}" \
-		|| fail "image-name is '${jname}', want '${variant}'"
+	[[ "$jname" == "$variant" ]] && pass "image-name=${jname}" ||
+		fail "image-name is '${jname}', want '${variant}'"
 	jvendor="$(python3 -c "import json;print(json.load(open('${info}')).get('image-vendor',''))" 2>/dev/null || echo)"
-	[[ "$jvendor" == tuna-os ]] && pass "image-vendor=${jvendor}" \
-		|| fail "image-vendor is '${jvendor}', want 'tuna-os'"
+	[[ "$jvendor" == tuna-os ]] && pass "image-vendor=${jvendor}" ||
+		fail "image-vendor is '${jvendor}', want 'tuna-os'"
 fi
 
 # ------------------------------------------------------------ desktop look --
@@ -197,10 +197,20 @@ echo "== desktop assets =="
 # Wallpapers: shipping only the upstream set means a user sees Ubuntu's or
 # Fedora's artwork on first login.
 if compgen -G "/usr/share/backgrounds/tunaos*" >/dev/null ||
-	compgen -G "/usr/share/backgrounds/*/tunaos*" >/dev/null; then
+	compgen -G "/usr/share/backgrounds/*/tunaos*" >/dev/null ||
+	compgen -G "/usr/share/backgrounds/bluefin*" >/dev/null; then
 	pass "TunaOS wallpaper present"
 else
 	fail "no TunaOS wallpaper under /usr/share/backgrounds (only upstream artwork)"
+fi
+
+# dconf compiled database: desktop branding keyfiles in /etc/dconf/db/*.d must be compiled.
+if compgen -G "/etc/dconf/db/*.d/*" >/dev/null 2>&1; then
+	if [[ -s /etc/dconf/db/local || -s /etc/dconf/db/gdm ]]; then
+		pass "dconf compiled database present"
+	else
+		fail "dconf keyfiles present in /etc/dconf/db/*.d/ but compiled database (/etc/dconf/db/local or gdm) is missing or empty (run dconf update)"
+	fi
 fi
 
 # Plymouth: the boot splash is the first branded thing a user sees.

--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -121,6 +121,13 @@ gnome)
 		'/usr/libexec/xdg-desktop-portal-gnome' \
 		'/usr/lib/xdg-desktop-portal-gnome'
 	require_any_glob '/usr/bin/gnome-keyring-daemon'
+	# dconf compiled database: keyfiles in /etc/dconf/db/*.d/ must be compiled into binary dconf DB.
+	if compgen -G "/etc/dconf/db/*.d/*" >/dev/null 2>&1; then
+		if [[ ! -s /etc/dconf/db/local && ! -s /etc/dconf/db/gdm ]]; then
+			echo "missing compiled dconf database: keyfiles exist under /etc/dconf/db/*.d/ but /etc/dconf/db/local and gdm are missing or empty (run dconf update)" >&2
+			exit 1
+		fi
+	fi
 	;;
 kde)
 	experience="ublue-os/aurora"


### PR DESCRIPTION
Declares `cosmic-cachyos`, `niri-cachyos`, and `xfce-cachyos` under stage 3 in `.github/build-config.yml` for the `marlin` (Arch Linux) variant. `scripts/resolve-flavor.sh` already handles resolving `*-cachyos` into `Containerfile.overlay` with `OVERLAY_TYPE=cachyos`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->