### PR TITLE
feat(iso-e2e): configurable readiness marker — accept tacklebox's generic TBOX_LIVE_READY

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -45,6 +45,13 @@
 #
 # Options:
 #   --timeout SEC         Per-phase timeout (default: 300)
+#   --live-marker RE      Extended regex the serial log must match to count
+#                         as ready. Default accepts both TUNAOS_LIVE_READY
+#                         (our images' tunaos-live-ready.service) and
+#                         TBOX_LIVE_READY (tacklebox's generic marker, which
+#                         its builders bake into non-tunaOS images — the
+#                         reference cells in iso-builder). Also settable via
+#                         the LIVE_MARKER env var.
 #   --output DIR          Where serial logs / screenshots are written
 #                         (default: ./iso-e2e-out)
 #   --memory MIB          QEMU guest RAM (default: 4096)
@@ -78,6 +85,7 @@ KICKSTART=""
 APP_CMD=""
 MODE="ready" # ready | install | kickstart | ssh | app-launch
 TIMEOUT=300
+LIVE_MARKER="${LIVE_MARKER:-TUNAOS_LIVE_READY|TBOX_LIVE_READY}"
 OUTPUT_DIR="./iso-e2e-out"
 MEMORY=4096
 CPUS=4
@@ -123,6 +131,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--timeout)
 		TIMEOUT="$2"
+		shift 2
+		;;
+	--live-marker)
+		LIVE_MARKER="$2"
 		shift 2
 		;;
 	--output)
@@ -836,7 +848,7 @@ screenshot_compare() {
 #
 # The screenshot fallback below exists because bootc base kernels ship
 # CONFIG_SERIAL_8250=m and a healthy live session often cannot get
-# TUNAOS_LIVE_READY onto the serial console. What it cannot distinguish is a
+# the readiness marker onto the serial console. What it cannot distinguish is a
 # healthy session from a dracut emergency shell: that renders text too, so
 # the framebuffer is "sane" and the run passes.
 #
@@ -869,7 +881,7 @@ boot_failed_on_serial() {
 # Sanity-check a captured screenshot: it must exist and show actual content
 # (not a black/blank framebuffer). Used as the readiness fallback when the
 # serial marker never arrives — the bootc base kernels ship
-# CONFIG_SERIAL_8250=m, so TUNAOS_LIVE_READY often can't reach the serial
+# CONFIG_SERIAL_8250=m, so the readiness marker often cannot reach the serial
 # console even though the live session is up (see research.md).
 # Returns 0 if the screenshot looks like a rendered screen, 1 otherwise.
 screenshot_sane() {
@@ -919,9 +931,9 @@ screenshot_sane() {
 wait_for_ready() {
 	local deadline=$(($(date +%s) + TIMEOUT))
 	local last_size=0
-	echo "==> Waiting up to ${TIMEOUT}s for TUNAOS_LIVE_READY..."
+	echo "==> Waiting up to ${TIMEOUT}s for readiness marker (${LIVE_MARKER})..."
 	while (($(date +%s) < deadline)); do
-		if [[ -f "$SERIAL_LOG" ]] && grep -q "TUNAOS_LIVE_READY" "$SERIAL_LOG" 2>/dev/null; then
+		if [[ -f "$SERIAL_LOG" ]] && grep -qE "$LIVE_MARKER" "$SERIAL_LOG" 2>/dev/null; then
 			echo "==> Readiness marker found"
 			return 0
 		fi

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -672,6 +672,24 @@ setup_runtime_check_stubs() {
   [ "$output" = "READY_FOUND" ]
 }
 
+@test "ready: default LIVE_MARKER accepts tacklebox's generic TBOX_LIVE_READY" {
+  # iso-builder's reference cells (aurora et al.) are built by tacklebox,
+  # which is a generic bootc ISO maker and bakes its own neutral marker
+  # rather than a tunaOS-branded one. The harness owns the contract, so
+  # its default accepts both.
+  run bash -c '
+    LIVE_MARKER="${LIVE_MARKER:-TUNAOS_LIVE_READY|TBOX_LIVE_READY}"
+    SERIAL_LOG="/tmp/test-serial3.log"
+    echo "some boot output" > "$SERIAL_LOG"
+    echo "TBOX_LIVE_READY uptime=12.3" >> "$SERIAL_LOG"
+    if grep -qE "$LIVE_MARKER" "$SERIAL_LOG" 2>/dev/null; then
+      echo "READY_FOUND"
+    fi
+    rm -f "$SERIAL_LOG"
+  '
+  [ "$output" = "READY_FOUND" ]
+}
+
 @test "ready: marker not found when absent" {
   run bash -c '
     SERIAL_LOG="/tmp/test-serial2.log"


### PR DESCRIPTION
tacklebox is a generic bootc ISO maker and shouldn't bake a tunaOS-branded unit into every image it builds — it's switching to a neutral `tbox-live-ready.service` printing `TBOX_LIVE_READY` (tuna-os/tacklebox#177). The harness owns the readiness contract, so `wait_for_ready` gains a configurable marker:

- `--live-marker RE` flag / `LIVE_MARKER` env, defaulting to `TUNAOS_LIVE_READY|TBOX_LIVE_READY` — tunaOS's own images keep working unchanged, tacklebox-built reference images (iso-builder's aurora cells) are recognized, and any other consumer can set their own string.
- The wait loop greps with `-E` against the configured regex; the announcement line names what it's waiting for.
- New bats case covering the generic marker under the default; stale comments genericized.

Verified the default regex against all three cases (tunaOS marker, tacklebox marker, absent) and `bash -n` clean. Ordering note: this merges **first**, then the tacklebox rename — the default accepting both makes the transition safe in either direction for engines already in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9hTUH9j7C8fJbCpuXefQN

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9hTUH9j7C8fJbCpuXefQN)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->