### PR TITLE
fix(iso-e2e): harden the configurable live marker (Copilot review on #1024)

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -45,13 +45,9 @@
 #
 # Options:
 #   --timeout SEC         Per-phase timeout (default: 300)
-#   --live-marker RE      Extended regex the serial log must match to count
-#                         as ready. Default accepts both TUNAOS_LIVE_READY
-#                         (our images' tunaos-live-ready.service) and
-#                         TBOX_LIVE_READY (tacklebox's generic marker, which
-#                         its builders bake into non-tunaOS images — the
-#                         reference cells in iso-builder). Also settable via
-#                         the LIVE_MARKER env var.
+#   --live-marker RE      Readiness regex for the serial log (env: LIVE_MARKER).
+#                         Default TUNAOS_LIVE_READY|TBOX_LIVE_READY — ours and
+#                         tacklebox's generic marker for non-tunaOS images.
 #   --output DIR          Where serial logs / screenshots are written
 #                         (default: ./iso-e2e-out)
 #   --memory MIB          QEMU guest RAM (default: 4096)
@@ -933,7 +929,7 @@ wait_for_ready() {
 	local last_size=0
 	echo "==> Waiting up to ${TIMEOUT}s for readiness marker (${LIVE_MARKER})..."
 	while (($(date +%s) < deadline)); do
-		if [[ -f "$SERIAL_LOG" ]] && grep -qE "$LIVE_MARKER" "$SERIAL_LOG" 2>/dev/null; then
+		if [[ -f "$SERIAL_LOG" ]] && grep -qE -- "$LIVE_MARKER" "$SERIAL_LOG" 2>/dev/null; then
 			echo "==> Readiness marker found"
 			return 0
 		fi

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -676,18 +676,17 @@ setup_runtime_check_stubs() {
   # iso-builder's reference cells (aurora et al.) are built by tacklebox,
   # which is a generic bootc ISO maker and bakes its own neutral marker
   # rather than a tunaOS-branded one. The harness owns the contract, so
-  # its default accepts both.
-  run bash -c '
-    LIVE_MARKER="${LIVE_MARKER:-TUNAOS_LIVE_READY|TBOX_LIVE_READY}"
-    SERIAL_LOG="/tmp/test-serial3.log"
-    echo "some boot output" > "$SERIAL_LOG"
-    echo "TBOX_LIVE_READY uptime=12.3" >> "$SERIAL_LOG"
-    if grep -qE "$LIVE_MARKER" "$SERIAL_LOG" 2>/dev/null; then
-      echo "READY_FOUND"
-    fi
-    rm -f "$SERIAL_LOG"
-  '
-  [ "$output" = "READY_FOUND" ]
+  # its default accepts both. The default is EVALUATED out of the script
+  # itself so this test fails if the shipped default ever drifts.
+  local default
+  default=$(unset LIVE_MARKER; eval "$(grep '^LIVE_MARKER=' "$BATS_TEST_DIRNAME/../../scripts/iso-e2e.sh")"; echo "$LIVE_MARKER")
+  [ -n "$default" ]
+  SERIAL_LOG="$BATS_TEST_TMPDIR/test-serial3.log"
+  echo "some boot output" > "$SERIAL_LOG"
+  echo "TBOX_LIVE_READY uptime=12.3" >> "$SERIAL_LOG"
+  grep -qE -- "$default" "$SERIAL_LOG"
+  echo "still booting" > "$SERIAL_LOG"
+  ! grep -qE -- "$default" "$SERIAL_LOG"
 }
 
 @test "ready: marker not found when absent" {


### PR DESCRIPTION
Follow-up applying the three actionable Copilot review comments from #1024 (which merged before they landed):

- **`grep -- ` guard** before the user-configurable `LIVE_MARKER` in both the harness wait loop and the bats test — a marker beginning with `-` is always a pattern, never an option.
- **`--help` truncation fixed**: the expanded `--live-marker` description pushed the header past `--help`'s `sed -n '2,50p'` window, cutting output mid-sentence. The option text is now three lines and the window closes cleanly.
- **Drift-proof test**: the default-marker bats case now *evaluates* the `LIVE_MARKER=` line out of `scripts/iso-e2e.sh` itself instead of hardcoding a copy, so it fails if the shipped default ever drifts from what it guards — and asserts both the match and the no-match direction.

`bash -n` clean; all `ready:` bats cases green locally, including the rewritten drift guard. (Unit Tests may still show the pre-existing `test_build_iso_group.bats` #16 bonito-nvidia failure — unrelated, fails on main, documented on #1024.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9hTUH9j7C8fJbCpuXefQN

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9hTUH9j7C8fJbCpuXefQN)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->