### PR TITLE
fix(bonito): restore xfce-nvidia flavor dropped by hummingbird insert

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -531,6 +531,11 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
+      - id: xfce-nvidia
+        stage: 3
+        build_image: true
+        build_iso: true
+        build_qcow2: false
   # ── Hummingbird ────────────────────────────────────────────────────────────
   # Fedora Hummingbird: container-native, hardened bootc distribution
   # (Konflux hermetic build model, CKI ARK kernel).


### PR DESCRIPTION
The Unit Tests job has been red on `main` since cace031, which inserted the hummingbird variant directly over bonito's stage-3 `xfce-nvidia` entry (the diff replaced that block with the new variant header). With the flavor gone, the community ISO group no longer resolves it on Fedora and `tests/bats/test_build_iso_group.bats:116` fails:

```
not ok 16 select: bonito community resolves to nvidia desktops
#   `[ "$(_select community bonito)" = "kde-nvidia cosmic-nvidia niri-nvidia xfce-nvidia" ]' failed
```

This restores the entry, matching what bonito-rawhide, yellowfin, and albacore all still declare:

```yaml
      - id: xfce-nvidia
        stage: 3
        build_image: true
        build_iso: true
        build_qcow2: false
```

Re-running the group-selection logic against the config now yields `kde-nvidia cosmic-nvidia niri-nvidia xfce-nvidia` for `community`/bonito, and the grand total stays at 8 grouped ISOs. `scripts/generate-workflows.py` produces no diff, since the generated per-variant workflows don't enumerate flavors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->