### PR TITLE
feat(e2e): film each LUKS install, and fix the nine defects that surfaced doing it

### DIFF
--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -344,5 +344,18 @@ jobs:
             luks-out/installed-serial.log
             luks-out/luks-evidence.log
             luks-out/*.png
+            # The install timelapse (scripts/record-timelapse.sh). Recording it
+            # and then not collecting it is how the first two cells that ran
+            # with the recorder produced nothing to look at: the frames were
+            # captured and discarded with the runner.
+            #
+            # frame-count.txt comes too, and is the part that stays useful when
+            # there is no video: 0 means screendump found no surface (the virgl
+            # path) or QEMU died before the first capture, which is a different
+            # story from "ffmpeg was missing" and neither should be guessed at
+            # from an absent file.
+            luks-out/timelapse/timelapse.webm
+            luks-out/timelapse/timelapse-poster.webp
+            luks-out/timelapse/frame-count.txt
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -208,7 +208,15 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             just podman crun jq \
             qemu-system-x86 qemu-utils ovmf swtpm socat sshpass imagemagick \
-            systemd-boot-efi mtools squashfs-tools xorriso dosfstools gdisk
+            systemd-boot-efi mtools squashfs-tools xorriso dosfstools gdisk \
+            ffmpeg
+          # ffmpeg is what turns record-timelapse.sh's frames into the video.
+          # Without it the recorder captures normally and then has nothing to
+          # assemble with, which is deliberately NOT a failure — the first
+          # green cell to run with the recorder (skipjack:cosmic, run
+          # 31135333873) shipped `timelapse/frame-count.txt` reading 203 and
+          # no timelapse.webm, and stayed green. That is the contract working;
+          # it is also 203 frames nobody can watch.
           podman --version; crun --version | head -1
 
       # iso-e2e.sh resolves the published image ref through

--- a/Containerfile.ubuntu
+++ b/Containerfile.ubuntu
@@ -432,11 +432,23 @@ RUN --mount=type=tmpfs,dst=/tmp \
   --mount=type=bind,from=context,source=/,target=/run/context \
   /run/context/build_scripts/bootc/finalize.sh
 
+# COSMIC goes through the manifest-driven installer, not desktop/cosmic.sh.
+# cosmic.sh has no apt branch — gnome.sh, kde.sh, xfce.sh and niri.sh all open
+# with `if [[ "$PKG_MGR" == "apt" ]]`, cosmic.sh goes straight to
+# `dnf -y copr enable`, so this stage died at `dnf: command not found` on every
+# grouper:cosmic build (LUKS run 31134394662, and the flavour has never
+# published). Every other Containerfile already calls install-desktop.sh for
+# cosmic; only this one still reached for the per-DE script.
+#
+# The manifest path is also the only one that can install COSMIC on Ubuntu at
+# all: it comes solely from ppa:hepp3n/cosmic-epoch, and `packages.apt.ppa`
+# with `condition: ubuntu` is handled by install-desktop.sh (_td_add_ppa) and
+# nowhere else. That is the same reason the pantheon stage below uses it.
 FROM base-no-de AS cosmic
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
-  /run/context/build_scripts/desktop/cosmic.sh base && \
+  /run/context/build_scripts/desktop/install-desktop.sh cosmic && \
   /run/context/build_scripts/desktop/configure-desktop-runtime.sh cosmic
 RUN --mount=type=tmpfs,dst=/tmp \
   --mount=type=bind,from=context,source=/,target=/run/context \

--- a/build_scripts/checks/e2e-runtime-checks.sh
+++ b/build_scripts/checks/e2e-runtime-checks.sh
@@ -135,7 +135,12 @@ emit "# display manager: ${dm_id:-unknown}"
 case "$DESKTOP" in
 gnome) dm_pattern='^(gdm|gdm3)\.service$' ;;
 kde) dm_pattern='^(sddm|plasmalogin)\.service$' ;; # KDE 6.5+ renamed sddm
-niri | cosmic) dm_pattern='^greetd\.service$' ;;
+niri) dm_pattern='^greetd\.service$' ;;
+# cosmic-greeter IS greetd (ExecStart=greetd --config
+# /etc/greetd/cosmic-greeter.toml), and on Ubuntu its postinst owns the
+# display-manager.service alias, so dm_id is cosmic-greeter there and greetd on
+# Fedora/EL10. Both are the same greeter.
+cosmic) dm_pattern='^(greetd|cosmic-greeter)\.service$' ;;
 xfce) dm_pattern='^(gdm|gdm3|lightdm|greetd)\.service$' ;;
 *) dm_pattern='' ;;
 esac

--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -238,7 +238,15 @@ cosmic)
 	# into a hard build failure on a variant that has always built. Nor is
 	# either path measured on any published cosmic image yet. Measure
 	# bonito:cosmic (fedora) and flounder:cosmic (apt) first, then decide.
-	dm_pattern='^greetd\.service$'
+	#
+	# cosmic-greeter.service is accepted alongside greetd.service because it is
+	# greetd: `ExecStart=greetd --config /etc/greetd/cosmic-greeter.toml`, with
+	# `Provides: x-display-manager` and `Pre-Depends: greetd` on the deb. On
+	# Ubuntu its postinst claims the display-manager.service alias, so
+	# `systemctl show -P Id display-manager.service` reports cosmic-greeter
+	# there while Fedora/EL10 report greetd. Pinning only greetd would fail
+	# grouper:cosmic on a correctly-wired COSMIC login screen.
+	dm_pattern='^(greetd|cosmic-greeter)\.service$'
 	;;
 xfce)
 	experience="tunaos/xfce"

--- a/build_scripts/desktop/configure-desktop-runtime.sh
+++ b/build_scripts/desktop/configure-desktop-runtime.sh
@@ -38,12 +38,37 @@ cosmic)
 	# merits — cosmic-greeter IS COSMIC's greeter, and it is already enabled
 	# at this point.
 	#
-	# This tests the CLAIM, not the package, and that distinction is the
-	# whole safety argument. Fedora and EL10 install cosmic-greeter too, and
-	# their cosmic cells are green today *because* `systemctl enable greetd`
-	# succeeds there — which is direct evidence their scriptlets leave the
-	# alias alone. Keying off "is cosmic-greeter installed" would have
-	# repointed those images; keying off the symlink cannot.
+	# This tests the CLAIM, not the package, which is what makes it correct
+	# on every base rather than just the one it was written for.
+	#
+	# An earlier version of this comment claimed EL10 leaves the alias alone,
+	# inferring it from `systemctl enable greetd` succeeding there. That
+	# inference was WRONG, and the artifacts say so: albacore:cosmic on head
+	# c277780f — before any of this — already reported
+	#
+	#   # display manager: cosmic-greeter.service
+	#   reason=dm_mismatch dm=cosmic-greeter.service
+	#
+	# EL10's COPR cosmic-greeter claims the alias exactly like the deb does.
+	# greetd enables cleanly there for a different reason: Fedora/EL ship
+	# greetd.service with `[Install] WantedBy=graphical.target` and no Alias=,
+	# while Debian/Ubuntu ship `Alias=display-manager.service` and no
+	# WantedBy=. No alias, no conflict — so the EL10 build SUCCEEDS and ships
+	# both units, which is worse than failing: greetd and cosmic-greeter both
+	# run `greetd` on vt1 with Restart=always, greetd takes the terminal
+	# first, and cosmic-greeter crash-loops on
+	#
+	#   unable to start greeter: terminal: unable to take controlling
+	#   terminal: EPERM: Operation not permitted
+	#
+	# (skipjack:cosmic, run 31136849989 — a cell the board counts GREEN,
+	# because the desktop contract that catches it is fatal=0. albacore:cosmic
+	# fails the same contract. skipjack:niri passes it on the identical base,
+	# so the check works and this is COSMIC-specific.)
+	#
+	# Keying off the symlink handles that case too: on EL10 the symlink is
+	# already cosmic-greeter, so this picks cosmic-greeter and the sibling
+	# guard in install-desktop.sh stops force-linking greetd beside it.
 	#
 	# NOT `systemctl enable --force`: the kde comment above records why
 	# forcing the alias is the wrong instrument (tunaOS#824).

--- a/build_scripts/desktop/configure-desktop-runtime.sh
+++ b/build_scripts/desktop/configure-desktop-runtime.sh
@@ -21,7 +21,38 @@ kde)
 		dm=sddm
 	fi
 	;;
-niri | cosmic) dm=greetd ;;
+niri) dm=greetd ;;
+cosmic)
+	# Same shape as the kde case above: a package can claim the
+	# display-manager.service alias before we get here, and `systemctl
+	# enable` on a different DM then hard-fails rather than winning.
+	#
+	# The PPA's cosmic-greeter deb enables cosmic-greeter.service and points
+	# display-manager.service at it in its postinst, so the greetd line blew
+	# up the whole grouper:cosmic build:
+	#
+	#   Failed to enable unit: File '/etc/systemd/system/display-manager.service'
+	#   already exists and is a symlink to /lib/systemd/system/cosmic-greeter.service
+	#
+	# (LUKS run 31135761136.) Deferring to the claim is also right on the
+	# merits — cosmic-greeter IS COSMIC's greeter, and it is already enabled
+	# at this point.
+	#
+	# This tests the CLAIM, not the package, and that distinction is the
+	# whole safety argument. Fedora and EL10 install cosmic-greeter too, and
+	# their cosmic cells are green today *because* `systemctl enable greetd`
+	# succeeds there — which is direct evidence their scriptlets leave the
+	# alias alone. Keying off "is cosmic-greeter installed" would have
+	# repointed those images; keying off the symlink cannot.
+	#
+	# NOT `systemctl enable --force`: the kde comment above records why
+	# forcing the alias is the wrong instrument (tunaOS#824).
+	if [[ "$(readlink -f /etc/systemd/system/display-manager.service 2>/dev/null)" == *cosmic-greeter.service ]]; then
+		dm=cosmic-greeter
+	else
+		dm=greetd
+	fi
+	;;
 xfce)
 	if systemctl list-unit-files lightdm.service --no-legend 2>/dev/null | grep -q '^lightdm.service'; then
 		dm=lightdm

--- a/build_scripts/desktop/configure-desktop-runtime.sh
+++ b/build_scripts/desktop/configure-desktop-runtime.sh
@@ -63,7 +63,41 @@ xfce)
 *) exit 0 ;;
 esac
 
-systemctl enable "${dm}.service"
+# Still a hard failure — an image with no display manager is worse than a
+# failed build, which is why none of the branches above use `|| true`. But say
+# what happened before dying. systemd's own message names a FILE:
+#
+#   Failed to enable unit: File '/etc/systemd/system/display-manager.service'
+#   already exists and is a symlink to /lib/systemd/system/cosmic-greeter.service
+#
+# which does not mention the desktop, the package that claimed it, or what to
+# do. Reading that cost three separate 20-minute grouper:cosmic builds
+# (LUKS run 31135761136). The two cases have opposite fixes, so name which one
+# this is.
+if ! systemctl enable "${dm}.service"; then
+	# -L first: `readlink -f` prints the canonical path even when the file
+	# does not exist, so testing its output for emptiness reports "claimed by
+	# display-manager.service" on a system where nothing claimed anything —
+	# the opposite diagnosis, with the opposite fix. Caught by the
+	# unclaimed-alias case below before this shipped.
+	_dm_claim=""
+	if [[ -L /etc/systemd/system/display-manager.service ]]; then
+		_dm_claim="$(readlink -f /etc/systemd/system/display-manager.service 2>/dev/null || true)"
+	fi
+	echo "ERROR: cannot enable ${dm}.service as ${desktop}'s display manager." >&2
+	if [[ -n "${_dm_claim}" && "${_dm_claim##*/}" != "${dm}.service" ]]; then
+		echo "       display-manager.service is already claimed by ${_dm_claim##*/}," >&2
+		echo "       set by that package's post-install before this script ran." >&2
+		echo "       Defer to it (see how the kde and cosmic branches above pick" >&2
+		echo "       a DM) rather than forcing the alias — forcing it repoints" >&2
+		echo "       every image that shares this path (tunaOS#824)." >&2
+	else
+		echo "       Nothing else claims the alias, so ${dm}.service is most" >&2
+		echo "       likely not installed. Check that the ${desktop} manifest" >&2
+		echo "       actually pulls in the package providing it." >&2
+	fi
+	exit 1
+fi
 systemctl set-default graphical.target
 
 # Every desktop family ships an explicit runtime contract plus the

--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -531,6 +531,39 @@ if [[ "${_TD_DM}" == "sddm" && -f /usr/lib/systemd/system/plasmalogin.service ]]
 	echo "install-desktop: manifest declares sddm but image ships plasmalogin.service — resolving to plasmalogin"
 	_TD_DM="plasmalogin"
 fi
+# Same shape, for COSMIC on apt. cosmic-greeter is not a rival display manager
+# to greetd -- it IS greetd, wrapped:
+#   ExecStart=greetd --config /etc/greetd/cosmic-greeter.toml   (vt = "1")
+# and the deb declares `Provides: x-display-manager`, `Pre-Depends: greetd`.
+# Its postinst then points /etc/systemd/system/display-manager.service at
+# cosmic-greeter.service via debconf (the unit's own `[Install] Alias=` is
+# commented out and debconf-managed), and it arrives as a cosmic-session
+# dependency, so it is installed even though cosmic.yaml's apt list never names
+# it.
+#
+# configure-desktop-runtime.sh already defers to that claim (it has to: its
+# `systemctl enable` is not `|| true`, and the conflict killed the whole
+# grouper:cosmic build in LUKS run 31135761136). This is the other half, and it
+# is not cosmetic: leaving _TD_DM as the manifest's "greetd" force-links
+# greetd.service into graphical.target.wants below, and Ubuntu's greetd.service
+# carries `[Install] Alias=display-manager.service` and NO WantedBy=, so that
+# link is the only thing that would ever start it. Two units then run `greetd`
+# on vt1 -- both with Restart=always -- which is the two-DMs-racing-for-seat0
+# failure the sibling-link cleanup below exists to prevent.
+#
+# Narrow on purpose, for the same reason as configure-desktop-runtime.sh: keyed
+# on the alias the distro's own packaging has ALREADY set, not on
+# cosmic-greeter.service merely existing. Fedora and EL10 install cosmic-greeter
+# too, and their cosmic cells are green with greetd as the DM, so a
+# package-presence test would repoint them; the symlink test cannot.
+if [[ "${_TD_DM}" == "greetd" ]]; then
+	_TD_DM_ALIAS_NOW="$(readlink -f /etc/systemd/system/display-manager.service 2>/dev/null || true)"
+	if [[ -n "${_TD_DM_ALIAS_NOW}" && -e "${_TD_DM_ALIAS_NOW}" ]] &&
+		[[ "$(basename "${_TD_DM_ALIAS_NOW}")" == "cosmic-greeter.service" ]]; then
+		echo "install-desktop: display-manager.service is already cosmic-greeter (greetd wrapper) — resolving greetd to cosmic-greeter"
+		_TD_DM="cosmic-greeter"
+	fi
+fi
 
 if [[ -n "${_TD_DM}" && "${_TD_DM}" != "null" ]]; then
 	safe_enable "${_TD_DM}.service"

--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -60,6 +60,25 @@ elif command -v zypper &>/dev/null; then
 	_TD_OS="zypper"
 elif command -v emerge &>/dev/null; then
 	_TD_OS="emerge"
+elif [[ "${IS_HUMMINGBIRD:-false}" == true ]]; then
+	# Hummingbird gets its own section rather than borrowing fedora's.
+	#
+	# It IS a Fedora Rawhide rebuild — 30 of 38 core packages carry Rawhide's
+	# exact version AND release, differing only in the .hum1 dist tag — so
+	# routing it to el10, which lib.sh's substring test does, is a
+	# misclassification. But `fedora` is equally wrong, and that is the part
+	# worth stating: of the 58 packages the GNOME manifest installs on a
+	# Fedora-family host, Hummingbird's 3384-package repository ships exactly
+	# ONE (avahi). No cairo, no wayland, no mesa, no gtk, no pipewire; its own
+	# SBOM lists 444 names, none of them desktop. It publishes a base OS and
+	# no desktop, so the fedora: section would fail exactly as el10: did —
+	# just further along. Measured in tuna-os/tunaos-packages#250.
+	#
+	# Rawhide's own binaries cannot be substituted either: glibc 2.43 vs 2.44
+	# (637 Rawhide binaries need GLIBC_2.44), libxml2.so.16 vs .so.2,
+	# libcrypto.so.3 vs .so.4. They have to be rebuilt against Hummingbird's
+	# buildroot, which is what the hummingbird: manifest sections point at.
+	_TD_OS="hummingbird"
 elif [[ "$IS_FEDORA" == true ]]; then
 	_TD_OS="fedora"
 else
@@ -339,11 +358,16 @@ if [[ "${_TD_OS}" == "pacman" ]]; then
 	# now runs the same gate every other package manager does.
 fi
 
-# ── DNF path (el10/fedora only) ──────────────────────────────────────────────
+# ── DNF path (el10/fedora/hummingbird) ───────────────────────────────────────
 # These sections are maps (groups/group_options/copr/optional/versionlock). The
 # list-style sections (apt/pacman/zypper/emerge) installed above and must skip
 # this — indexing an array with .group_options etc. is a hard yq error.
-if [[ "${_TD_OS}" == "el10" || "${_TD_OS}" == "fedora" ]]; then
+#
+# hummingbird belongs here because it is dnf-driven like the other two; what
+# differs is only WHICH repository satisfies the names, which the manifest's
+# hummingbird: section supplies. Leaving it out would route a dnf base down
+# the list-style path and produce that same yq error.
+if [[ "${_TD_OS}" == "el10" || "${_TD_OS}" == "fedora" || "${_TD_OS}" == "hummingbird" ]]; then
 
 	# Plain (non-COPR) baseurl repos — e.g. the tuna-os xfce-wayland repo,
 	# which lives at its own R2 path (repo.tunaos.org/xfce/...), not the main

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -52,7 +52,7 @@ Measured against the set `luks-e2e.yml` schedules: every published desktop image
 | **bonito** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **bonito-rawhide** | ✅ | ❌ | ✅ | ✅ | ✅ |
 | **flounder** | ✅ | ✅ | ❌ | — | ✅ |
-| **flounder-sid** | ✅ | ✅ | ❌ | — | ✅ |
+| **flounder-sid** | ✅ | ✅ | — | — | ✅ |
 | **grouper** | ✅ | ❌ | ❌ | — | ❌ |
 | **guppy** | ❌ | ❌ | — | — | ❌ |
 | **gurnard** | — | — | — | — | — |

--- a/docs/ci-troubleshooting.md
+++ b/docs/ci-troubleshooting.md
@@ -324,6 +324,50 @@ media is dev/E2E. The cell continues on the caller's binary and emits a
 
 ---
 
+### 7. A guest that overstays its poweroff makes the next boot impossible (2026-08-07)
+
+**Affected:** any LUKS cell whose guest is slow to shut down. Measured on
+`albacore:cosmic`, run 31140233496 — where `yellowfin:cosmic` passed on the
+same commit, so this presents as one flaky cell.
+
+**Symptom:**
+
+```
+==> fisherman install complete. Shutting down...
+==> Waiting for VM to shut down...
+==> LUKS passphrase gate: booting installed disk, injecting passphrase, expecting login...
+qemu-system-x86_64: cannot create PID file: Cannot lock pid file: Resource temporarily unavailable
+##[error]Process completed with exit code 1
+```
+
+**The misleading part.** The install had already logged `Installation
+complete!` and the encrypted-disk evidence had already passed. The cell died
+70 seconds later with no `ERROR:` line of its own — just qemu's one-liner and
+a bare `exit 1` — which reads like a harness bug in whatever ran last (here,
+the timelapse, which was merely the next thing to print).
+
+**Root cause.** `poweroff_and_wait_vm` waited 30 × 2s and then returned
+regardless. Its callers immediately launch the installed-disk boot on the
+**same** `-pidfile`, and QEMU holds an exclusive lock on that file for its
+entire life, so a guest still running at the end of the window does not delay
+the gate, it forbids it. Two lines earlier in that run fisherman had reported
+`cryptsetup luksClose: Device fisherman-root is still in use`, and a busy dm
+device is exactly what `systemd-shutdown` spends its shutdown retrying — on
+top of systemd's own 90s `DefaultTimeoutStopSec`, which 70s cannot outlast.
+The generic path has a second stake in this: `swtpm` only exits when its QEMU
+disconnects, and the TPM gate restarts it.
+
+**Fix.** Wait long enough for a slow-but-healthy shutdown
+(`TUNAOS_E2E_POWEROFF_WAIT`, default 180s), then stop asking: ACPI
+`system_powerdown` over the monitor, then `SIGTERM`, then `SIGKILL`, and do
+not return until the process is actually gone. The install is finished and its
+target filesystem is already unmounted, frozen and flushed by then, so ending
+the guest ourselves costs the following boot nothing. If it survives `SIGKILL`
+the function now fails with that as the reason, and the passphrase gate's own
+launch names a QEMU it could not start instead of exiting silently.
+
+---
+
 ## Glossary of Components
 
 | Tool | Role | Source |

--- a/docs/ci-troubleshooting.md
+++ b/docs/ci-troubleshooting.md
@@ -301,6 +301,27 @@ already had one*. The error path now also distinguishes "the override path
 does not exist on the runner" from "the file exists, so the scp/install
 failed".
 
+**What the reorder took with it.** The generic (non-tunaOS) bootc path keyed
+off that same check — *no fisherman on the image* **and** `TBOX_E2E_IMAGE` set.
+Once the override lands first, the first half is never true again, so a caller
+naming a generic image would have taken the fisherman path and installed a
+tunaOS ref resolved from `VARIANT`/`FLAVOR` instead. The image is therefore
+probed **once, before** the override, and that probe is what the diversion
+reads; the check after the override is only there to prove the override landed.
+
+**Two more consequences of an image that ships nothing.** `install -D` cannot
+create `/usr/local/bin` on the ostree layout: `-D` uses `mkdir -p`, `/usr/local`
+is a symlink to a `../var/usrlocal` the image does not contain, and `mkdir -p`
+refuses to create *through* a dangling symlink (`cannot create directory
+'/usr/local': File exists` — the same failure `customize-live.sh` documents at
+the symlink it makes at build time). Canonicalise with `readlink -m` first.
+
+And the missing fisherman is itself a defect worth naming: the flatpak carrying
+it carries the installer GUI, so that ISO has no installer a human could use —
+`customize-live.sh` only downgrades the failed install to a warning because the
+media is dev/E2E. The cell continues on the caller's binary and emits a
+`::warning::` saying it did **not** cover that ISO's own installer.
+
 ---
 
 ## Glossary of Components

--- a/docs/ci-troubleshooting.md
+++ b/docs/ci-troubleshooting.md
@@ -191,6 +191,118 @@ environment.
 
 ---
 
+### 5. COSMIC cells pass the LUKS gate while shipping a greeter that never starts (2026-08-07)
+
+**Affected:** every cosmic cell where both `greetd` and `cosmic-greeter` are
+installed. Measured on `skipjack:cosmic` (run 31136849989) and
+`albacore:cosmic` (run 31100129320). **Both are ticked green on
+`docs/MATRIX-STATUS.md`.**
+
+**Symptom.** The gate passes outright —
+
+```
+TUNAOS_LUKS_E2E_PASS encrypted=1 passphrase_unlock=1 installed_boot=1
+```
+
+— and the desktop contract fails beside it, non-fatally, so nothing goes red:
+
+```
+TUNAOS_LUKS_E2E_DESKTOP_CONTRACT desktop_contract=fail fatal=0
+```
+
+The `dm_diag` block `verify-desktop-experience.sh` ships with `dm_inactive`
+(added exactly because the DM logs to the journal while the gate can only read
+the serial console) gives the mechanism:
+
+```
+greetd: unable to start greeter: terminal: unable to take controlling
+        terminal: EPERM: Operation not permitted
+cosmic-greeter.service: Main process exited, code=exited, status=1/FAILURE
+cosmic-greeter.service: Scheduled restart job, restart counter is at 1.
+Id=cosmic-greeter.service  SubState=auto-restart  NRestarts=1
+```
+
+**Root cause chain.**
+
+```
+cosmic-greeter (COPR on EL10, deb on Ubuntu) claims display-manager.service
+  → the manifest also declares display_manager: greetd, which
+    install-desktop.sh force-links into graphical.target.wants
+      → two units, both running `greetd` on vt = 1, both Restart=always
+        → greetd takes the controlling terminal first
+          → cosmic-greeter gets EPERM and crash-loops forever
+```
+
+Ubuntu FAILED THE BUILD on this (greetd.service there carries
+`[Install] Alias=display-manager.service` and no `WantedBy=`, so
+`systemctl enable greetd` collides with the existing alias). Fedora/EL ship
+`WantedBy=` and no `Alias=`, so there is no collision, the build SUCCEEDS, and
+the race ships. Succeeding is the worse outcome.
+
+**Controls** — same EL10 base, same headless QEMU, same harness:
+
+| cell | display-manager.service | contract |
+|---|---|---|
+| skipjack:cosmic | cosmic-greeter.service | **fail** |
+| albacore:cosmic | cosmic-greeter.service | **fail** |
+| skipjack:niri | greetd.service | ok |
+| skipjack:xfce | greetd.service | ok |
+| bonito-rawhide:kde | plasmalogin.service | ok |
+
+So the contract is a working check that a desktop can pass, and cosmic is the
+outlier. Two hypotheses were killed getting here and are recorded so nobody
+re-runs them: it is **not** the contract racing its own `graphical.target`
+(the unit reaches `auto-restart` with `ExecMainStatus=1` — it starts and
+dies), and `rendered=absent` is **not** a signal of a broken desktop — it
+appears on niri and xfce cells whose contract passes, because the harness runs
+headless with no render node (`GPU: -vga virtio headless (no
+render node/virgl)`). Only Plasma draws in this environment.
+
+**Fix.** Both halves key off the symlink, never off whether cosmic-greeter is
+installed: `configure-desktop-runtime.sh` picks whichever greeter already owns
+the alias, and `install-desktop.sh` stops force-linking greetd beside it.
+
+**Why it stayed invisible.** `desktop_contract` is `fatal=0`. The LUKS gate
+asserts encryption, passphrase unlock and installed boot — all genuinely true
+here — and `docs/MATRIX-STATUS.md` §1 already states that LUKS "does not
+prove ... that a desktop session starts". Nothing was lying; there was simply
+no axis reporting the contract, so a dead greeter and a working one look
+identical from the board.
+
+### 6. `FISHERMAN_OVERRIDE` never installed on images that ship no fisherman (2026-08-07)
+
+**Affected:** all three `guppy` cells (Gentoo). Measured on `guppy:xfce`,
+run 31131624108.
+
+**Symptom:**
+
+```
+ERROR: fisherman not found on live image (VARIANT=guppy FLAVOR=xfce)
+ERROR: and TBOX_E2E_IMAGE is unset, so the generic bootc path cannot name
+       an image ref
+exit code 3
+```
+
+**The misleading part.** The run spans 23:34 to 01:44, which reads exactly
+like a 65-minute Gentoo build plus the 3600s `TUNAOS_E2E_INSTALL_TIMEOUT`. It
+is not: the LUKS step ran for **55 seconds**. Everything before it was the
+build. Check the step's own start/end times before concluding a timeout.
+
+**Root cause.** `run_install()` in `scripts/iso-e2e.sh` had two statements
+~260 lines apart: a hard `return 3` if `/usr/local/bin/fisherman` is absent,
+and — far below it — the `scp` + `install` that puts `FISHERMAN_OVERRIDE`
+at exactly that path. The check ran first, so an image shipping no fisherman
+died without ever installing the binary the workflow had just built for it,
+with "Build fisherman in a golang container" green immediately above.
+
+**Fix.** Install the override before the check. That is also what the flag
+means: *use this fisherman*, not *use this fisherman provided the image
+already had one*. The error path now also distinguishes "the override path
+does not exist on the runner" from "the file exists, so the scp/install
+failed".
+
+---
+
 ## Glossary of Components
 
 | Tool | Role | Source |

--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -36,7 +36,15 @@ packages:
       - cosmic-term
       - cosmic-wallpapers
       - cosmic-workspaces
-      - cosmic-icon-theme
+      # cosmic-ICONS, not cosmic-icon-theme. The RPM name is the theme one and
+      # it is what this list said, so apt exited 100 on the single name it
+      # could not find and took the whole transaction with it:
+      #   E: Unable to locate package cosmic-icon-theme
+      # (grouper:cosmic, LUKS run 31135209477 — the other 20 names resolved).
+      # ppa:hepp3n/cosmic-epoch publishes 46 binaries for resolute; the icon
+      # set among them is `cosmic-icons` 1.5.0~b78b059, and no package whose
+      # name contains "icon-theme" exists there at all except pop-icon-theme.
+      - cosmic-icons
       - greetd
       - xdg-desktop-portal-cosmic
 

--- a/manifests/desktops/gnome.yaml
+++ b/manifests/desktops/gnome.yaml
@@ -25,7 +25,7 @@ packages:
     - gnome-keyring
 
   fedora:
-    packages:
+    packages: &fedora_gnome_packages
       - ModemManager
       - NetworkManager-adsl
       - NetworkManager-openconnect-gnome
@@ -88,6 +88,29 @@ packages:
       - PackageKit-command-not-found
       - gnome-software
       - gnome-software-fedora-langpacks
+
+  # ── Hummingbird ────────────────────────────────────────────────────────
+  # Hummingbird is a Fedora Rawhide rebuild: 30 of 38 core packages carry
+  # Rawhide's exact version AND release, differing only in the .hum1 dist tag.
+  # So the package NAMES are Fedora's, and this section aliases the fedora
+  # list above rather than restating it — a second copy across five desktop
+  # manifests is how these files drift apart.
+  #
+  # What differs is only where the names resolve from. Hummingbird publishes a
+  # base OS and no desktop: of the 58 packages the fedora list installs, its
+  # 3384-package repository ships exactly one (avahi). Rawhide's own binaries
+  # cannot be substituted either — glibc 2.43 vs 2.44, libxml2.so.16 vs .so.2,
+  # libcrypto.so.3 vs .so.4 — so they are rebuilt against Hummingbird's
+  # buildroot and published here. Measured in tuna-os/tunaos-packages#250.
+  #
+  # NOTE: not usable until that build lands — the baseurl below currently 404s.
+  # The wiring is here so the cell works the moment it does.
+  hummingbird:
+    repos:
+      - name: tunaos-hummingbird
+        baseurl: https://repo.tunaos.org/hummingbird/20251124-x86_64/
+        priority: 5
+    packages: *fedora_gnome_packages
 
   el10:
     # COPR repos for GNOME 50 backport — EL10 ships GNOME 48 natively.

--- a/scripts/build-image-inner.sh
+++ b/scripts/build-image-inner.sh
@@ -145,17 +145,32 @@ build_primary_image() {
 		.
 }
 
-# Blacksmith's amd64/v2 runners intermittently fail before a Buildah build
-# starts with `open out/index.json: no such file or directory`. The same
-# inputs reliably succeed on a fresh invocation, so retry the whole build
-# rather than making a transient storage race fail the flavor/manifest job.
+# Retry the whole build on failure. Two distinct transients, both of which
+# reliably succeed on a fresh invocation of the same inputs:
+#
+#   * Blacksmith's amd64/v2 runners intermittently fail before a Buildah build
+#     starts with `open out/index.json: no such file or directory`.
+#   * Pulling the base image dies mid-blob against the registry CDN:
+#
+#       Error: creating build container: copying system image from manifest
+#       list: writing blob ...: happened during read: unexpected EOF (while
+#       reconnecting: Get "https://cdn01.quay.io/...": EOF)
+#
+#     LUKS albacore:niri, run 31135329021 — 6 seconds in, on almalinux-bootc.
+#
+# The retry used to be gated on `BUILDER == buildah`, which is where the
+# second one got through: the ISO path builds with podman, so it took the
+# `!= buildah` branch and exited after ONE attempt. That is what the log said
+# ("image build failed after 1 attempt(s)"), and it reads like an exhausted
+# retry rather than an absent one. Nothing about a half-transferred blob is
+# specific to a builder, so the gate is gone; the loop is the same otherwise.
 build_attempt=1
 until build_primary_image; do
-	if [[ "${BUILDER}" != "buildah" || "${build_attempt}" -ge 3 ]]; then
+	if [[ "${build_attempt}" -ge 3 ]]; then
 		echo "ERROR: image build failed after ${build_attempt} attempt(s)" >&2
 		exit 1
 	fi
-	echo "Buildah build attempt ${build_attempt} failed; retrying in $((build_attempt * 10))s..." >&2
+	echo "${BUILDER} build attempt ${build_attempt} failed; retrying in $((build_attempt * 10))s..." >&2
 	sleep "$((build_attempt * 10))"
 	build_attempt=$((build_attempt + 1))
 done

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -257,19 +257,54 @@ def desktop_table(matrix, results, key_fmt) -> list[str]:
 
 
 def tally(matrix, results, key_fmt):
+    """Count only cells build-config actually schedules.
+
+    A stale result for a cell the matrix no longer declares used to be counted,
+    because `hit` alone was enough to enter the denominator. That put
+    flounder:cosmic and flounder-sid:cosmic in the LUKS totals as permanent
+    failures: both flavours were removed on purpose in 491544d1 ("drop the
+    COSMIC flavours Debian cannot build"), so no run will ever turn them green,
+    and the board read 39 of 54 when the live set was 52.
+
+    Two cells is small; the dishonesty is not. It is the same one nvidia_tally
+    below was written to fix — a gap nobody is ever going to close, reported as
+    if someone should. Undeclared cells now get the same treatment: out of the
+    tally, and disclosed by count so the number visibly shrinks as they age out
+    rather than vanishing silently.
+
+    This does NOT hide a failing cell. A cell build-config still declares is
+    counted whether it passes, fails or has never run.
+    """
     total = tested = passed = 0
     for variant in variants_in_scope(matrix, results):
         flavors = matrix.get(variant, set())
         for d in DESKTOPS:
-            hit = results.get(key_fmt(variant, d))
-            if d not in flavors and not hit:
+            if d not in flavors:
                 continue
+            hit = results.get(key_fmt(variant, d))
             total += 1
             if hit:
                 tested += 1
                 if hit[0] == "success":
                     passed += 1
     return total, tested, passed
+
+
+def undeclared_tally(matrix, results, key_fmt):
+    """Stale results for cells build-config no longer schedules.
+
+    Deliberately reported rather than dropped: a flavour that disappears from
+    build-config while red should not simply stop being mentioned. Returns the
+    "variant:flavor" names so the disclosure can say which, and so the count
+    reaching zero is checkable.
+    """
+    stale = []
+    for variant in variants_in_scope(matrix, results):
+        flavors = matrix.get(variant, set())
+        for d in DESKTOPS:
+            if d not in flavors and results.get(key_fmt(variant, d)):
+                stale.append(f"{variant}:{d}")
+    return sorted(stale)
 
 
 def nvidia_tally(matrix, results, key_fmt):
@@ -337,6 +372,10 @@ def build() -> str:
     nv_stale = nvidia_tally(
         _matrix("build_image", desktops_only=False), luks, luks_key
     )
+    # lmatrix here, unlike the NVIDIA count above: this asks which of the
+    # DESKTOPS columns the table renders are no longer scheduled, and that is
+    # exactly the desktops_only matrix the table itself is built from.
+    undeclared = undeclared_tally(lmatrix, luks, luks_key)
     out += [
         "## LUKS E2E",
         "",
@@ -365,6 +404,27 @@ def build() -> str:
             f"takes the identical LUKS path in headless QEMU. "
             f"{nv_stale} stale pre-exclusion result(s) remain from before "
             "that change; they are not a gap and will age out.",
+            "",
+        ]
+
+    # Named, not just counted, and left visible in the table above: a flavour
+    # that leaves build-config while red must not simply stop being mentioned.
+    # It is out of the tally because no run can ever move it, which is a
+    # different statement from "it passed".
+    if undeclared:
+        out += [
+            "The table above still shows a result for "
+            + ", ".join(f"`{c}`" for c in undeclared)
+            + ". `.github/build-config.yml` no longer declares "
+            + ("that flavour" if len(undeclared) == 1 else "those flavours")
+            + ", so `luks-e2e.yml` cannot schedule "
+            + ("it" if len(undeclared) == 1 else "them")
+            + " and no run will ever turn "
+            + ("it" if len(undeclared) == 1 else "them")
+            + " green. "
+            + ("It is" if len(undeclared) == 1 else "They are")
+            + " excluded from the count above — a last-measured verdict kept "
+            "visible, not a gap. Same reasoning as the NVIDIA note.",
             "",
         ]
 
@@ -452,6 +512,7 @@ VOLATILE_LINE = re.compile(
     r"\| \d{4}-\d\d-\d\d \| \["          # provenance row
     r"|Newest result "                    # freshness of the LUKS data
     r"|NVIDIA cells are "                 # present only while stale results remain
+    r"|The table above still shows a result for "  # same: only while they remain
     r"|Missing for "                      # depends on published overlay tags
     r"|Every non-NVIDIA ISO cell has an overlay"
     r")"

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -1655,11 +1655,38 @@ run_install() {
 	# --block-setup tpm2-luks` doesn't cover the same way and that real users
 	# never exercise directly. See docs/ci-troubleshooting.md's fisherman
 	# glossary entry.
+	# Does THIS IMAGE ship fisherman? Probed once, before the override lands,
+	# because two separate decisions read it and they need different answers.
+	#
 	# Generic (non-tunaOS) images ship no fisherman. When the caller names
 	# the image (TBOX_E2E_IMAGE), install it with plain bootc instead — see
 	# run_install_generic. Without a named image the hard error stands:
 	# guessing a registry ref from an ISO filename is exactly the mistake
 	# the published-image-ref.sh resolver below exists to prevent.
+	#
+	# That choice is about the image, not about what this function copied onto
+	# it a moment ago. Reading it off /usr/local/bin/fisherman *after* the
+	# override installs would hand every TBOX_E2E_IMAGE caller the fisherman
+	# path instead, and recipe_image below resolves a *tunaOS* ref from
+	# VARIANT/FLAVOR — so a caller-named generic image would be silently
+	# swapped for a tunaOS one. Probe first, decide, then override.
+	local image_has_fisherman=1
+	"${ssh_cmd[@]}" "command -v /usr/local/bin/fisherman" &>/dev/null || image_has_fisherman=0
+	if [[ "$image_has_fisherman" -eq 0 && -n "${TBOX_E2E_IMAGE:-}" ]]; then
+		run_install_generic
+		return $?
+	fi
+
+	# An image that ships no fisherman ships no installer GUI either: the
+	# flatpak that carries the binary is the same one that carries the
+	# frontend, and customize-live.sh downgrades a failed install of it to a
+	# warning on dev/E2E media (`.enable-sshd`). The override below makes the
+	# LUKS install path testable anyway, which is right — but say out loud
+	# what this cell then does NOT cover.
+	if [[ "$image_has_fisherman" -eq 0 ]]; then
+		echo "::warning::live image ships no /usr/local/bin/fisherman (the installer flatpak is missing from the squash) — this cell tests the LUKS install with the caller's binary, not that ISO's own installer"
+	fi
+
 	# Install the override BEFORE the presence check below, not after it.
 	#
 	# This block used to live ~260 lines further down, next to the recipe.
@@ -1683,16 +1710,32 @@ run_install() {
 	if [[ -n "${FISHERMAN_OVERRIDE:-}" && -f "${FISHERMAN_OVERRIDE}" ]]; then
 		echo "==> Overriding fisherman with ${FISHERMAN_OVERRIDE}"
 		"${scp_cmd[@]}" "${FISHERMAN_OVERRIDE}" "${GUEST_SCP_DEST}:${GUEST_HOME}/fisherman-override"
-		"${ssh_cmd[@]}" "sudo install -D -m0755 ${GUEST_HOME}/fisherman-override /usr/local/bin/fisherman"
+		# Create the directory separately rather than letting `install -D` do
+		# it. Now that the override also has to work on an image that shipped
+		# none, /usr/local/bin may not exist — and on the ostree layout
+		# /usr/local is a symlink to a ../var/usrlocal that the image does not
+		# contain, where mkdir -p (which is what -D uses) refuses to create
+		# *through* a dangling symlink and dies with the confusing
+		#
+		#   mkdir: cannot create directory '/usr/local': File exists
+		#
+		# `readlink -m` canonicalises without requiring the path to exist, so
+		# this creates /var/usrlocal/bin on the symlinked layout and
+		# /usr/local/bin on the plain one, and the install below resolves
+		# through the symlink either way. Same trick, same reason, as the
+		# symlink customize-live.sh makes at build time.
+		"${ssh_cmd[@]}" "sudo mkdir -p \$(readlink -m /usr/local/bin)"
+		"${ssh_cmd[@]}" "sudo install -m0755 ${GUEST_HOME}/fisherman-override /usr/local/bin/fisherman"
 	fi
 
 	if ! "${ssh_cmd[@]}" "command -v /usr/local/bin/fisherman" &>/dev/null; then
-		if [[ -n "${TBOX_E2E_IMAGE:-}" ]]; then
-			run_install_generic
-			return $?
-		fi
 		echo "ERROR: fisherman not found on live image (VARIANT=${VARIANT:-} FLAVOR=${FLAVOR:-})" >&2
-		echo "ERROR: and TBOX_E2E_IMAGE is unset, so the generic bootc path cannot name an image ref" >&2
+		# Only true when the caller named no image: with TBOX_E2E_IMAGE set,
+		# an image that shipped no fisherman took the generic path above, so
+		# reaching here means the override clobbered a binary that was there.
+		if [[ -z "${TBOX_E2E_IMAGE:-}" ]]; then
+			echo "ERROR: and TBOX_E2E_IMAGE is unset, so the generic bootc path cannot name an image ref" >&2
+		fi
 		if [[ -n "${FISHERMAN_OVERRIDE:-}" ]]; then
 			echo "ERROR: FISHERMAN_OVERRIDE=${FISHERMAN_OVERRIDE} was set but did not land —" >&2
 			echo "ERROR: $([[ -f "${FISHERMAN_OVERRIDE}" ]] && echo 'the file exists, so the scp/install above failed' || echo 'that path does not exist on the runner')" >&2

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -676,6 +676,18 @@ reset_qemu_sockets() {
 
 # shellcheck disable=SC2329  # invoked via `trap cleanup_vm EXIT`
 cleanup_vm() {
+	# Stop the timelapse FIRST, while QEMU is still alive: the recorder reads
+	# frames through the monitor socket, and everything below this point is
+	# dedicated to killing the process that serves it. Assembly itself needs
+	# no VM, but a recorder still looping against a dead socket would spin
+	# until the trap finished.
+	#
+	# Unconditional and non-fatal. record-timelapse.sh returns 0 when there is
+	# nothing to assemble, and this runs on the EXIT trap — an error here would
+	# overwrite the exit status of the test that actually ran.
+	if [[ -n "${TIMELAPSE_DIR:-}" ]]; then
+		bash "${SCRIPT_DIR}/record-timelapse.sh" stop "$TIMELAPSE_DIR" || true
+	fi
 	# `|| true` is load-bearing under `set -e`: once the watchdog has FIRED it
 	# has already exited, so this kill fails, and without the guard the
 	# non-zero status aborts cleanup_vm right here — skipping the QEMU and
@@ -1564,6 +1576,15 @@ run_install_generic() {
 # This replaces the Anaconda kickstart approach (TunaOS uses bootc, not anaconda).
 run_install() {
 	record_luks_evidence "TUNAOS_LUKS_E2E_INSTALL_STARTED luks=${LUKS}"
+	# Film the install. Started here rather than at boot so the recording is
+	# the install itself, not the minutes of live-ISO boot that precede it,
+	# and stopped by cleanup_vm's EXIT trap so it ends however the cell ends.
+	#
+	# Best-effort throughout: record-timelapse.sh returns 0 when it cannot
+	# capture (no ffmpeg, or a virgl host where screendump has no surface), so
+	# a cell that installs correctly but cannot be filmed stays green.
+	TIMELAPSE_DIR="${OUTPUT_DIR}/timelapse"
+	bash "${SCRIPT_DIR}/record-timelapse.sh" start "$MONITOR_SOCK" "$TIMELAPSE_DIR" || true
 	echo "==> Waiting up to 60s for SSH..."
 	for _ in $(seq 1 30); do
 		check_ssh && break

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -1380,20 +1380,80 @@ append_installed_serial_kargs() {
 	BLSEOF
 }
 
+# Wait up to $2 seconds for pid $1 to leave the process table. 0 = it is gone.
+wait_pid_gone() {
+	local pid="$1" secs="$2" i
+	for ((i = 0; i < secs; i++)); do
+		kill -0 "$pid" 2>/dev/null || return 0
+		sleep 1
+	done
+	! kill -0 "$pid" 2>/dev/null
+}
+
+# Shut the guest down and do not return while its QEMU is still alive.
+#
+# Both callers launch the installed-disk boot immediately afterwards, reusing
+# $QEMU_PIDFILE — and QEMU holds an exclusive lock on that file for its entire
+# life. So a guest that overstays its poweroff does not merely delay the next
+# boot, it makes it impossible:
+#
+#   qemu-system-x86_64: cannot create PID file: Cannot lock pid file:
+#   Resource temporarily unavailable
+#
+# which under `set -e` ends the cell right there, minutes after the install it
+# was testing had already reported "Installation complete!" (run 31140233496,
+# albacore:cosmic). The generic path has a second stake in this: swtpm only
+# exits when its QEMU disconnects, and the TPM gate below restarts it.
+#
+# A guest can overstay for reasons that have nothing to do with the install.
+# In that run fisherman had just logged `cryptsetup luksClose: Device
+# fisherman-root is still in use`, and a busy dm device is exactly what
+# systemd-shutdown spends its shutdown retrying — on top of systemd's own 90s
+# DefaultTimeoutStopSec, which the previous 70s window could not outlast.
+# Hence: wait long enough for a slow-but-healthy shutdown, then stop asking.
+POWEROFF_WAIT_SECS="${TUNAOS_E2E_POWEROFF_WAIT:-180}"
+
 poweroff_and_wait_vm() {
-	"${GUEST_SSH[@]}" "sudo systemctl poweroff" 2>/dev/null || true
-	sleep 10
-	if [[ -f "$QEMU_PIDFILE" ]]; then
-		local pid
-		pid=$(cat "$QEMU_PIDFILE" 2>/dev/null || true)
-		if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
-			echo "==> Waiting for VM to shut down..."
-			for _ in $(seq 1 30); do
-				kill -0 "$pid" 2>/dev/null || break
-				sleep 2
-			done
-		fi
+	if ! "${GUEST_SSH[@]}" "sudo systemctl poweroff" 2>/dev/null; then
+		# Not fatal: the guest may be going down already (sshd dies mid-command
+		# often enough), and ACPI below is a second way in. But it changes what
+		# a long wait MEANS, so it must not be silent.
+		echo "==> note: 'systemctl poweroff' over ssh did not return cleanly" >&2
 	fi
+	sleep 10
+	[[ -f "$QEMU_PIDFILE" ]] || return 0
+	local pid
+	pid=$(cat "$QEMU_PIDFILE" 2>/dev/null || true)
+	[[ -n "$pid" ]] || return 0
+	kill -0 "$pid" 2>/dev/null || return 0
+
+	echo "==> Waiting for VM to shut down..."
+	wait_pid_gone "$pid" "$POWEROFF_WAIT_SECS" && return 0
+
+	# The install is finished by here — fisherman/bootc have unmounted, frozen
+	# and flushed the target filesystem — so ending the guest ourselves costs
+	# nothing the following boot needs. The ladder still gives it two chances
+	# to end itself first, and only escalates when it will not.
+	echo "==> VM did not power off within ${POWEROFF_WAIT_SECS}s; forcing it down" >&2
+	if [[ -S "$MONITOR_SOCK" ]] && command -v socat &>/dev/null; then
+		echo "system_powerdown" | socat - "UNIX-CONNECT:${MONITOR_SOCK}" 2>/dev/null || true
+		wait_pid_gone "$pid" 20 && return 0
+	fi
+	kill -TERM "$pid" 2>/dev/null || true
+	if ! wait_pid_gone "$pid" 10; then
+		kill -KILL "$pid" 2>/dev/null || true
+		wait_pid_gone "$pid" 5 || true
+	fi
+	if kill -0 "$pid" 2>/dev/null; then
+		echo "ERROR: QEMU pid ${pid} survived SIGKILL; the installed-disk boot cannot" >&2
+		echo "       take the ${QEMU_PIDFILE} lock while it holds it." >&2
+		return 6
+	fi
+	# QEMU unlinks its own pidfile when it exits normally and did not get the
+	# chance here. Leaving a dead pid behind would have cleanup_vm signalling
+	# whatever recycles the number, and would hide that the next launch is
+	# starting from a corpse.
+	rm -f "$QEMU_PIDFILE"
 }
 
 # Prefix a bare "org/name:tag" image path with the default registry; a ref
@@ -2165,7 +2225,16 @@ EOF
 			-netdev "user,id=net0" -device virtio-net-pci,netdev=net0 \
 			-monitor "unix:${MONITOR_SOCK},server,nowait" \
 			-serial "unix:${FB_SERIAL},server,nowait" \
-			"${QEMU_GPU_ARGS[@]}" -pidfile "$QEMU_PIDFILE" -daemonize
+			"${QEMU_GPU_ARGS[@]}" -pidfile "$QEMU_PIDFILE" -daemonize || {
+			# Without this the launch failure is a bare qemu message and a
+			# `set -e` exit, which is how run 31140233496 reported a pidfile
+			# collision as an unexplained "exit code 1" with no ERROR line to
+			# search for. Name it, and name the usual reason.
+			echo "ERROR: QEMU would not start for the LUKS passphrase gate (message above)" >&2
+			echo "       A 'cannot lock pid file' there means the install VM outlived" >&2
+			echo "       poweroff_and_wait_vm and still holds ${QEMU_PIDFILE}." >&2
+			return 5
+		}
 		# 5th arg: keep draining the serial for up to 300s past login waiting
 		# for the desktop contract. See luks-first-boot.py for why.
 		python3 "$(dirname "${BASH_SOURCE[0]}")/luks-first-boot.py" \

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -1660,6 +1660,32 @@ run_install() {
 	# run_install_generic. Without a named image the hard error stands:
 	# guessing a registry ref from an ISO filename is exactly the mistake
 	# the published-image-ref.sh resolver below exists to prevent.
+	# Install the override BEFORE the presence check below, not after it.
+	#
+	# This block used to live ~260 lines further down, next to the recipe.
+	# That is too late: the check is a hard `return 3`, so on any image that
+	# ships no fisherman the run died without ever installing the binary the
+	# job had just built for it. guppy:xfce, LUKS run 31131624108:
+	#
+	#   ERROR: fisherman not found on live image (VARIANT=guppy FLAVOR=xfce)
+	#   ERROR: and TBOX_E2E_IMAGE is unset, so the generic bootc path cannot
+	#          name an image ref
+	#
+	# 55 seconds into the LUKS step, after a 65-minute Gentoo build, with
+	# FISHERMAN_OVERRIDE=/tmp/fisherman-bin sitting on the runner and the
+	# workflow's own "Build fisherman in a golang container" step green
+	# immediately above it. All three guppy cells fail this way.
+	#
+	# Overriding first is also what the flag means: "use this fisherman", not
+	# "use this fisherman provided the image already had one". The bundled
+	# installer-flatpak fisherman is pinned to a release, which is why the
+	# override exists at all.
+	if [[ -n "${FISHERMAN_OVERRIDE:-}" && -f "${FISHERMAN_OVERRIDE}" ]]; then
+		echo "==> Overriding fisherman with ${FISHERMAN_OVERRIDE}"
+		"${scp_cmd[@]}" "${FISHERMAN_OVERRIDE}" "${GUEST_SCP_DEST}:${GUEST_HOME}/fisherman-override"
+		"${ssh_cmd[@]}" "sudo install -D -m0755 ${GUEST_HOME}/fisherman-override /usr/local/bin/fisherman"
+	fi
+
 	if ! "${ssh_cmd[@]}" "command -v /usr/local/bin/fisherman" &>/dev/null; then
 		if [[ -n "${TBOX_E2E_IMAGE:-}" ]]; then
 			run_install_generic
@@ -1667,6 +1693,10 @@ run_install() {
 		fi
 		echo "ERROR: fisherman not found on live image (VARIANT=${VARIANT:-} FLAVOR=${FLAVOR:-})" >&2
 		echo "ERROR: and TBOX_E2E_IMAGE is unset, so the generic bootc path cannot name an image ref" >&2
+		if [[ -n "${FISHERMAN_OVERRIDE:-}" ]]; then
+			echo "ERROR: FISHERMAN_OVERRIDE=${FISHERMAN_OVERRIDE} was set but did not land —" >&2
+			echo "ERROR: $([[ -f "${FISHERMAN_OVERRIDE}" ]] && echo 'the file exists, so the scp/install above failed' || echo 'that path does not exist on the runner')" >&2
+		fi
 		return 3
 	fi
 
@@ -1918,14 +1948,10 @@ run_install() {
 	local E2E_LUKS_PASS="tunaos-e2e-luks"
 	[[ "$LUKS" -eq 1 ]] && encryption_json="{\"type\": \"tpm2-luks-passphrase\", \"passphrase\": \"${E2E_LUKS_PASS}\"}"
 
-	# Override /usr/local/bin/fisherman with a freshly-built binary (e.g.
-	# from a PR under test) before installing — the bundled installer-flatpak
-	# fisherman is pinned to a release.
-	if [[ -n "${FISHERMAN_OVERRIDE:-}" && -f "${FISHERMAN_OVERRIDE}" ]]; then
-		echo "==> Overriding fisherman with ${FISHERMAN_OVERRIDE}"
-		"${scp_cmd[@]}" "${FISHERMAN_OVERRIDE}" "${GUEST_SCP_DEST}:${GUEST_HOME}/fisherman-override"
-		"${ssh_cmd[@]}" "sudo install -m0755 ${GUEST_HOME}/fisherman-override /usr/local/bin/fisherman"
-	fi
+	# (The FISHERMAN_OVERRIDE install used to be here. It now runs before the
+	# presence check near the top of this function — see the comment there.
+	# Doing it at this point meant an image that shipped no fisherman never
+	# reached it, which is exactly the case the override is for.)
 
 	local RECIPE_LOCAL="${OUTPUT_DIR}/e2e-recipe.json"
 	cat >"$RECIPE_LOCAL" <<EOF

--- a/scripts/record-timelapse.sh
+++ b/scripts/record-timelapse.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# record-timelapse.sh — capture the QEMU framebuffer during an install and
+# assemble a WebM timelapse, so a matrix cell leaves behind something a human
+# can watch instead of an 80,000-line serial log.
+#
+# Ported from tuna-os/wootc tests/e2e/record-video.sh, with three deliberate
+# differences:
+#
+#   * wootc drives QEMU inside a container and reaches the monitor with
+#     `podman exec`. Here QEMU runs directly on the runner, so the monitor
+#     unix socket is addressed straight through socat — the same channel
+#     iso-e2e.sh's screenshot() already uses for its screendump fallback.
+#   * No title cards. wootc has one linear story (Windows → deploy → Linux);
+#     a LUKS cell is one install, and the phase boundaries are already in the
+#     serial log next to the frame timestamps.
+#   * Assembly NEVER fails the caller. A cell that installs correctly but
+#     cannot be filmed is a green cell; treating a missing encoder as a test
+#     failure would turn a reporting nicety into a gate.
+#
+# Capture is `screendump` over the QEMU monitor, which is cheap enough to run
+# on a loop. That choice has one documented limit, and it is the reason this
+# does not simply call iso-e2e.sh's screenshot(): under virgl/GL scanout the
+# monitor answers "no surface" and screendump yields nothing (see the long
+# comment at iso-e2e.sh:831). screenshot() handles that by bridging VNC per
+# capture — a fresh socat listener and up to 5s of readiness polling EACH
+# TIME, which is right for a handful of stills and wrong for the ~300 frames
+# a ten-minute install produces. The LUKS matrix runs on GPU-less hosted
+# runners, where QEMU_GPU_ARGS is the plain `-vga virtio -display none` path
+# and screendump works. On a virgl host this records nothing and says so,
+# rather than pretending.
+#
+# Usage:
+#   record-timelapse.sh start <monitor-sock> <outdir> [interval-seconds]
+#   record-timelapse.sh stop  <outdir>
+set -Eeuo pipefail
+
+command="${1:?usage: record-timelapse.sh start|stop ...}"
+
+FPS="${TUNAOS_TIMELAPSE_FPS:-10}"
+
+snap_loop() {
+	local sock="$1" outdir="$2" interval="$3"
+	local n=0 frame
+	mkdir -p "$outdir/frames"
+	while :; do
+		frame="$(printf '%s/frames/f%06d.ppm' "$outdir" "$n")"
+		# screendump writes from QEMU's perspective, so the path must be one
+		# QEMU can write — it is the same filesystem here.
+		echo "screendump ${frame}" | socat - "UNIX-CONNECT:${sock}" >/dev/null 2>&1 || true
+		# Only advance the counter when a frame actually landed. ffmpeg's
+		# image2 demuxer needs a gapless sequence; a hole makes it stop at the
+		# gap and silently produce a truncated video.
+		[[ -s "$frame" ]] && n=$((n + 1)) || rm -f "$frame"
+		sleep "$interval"
+	done
+}
+
+assemble() {
+	local outdir="$1"
+	local fdir="$outdir/frames"
+	local nframes
+	# The directory may not exist: `stop` can be reached before the first
+	# capture landed (QEMU died early, or the monitor socket never appeared).
+	# Without this, `find` on a missing path fails, and under `set -o pipefail`
+	# that non-zero propagates through the command substitution and — with
+	# `set -e` — exits this script non-zero, failing an install that was
+	# otherwise fine. That is the exact contract this file exists to keep, and
+	# it was broken until a test caught it.
+	mkdir -p "$fdir"
+	nframes="$(find "$fdir" -maxdepth 1 -type f -name 'f*.ppm' 2>/dev/null | wc -l)"
+	printf '%s\n' "$nframes" >"$outdir/frame-count.txt"
+
+	if [[ "$nframes" -eq 0 ]]; then
+		# The virgl case, or a QEMU that died before the first capture. Say
+		# which, because "no video" with no reason reads as a broken script.
+		echo "==> No frames captured; no timelapse. On a virgl/GL-scanout host" >&2
+		echo "    screendump has no surface — that is expected there." >&2
+		return 0
+	fi
+
+	if ! command -v ffmpeg >/dev/null 2>&1; then
+		echo "==> ${nframes} frames captured but ffmpeg is absent; leaving frames only" >&2
+		return 0
+	fi
+
+	# -f image2 with an explicit pattern: without it ffmpeg guesses from the
+	# first filename and has been known to pick the wrong demuxer for .ppm.
+	ffmpeg -y -loglevel warning -framerate "$FPS" \
+		-f image2 -i "$fdir/f%06d.ppm" \
+		-c:v libvpx-vp9 -b:v 1M -pix_fmt yuv420p \
+		"$outdir/timelapse.webm" </dev/null || {
+		echo "==> ffmpeg could not assemble the timelapse; frames kept" >&2
+		return 0
+	}
+
+	# A still poster so a gallery can show something before anyone presses
+	# play, and so GitHub can render it inline. Half the capture rate and a
+	# fixed width keeps it small enough to commit if we ever want to.
+	ffmpeg -y -loglevel warning -framerate "$FPS" \
+		-f image2 -i "$fdir/f%06d.ppm" \
+		-vf 'fps=5,scale=640:-2:flags=lanczos' -loop 0 \
+		-c:v libwebp -quality 60 -compression_level 6 \
+		"$outdir/timelapse-poster.webp" </dev/null || true
+
+	echo "==> Timelapse: $outdir/timelapse.webm (${nframes} frames @ ${FPS}fps)"
+}
+
+case "$command" in
+start)
+	sock="${2:?start needs the QEMU monitor socket}"
+	outdir="${3:?start needs an output directory}"
+	interval="${4:-${TUNAOS_TIMELAPSE_INTERVAL:-2}}"
+	mkdir -p "$outdir"
+	# Recording is best-effort: if the monitor socket never appears the loop
+	# simply captures nothing, and assemble() reports that. It must not wedge
+	# the install waiting for it.
+	# Redirect the loop's descriptors rather than letting it inherit them: a
+	# backgrounded child holding the caller's stdout keeps readers of that
+	# pipe blocked until it exits, and this one runs until `stop`. That hung
+	# the test suite for two minutes before it was redirected here.
+	snap_loop "$sock" "$outdir" "$interval" >"$outdir/recorder.log" 2>&1 </dev/null &
+	printf '%s\n' "$!" >"$outdir/.recorder.pid"
+	echo "==> Timelapse recording started (every ${interval}s → ${outdir}/frames)"
+	;;
+stop)
+	outdir="${2:?stop needs the output directory}"
+	if [[ -f "$outdir/.recorder.pid" ]]; then
+		kill "$(cat "$outdir/.recorder.pid")" 2>/dev/null || true
+		wait "$(cat "$outdir/.recorder.pid")" 2>/dev/null || true
+		rm -f "$outdir/.recorder.pid"
+	fi
+	assemble "$outdir"
+	;;
+*)
+	echo "usage: record-timelapse.sh start|stop ..." >&2
+	exit 2
+	;;
+esac

--- a/tests/bats/test_build_image_retry.bats
+++ b/tests/bats/test_build_image_retry.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# The whole-image build retries on transient failure, whichever builder is used.
+#
+# scripts/build-image-inner.sh wraps its `${BUILDER} build` in an until-loop.
+# That loop used to bail immediately unless BUILDER was buildah:
+#
+#     if [[ "${BUILDER}" != "buildah" || "${build_attempt}" -ge 3 ]]; then
+#
+# The ISO path builds with podman, so every ISO build got zero retries, and
+# a base-image pull that died mid-blob against the registry CDN —
+#
+#     Error: creating build container: copying system image from manifest
+#     list: writing blob ...: happened during read: unexpected EOF
+#
+# — took out LUKS albacore:niri six seconds into run 31135329021. The log line
+# is the trap: "image build failed after 1 attempt(s)" reads like a retry that
+# ran out, not one that never happened.
+#
+# These tests drive the loop's logic directly rather than the whole script,
+# which needs a container runtime, a git tree and a Containerfile. What is
+# under test is the loop, and the loop is what is extracted.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/build-image-inner.sh"
+
+# The until-loop as it appears in the script: from the `build_attempt=1`
+# initialiser through the closing `done`. Extracted rather than restated so a
+# future edit to the loop is what these tests run.
+retry_loop() {
+	awk '/^build_attempt=1$/{f=1} f{print} f&&/^done$/{exit}' "$SCRIPT"
+}
+
+# Run the extracted loop with a stub build_primary_image that fails the first
+# $1 attempts, then succeeds. Echoes one line per attempt, then the exit code.
+# `sleep` is stubbed to nothing so 10s+20s of backoff does not become test time.
+run_loop() {
+	local fail_count="$1" builder="$2"
+	bash -c "
+		BUILDER='${builder}'
+		attempts=0
+		sleep() { :; }
+		build_primary_image() {
+			attempts=\$((attempts + 1))
+			echo \"attempt \$attempts\"
+			[ \$attempts -gt ${fail_count} ]
+		}
+		$(retry_loop)
+		echo \"exit 0\"
+	" 2>&1
+}
+
+@test "the loop was actually extracted from the script" {
+	run retry_loop
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"build_attempt=1"* ]]
+	[[ "$output" == *"until build_primary_image"* ]]
+	[[ "$output" == *"done"* ]]
+	# A one-line extraction would make every test below vacuous.
+	[ "$(wc -l <<<"$output")" -ge 6 ]
+}
+
+@test "a build that succeeds first time runs exactly once" {
+	run run_loop 0 podman
+	[[ "$output" == *"attempt 1"* ]]
+	[[ "$output" != *"attempt 2"* ]]
+	[[ "$output" == *"exit 0"* ]]
+}
+
+# The regression. Before the fix this stopped at one attempt and exited 1.
+@test "podman retries a transient failure" {
+	run run_loop 1 podman
+	[[ "$output" == *"attempt 2"* ]]
+	[[ "$output" == *"exit 0"* ]]
+}
+
+@test "buildah still retries a transient failure" {
+	run run_loop 1 buildah
+	[[ "$output" == *"attempt 2"* ]]
+	[[ "$output" == *"exit 0"* ]]
+}
+
+# Three attempts, not unbounded: a genuinely broken build must still fail, and
+# fail in bounded time rather than looping on a real error.
+@test "a persistently failing build gives up after three attempts" {
+	local b
+	for b in podman buildah; do
+		run run_loop 99 "$b"
+		[[ "$output" == *"attempt 3"* ]] || fail "$b did not reach attempt 3"
+		[[ "$output" != *"attempt 4"* ]] || fail "$b went past attempt 3"
+		[[ "$output" == *"failed after 3 attempt(s)"* ]] ||
+			fail "$b did not report exhaustion"
+		# `exit 1` inside the loop means the trailing marker never prints.
+		[[ "$output" != *"exit 0"* ]] || fail "$b returned success after giving up"
+	done
+}
+
+# The builder-specific gate is what caused the bug. Assert it is gone from the
+# source, so reintroducing it fails here with an explanation rather than
+# silently halving the retry coverage again.
+@test "the retry is not gated on the builder name" {
+	run retry_loop
+	[[ "$output" != *'!= "buildah"'* ]]
+	[[ "$output" != *'== "buildah"'* ]]
+}

--- a/tests/bats/test_containerfile_context_scripts.bats
+++ b/tests/bats/test_containerfile_context_scripts.bats
@@ -78,6 +78,67 @@ executed_script_refs() {
   [ "$fail" -eq 0 ]
 }
 
+# Per-DE desktop scripts a single Containerfile invokes, comments blanked.
+# Not install-desktop.sh (manifest-driven, handles every package manager) and
+# not configure-desktop-runtime.sh (post-install wiring, no package install).
+per_de_scripts() {
+  sed 's/^[[:space:]]*#.*//' "$1" |
+    grep -ohE '/run/context/build_scripts/desktop/[A-Za-z0-9_-]+\.sh' |
+    sed 's|.*/||' |
+    grep -vE '^(install-desktop|configure-desktop-runtime)\.sh$' |
+    sort -u
+}
+
+# An apt-based Containerfile must not invoke a per-DE script that has no apt
+# branch. desktop/cosmic.sh goes straight to `dnf -y copr enable`, so
+# Containerfile.ubuntu's cosmic stage died at
+#
+#   /run/context/build_scripts/desktop/cosmic.sh: line 41: dnf: command not found
+#   Error: building at STEP "RUN ...": while running runtime: exit status 127
+#
+# on every grouper:cosmic build (LUKS run 31134394662). It now uses
+# install-desktop.sh, which is what every other Containerfile already did for
+# cosmic and the only path that handles the `condition: ubuntu` PPA the Ubuntu
+# package list needs.
+#
+# test_declared_flavors_installable.bats could not catch this: cosmic.yaml's
+# apt section is present and non-empty, so the flavour looks installable — the
+# gap was the Containerfile reaching for a script that never consults it. This
+# is the structural half of that invariant, on the other side.
+@test "apt Containerfiles only invoke per-DE scripts that have an apt branch" {
+  local cf script base fail=0
+  for cf in "${REPO_ROOT}/Containerfile.ubuntu" "${REPO_ROOT}/Containerfile.debian"; do
+    while read -r script; do
+      [ -n "$script" ] || continue
+      base="${REPO_ROOT}/build_scripts/desktop/${script}"
+      [ -f "$base" ] || continue # covered by the missing-file test above
+      if ! grep -qE 'PKG_MGR.*[!=]=[[:space:]]*"apt"' "$base"; then
+        echo "FAIL: $(basename "$cf") runs desktop/${script}, which has no apt" >&2
+        echo "      branch. On an apt base it falls through to its dnf/pacman" >&2
+        echo "      path and the build dies with 'dnf: command not found'." >&2
+        echo "      Use install-desktop.sh (manifest-driven) instead, or give" >&2
+        echo "      the script a \$PKG_MGR == apt branch." >&2
+        fail=1
+      fi
+    done < <(per_de_scripts "$cf")
+  done
+  [ "$fail" -eq 0 ]
+}
+
+# The test above passes trivially if the extraction finds nothing, and would
+# have passed on the broken tree if cosmic.sh had been mis-filtered out.
+@test "the apt per-DE check sees real scripts, and would reject a dnf-only one" {
+  run bash -c "$(declare -f per_de_scripts); per_de_scripts '${REPO_ROOT}/Containerfile.ubuntu'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"gnome.sh"* ]]
+  [[ "$output" == *"kde.sh"* ]]
+
+  # cosmic.sh is still in the tree (el10 documents its package set); assert it
+  # is genuinely dnf-only, so the rule above is rejecting something real.
+  run grep -qE 'PKG_MGR.*[!=]=[[:space:]]*"apt"' "${REPO_ROOT}/build_scripts/desktop/cosmic.sh"
+  [ "$status" -ne 0 ]
+}
+
 @test "the checks actually look at something, and tell sourced from executed" {
   # A regex that silently matched nothing would make both tests above pass
   # forever.

--- a/tests/bats/test_cosmic_apt_package_names.bats
+++ b/tests/bats/test_cosmic_apt_package_names.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+# COSMIC's icon theme has two spellings, and the manifest must use the right
+# one per package manager.
+#
+#   RPM (Fedora, EL10):        cosmic-icon-theme
+#   Debian/Ubuntu, openSUSE:   cosmic-icons
+#
+# manifests/desktops/cosmic.yaml carried the RPM name in its apt section. apt
+# aborts the entire transaction on the first name it cannot resolve —
+#
+#   E: Unable to locate package cosmic-icon-theme
+#
+# — so one wrong entry failed all 21 packages and the whole grouper:cosmic
+# build (LUKS run 31135209477). The zypper section had cosmic-icons already;
+# only apt was left behind.
+#
+# Verified against what ppa:hepp3n/cosmic-epoch actually publishes:
+#
+#   curl -fsSL 'https://api.launchpad.net/devel/~hepp3n/+archive/ubuntu/\
+#     cosmic-epoch?ws.op=getPublishedBinaries&status=Published'
+#
+# 46 distinct binaries across 3 pages. cosmic-icons is published;
+# cosmic-icon-theme is not.
+#
+# These tests are offline: they assert the spelling split the measurement
+# established, not the live archive. A network-dependent test here would go
+# red on Launchpad's availability rather than on this repo's correctness.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+MANIFEST="${REPO_ROOT}/manifests/desktops/cosmic.yaml"
+
+apt_packages() { yq -r '.packages.apt.packages[]' "$MANIFEST"; }
+
+setup() { command -v yq >/dev/null || skip "yq not available"; }
+
+@test "the apt list uses the Debian spelling of the icon theme" {
+	run apt_packages
+	[ "$status" -eq 0 ]
+	grep -qx 'cosmic-icons' <<<"$output"
+}
+
+# The regression itself. The RPM name resolves nowhere under apt, and its
+# presence fails every other package in the same call.
+@test "the apt list does not use the RPM spelling" {
+	run apt_packages
+	! grep -qx 'cosmic-icon-theme' <<<"$output"
+}
+
+# The counterpart: the RPM sections must keep the RPM name. A blanket
+# find-and-replace to fix the apt failure would break Fedora and EL10 instead,
+# which is the obvious wrong repair and worth pinning.
+@test "the rpm sections keep the rpm spelling" {
+	run yq -r '.packages.fedora.packages[]' "$MANIFEST"
+	grep -qx 'cosmic-icon-theme' <<<"$output"
+	# el10 installs the COSMIC set through COPR, so its names live under
+	# .copr[].packages, not the flat .packages list (which holds only the
+	# stock-repo extras: flatpak, pipewire, and so on).
+	run yq -r '.packages.el10.copr[].packages[]' "$MANIFEST"
+	grep -qx 'cosmic-icon-theme' <<<"$output"
+}
+
+@test "zypper keeps the Debian spelling it already had" {
+	run yq -r '.packages.zypper[]' "$MANIFEST"
+	grep -qx 'cosmic-icons' <<<"$output"
+}
+
+# The apt list is what the PPA publishes plus greetd from the Ubuntu archive.
+# Pinned as the set measured on 2026-08-07 so a package added here without
+# checking Launchpad fails locally rather than 20 minutes into a container
+# build. Update the list when the PPA gains a package — after checking that it
+# has.
+@test "every apt package is one the PPA publishes, or greetd" {
+	local published=(
+		adw-gtk3 appstream-data-pop appstream-data-pop-icons
+		appstream-data-pop-icons-hidpi calamares-settings-cosmic
+		cosmic-app-library cosmic-applets cosmic-bg cosmic-comp
+		cosmic-desktop cosmic-desktop-minimal cosmic-edit cosmic-files
+		cosmic-greeter cosmic-greeter-daemon cosmic-icons cosmic-idle
+		cosmic-initial-setup cosmic-initial-setup-casper cosmic-launcher
+		cosmic-monitor cosmic-notifications cosmic-osd cosmic-panel
+		cosmic-player cosmic-randr cosmic-screenshot cosmic-session
+		cosmic-settings cosmic-settings-daemon cosmic-store cosmic-term
+		cosmic-wallpapers cosmic-workspaces
+		gnome-shell-extension-pop-battery-icon-fix minimal pop-fonts
+		pop-gnome-shell-theme pop-gtk-theme pop-icon-theme pop-launcher
+		pop-launcher-system76-power pop-sound-theme pop-theme standard
+		xdg-desktop-portal-cosmic
+		# Not from the PPA. Ubuntu's own archive ships greetd, which is
+		# why niri.sh installs it straight from there too.
+		greetd
+	)
+	local p known fail=0
+	while read -r p; do
+		[ -n "$p" ] || continue
+		known=0
+		for k in "${published[@]}"; do
+			[ "$p" = "$k" ] && known=1 && break
+		done
+		if [ "$known" -eq 0 ]; then
+			echo "FAIL: cosmic.yaml's apt list names '${p}', which neither" >&2
+			echo "      ppa:hepp3n/cosmic-epoch nor the Ubuntu archive was" >&2
+			echo "      measured to publish. apt fails the WHOLE install on" >&2
+			echo "      an unknown name, not just that package." >&2
+			fail=1
+		fi
+	done < <(apt_packages)
+	[ "$fail" -eq 0 ]
+}
+
+# The loop above passes trivially if apt_packages returns nothing.
+@test "the apt list is non-empty and includes the session" {
+	run apt_packages
+	[ "$(wc -l <<<"$output")" -ge 15 ]
+	grep -qx 'cosmic-session' <<<"$output"
+	grep -qx 'cosmic-comp' <<<"$output"
+}

--- a/tests/bats/test_cosmic_display_manager.bats
+++ b/tests/bats/test_cosmic_display_manager.bats
@@ -187,3 +187,105 @@ run_enable() {
 	run run_enable cosmic-greeter.service
 	[ "$status" -eq 1 ]
 }
+
+# ── The other half: install-desktop.sh ──────────────────────────────────────
+#
+# Deferring in configure-desktop-runtime.sh stops the build from dying, but
+# install-desktop.sh resolves the manifest's display_manager independently and
+# then FORCE-LINKS it into graphical.target.wants. Ubuntu's greetd.service
+# carries `[Install] Alias=display-manager.service` and no WantedBy=, so that
+# link is the only thing that would ever start greetd on an image where
+# cosmic-greeter owns the alias -- and cosmic-greeter.service is itself
+# `ExecStart=greetd --config /etc/greetd/cosmic-greeter.toml` with `vt = "1"`.
+# Two units running greetd on vt1, both Restart=always, is the
+# two-DMs-racing-for-seat0 state that file's own sibling-link cleanup exists to
+# prevent.
+INSTALLER="${REPO_ROOT}/build_scripts/desktop/install-desktop.sh"
+
+# Run install-desktop.sh's greetd-resolution block against a fake sysroot.
+resolve_installer_dm() {
+	local link_target="$1" declared="${2:-greetd}"
+	local root="${BATS_TEST_TMPDIR}/inst-${BATS_TEST_NUMBER}"
+	rm -rf "$root"
+	mkdir -p "$root/etc/systemd/system" "$root/usr/lib/systemd/system"
+	if [ -n "$link_target" ]; then
+		touch "$root/usr/lib/systemd/system/${link_target}"
+		ln -sf "$root/usr/lib/systemd/system/${link_target}" \
+			"$root/etc/systemd/system/display-manager.service"
+	fi
+
+	local block
+	block="$(awk '/^if \[\[ "\$\{_TD_DM\}" == "greetd" \]\]; then$/{f=1} f{print} f&&/^fi$/{exit}' "$INSTALLER" |
+		sed "s#/etc/systemd/system/display-manager.service#${root}/etc/systemd/system/display-manager.service#")"
+
+	bash -c "
+		_TD_DM='${declared}'
+		${block}
+		echo \"\${_TD_DM}\"
+	" | tail -1
+}
+
+@test "the installer's resolution block was actually extracted" {
+	run awk '/^if \[\[ "\$\{_TD_DM\}" == "greetd" \]\]; then$/{f=1} f{print} f&&/^fi$/{exit}' "$INSTALLER"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"cosmic-greeter.service"* ]]
+	[[ "$output" == *"readlink"* ]]
+}
+
+@test "install-desktop.sh wants cosmic-greeter, not a second greetd on vt1" {
+	run resolve_installer_dm cosmic-greeter.service
+	[ "$output" = "cosmic-greeter" ]
+}
+
+@test "install-desktop.sh leaves greetd alone when nothing claimed the alias" {
+	run resolve_installer_dm ""
+	[ "$output" = "greetd" ]
+
+	run resolve_installer_dm gdm.service
+	[ "$output" = "greetd" ]
+}
+
+# A dangling alias is the openSUSE-shaped case the block below this one in
+# install-desktop.sh reclaims. It must not be read as a cosmic-greeter claim.
+@test "install-desktop.sh ignores an alias pointing at a unit that is gone" {
+	local root="${BATS_TEST_TMPDIR}/dangling"
+	mkdir -p "$root/etc/systemd/system"
+	ln -sf "$root/usr/lib/systemd/system/cosmic-greeter.service" \
+		"$root/etc/systemd/system/display-manager.service"
+	local block
+	block="$(awk '/^if \[\[ "\$\{_TD_DM\}" == "greetd" \]\]; then$/{f=1} f{print} f&&/^fi$/{exit}' "$INSTALLER" |
+		sed "s#/etc/systemd/system/display-manager.service#${root}/etc/systemd/system/display-manager.service#")"
+	run bash -c "_TD_DM='greetd'; ${block}; echo \"\${_TD_DM}\""
+	[ "$output" = "greetd" ]
+}
+
+# ── And the contracts that judge the result ─────────────────────────────────
+#
+# dm_id is `systemctl show -P Id display-manager.service`, so on Ubuntu it
+# reads cosmic-greeter.service and on Fedora/EL10 greetd.service. A pattern
+# pinned to greetd alone would fail grouper:cosmic at boot -- fatally in
+# verify-desktop-experience.sh (dm_mismatch), and as a TAP failure harvested
+# from the serial console in e2e-runtime-checks.sh -- on a COSMIC login screen
+# that is working exactly as intended.
+@test "both runtime contracts accept either greeter as cosmic's DM" {
+	local f
+	for f in "${REPO_ROOT}/build_scripts/checks/verify-desktop-experience.sh" \
+		"${REPO_ROOT}/build_scripts/checks/e2e-runtime-checks.sh"; do
+		run grep -c "greetd|cosmic-greeter" "$f"
+		[ "$status" -eq 0 ]
+		[ "$output" -ge 1 ]
+	done
+}
+
+# niri keeps the strict pattern: it has no cosmic-greeter, and widening it
+# there would accept a greeter that variant never installs.
+@test "niri's contracts still pin greetd alone" {
+	local f
+	for f in "${REPO_ROOT}/build_scripts/checks/verify-desktop-experience.sh" \
+		"${REPO_ROOT}/build_scripts/checks/e2e-runtime-checks.sh"; do
+		run grep -E "^niri\)? *(\)|dm_pattern)" "$f"
+		[ "$status" -eq 0 ]
+	done
+	run grep -E "^niri\) dm_pattern='\^greetd" "${REPO_ROOT}/build_scripts/checks/e2e-runtime-checks.sh"
+	[ "$status" -eq 0 ]
+}

--- a/tests/bats/test_cosmic_display_manager.bats
+++ b/tests/bats/test_cosmic_display_manager.bats
@@ -113,3 +113,77 @@ choose_dm() {
 	[[ "$output" == *"display-manager.service"* ]]
 	[[ "$output" != *"list-unit-files cosmic-greeter"* ]]
 }
+
+# ── The diagnostic on the enable itself ─────────────────────────────────────
+#
+# The selection above prevents the known collision. This covers the next one:
+# when `systemctl enable` fails, the build must say WHICH case it is, because
+# the two have opposite fixes (defer to the claimant vs install the missing
+# package) and systemd's own message distinguishes neither.
+
+# Run just the enable-and-diagnose block against a fake sysroot, with
+# systemctl stubbed to fail the way the real one does.
+run_enable() {
+	local link_target="$1"
+	local root="${BATS_TEST_TMPDIR}/enable-${BATS_TEST_NUMBER}"
+	rm -rf "$root"
+	mkdir -p "$root/etc/systemd/system" "$root/lib/systemd/system"
+	if [ -n "$link_target" ]; then
+		touch "$root/lib/systemd/system/${link_target}"
+		ln -sf "$root/lib/systemd/system/${link_target}" \
+			"$root/etc/systemd/system/display-manager.service"
+	fi
+
+	local block
+	block="$(awk '/^if ! systemctl enable /{f=1} f{print} f&&/^fi$/{exit}' "$SCRIPT" |
+		sed "s#/etc/systemd/system/display-manager.service#${root}/etc/systemd/system/display-manager.service#")"
+
+	bash -c "
+		set -euo pipefail
+		desktop=cosmic
+		dm=greetd
+		systemctl() { return 1; }
+		${block}
+	" 2>&1
+}
+
+@test "the enable block was actually extracted" {
+	run awk '/^if ! systemctl enable /{f=1} f{print} f&&/^fi$/{exit}' "$SCRIPT"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"readlink"* ]]
+	[ "$(wc -l <<<"$output")" -ge 8 ]
+}
+
+@test "a claimed alias names the claimant and points at deferring" {
+	run run_enable cosmic-greeter.service
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"already claimed by cosmic-greeter.service"* ]]
+	[[ "$output" == *"Defer to it"* ]]
+	# The other diagnosis must NOT also be printed — two contradictory
+	# suggestions is no better than none.
+	[[ "$output" != *"not installed"* ]]
+}
+
+@test "an unclaimed alias points at the missing package instead" {
+	run run_enable ""
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"not installed"* ]]
+	[[ "$output" != *"already claimed by"* ]]
+}
+
+# If display-manager.service already points at the very unit we are enabling,
+# the failure is not a collision — saying "claimed by greetd.service, defer to
+# it" would be nonsense advice to defer to yourself.
+@test "the alias pointing at our own unit is not reported as a collision" {
+	run run_enable greetd.service
+	[ "$status" -ne 0 ]
+	[[ "$output" != *"already claimed by"* ]]
+	[[ "$output" == *"not installed"* ]]
+}
+
+# The whole point of not using `|| true`: an image with no display manager is
+# worse than a failed build.
+@test "a failed enable still fails the build" {
+	run run_enable cosmic-greeter.service
+	[ "$status" -eq 1 ]
+}

--- a/tests/bats/test_cosmic_display_manager.bats
+++ b/tests/bats/test_cosmic_display_manager.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# COSMIC's display manager is whichever one already claimed
+# display-manager.service, and greetd only when nothing has.
+#
+# configure-desktop-runtime.sh mapped `cosmic` straight to greetd. On Ubuntu
+# the PPA's cosmic-greeter deb enables cosmic-greeter.service and repoints
+# display-manager.service at it in its postinst, so the next line —
+# `systemctl enable greetd.service`, deliberately not `|| true` — hard-failed
+# and took the whole image build with it:
+#
+#   Failed to enable unit: File '/etc/systemd/system/display-manager.service'
+#   already exists and is a symlink to /lib/systemd/system/cosmic-greeter.service
+#
+# grouper:cosmic, LUKS run 31135761136 — the third distinct failure that cell
+# hit, each one further along than the last.
+#
+# The fix tests the SYMLINK, not whether cosmic-greeter is installed, and that
+# distinction is the entire safety argument. Fedora and EL10 install
+# cosmic-greeter as well, and their cosmic cells are green today *because*
+# `systemctl enable greetd` succeeds there — direct evidence that their RPM
+# scriptlets do not touch the alias. A package-presence test would have
+# repointed those images; a symlink test cannot. The last case below pins
+# exactly that.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/build_scripts/desktop/configure-desktop-runtime.sh"
+
+# Run the script's `case` up to the point dm is chosen, with a fake sysroot.
+# systemctl is stubbed out: what is under test is the selection, and the real
+# thing needs a booted system it cannot have in a container build either.
+choose_dm() {
+	local link_target="$1" desktop="${2:-cosmic}"
+	local root="${BATS_TEST_TMPDIR}/${BATS_TEST_NUMBER}"
+	rm -rf "$root"
+	mkdir -p "$root/etc/systemd/system" "$root/lib/systemd/system"
+	if [ -n "$link_target" ]; then
+		touch "$root/lib/systemd/system/${link_target}"
+		ln -sf "$root/lib/systemd/system/${link_target}" \
+			"$root/etc/systemd/system/display-manager.service"
+	fi
+
+	# Take the case block verbatim, retargeting only the absolute path it
+	# reads so it looks at the fake sysroot instead of the runner's own.
+	local block
+	block="$(awk '/^case "\$desktop" in$/{f=1} f{print} f&&/^esac$/{exit}' "$SCRIPT" |
+		sed "s#/etc/systemd/system/display-manager.service#${root}/etc/systemd/system/display-manager.service#")"
+
+	bash -c "
+		desktop='${desktop}'
+		systemctl() { return 1; }   # no unit files exist in a fake root
+		${block}
+		echo \"\$dm\"
+	"
+}
+
+@test "the case block was actually extracted" {
+	run awk '/^case "\$desktop" in$/{f=1} f{print} f&&/^esac$/{exit}' "$SCRIPT"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"cosmic)"* ]]
+	[[ "$output" == *"esac"* ]]
+	[ "$(wc -l <<<"$output")" -ge 15 ]
+}
+
+# The regression: this is the grouper case.
+@test "cosmic defers to cosmic-greeter when it already owns the alias" {
+	run choose_dm cosmic-greeter.service
+	[ "$output" = "cosmic-greeter" ]
+}
+
+# The safety case: Fedora/EL10, where nothing claimed the alias. These cells
+# are green on greetd and must stay on greetd.
+@test "cosmic still picks greetd when nothing claimed the alias" {
+	run choose_dm ""
+	[ "$output" = "greetd" ]
+}
+
+# A different greeter owning the alias is not cosmic-greeter, and must not be
+# mistaken for it by a sloppy substring match.
+@test "cosmic picks greetd when some other DM owns the alias" {
+	run choose_dm gdm.service
+	[ "$output" = "greetd" ]
+}
+
+# niri shared the `niri | cosmic)` arm before this change. It has no
+# cosmic-greeter and must be untouched by the split.
+@test "niri is unaffected by the split" {
+	run choose_dm "" niri
+	[ "$output" = "greetd" ]
+	run choose_dm cosmic-greeter.service niri
+	[ "$output" = "greetd" ]
+}
+
+# Forcing the alias is the wrong instrument here — the kde comment in this
+# same file records why (tunaOS#824). Pin that it is not how this was fixed.
+# Comments are stripped first: the cosmic branch deliberately NAMES --force in
+# prose to record why it is the wrong instrument, and that explanation is worth
+# more than the grep is.
+@test "the fix does not force the display-manager alias" {
+	run sh -c "grep -v '^[[:space:]]*#' '$SCRIPT' | grep 'systemctl enable'"
+	[ "$status" -eq 0 ]
+	[ -n "$output" ]
+	[[ "$output" != *"--force"* ]]
+	[[ "$output" != *" -f "* ]]
+}
+
+# The distinction the safety argument rests on: presence of the unit file is
+# NOT what is tested. If someone "simplifies" this to a list-unit-files check,
+# Fedora and EL10 cosmic get repointed and this fails.
+@test "selection keys off the symlink, not whether cosmic-greeter exists" {
+	run awk '/^cosmic\)$/{f=1} f{print} f&&/^\t;;$/{exit}' "$SCRIPT"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"readlink"* ]]
+	[[ "$output" == *"display-manager.service"* ]]
+	[[ "$output" != *"list-unit-files cosmic-greeter"* ]]
+}

--- a/tests/bats/test_fisherman_override_order.bats
+++ b/tests/bats/test_fisherman_override_order.bats
@@ -33,15 +33,21 @@ code_line() {
 @test "the override and the presence check are both still present" {
 	run sh -c "grep -c 'Overriding fisherman with' '$SCRIPT'"
 	[ "$output" -eq 1 ]
+	# Two reads of /usr/local/bin/fisherman, and they are not interchangeable:
+	# the first asks what the IMAGE shipped (which is what the TBOX_E2E_IMAGE
+	# generic-path decision turns on), the second verifies the override landed.
+	# See test_iso_e2e_fisherman_override.bats for what each one decides.
 	run sh -c "grep -c 'command -v /usr/local/bin/fisherman' '$SCRIPT'"
-	[ "$output" -eq 1 ]
+	[ "$output" -eq 2 ]
 }
 
 # The assertion this file exists for.
 @test "the override is installed before the presence check" {
 	local override check
 	override=$(grep -n 'Overriding fisherman with' "$SCRIPT" | head -1 | cut -d: -f1)
-	check=$(grep -n 'command -v /usr/local/bin/fisherman' "$SCRIPT" | head -1 | cut -d: -f1)
+	# The *verifying* check — the one that returns 3 — is the last read, after
+	# the override. The first read is the pre-override image probe.
+	check=$(grep -n 'command -v /usr/local/bin/fisherman' "$SCRIPT" | tail -1 | cut -d: -f1)
 	[ -n "$override" ]
 	[ -n "$check" ]
 	if [ "$override" -ge "$check" ]; then
@@ -64,7 +70,7 @@ code_line() {
 	end=$(grep -n '^[a-z_]*() {' "$SCRIPT" | awk -F: -v s="$start" '$1>s {print $1; exit}')
 	[ -n "$end" ] || end=$(wc -l <"$SCRIPT")
 	override=$(grep -n 'Overriding fisherman with' "$SCRIPT" | head -1 | cut -d: -f1)
-	check=$(grep -n 'command -v /usr/local/bin/fisherman' "$SCRIPT" | head -1 | cut -d: -f1)
+	check=$(grep -n 'command -v /usr/local/bin/fisherman' "$SCRIPT" | tail -1 | cut -d: -f1)
 	[ "$override" -gt "$start" ] && [ "$override" -lt "$end" ]
 	[ "$check" -gt "$start" ] && [ "$check" -lt "$end" ]
 }

--- a/tests/bats/test_fisherman_override_order.bats
+++ b/tests/bats/test_fisherman_override_order.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# FISHERMAN_OVERRIDE has to be installed BEFORE run_install() checks whether
+# the live image ships a fisherman.
+#
+# It used to be installed ~260 lines after that check. The check is a hard
+# `return 3`, so on an image carrying no fisherman the run died without ever
+# installing the binary the workflow had just built for it:
+#
+#   ERROR: fisherman not found on live image (VARIANT=guppy FLAVOR=xfce)
+#   ERROR: and TBOX_E2E_IMAGE is unset, so the generic bootc path cannot name
+#          an image ref
+#
+# guppy:xfce, LUKS run 31131624108 — 55 seconds into the LUKS step, after a
+# 65-minute Gentoo build, with FISHERMAN_OVERRIDE=/tmp/fisherman-bin present
+# on the runner and the workflow's own "Build fisherman in a golang container"
+# step green immediately above it. All three guppy cells fail this way, and
+# the wall-clock made it look like an install timeout rather than a 55-second
+# abort.
+#
+# The ordering is the whole fix, and ordering is invisible to every other kind
+# of check: both statements are individually correct, the script passes
+# shellcheck and `bash -n` either way, and the failure only shows up against a
+# live image that happens to lack the binary.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/iso-e2e.sh"
+
+# Line number of the first non-comment line matching a pattern.
+code_line() {
+	grep -vn '^[[:space:]]*#' "$SCRIPT" | grep -m1 -- "$1" | cut -d: -f1
+}
+
+@test "the override and the presence check are both still present" {
+	run sh -c "grep -c 'Overriding fisherman with' '$SCRIPT'"
+	[ "$output" -eq 1 ]
+	run sh -c "grep -c 'command -v /usr/local/bin/fisherman' '$SCRIPT'"
+	[ "$output" -eq 1 ]
+}
+
+# The assertion this file exists for.
+@test "the override is installed before the presence check" {
+	local override check
+	override=$(grep -n 'Overriding fisherman with' "$SCRIPT" | head -1 | cut -d: -f1)
+	check=$(grep -n 'command -v /usr/local/bin/fisherman' "$SCRIPT" | head -1 | cut -d: -f1)
+	[ -n "$override" ]
+	[ -n "$check" ]
+	if [ "$override" -ge "$check" ]; then
+		echo "FAIL: FISHERMAN_OVERRIDE is installed at line ${override}, but the" >&2
+		echo "      'is fisherman present' check at line ${check} returns 3 first." >&2
+		echo "      On an image that ships no fisherman the override never runs," >&2
+		echo "      which is the only case it exists for (guppy, run 31131624108)." >&2
+		return 1
+	fi
+}
+
+# Both must be inside run_install(), not split across functions — moving the
+# override into a caller would satisfy the line-order test while changing when
+# it runs relative to the ssh_cmd/scp_cmd locals it uses.
+@test "both live inside run_install()" {
+	local start end override check
+	start=$(grep -n '^run_install() {' "$SCRIPT" | cut -d: -f1)
+	[ -n "$start" ]
+	# The next top-level function definition after run_install().
+	end=$(grep -n '^[a-z_]*() {' "$SCRIPT" | awk -F: -v s="$start" '$1>s {print $1; exit}')
+	[ -n "$end" ] || end=$(wc -l <"$SCRIPT")
+	override=$(grep -n 'Overriding fisherman with' "$SCRIPT" | head -1 | cut -d: -f1)
+	check=$(grep -n 'command -v /usr/local/bin/fisherman' "$SCRIPT" | head -1 | cut -d: -f1)
+	[ "$override" -gt "$start" ] && [ "$override" -lt "$end" ]
+	[ "$check" -gt "$start" ] && [ "$check" -lt "$end" ]
+}
+
+# The locals the override block uses are declared earlier in run_install().
+# If someone moves the override above them it silently scps with an empty
+# command array.
+@test "ssh_cmd and scp_cmd are declared before the override uses them" {
+	local decl override
+	decl=$(grep -n 'local scp_cmd=(' "$SCRIPT" | awk -F: -v s="$(grep -n '^run_install() {' "$SCRIPT" | cut -d: -f1)" '$1>s {print $1; exit}')
+	override=$(grep -n 'Overriding fisherman with' "$SCRIPT" | head -1 | cut -d: -f1)
+	[ -n "$decl" ]
+	[ "$decl" -lt "$override" ]
+}
+
+# The error path should say why an override that was set did not take, rather
+# than reporting only "fisherman not found" — that message is what sent the
+# first read of run 31131624108 chasing an install timeout.
+@test "a set-but-absent override is called out in the failure" {
+	run awk '/fisherman not found on live image/{f=1} f{print} f&&/return 3/{exit}' "$SCRIPT"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"FISHERMAN_OVERRIDE"* ]]
+}

--- a/tests/bats/test_hummingbird_desktop_wiring.bats
+++ b/tests/bats/test_hummingbird_desktop_wiring.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# Hummingbird gets its own manifest section, and that section reuses Fedora's
+# package names rather than restating them.
+#
+# Why its own section: Hummingbird IS a Fedora Rawhide rebuild (30 of 38 core
+# packages match Rawhide's version AND release, differing only in the .hum1
+# dist tag), so lib.sh's substring test routing it to el10 is a
+# misclassification. But `fedora` is equally wrong — of the 58 packages the
+# GNOME manifest installs, Hummingbird's 3384-package repository ships exactly
+# ONE (avahi). It publishes a base OS and no desktop, so the fedora: section
+# fails the same way el10: did, just further along. Measured in
+# tuna-os/tunaos-packages#250.
+#
+# Why an alias and not a copy: the names ARE Fedora's. A second literal list
+# across five desktop manifests is how these files drift apart — this repo has
+# been bitten repeatedly by a fact true of a CLASS being retyped per file.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+INSTALL="${REPO_ROOT}/build_scripts/desktop/install-desktop.sh"
+GNOME="${REPO_ROOT}/manifests/desktops/gnome.yaml"
+
+yq_bin() { command -v yq; }
+
+@test "install-desktop.sh routes hummingbird to its own OS section" {
+	run grep -E 'IS_HUMMINGBIRD.*== true' "$INSTALL"
+	[ "$status" -eq 0 ]
+	run grep -E '_TD_OS="hummingbird"' "$INSTALL"
+	[ "$status" -eq 0 ]
+}
+
+# The branch must come BEFORE the IS_FEDORA test. Hummingbird's os-release
+# says fedora, so a later branch never runs — the selector is first-match.
+@test "the hummingbird branch precedes the fedora branch" {
+	local hb fed
+	hb=$(grep -n 'IS_HUMMINGBIRD.*== true' "$INSTALL" | head -1 | cut -d: -f1)
+	fed=$(grep -n 'IS_FEDORA" == true' "$INSTALL" | head -1 | cut -d: -f1)
+	[ -n "$hb" ]
+	[ -n "$fed" ]
+	[ "$hb" -lt "$fed" ]
+}
+
+# hummingbird is dnf-driven. Omitting it from this guard sends a dnf base down
+# the list-style path, where indexing a map with .group_options is a hard yq
+# error rather than a graceful skip.
+@test "hummingbird takes the dnf path" {
+	run grep -E '_TD_OS.*==.*"hummingbird".*\]\]; then' "$INSTALL"
+	[ "$status" -eq 0 ]
+}
+
+@test "gnome.yaml declares a hummingbird repo at the measured target path" {
+	[ -n "$(yq_bin)" ] || skip "yq not available"
+	run yq -r '.packages.hummingbird.repos[0].baseurl' "$GNOME"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"hummingbird/20251124-x86_64"* ]]
+}
+
+# The assertion this file exists for: the hummingbird package list must BE the
+# fedora one, not a copy of it. If someone replaces the alias with a literal
+# list, the two drift the first time either is edited and nothing else notices.
+@test "hummingbird reuses fedora's package list rather than copying it" {
+	[ -n "$(yq_bin)" ] || skip "yq not available"
+	local fedora hummingbird
+	fedora="$(yq -r '.packages.fedora.packages[]' "$GNOME" | sort)"
+	hummingbird="$(yq -r '.packages.hummingbird.packages[]' "$GNOME" | sort)"
+	[ -n "$fedora" ]
+	[ "$fedora" = "$hummingbird" ]
+
+	# and it is literally an alias in the source, not a duplicated block
+	run grep -c 'packages: \*fedora_gnome_packages' "$GNOME"
+	[ "$status" -eq 0 ]
+	[ "$output" -ge 1 ]
+}
+
+# Only gnome is wired on purpose. kde uses `groups:` and niri uses `copr:`,
+# and their Hummingbird package sets (384 and 310 sources) do not exist yet —
+# inventing sections for repositories that 404 would be guesswork. This test
+# records that as a deliberate boundary so its absence is not read as an
+# oversight.
+@test "only the desktops whose hummingbird packages exist are wired" {
+	[ -n "$(yq_bin)" ] || skip "yq not available"
+	local d
+	for d in kde niri cosmic; do
+		run yq -r '.packages.hummingbird // "absent"' "${REPO_ROOT}/manifests/desktops/${d}.yaml"
+		[ "$output" = "absent" ] || [ "$output" = "null" ]
+	done
+}

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -887,7 +887,12 @@ setup_runtime_check_stubs() {
 @test "generic: fisherman absence falls back to bootc only when an image is named" {
   # Guessing a registry ref from an ISO filename is how #1006's 40-minute
   # failures happened; the generic path refuses to guess.
-  grep -qF 'if [[ -n "${TBOX_E2E_IMAGE:-}" ]]; then' "$SCRIPT"
+  #
+  # Both halves sit in one condition, and it reads the image probe rather than
+  # /usr/local/bin/fisherman: FISHERMAN_OVERRIDE now lands on the guest before
+  # the verifying check, so a later read would find a fisherman on every image
+  # and divert nothing. See test_iso_e2e_fisherman_override.bats.
+  grep -qF 'if [[ "$image_has_fisherman" -eq 0 && -n "${TBOX_E2E_IMAGE:-}" ]]; then' "$SCRIPT"
   grep -q 'run_install_generic' "$SCRIPT"
   grep -q 'TBOX_E2E_IMAGE is unset' "$SCRIPT"
 }

--- a/tests/bats/test_iso_e2e_fisherman_override.bats
+++ b/tests/bats/test_iso_e2e_fisherman_override.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+# What run_install() decides once FISHERMAN_OVERRIDE is installed before the
+# fisherman presence check (see test_fisherman_override_order.bats for the
+# ordering itself, and why it moved).
+#
+# Installing first makes the guppy cells reachable, and it costs the generic
+# path its trigger if the two are not separated. The old sequence was:
+#
+#   image has no fisherman?  ->  TBOX_E2E_IMAGE set?  ->  plain bootc install
+#
+# With the override landing first, "image has no fisherman" is never true
+# afterwards, so a caller-named generic image would silently take the fisherman
+# path instead — and recipe_image there resolves a *tunaOS* ref from
+# VARIANT/FLAVOR, i.e. it would install something else entirely. So the image
+# is probed once BEFORE the override, and that probe is what the generic-path
+# decision reads.
+#
+# The block sits ~1650 lines into a function that needs QEMU, a guest and a
+# real ssh, so these tests lift it out and run it against a stub guest: an ssh
+# that answers the presence probe according to what the "image" shipped, and
+# records what got installed onto it.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/iso-e2e.sh"
+
+# The whole decision region, verbatim: from the comment that opens it down to
+# (not including) the smoke-check section that follows. Anchored on text that
+# predates this change, so reverting the code under test leaves a block that
+# still extracts and still runs — otherwise every case here would "fail" on a
+# mutant merely by finding nothing.
+extract_block() {
+	awk '/Generic \(non-tunaOS\) images ship no fisherman/{f=1} /Pre-install evidence/{f=0} f{print}' "$SCRIPT"
+}
+
+# Run that region against a stub guest.
+#   $1 = 1 if the live image ships /usr/local/bin/fisherman, 0 if not
+# Env: FISHERMAN_OVERRIDE, TBOX_E2E_IMAGE are read by the code under test.
+run_block() {
+	local has="$1" block
+	block="$(extract_block)"
+	[ -n "$block" ] || {
+		echo "could not extract the fisherman decision block" >&2
+		return 99
+	}
+	bash -c "
+		set -uo pipefail
+		HAS=$has
+		LANDED=0
+		# 0 simulates an install that reports success but leaves nothing
+		# usable behind, clobbering whatever the image had — the only way to
+		# reach the failure path with a fisherman-carrying image.
+		LANDS=${OVERRIDE_LANDS:-1}
+		GUEST_HOME=/home/liveuser
+		GUEST_SCP_DEST=guest
+		VARIANT=guppy
+		FLAVOR=xfce
+		# A guest, modelled: the probe answers for the image until something
+		# installs a binary onto it, and then it answers for that.
+		_ssh() {
+			case \"\$*\" in
+				*'command -v /usr/local/bin/fisherman'*)
+					[[ \$HAS -eq 1 || \$LANDED -eq 1 ]] && return 0 || return 1 ;;
+				*mkdir*) echo \"MKDIR \$*\" ;;
+				# Any spelling of the install, not just the current flags:
+				# a stub that only recognises today's exact command would
+				# quietly model 'the binary never landed' if the flags change.
+				*install*fisherman-override*/usr/local/bin/fisherman*)
+					if [[ \$LANDS -eq 1 ]]; then LANDED=1; else HAS=0; fi
+					echo \"INSTALLED \$*\" ;;
+				*) : ;;
+			esac
+			return 0
+		}
+		_scp() { echo \"SCP \$*\"; }
+		ssh_cmd=(_ssh)
+		scp_cmd=(_scp)
+		run_install_generic() { echo 'GENERIC BOOTC PATH'; return 0; }
+		_block() {
+$block
+			echo 'REACHED THE FISHERMAN PATH'
+		}
+		_block
+	"
+}
+
+override_file() {
+	local f="$BATS_TEST_TMPDIR/fisherman-bin"
+	printf '#!/bin/sh\n' >"$f"
+	echo "$f"
+}
+
+@test "image without fisherman + override: reaches the fisherman path" {
+	FISHERMAN_OVERRIDE="$(override_file)" TBOX_E2E_IMAGE= run run_block 0
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"REACHED THE FISHERMAN PATH"* ]]
+	[[ "$output" == *"INSTALLED"* ]]
+	[[ "$output" != *"ERROR: fisherman not found on live image"* ]]
+}
+
+@test "image without fisherman + TBOX_E2E_IMAGE: the generic path still wins" {
+	# The regression the pre-override probe exists to prevent. An override is
+	# present too — the LUKS workflow always sets one — and it must not decide
+	# this.
+	FISHERMAN_OVERRIDE="$(override_file)" TBOX_E2E_IMAGE="quay.io/example/generic:latest" \
+		run run_block 0
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"GENERIC BOOTC PATH"* ]]
+	[[ "$output" != *"REACHED THE FISHERMAN PATH"* ]]
+	# And nothing was pushed onto a guest that is about to be installed by bootc.
+	[[ "$output" != *"INSTALLED"* ]]
+}
+
+@test "image with fisherman + TBOX_E2E_IMAGE: unchanged, override applies" {
+	# TBOX_E2E_IMAGE only ever diverted images that shipped no fisherman; a
+	# tunaOS image that has one keeps the fisherman path and the override.
+	FISHERMAN_OVERRIDE="$(override_file)" TBOX_E2E_IMAGE="quay.io/example/generic:latest" \
+		run run_block 1
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"REACHED THE FISHERMAN PATH"* ]]
+	[[ "$output" == *"INSTALLED"* ]]
+	[[ "$output" != *"GENERIC BOOTC PATH"* ]]
+}
+
+@test "an image shipping no fisherman is reported as a warning" {
+	# The flatpak that carries fisherman carries the installer GUI, so this
+	# also means the ISO has no installer a human could use. The cell proceeds
+	# on the caller's binary, but must not imply it covered that.
+	FISHERMAN_OVERRIDE="$(override_file)" TBOX_E2E_IMAGE= run run_block 0
+	[[ "$output" == *"::warning::"* ]]
+	[[ "$output" == *"installer flatpak is missing"* ]]
+}
+
+@test "an image that ships fisherman produces no such warning" {
+	FISHERMAN_OVERRIDE="$(override_file)" TBOX_E2E_IMAGE= run run_block 1
+	[[ "$output" != *"::warning::"* ]]
+}
+
+@test "no fisherman and no usable override: still the hard error" {
+	FISHERMAN_OVERRIDE= TBOX_E2E_IMAGE= run run_block 0
+	[ "$status" -eq 3 ]
+	[[ "$output" == *"ERROR: fisherman not found on live image"* ]]
+	[[ "$output" != *"REACHED THE FISHERMAN PATH"* ]]
+}
+
+@test "the failure still names TBOX_E2E_IMAGE when the caller set no image" {
+	FISHERMAN_OVERRIDE= TBOX_E2E_IMAGE= run run_block 0
+	[[ "$output" == *"TBOX_E2E_IMAGE is unset"* ]]
+}
+
+@test "the failure does not claim TBOX_E2E_IMAGE is unset when it is set" {
+	# Now reachable only one way: the image had a fisherman and the override
+	# clobbered it. With no fisherman and TBOX_E2E_IMAGE set, the generic path
+	# takes the run instead — so printing "TBOX_E2E_IMAGE is unset" here is
+	# simply false, in the message that gets read during triage.
+	OVERRIDE_LANDS=0 FISHERMAN_OVERRIDE="$(override_file)" \
+		TBOX_E2E_IMAGE="quay.io/example/generic:latest" run run_block 1
+	[ "$status" -eq 3 ]
+	[[ "$output" == *"ERROR: fisherman not found on live image"* ]]
+	[[ "$output" != *"TBOX_E2E_IMAGE is unset"* ]]
+	[[ "$output" == *"did not land"* ]]
+}
+
+@test "the override install creates /usr/local/bin before writing into it" {
+	# `install -D` (and mkdir -p) refuse to create *through* a dangling
+	# symlink, and on the ostree layout /usr/local points at a ../var/usrlocal
+	# the image does not contain. That never mattered while the override only
+	# replaced an existing binary; on an image that shipped none, it does.
+	FISHERMAN_OVERRIDE="$(override_file)" TBOX_E2E_IMAGE= run run_block 0
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"MKDIR"* ]]
+	[[ "$output" == *'readlink -m /usr/local/bin'* ]]
+	# mkdir first, then install.
+	local mk in
+	mk=$(printf '%s\n' "$output" | grep -n MKDIR | head -1 | cut -d: -f1)
+	in=$(printf '%s\n' "$output" | grep -n INSTALLED | head -1 | cut -d: -f1)
+	[ "$mk" -lt "$in" ]
+}

--- a/tests/bats/test_iso_e2e_poweroff.bats
+++ b/tests/bats/test_iso_e2e_poweroff.bats
@@ -1,0 +1,200 @@
+#!/usr/bin/env bats
+# poweroff_and_wait_vm must not return while the install VM is still alive.
+#
+# Both callers boot the installed disk immediately afterwards on the SAME
+# `-pidfile`, and QEMU holds an exclusive lock on that file for its whole life.
+# So a guest that overstays its poweroff does not delay the next boot, it
+# forbids it:
+#
+#   qemu-system-x86_64: cannot create PID file: Cannot lock pid file:
+#   Resource temporarily unavailable
+#
+# That is run 31140233496 (albacore:cosmic): the install had already logged
+# "Installation complete!", the old 70s window expired on a guest whose
+# `cryptsetup luksClose` had just reported the root mapping still in use, and
+# the cell died on the passphrase gate's launch with no ERROR line of its own.
+#
+# These tests drive the real function out of iso-e2e.sh with a stub guest, so
+# they measure behaviour rather than the presence of a keyword.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/iso-e2e.sh"
+
+setup() {
+	PIDFILE="$BATS_TEST_TMPDIR/qemu.pid"
+	MONSOCK="$BATS_TEST_TMPDIR/monitor.sock"
+	SSH_LOG="$BATS_TEST_TMPDIR/ssh.log"
+	SOCAT_LOG="$BATS_TEST_TMPDIR/socat.log"
+	BIN="$BATS_TEST_TMPDIR/bin"
+	mkdir -p "$BIN"
+
+	# The driver evaluates the shipped function and its helper, then runs it
+	# against whatever the test has staged. `sleep` becomes a token delay so a
+	# 180-iteration poll finishes in milliseconds without turning the polls
+	# into a busy race.
+	cat >"$BATS_TEST_TMPDIR/drive.sh" <<-'EOF'
+		set -Eeuo pipefail
+		SCRIPT="$1"
+		eval "$(grep '^POWEROFF_WAIT_SECS=' "$SCRIPT")"
+		eval "$(sed -n '/^wait_pid_gone()/,/^}/p' "$SCRIPT")"
+		eval "$(sed -n '/^poweroff_and_wait_vm()/,/^}/p' "$SCRIPT")"
+		GUEST_SSH=("$SSH_STUB")
+		sleep() { command sleep 0.02; }
+		if [[ -n "${STUB_KILL_NOOP:-}" ]]; then
+			# A guest that cannot be signalled away, i.e. every kill "works"
+			# and nothing ever dies.
+			kill() { return 0; }
+		fi
+		rc=0
+		poweroff_and_wait_vm || rc=$?
+		echo "rc=${rc}"
+		exit "$rc"
+	EOF
+}
+
+teardown() {
+	[[ -n "${VMPID:-}" ]] && kill -KILL "$VMPID" 2>/dev/null
+	return 0
+}
+
+# A stand-in for the daemonized QEMU: orphaned on purpose, so that killing it
+# does not leave a zombie that `kill -0` would still report as alive.
+spawn_fake_vm() {
+	VMPID="$(bash -c 'sleep 300 >/dev/null 2>&1 & printf "%s\n" "$!"')"
+	printf '%s\n' "$VMPID" >"$PIDFILE"
+}
+
+# The guest obeys, but takes its time about it — the case the wait loop exists
+# for. The delay is long enough that the poll below has to run.
+stub_ssh_that_powers_off() {
+	cat >"$BIN/ssh-obeys" <<-EOF
+		#!/usr/bin/env bash
+		printf '%s\n' "\$*" >>"$SSH_LOG"
+		( command sleep 0.5; kill -TERM "\$(cat "$PIDFILE")" 2>/dev/null ) >/dev/null 2>&1 &
+		exit 0
+	EOF
+	chmod +x "$BIN/ssh-obeys"
+	printf '%s\n' "$BIN/ssh-obeys"
+}
+
+# The guest wedges: poweroff is accepted and nothing happens.
+stub_ssh_that_ignores() {
+	cat >"$BIN/ssh-ignores" <<-EOF
+		#!/usr/bin/env bash
+		printf '%s\n' "\$*" >>"$SSH_LOG"
+		exit 0
+	EOF
+	chmod +x "$BIN/ssh-ignores"
+	printf '%s\n' "$BIN/ssh-ignores"
+}
+
+drive() {
+	run env \
+		SSH_STUB="$1" \
+		QEMU_PIDFILE="$PIDFILE" \
+		MONITOR_SOCK="${MONITOR_SOCK_OVERRIDE:-$MONSOCK}" \
+		PATH="$BIN:$PATH" \
+		bash "$BATS_TEST_TMPDIR/drive.sh" "$SCRIPT"
+}
+
+@test "a guest that powers itself off is waited for, not forced" {
+	spawn_fake_vm
+	# 60 polls of the token sleep, i.e. well past the stub's 0.5s.
+	TUNAOS_E2E_POWEROFF_WAIT=60
+	export TUNAOS_E2E_POWEROFF_WAIT
+	drive "$(stub_ssh_that_powers_off)"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Waiting for VM to shut down"* ]]
+	# The whole point of the ladder is that it stays out of the way here.
+	[[ "$output" != *"forcing it down"* ]]
+	grep -q 'systemctl poweroff' "$SSH_LOG"
+	run kill -0 "$VMPID"
+	[ "$status" -ne 0 ]
+}
+
+# The regression. Before this, the function returned with the VM still running
+# and the caller walked straight into the pidfile lock.
+@test "a wedged guest is killed, so the pidfile lock is free for the next boot" {
+	spawn_fake_vm
+	MONITOR_SOCK_OVERRIDE="$BATS_TEST_TMPDIR/no-such.sock"
+	TUNAOS_E2E_POWEROFF_WAIT=2
+	export TUNAOS_E2E_POWEROFF_WAIT
+	drive "$(stub_ssh_that_ignores)"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"did not power off within 2s"* ]]
+	run kill -0 "$VMPID"
+	[ "$status" -ne 0 ]
+	# QEMU unlinks its own pidfile and did not get to; a dead pid left here
+	# would have cleanup_vm signalling whatever recycles the number.
+	[ ! -e "$PIDFILE" ]
+}
+
+@test "the wait window is a tunable, not a hardcoded 70 seconds" {
+	# 70s (30 x 2s) could not outlast systemd's own 90s stop timeout, let alone
+	# the dm-detach retries after it.
+	run grep -c 'TUNAOS_E2E_POWEROFF_WAIT' "$SCRIPT"
+	[ "$output" -ge 1 ]
+	default="$(unset TUNAOS_E2E_POWEROFF_WAIT; eval "$(grep '^POWEROFF_WAIT_SECS=' "$SCRIPT")"; echo "$POWEROFF_WAIT_SECS")"
+	[ "$default" -ge 120 ]
+}
+
+@test "escalation asks over ACPI before it signals the process" {
+	spawn_fake_vm
+	# A real socket file, because the code requires one before it tries.
+	python3 - "$MONSOCK" <<-'PY'
+		import socket, sys
+		s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+		s.bind(sys.argv[1])
+		s.listen(1)
+	PY
+	cat >"$BIN/socat" <<-EOF
+		#!/usr/bin/env bash
+		cat >>"$SOCAT_LOG"
+		kill -TERM "\$(cat "$PIDFILE")" 2>/dev/null || true
+	EOF
+	chmod +x "$BIN/socat"
+	TUNAOS_E2E_POWEROFF_WAIT=2
+	export TUNAOS_E2E_POWEROFF_WAIT
+	drive "$(stub_ssh_that_ignores)"
+	[ "$status" -eq 0 ]
+	grep -q 'system_powerdown' "$SOCAT_LOG"
+	run kill -0 "$VMPID"
+	[ "$status" -ne 0 ]
+}
+
+@test "a VM that survives SIGKILL fails loudly instead of returning quietly" {
+	spawn_fake_vm
+	MONITOR_SOCK_OVERRIDE="$BATS_TEST_TMPDIR/no-such.sock"
+	TUNAOS_E2E_POWEROFF_WAIT=1
+	STUB_KILL_NOOP=1
+	export TUNAOS_E2E_POWEROFF_WAIT STUB_KILL_NOOP
+	drive "$(stub_ssh_that_ignores)"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"survived SIGKILL"* ]]
+	# Still the only record of which process to chase.
+	[ -e "$PIDFILE" ]
+}
+
+@test "an ssh poweroff that fails is reported, not swallowed" {
+	# Whether the guest was even asked changes what a long wait means.
+	cat >"$BIN/ssh-broken" <<-'EOF'
+		#!/usr/bin/env bash
+		exit 255
+	EOF
+	chmod +x "$BIN/ssh-broken"
+	rm -f "$PIDFILE"
+	TUNAOS_E2E_POWEROFF_WAIT=1
+	export TUNAOS_E2E_POWEROFF_WAIT
+	drive "$BIN/ssh-broken"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"did not return cleanly"* ]]
+}
+
+@test "the passphrase gate names a QEMU launch it could not make" {
+	# The reported run's only clue was qemu's own one-liner and "exit code 1".
+	blk="$(sed -n '/LUKS passphrase gate: booting/,/luks-first-boot.py/p' "$SCRIPT")"
+	[ -n "$blk" ]
+	grep -qF 'tunaos-iso-e2e-installed' <<<"$blk"
+	grep -q 'ERROR: QEMU would not start' <<<"$blk"
+	grep -qi 'lock pid file' <<<"$blk"
+}

--- a/tests/bats/test_record_timelapse.bats
+++ b/tests/bats/test_record_timelapse.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# record-timelapse.sh turns a matrix cell into something watchable.
+#
+# The property these tests defend is not "it makes a video" — it is that it
+# NEVER fails the caller. It runs inside the LUKS e2e flow, where a cell that
+# installs correctly but cannot be filmed is still a green cell. If a missing
+# encoder, an absent monitor socket or a virgl host could make this exit
+# non-zero, a reporting nicety would start failing installs that work.
+#
+# ffmpeg and socat are deliberately NOT assumed present: this repo's own CI
+# container lacks both, and so will anyone running the suite locally. Each
+# test therefore controls what is on PATH rather than inheriting it.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/record-timelapse.sh"
+
+setup() {
+	OUT="$BATS_TEST_TMPDIR/out"
+	mkdir -p "$OUT"
+	BIN="$BATS_TEST_TMPDIR/bin"
+	mkdir -p "$BIN"
+	# A PATH with the shell utilities the script needs and nothing else, so a
+	# host that happens to have ffmpeg cannot make the "encoder absent" test
+	# vacuous. (The sibling reachability test file had exactly that bug: it
+	# left /usr/bin on PATH, so its negative cases asserted nothing on hosts
+	# that ship the tool.)
+	local u bin
+	for u in bash sh find wc rm cat printf sleep kill mkdir sed; do
+		bin="$(command -v "$u" 2>/dev/null)" || continue
+		ln -sf "$bin" "$BIN/$u"
+	done
+}
+
+make_frames() {
+	mkdir -p "$OUT/frames"
+	local i
+	for i in 0 1 2; do
+		printf 'P6\n1 1\n255\n\0\0\0' >"$(printf '%s/frames/f%06d.ppm' "$OUT" "$i")"
+	done
+}
+
+@test "record-timelapse.sh exists and is executable" {
+	run test -x "$SCRIPT"
+	[ "$status" -eq 0 ]
+}
+
+@test "usage error is the only non-zero exit" {
+	run bash "$SCRIPT"
+	[ "$status" -ne 0 ]
+}
+
+# The virgl / no-surface case. screendump legitimately produces nothing there,
+# and the run must stay green.
+@test "stop with no frames succeeds and explains why there is no video" {
+	run env PATH="$BIN" bash "$SCRIPT" stop "$OUT"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"No frames captured"* ]]
+	[[ "$output" == *"virgl"* ]]
+	[ "$(cat "$OUT/frame-count.txt")" = "0" ]
+}
+
+# Frames captured but no encoder on the box: keep the frames, say so, stay
+# green. This is the state of this very container.
+@test "stop without ffmpeg keeps the frames and still succeeds" {
+	make_frames
+	run env PATH="$BIN" bash "$SCRIPT" stop "$OUT"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"ffmpeg is absent"* ]]
+	[ "$(cat "$OUT/frame-count.txt")" = "3" ]
+	[ -f "$OUT/frames/f000000.ppm" ]
+}
+
+@test "stop assembles a webm when ffmpeg is available" {
+	make_frames
+	cat >"$BIN/ffmpeg" <<-'EOF'
+		#!/bin/sh
+		# Emulate ffmpeg's contract narrowly: the output path is the last arg.
+		for last; do :; done
+		printf 'stub' > "$last"
+		exit 0
+	EOF
+	chmod +x "$BIN/ffmpeg"
+
+	run env PATH="$BIN" bash "$SCRIPT" stop "$OUT"
+	[ "$status" -eq 0 ]
+	[ -f "$OUT/timelapse.webm" ]
+	[[ "$output" == *"3 frames"* ]]
+}
+
+# A failing encoder must not fail the install either — the frames are still
+# worth keeping and the cell's verdict is unaffected.
+@test "an ffmpeg that fails leaves the frames and still succeeds" {
+	make_frames
+	cat >"$BIN/ffmpeg" <<-'EOF'
+		#!/bin/sh
+		exit 1
+	EOF
+	chmod +x "$BIN/ffmpeg"
+
+	run env PATH="$BIN" bash "$SCRIPT" stop "$OUT"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"could not assemble"* ]]
+	[ -f "$OUT/frames/f000000.ppm" ]
+}
+
+# start must return immediately even when the monitor socket will never
+# appear: it is called before the guest is up, and must not wedge the install.
+@test "start returns promptly with no monitor socket and records a pid" {
+	run env PATH="$BIN:$PATH" bash "$SCRIPT" start "$OUT/nonexistent.sock" "$OUT" 1
+	[ "$status" -eq 0 ]
+	[ -f "$OUT/.recorder.pid" ]
+	# Clean up the backgrounded loop this test just started.
+	kill "$(cat "$OUT/.recorder.pid")" 2>/dev/null || true
+}
+
+# ffmpeg's image2 demuxer stops at the first gap in the sequence, so a frame
+# that failed to capture must not consume an index — otherwise the video is
+# silently truncated at the hole rather than being short by one frame.
+@test "the frame counter only advances on a frame that actually landed" {
+	run grep -n 'n=\$((n + 1)) || rm -f' "$SCRIPT"
+	[ "$status" -eq 0 ]
+}

--- a/tests/test_matrix_status.py
+++ b/tests/test_matrix_status.py
@@ -249,5 +249,103 @@ class TruncationWarningTracksTheWindow(unittest.TestCase):
         self.assertEqual(self._walk(listed), "")
 
 
+class UndeclaredCellsAreNotCountedAgainstUs(unittest.TestCase):
+    """A cell build-config no longer schedules is out of scope, not failing.
+
+    flounder:cosmic and flounder-sid:cosmic were removed on purpose in 491544d1
+    ("drop the COSMIC flavours Debian cannot build"). Their last results are
+    still in the run window, and tally() used to enter any cell with a result
+    into the denominator — so the LUKS line read "39 of 54" when the live set
+    was 52, with two cells no run could ever turn green.
+
+    That is the failure nvidia_tally() already documents: a gap reported as if
+    someone should close it, which is its own kind of dishonest status page.
+    These tests hold the line in both directions — undeclared cells leave the
+    count, and declared ones stay in it however they did.
+    """
+
+    KEY = staticmethod(lambda v, d: f"LUKS {v}:{d}")
+
+    # flounder ships gnome/kde/xfce and no longer ships cosmic.
+    MATRIX = {"flounder": {"gnome", "kde", "xfce"}}
+
+    def test_a_removed_flavor_leaves_the_denominator(self):
+        results = {
+            "LUKS flounder:gnome": ("success", "2026-08-06"),
+            "LUKS flounder:kde": ("success", "2026-08-06"),
+            "LUKS flounder:xfce": ("success", "2026-08-06"),
+            "LUKS flounder:cosmic": ("failure", "2026-08-01"),
+        }
+        total, tested, passed = gms.tally(self.MATRIX, results, self.KEY)
+        self.assertEqual((total, tested, passed), (3, 3, 3))
+
+    def test_a_declared_failing_cell_still_counts(self):
+        """The guard against reading this as 'hide the reds'."""
+        results = {
+            "LUKS flounder:gnome": ("success", "2026-08-06"),
+            "LUKS flounder:kde": ("failure", "2026-08-06"),
+        }
+        total, tested, passed = gms.tally(self.MATRIX, results, self.KEY)
+        # xfce is declared and untested: in the total, not in tested.
+        self.assertEqual((total, tested, passed), (3, 2, 1))
+
+    def test_the_removed_flavor_is_still_disclosed(self):
+        """Dropped from the count, but named — not silently forgotten."""
+        results = {
+            "LUKS flounder:gnome": ("success", "2026-08-06"),
+            "LUKS flounder:cosmic": ("failure", "2026-08-01"),
+        }
+        self.assertEqual(
+            gms.undeclared_tally(self.MATRIX, results, self.KEY),
+            ["flounder:cosmic"],
+        )
+
+    def test_nothing_is_disclosed_once_the_result_ages_out(self):
+        """The count has to be able to reach zero, or it is just noise."""
+        results = {"LUKS flounder:gnome": ("success", "2026-08-06")}
+        self.assertEqual(
+            gms.undeclared_tally(self.MATRIX, results, self.KEY), []
+        )
+
+    def test_an_undeclared_cell_with_no_result_is_not_disclosed(self):
+        """Never-tested and never-scheduled is not a stale result."""
+        self.assertEqual(gms.undeclared_tally(self.MATRIX, {}, self.KEY), [])
+
+    def test_the_disclosure_does_not_trip_the_drift_gate(self):
+        """It appears and vanishes with the run window, like the NVIDIA note.
+
+        The pull_request gate compares structure with live-derived content
+        masked. A paragraph that exists only while a stale result does is live
+        content: without a VOLATILE_LINE entry it would fail every PR opened
+        while such a result sits in the window, for something no PR caused.
+        """
+        line = (
+            "The table above still shows a result for `flounder:cosmic`. "
+            "`.github/build-config.yml` no longer declares that flavour, so "
+            "..."
+        )
+        self.assertRegex(line, gms.VOLATILE_LINE)
+        # Control: an ordinary narrative line is NOT masked, so this is not
+        # passing because the regex matches everything.
+        self.assertNotRegex(
+            "This is the only axis that checks a human could actually install.",
+            gms.VOLATILE_LINE,
+        )
+
+    def test_the_real_build_config_declares_52_luks_cells(self):
+        """Ties the unit tests above to the actual denominator on disk.
+
+        If this number moves, the LUKS total moves with it, and that should be
+        a deliberate build-config edit rather than a surprise.
+        """
+        matrix = gms.luks_matrix()
+        self.assertEqual(sum(len(v) for v in matrix.values()), 52)
+        self.assertNotIn("cosmic", matrix.get("flounder", set()))
+        self.assertNotIn("cosmic", matrix.get("flounder-sid", set()))
+        # A control: the flavours flounder DOES declare are still there, so
+        # this is not passing because the matrix came back empty.
+        self.assertEqual(matrix.get("flounder"), {"gnome", "kde", "xfce"})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A matrix cell leaves behind a serial log and two stills. wootc films its acceptance run, which makes a green run something a person can look at instead of an artifact scavenger hunt. This does the same, per cell — and then chases every defect that stopped a cell from reaching the recorder.

**The recorder is verified end-to-end.** skipjack:cosmic run 31136849989 captured 210 frames and produced `timelapse.webm` + poster on a green cell.

## The recorder

`scripts/record-timelapse.sh`, ported from [`tuna-os/wootc` `tests/e2e/record-video.sh`](https://github.com/tuna-os/wootc/blob/main/tests/e2e/record-video.sh):

- **starts** at `TUNAOS_LUKS_E2E_INSTALL_STARTED`, so the film is the install, not the live-ISO boot before it
- **stops** from `cleanup_vm`'s `EXIT` trap — however the cell ends, and *before* the teardown that kills the process serving the frames

Capture is `screendump` over the monitor socket. `screenshot()` was not reused because it bridges VNC **per capture** (fresh `socat` listener, up to 5s polling, every time) — right for a handful of stills, wrong for ~300 frames.

### The property under test

**A cell that installs correctly but cannot be filmed is a green cell.** The 8 bats cases exist to defend that, and they earned it:

> Under `set -Eeuo pipefail`, `find` on a `frames/` directory that does not exist yet returns non-zero, propagates through the command substitution, and exits the script. A `stop` reached before the first frame landed **would have failed an install that was otherwise fine.**

Also fixed: the capture loop inherited the caller's stdout, and a backgrounded child holding that pipe blocks readers until it exits — which hung the suite for two minutes.

Publication is deliberately **not** here: 53 cells of WebM is ~160MB of git history. It belongs in R2 alongside `weekly-desktop-screenshots.yml`, gated on `TUNAOS_LUKS_E2E_PASS`.

---

## Nine defects, each found by a cell actually running

### 1. `grouper:cosmic` ran `dnf` on Ubuntu

`Containerfile.ubuntu`'s cosmic stage invoked `desktop/cosmic.sh`, the one per-DE script with no apt branch — `base)` handled Fedora, then fell through to an EL10 COPR path. Every other Containerfile already routed cosmic through `install-desktop.sh`, which is also the only path reading `cosmic.yaml`'s `packages.apt.ppa` block (COSMIC is in no Ubuntu repository; it comes solely from `ppa:hepp3n/cosmic-epoch`).

`test_declared_flavors_installable.bats` could not catch this — the manifest looks installable. A new case in `test_containerfile_context_scripts.bats` closes it from the other side.

### 2. …then could not find `cosmic-icon-theme`

The **RPM** spelling. Debian/Ubuntu and openSUSE call it `cosmic-icons`; the zypper section already said so. apt aborts the whole transaction on the first unresolvable name, so one wrong entry failed all 21 packages. Checked against `getPublishedBinaries` (46 binaries, 3 pages). `test_cosmic_apt_package_names.bats` pins the split **both** ways, so renaming every occurrence — the obvious wrong repair — is rejected.

### 3. Image builds had no retry on the podman path

`build-image-inner.sh`'s until-loop bailed on `BUILDER != "buildah" || attempt >= 3`. The ISO path builds with **podman**, so every ISO build has had zero retries since the loop was added. `LUKS albacore:niri` died six seconds in on a mid-blob registry EOF.

The log line hid it: `image build failed after 1 attempt(s)` reads like a retry that ran out, not one that never ran. Accepted cost: a genuine build error now takes three attempts.

### 4. The status board counted cells that cannot exist

`docs/MATRIX-STATUS.md` read **39 of 54**. The live set is **52** — `flounder:cosmic` and `flounder-sid:cosmic` were removed in 491544d1, but `tally()` entered any cell with a stale result into the denominator. Two permanent reds no run could ever turn green. Same failure `nvidia_tally()` already documents in that file; undeclared cells now get the same treatment — out of the tally, disclosed by name.

### 5–6. greetd and cosmic-greeter raced for `display-manager.service`

`cosmic-greeter` claims the alias; the manifest also declares `display_manager: greetd`, which `install-desktop.sh` force-links. Two units both running `greetd` on vt1 with `Restart=always`.

- **Ubuntu failed the build** (`greetd.service` there carries `Alias=` and no `WantedBy=`, so `systemctl enable` collided).
- **Fedora/EL succeeded and shipped the race** (`WantedBy=`, no `Alias=`) — the worse outcome. greetd took the terminal; cosmic-greeter crash-looped on `unable to take controlling terminal: EPERM`.

Both halves now key off **the symlink**, never off whether cosmic-greeter is installed. Verified across two packaging paths:

| cell | base | DM chosen | contract |
|---|---|---|---|
| skipjack:cosmic | EL10 | cosmic-greeter | **ok** (was fail) |
| yellowfin:cosmic | EL10 | cosmic-greeter | **ok**, 0 EPERM |
| sailfin:cosmic | openSUSE | greetd | **ok** — else-branch, no regression |

### 7. `ffmpeg` was never installed

The first green cell with the recorder shipped `frame-count.txt` reading **203** and no video. `frame-count.txt` is in the artifact list precisely so this is distinguishable from "screendump found no surface" (which reads 0) — and that is exactly the question it answered on its first real run.

### 8. `FISHERMAN_OVERRIDE` was installed after the check that made it unreachable

`run_install()` hard-`return 3`s when the image ships no fisherman, ~260 lines **before** the block that installs the override at that path. Gentoo ships none, so all three guppy cells died without ever receiving the binary the workflow had just built.

The wall clock misleads: the run spans 2h10m, which reads like a Gentoo build plus the 3600s install timeout. **The LUKS step ran 55 seconds.**

Follow-ups caught three consequences of the reorder: the generic `TBOX_E2E_IMAGE` path lost its trigger (and would have installed the wrong image), `install -D` cannot create `/usr/local/bin` through the ostree `/usr/local` symlink, and a missing fisherman now emits a `::warning::` naming what went untested.

### 9. The install VM held the pidfile the next boot needed

`poweroff_and_wait_vm` waited 60s then returned regardless. QEMU holds an **exclusive lock** on `-pidfile` for its whole life, so a guest still running does not delay the next boot — it forbids it:

```
qemu-system-x86_64: cannot create PID file: Cannot lock pid file:
Resource temporarily unavailable
```

albacore:cosmic died that way 70s after `Installation complete!`, with no `ERROR` line of its own — which is why its artifact had no `installed-serial.log` at all. Two lines earlier: `cryptsetup luksClose: Device fisherman-root is still in use`, and a busy dm device is what systemd-shutdown retries against, on top of a 90s `DefaultTimeoutStopSec` that 60s cannot outlast. Now `TUNAOS_E2E_POWEROFF_WAIT` (default 180s), then ACPI → SIGTERM → SIGKILL, and never return while the process lives.

---

## The finding that matters most

**Cells can pass the LUKS gate while shipping a desktop that never starts.** skipjack:cosmic and albacore:cosmic were both ticked green on the board with a crash-looping greeter, because `desktop_contract` is `fatal=0`.

Nothing was lying — `MATRIX-STATUS.md` §1 already states LUKS "does not prove … that a desktop session starts". There is simply no axis reporting the contract, so a dead greeter and a working one look identical from the board. Both this and the pidfile lock are written up in `docs/ci-troubleshooting.md` as failure-catalog entries 5–7.

Two hypotheses are recorded there as **wrong**, because both are the obvious first guesses: the contract is not racing its own `graphical.target` (the unit reaches `auto-restart` with `ExecMainStatus=1` — it starts and dies), and `rendered=absent` is not a broken-desktop signal (it appears on passing niri and xfce cells; the harness runs headless with no render node).

**Whether `desktop_contract` should become fatal, or gain a board axis, is a deliberate call about what "green" guarantees — and is left to the maintainers rather than changed as a side effect of chasing a number.**