### PR TITLE
fix(iso-e2e): also pass the vsock key as ssh.ephemeral-authorized_keys-all

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -571,9 +571,27 @@ setup_vsock() {
 	# alphabet contains no commas, so no QEMU option-escaping is needed.
 	local pub_b64
 	pub_b64=$(base64 <"${VSOCK_SSH_KEY}.pub" | tr -d '\n')
+	# The key rides under TWO credential names because they are consumed by
+	# different mechanisms and only the second one is known to work on the
+	# aurora-shaped images this fallback exists for:
+	#
+	#   ssh.authorized_keys.root — tmpfiles provision.conf writes it to
+	#     /root/.ssh/authorized_keys. On bootc/ostree images /root is a
+	#     symlink into /var/roothome, and aurora attempt 7 (iso-builder run
+	#     31115116876) proved the file never lands: the vsock handshake
+	#     completed and sshd answered "Permission denied (publickey)".
+	#     Kept because it is the documented generic mechanism and costs one
+	#     SMBIOS string.
+	#   ssh.ephemeral-authorized_keys-all — imported by the generated
+	#     sshd-vsock/sshd-unix-local instances themselves (verified in
+	#     aurora's systemd-ssh-generator: AuthorizedKeysFile
+	#     ${CREDENTIALS_DIRECTORY}/ssh.ephemeral-authorized_keys-all),
+	#     valid for every user with no home-directory involvement — exactly
+	#     the listener this fallback dials.
 	VSOCK_ARGS=(
 		-device "vhost-vsock-pci,guest-cid=${VSOCK_CID}"
 		-smbios "type=11,value=io.systemd.credential.binary:ssh.authorized_keys.root=${pub_b64}"
+		-smbios "type=11,value=io.systemd.credential.binary:ssh.ephemeral-authorized_keys-all=${pub_b64}"
 	)
 	echo "==> vsock SSH fallback armed (guest-cid=${VSOCK_CID})"
 }

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -839,12 +839,17 @@ setup_runtime_check_stubs() {
 }
 
 @test "vsock: root key rides the SMBIOS credential, device on the live boot only" {
-  # The whole fallback is contract: systemd's tmpfiles provision.conf imports
-  # ssh.authorized_keys.root from SMBIOS type 11 into /root/.ssh, and
-  # systemd-ssh-generator answers on the vsock the device provides. Both
-  # halves have to stay on the QEMU command line of the LIVE boot (the
+  # The whole fallback is contract: the key must reach the guest under BOTH
+  # credential names. provision.conf's ssh.authorized_keys.root writes
+  # /root/.ssh/authorized_keys — which never lands on bootc images, where
+  # /root is a symlink into /var/roothome (aurora attempt 7, run
+  # 31115116876: vsock handshake completed, "Permission denied (publickey)").
+  # ssh.ephemeral-authorized_keys-all is consumed by the generated
+  # sshd-vsock instance itself and is the one that actually authenticates
+  # there. Both must stay on the QEMU command line of the LIVE boot (the
   # installed boots are serial-gated and get no vsock device).
   grep -q 'io.systemd.credential.binary:ssh.authorized_keys.root=' "$SCRIPT"
+  grep -q 'io.systemd.credential.binary:ssh.ephemeral-authorized_keys-all=' "$SCRIPT"
   grep -q 'vhost-vsock-pci,guest-cid=' "$SCRIPT"
   # Absent host support must leave the command line untouched (VSOCK_ARGS
   # stays empty), so the expansion needs the set -u-safe guard form.


### PR DESCRIPTION
## What

Two-line fix from real evidence: aurora attempt 7 (iso-builder run [31115116876](https://github.com/tuna-os/iso-builder/actions/runs/31115116876)) proved the vsock transport works end-to-end — QEMU device attached, socat reached the guest's `sshd-vsock.socket`, full SSH handshake — but auth failed: `root@e2e-vsock: Permission denied (publickey,...)`.

## Why

`ssh.authorized_keys.root` relies on systemd's tmpfiles `provision.conf` writing `/root/.ssh/authorized_keys`. On bootc/ostree images `/root` is a symlink into `/var/roothome`, and the file never lands.

Verified in the aurora image itself: its `systemd-ssh-generator` generates the vsock/unix-local sshd instances with

```
AuthorizedKeysFile ${CREDENTIALS_DIRECTORY}/ssh.ephemeral-authorized_keys-all .ssh/authorized_keys
ImportCredential=ssh.ephemeral-authorized_keys-all
```

so a key passed under `ssh.ephemeral-authorized_keys-all` authenticates any user on exactly the listener the fallback dials — no home directory involved. The key now rides under **both** credential names (provision.conf stays for images where it works; costs one SMBIOS string).

## Testing

- Drift-guard bats test extended to require both credential names; full `test_iso_e2e.bats` green locally (73 ok; only the 4 known container-env `e2e-smoke/runtime-checks` failures that fail identically on main here).
- `bash -n`, shellcheck (0 warnings+), `shfmt -d` clean.
- Real validation: the next aurora dispatch exercises it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9hTUH9j7C8fJbCpuXefQN

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9hTUH9j7C8fJbCpuXefQN)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->