### PR TITLE
docs: fill the installer parity matrix from the frontends' GPU-less captures

### DIFF
--- a/.github/workflows/frontend-parity.yml
+++ b/.github/workflows/frontend-parity.yml
@@ -1,0 +1,45 @@
+name: frontend parity
+
+# Imports each installer frontend's GPU-less capture report into the parity
+# matrix in docs/INSTALLER-FRONTENDS.md.
+#
+# The matrix's other source is installer-smoke.yml, which needs a virgl-capable
+# host — which is why Niri and XFCE have never been evaluated at all. This does
+# not replace it: it fills the screen columns from evidence that a stock runner
+# can actually produce, and leaves launch/render/advance to the VM run. See the
+# doc for why those must not be conflated.
+
+on:
+  schedule:
+    - cron: "30 6 * * *"   # after matrix-status at 06:00
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  import:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: import parity reports
+        env:
+          # Needs read access to the frontend repos' artifacts, which the
+          # default GITHUB_TOKEN does not have — it is scoped to this repo.
+          GH_TOKEN: ${{ secrets.FRONTEND_READ_TOKEN || github.token }}
+        run: python3 scripts/import-frontend-parity.py
+
+      - name: commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/INSTALLER-FRONTENDS.md
+          if git diff --cached --quiet; then
+            echo "no parity changes"
+            exit 0
+          fi
+          # Pushed only when a cell actually moves, same rule as matrix-status.
+          git commit -m "docs: import installer frontend parity reports [skip ci]"
+          git push

--- a/docs/INSTALLER-FRONTENDS.md
+++ b/docs/INSTALLER-FRONTENDS.md
@@ -76,6 +76,33 @@ Filled from each run's `walkthrough-<flavor>.json`.
 
 _GPU_ = needs a virgl-capable host to evaluate; blank on GPU-less CI is expected.
 
+### Screen parity from GPU-less capture
+
+The matrix above is filled by `scripts/installer-walkthrough.py`, which needs a
+virgl-capable host. That is why Niri and XFCE read `_GPU_`: they have **never
+been evaluated**, and two crash-on-launch bugs plus a 93%-white screen survived
+in that gap — because a blank cell and a passing cell look identical to a
+reader.
+
+Each frontend repo now also runs an offscreen screenshot capture on a stock
+runner and emits the same `walkthrough-<flavor>.json`.
+`scripts/import-frontend-parity.py` imports those into the table below.
+
+**The two sources are not interchangeable, and are deliberately not merged.**
+An offscreen capture drives the wizard's pages in-process, so it cannot observe
+the three things the first columns above measure: that the flatpak launches
+under the real desktop, that a GL-less compositor can draw it — precisely what
+Niri and XFCE are suspected to fail — or that a keypress advances the wizard
+(KDE's `enter` defect is invisible to it by construction). Folding a `✅ᶜ` into
+a `✅` would claim coverage nobody has, which is a worse failure than the blank
+cells it replaces. So the import fills the screen columns only, and tags them.
+
+<!-- BEGIN GENERATED — scripts/import-frontend-parity.py -->
+
+_Not yet imported — run `scripts/import-frontend-parity.py`._
+
+<!-- END GENERATED — scripts/import-frontend-parity.py -->
+
 ### KDE — run 29684495194 (yellowfin, strict) — PASSES
 
 With the widened focus search the run reaches **6/8 transitions, 7 visual

--- a/scripts/import-frontend-parity.py
+++ b/scripts/import-frontend-parity.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Fill the installer parity matrix from the frontends' GPU-less captures.
+
+WHY. `docs/INSTALLER-FRONTENDS.md` has a parity matrix fed by
+`walkthrough-<flavor>.json`, and the only producer of that file has been
+`scripts/installer-walkthrough.py` — a VM harness that OCRs QEMU screendumps
+and therefore needs a virgl-capable host. niri and xfce are Smithay
+compositors that render nothing without EGL_EXT_device_drm, so their rows have
+read `_GPU_` since the matrix was written: never evaluated, not once. Two
+crash-on-launch bugs and a 93%-white screen survived in exactly that gap,
+because "no data" and "fine" look identical in a table.
+
+Each frontend repo now runs an offscreen screenshot capture on a stock runner
+and emits the same `walkthrough-<flavor>.json`. This imports those.
+
+    scripts/import-frontend-parity.py [--check]
+
+WHAT THIS MUST NOT DO, and the reason the script is shaped the way it is.
+
+An offscreen capture and a VM run do NOT measure the same thing, and merging
+them into one ✅ would be a worse failure than the blank cells it replaces —
+it would claim coverage nobody has. Specifically, a capture that drives pages
+programmatically inside the app's own process cannot speak to:
+
+  * **Launches** — whether the flatpak starts under the real desktop.
+  * **Renders** — whether a compositor with no GL can draw it. This is the
+    precise thing niri and xfce are suspected to fail, and the capture runs
+    offscreen, so it can never observe it.
+  * **Advances** — whether a keypress moves the wizard. The capture calls
+    navigateTo() directly. KDE's "enter activates no button" defect
+    (tuna-installer-kde#4) is invisible to it by construction.
+
+So this importer fills the SCREEN columns only, and tags every cell it writes
+with its source. The first three columns stay the VM run's territory and are
+left exactly as they are.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DOC = os.path.join(REPO, "docs", "INSTALLER-FRONTENDS.md")
+BEGIN = "<!-- BEGIN GENERATED — scripts/import-frontend-parity.py -->"
+END = "<!-- END GENERATED — scripts/import-frontend-parity.py -->"
+
+# gnome is upstream and unmodified, and ships no capture of ours.
+FRONTENDS = [
+    ("KDE", "kde", "tuna-os/tuna-installer-kde"),
+    ("COSMIC", "cosmic", "tuna-os/tuna-installer-cosmic"),
+    ("Niri", "niri", "tuna-os/tuna-installer-niri"),
+    ("XFCE", "xfce", "tuna-os/tuna-installer-xfce"),
+]
+
+SCREENS = ["welcome", "disk", "encryption", "summary", "install", "done"]
+REQUIRED = {"welcome", "disk", "summary"}
+
+
+class _Failed:
+    """A gh invocation that could not happen. Shaped like CompletedProcess so
+    callers need no special case — a missing gh degrades to 'unfetched', which
+    the matrix renders as ⬜, rather than taking the import down with a
+    traceback."""
+    returncode, stdout, stderr = 1, "", "gh CLI not found on PATH"
+
+
+def gh(*args, **kw):
+    try:
+        return subprocess.run(["gh", *args], capture_output=True, text=True, **kw)
+    except FileNotFoundError:
+        return _Failed()
+
+
+def fetch(repo, flavor, dest):
+    """Newest walkthrough-<flavor>.json from that repo's screenshots workflow.
+
+    Returns (data, run_url) or (None, reason). A frontend we cannot fetch is
+    reported as unfetched — never silently dropped, and never carried forward
+    from a previous import. A stale row that looks current is the failure mode
+    this whole document exists to prevent.
+    """
+    r = gh("run", "list", "--repo", repo, "--workflow", "screenshots.yml",
+           "--limit", "10", "--json", "databaseId,conclusion,headBranch,url")
+    if r.returncode:
+        return None, f"gh run list failed: {r.stderr.strip()[:120]}"
+    try:
+        runs = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None, "could not parse gh output"
+
+    # Only main. A PR run reports the branch's frontend, not the shipped one.
+    runs = [x for x in runs if x.get("headBranch") == "main"]
+    if not runs:
+        return None, "no runs on main"
+
+    for run in runs:
+        out = os.path.join(dest, str(run["databaseId"]))
+        d = gh("run", "download", str(run["databaseId"]), "--repo", repo,
+               "--name", "gui-screenshots", "--dir", out)
+        if d.returncode:
+            continue
+        path = os.path.join(out, f"walkthrough-{flavor}.json")
+        if not os.path.exists(path):
+            # The capture ran but predates the parity emitter.
+            continue
+        with open(path) as fh:
+            return json.load(fh), run["url"]
+    return None, "no run carried a parity report"
+
+
+def cell(data, screen):
+    reached = (data.get("screens") or {}).get(screen)
+    if reached is None:
+        return "⬜"
+    if reached:
+        return "✅ᶜ"
+    # A required screen the capture could not find is a real gap — but it is
+    # as often the frontend's wording missing the spec's keywords as a missing
+    # screen. Both matter; neither is "it failed to install".
+    return "❌ᶜ" if screen in REQUIRED else "⬜ᶜ"
+
+
+def render(results):
+    lines = [
+        BEGIN,
+        "",
+        "| Frontend | Source | welcome | disk | encryption | summary | install | done |",
+        "|----------|--------|---------|------|------------|---------|---------|------|",
+    ]
+    notes = []
+    for label, flavor, repo in FRONTENDS:
+        data, ref = results[flavor]
+        if data is None:
+            lines.append(f"| {label} | — | " + " | ".join(["⬜"] * 6)
+                         + " |")
+            notes.append(f"- **{label}** — no parity report imported ({ref}).")
+            continue
+        cells = " | ".join(cell(data, s) for s in SCREENS)
+        src = f"[capture]({ref})"
+        lines.append(f"| {label} | {src} | {cells} |")
+        notes.append(
+            f"- **{label}** — {data.get('frames')} pages, "
+            f"{data.get('rendered_frames')} passed the pixel audit, "
+            f"{data.get('advanced_transitions')} transitions. "
+            f"Text from `{data.get('text_source', 'unknown')}`.")
+    lines += ["", "ᶜ = GPU-less offscreen capture in the frontend's own repo.",
+              "**It attests to screen parity only.** It drives pages in-process,",
+              "so it cannot observe whether the app launches under the real",
+              "desktop, whether a GL-less compositor can draw it, or whether a",
+              "keypress advances the wizard — the first three columns of the",
+              "matrix above remain the VM walkthrough's job, and a green row",
+              "here is not a substitute for one.", ""]
+    lines += notes + ["", END]
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true",
+                    help="fail if the doc is out of date; write nothing")
+    args = ap.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        results = {f: fetch(repo, f, tmp) for _, f, repo in FRONTENDS}
+
+    for label, flavor, _ in FRONTENDS:
+        data, ref = results[flavor]
+        print(f"{label:8s} {'ok' if data else 'MISSING'}  {ref}")
+
+    block = render(results)
+    with open(DOC) as fh:
+        doc = fh.read()
+
+    if BEGIN in doc and END in doc:
+        new = re.sub(re.escape(BEGIN) + r".*?" + re.escape(END), block, doc,
+                     flags=re.S)
+    else:
+        print(f"FAIL: markers not found in {DOC}", file=sys.stderr)
+        return 2
+
+    if args.check:
+        if new != doc:
+            print("FAIL: parity section is out of date — run without --check",
+                  file=sys.stderr)
+            return 1
+        print("parity section is current")
+        return 0
+
+    if new == doc:
+        print("no change")
+        return 0
+    with open(DOC, "w") as fh:
+        fh.write(new)
+    print(f"updated {DOC}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Proposal — the consumer side of tuna-installer-kde#9, tuna-installer-niri#9, tuna-installer-xfce#6.** Please review the shape before merging; the three producer PRs are also unmerged.

## Why

The parity matrix in `docs/INSTALLER-FRONTENDS.md` is fed by `scripts/installer-walkthrough.py`, which needs a virgl-capable host. So **Niri and XFCE have read `_GPU_` since the matrix was written — never evaluated, not once.** Two crash-on-launch bugs and a 93%-white screen survived in exactly that gap, because a blank cell and a passing cell look identical to a reader. This document already makes that argument for `MATRIX-STATUS.md`; the frontend matrix is the place it has not yet been applied.

Each frontend repo now runs an offscreen capture on a stock GitHub runner and emits the **same** `walkthrough-<flavor>.json` this repo already consumes. No new contract, no new schema — `scripts/import-frontend-parity.py` imports them.

## The design decision worth reviewing

**The two sources are deliberately not merged into one column.**

An offscreen capture drives the wizard's pages in-process. It therefore *cannot* observe the three things the existing columns measure:

| Column | Why the capture can't speak to it |
|---|---|
| **Launches** | It never starts the flatpak under the real desktop. |
| **Renders** | It runs offscreen — and "can a GL-less compositor draw this" is *precisely* what Niri and XFCE are suspected to fail. |
| **Advances** | It calls `navigateTo()` directly. KDE's `enter`-activates-nothing defect (tuna-installer-kde#4) is invisible to it by construction. |

Folding a `✅ᶜ` into a `✅` would claim coverage nobody has — a worse failure than the blank cells it replaces, and the same class of mistake as the old `pgrep` check that matched its own command line. So the import writes the **screen columns only**, into its own tagged table with an explicit legend, and leaves launch/render/advance to the VM run.

Other honesty properties:

- A frontend that cannot be fetched renders `⬜` and is **named in the notes** — never carried forward from a previous import. A stale row that looks current is the failure this document exists to prevent.
- Only `main` runs are read. A PR run reports the branch's frontend, not the shipped one.
- Missing `gh` degrades to "unfetched", not a traceback.

## Verified

Rendering was checked against the three **real** reports produced by those PRs' captures (run locally: GTK3 under Xvfb, QML via PyQt6 offscreen, and Qt6 Widgets built with `-DBUILD_CAPTURE=ON`):

| Frontend | Source | welcome | disk | encryption | summary | install | done |
|----------|--------|---------|------|------------|---------|---------|------|
| Niri | capture | ✅ᶜ | ❌ᶜ | ✅ᶜ | ✅ᶜ | ⬜ᶜ | ✅ᶜ |
| XFCE | capture | ✅ᶜ | ❌ᶜ | ⬜ᶜ | ✅ᶜ | ⬜ᶜ | ✅ᶜ |
| KDE | capture | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ⬜ᶜ | ✅ᶜ |

**This is the first data those Niri and XFCE rows have ever carried.**

## Two findings that fall straight out of it

1. **`disk` fails on both Niri and XFCE — because of the keyword list, not a missing screen.** Niri's disk page heads "Destination"; XFCE's heads "Where should TunaOS be installed?". The spec wants `where tunaos will be installed`. KDE matches *three* of the disk keywords outright, which strongly suggests `tests/installer-screens.yaml` was written from KDE's wording. Whether that is fixed in the two frontends or in the spec is worth deciding deliberately — I did not tune any keyword to make it go green.
2. **"KDE has no encryption screen" is out of date.** The capture matches `disk encryption` on KDE's dedicated encryption page — *not* the `Encryption: None` row on confirm that the spec's comments warn about. tuna-installer-kde#6 added it. The matrix would have gone on asserting the gap indefinitely.

## Blocker

`GITHUB_TOKEN` is scoped to this repo and cannot read the frontend repos' artifacts. The workflow reads `secrets.FRONTEND_READ_TOKEN` and falls back to `github.token`; **that secret needs creating or the scheduled import will import nothing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->