### PR TITLE
fix(iso-e2e): enable tpm2-luks via a bootc install-config drop-in

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -1103,7 +1103,7 @@ wait_for_ready() {
 				echo "    [ssh: guest is alive — checking why marker hasn't fired]"
 				sshpass -p live ssh $ssh_opts liveuser@127.0.0.1 -p "$SSH_PORT" \
 					"systemctl status tunaos-live-ready.service 2>&1 || true; echo '---'; systemctl is-active graphical.target 2>&1 || true" \
-					>> "$SERIAL_LOG" 2>/dev/null || true
+					>>"$SERIAL_LOG" 2>/dev/null || true
 				# Also try grepping serial log for an install-checks result as
 				# a backup readiness signal — it means the system is well past
 				# boot and the marker just didn't fire.
@@ -1455,8 +1455,23 @@ run_install_generic() {
 		return 3
 	fi
 
-	local block_setup=""
-	[[ "$LUKS" -eq 1 ]] && block_setup="--block-setup tpm2-luks"
+	local block_setup="" luks_cfg_mount=""
+	if [[ "$LUKS" -eq 1 ]]; then
+		block_setup="--block-setup tpm2-luks"
+		# bootc refuses --block-setup tpm2-luks unless the image's install
+		# config opts in: "Block setup Tpm2Luks is not enabled in
+		# installation config" (attempt 11, iso-builder run 31125136026 —
+		# it wiped /dev/vda and stopped one line later). Stock images ship
+		# no such opt-in, and it is install-time POLICY, not image content:
+		# stage a config drop-in on the scratch disk and bind-mount it into
+		# the installing container instead of mutating the image. "direct"
+		# stays in the list so the default path remains enabled too.
+		"${ssh_cmd[@]}" "printf '[install]\nblock = [\"direct\", \"tpm2-luks\"]\n' | sudo tee /var/lib/containers/tbox-install-luks.toml >/dev/null" || {
+			echo "ERROR: could not stage the bootc install-config drop-in" >&2
+			return 3
+		}
+		luks_cfg_mount="-v /var/lib/containers/tbox-install-luks.toml:/usr/lib/bootc/install/90-tbox-luks.toml:ro"
+	fi
 	echo "==> Running bootc install to-disk on /dev/vda..."
 	# The canonical containerized install (bootc docs): privileged, host pid,
 	# /dev and the store bind-mounted. The kargs the passphrase-gate path
@@ -1464,6 +1479,7 @@ run_install_generic() {
 	# entries it writes, and --karg is the supported way in.
 	if ! timeout 1800 "${ssh_cmd[@]}" "sudo podman run --rm --privileged --pid=host \
 		-v /var/lib/containers:/var/lib/containers -v /dev:/dev \
+		${luks_cfg_mount} \
 		--security-opt label=type:unconfined_t \
 		${imgref} \
 		bootc install to-disk --wipe ${block_setup} \

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -908,6 +908,13 @@ setup_runtime_check_stubs() {
   grep -q 'bootc install to-disk --wipe' "$SCRIPT"
   grep -qF 'block_setup="--block-setup tpm2-luks"' "$SCRIPT"
   grep -q -- '--karg console=ttyS0,115200n8 --karg rd.plymouth=0 --karg plymouth.enable=0' "$SCRIPT"
+  # bootc gates --block-setup tpm2-luks on the image's install config
+  # ("Block setup Tpm2Luks is not enabled in installation config", attempt
+  # 11 / run 31125136026). The opt-in is install-time policy, delivered as
+  # a drop-in bind-mounted into the installing container — never baked
+  # into the image. "direct" must stay enabled alongside it.
+  grep -qF 'block = [\"direct\", \"tpm2-luks\"]' "$SCRIPT"
+  grep -qF '/usr/lib/bootc/install/90-tbox-luks.toml:ro' "$SCRIPT"
 }
 
 @test "generic: the unlock gate restarts swtpm on preserved state" {


### PR DESCRIPTION
## What

The next (and hopefully last) rung of the aurora ladder. Attempt 11 (iso-builder run [31125136026](https://github.com/tuna-os/iso-builder/actions/runs/31125136026)) validated nearly the entire generic install path:

- **vsock SSH as root via `ssh.ephemeral-authorized_keys-all`: worked** (every guest command in the log rode `e2e-vsock` — #1031 confirmed in production)
- smoke checks ran over it (11/13, warn-only)
- scratch-disk container storage staged (32G ext4 on `/var/lib/containers`), swap at 12G
- the full `ghcr.io/ublue-os/aurora:stable` pulled in **~2.5 minutes** through the MTU-clamped SLIRP

Then `bootc install to-disk` wiped `/dev/vda` and stopped one line later:

```
error: Installing to disk: Creating rootfs: Block setup Tpm2Luks is not enabled in installation config
```

## Why / How

bootc gates `--block-setup tpm2-luks` on the image's install config under `/usr/lib/bootc/install/`, and stock images ship no such opt-in. The opt-in is install-time **policy**, not image content — so the harness stages a drop-in on the scratch disk and bind-mounts it into the installing container (no image mutation):

```toml
[install]
block = ["direct", "tpm2-luks"]
```

`direct` stays in the list so the default block setup remains enabled.

Also carries a one-character shfmt fix in the `wait_for_ready` ssh probe that predates this change (would otherwise trip this PR's lint).

## Testing

- Extended the `generic: bootc install…` bats test to pin both the drop-in content and the bind-mount destination; full suite green locally except the 4 known container-env cases that fail identically on main here.
- `bash -n`, shellcheck (0 warnings+), `shfmt -d` clean.
- Real validation: aurora attempt 12 dispatches after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9hTUH9j7C8fJbCpuXefQN

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9hTUH9j7C8fJbCpuXefQN)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->