### PR TITLE
tests: broaden the installer screen keywords, which were KDE-specific

### DIFF
--- a/tests/installer-screens.yaml
+++ b/tests/installer-screens.yaml
@@ -31,8 +31,21 @@ screens:
     title: Disk / target selection
     required: true
     # Heading/prompt text, not the "Target Disk: vda" row on the summary.
+    #
+    # MEASURED 2026-08-07 against the frontends' real headings. The list below
+    # was evidently written from KDE's wording — KDE matches three of these
+    # outright while Niri and XFCE matched none, which read as "no disk screen"
+    # for two frontends that plainly have one:
+    #     KDE     "Select Target Disk"                  matched
+    #     Niri    "Destination"                         no match
+    #     XFCE    "Where should TunaOS be installed?"   no match ("should be"
+    #                                                    vs "will be")
+    # "destination" is admitted as a bare-ish noun deliberately: it is the
+    # entire heading on Niri, and it does not appear as a field label on any
+    # other screen in any of the four frontends.
     keywords: ["select target disk", "select a disk", "choose the disk",
-               "available disks", "where tunaos will be installed"]
+               "available disks", "where tunaos will be installed",
+               "where should tunaos be installed", "destination"]
 
   - id: encryption
     title: Disk encryption (LUKS)
@@ -61,8 +74,38 @@ screens:
     # NOT "installing tunaos": the welcome page says "guide you through
     # installing TunaOS onto your computer". Progress screens say what they
     # are DOING, so match that instead.
+    #
+    # MEASURED 2026-08-07: ZERO of the four frontends matched this list.
+    #     KDE     (no contract keyword present)
+    #     Niri    "Installing…"
+    #     XFCE    "Installing TunaOS"
+    #     COSMIC  "Installing"
+    # Four frontends failing the same optional screen is one wrong list, not
+    # four wording bugs.
+    #
+    # NOT bare "installing", which was the obvious fix and is wrong. Niri's
+    # ENCRYPTION page reads "cannot be turned on later without reinstalling",
+    # and "installing" is a substring of "reinstalling". Encryption is not the
+    # first state, so the crediting rule would NOT have caught it: bare
+    # "installing" manufactures a phantom install row on the encryption screen.
+    # Exactly the failure the notes above this list were written about.
+    #
+    # "installing tunaos" IS safe, and the comment above rejects it because
+    # Niri's WELCOME prose says "guide you through installing TunaOS onto your
+    # computer" — correct, but that prose lives on the FIRST state, which the
+    # crediting rule already defends. So it is admitted, with the ellipsis form
+    # for Niri's own heading.
+    #
+    # The fisherman step lines are included too. Every frontend streams the
+    # same backend, so "partitioning" and "installing image" appear on the
+    # progress screen of all four and on no other screen — the strongest
+    # evidence available that an install is actually under way, which is the
+    # principle this list already states ("progress screens say what they are
+    # DOING").
     keywords: ["installation progress", "copying files", "deploying",
-               "please wait", "writing image"]
+               "please wait", "writing image",
+               "installing tunaos", "installing\u2026",
+               "partitioning", "installing image"]
 
   - id: done
     title: Finished / reboot


### PR DESCRIPTION
**Proposal.** The parity matrix reports screens as absent that plainly exist, and it is the keyword list rather than the frontends. Measured against all four frontends' real headings, 2026-08-07:

| screen | KDE | Niri | XFCE | COSMIC |
|---|---|---|---|---|
| `disk` | "Select Target Disk" ✅ | "Destination" ❌ | "Where should TunaOS be installed?" ❌ | — |
| `install` | ❌ | "Installing…" ❌ | "Installing TunaOS" ❌ | "Installing" ❌ |

KDE matches *three* disk keywords outright and no other frontend matches any — the list was evidently written from KDE's wording. And **zero of four** match the install list.

Four frontends failing the same screen is one wrong list, not four wording bugs.

This matters beyond tidiness. A matrix that reports false negatives is one readers learn to discount, and the entire argument for this matrix — made in `docs/INSTALLER-FRONTENDS.md` — is that a blank cell must never read as a passing cell.

## The obvious fix is wrong, and checking is what caught it

Admitting bare `"installing"` looks right and isn't. Niri's **encryption** page reads *"cannot be turned on later without **reinstalling**"*, and `installing` is a substring of `reinstalling`. Encryption is not the first state, so the crediting rule would **not** have defended it — bare `"installing"` manufactures a phantom `install` row on the encryption screen.

That is exactly the failure the existing comments in this file were written about (the `"encrypt"` → `"Encryption: None"` case, and the `"%"` → OCR-noise case), so I applied the same discipline rather than setting it aside.

## What is admitted, and why

- **`"installing tunaos"`, `"installing…"`** — the file's comment rejects the former because Niri's welcome prose says *"guide you through installing TunaOS onto your computer"*. Fair, but that prose lives on the **first state**, and the crediting rule already defends precisely that case. The objection is answered rather than ignored.
- **`"partitioning"`, `"installing image"`** — fisherman's own step lines. Every frontend streams the same backend, so these appear on all four progress screens and nowhere else. That is the strongest evidence available that an install is genuinely under way, and it follows the principle this list already states: *progress screens say what they are DOING*.
- **`"destination"`** — a near-bare noun, admitted deliberately: it is the entire heading on Niri and appears as a field label on no other screen in any frontend.
- **`"where should tunaos be installed"`** — XFCE's actual phrasing; the existing entry says "will be".

## Verified in both directions

Against the frontends' real screen text:

```
false positives for 'install' keywords on non-progress screens: none
install credited: xfce-progress [installing tunaos, partitioning, installing image]
                  niri-progress [installing…, partitioning]
disk credited:    niri-disk [destination]
                  xfce-disk [where should tunaos be installed]
```

## Alternative worth considering

The other way to fix this is to converge the frontends' wording instead of broadening the spec — one product vocabulary, and the matcher stays strict. That is a better end state and a bigger change, and it is your call. This PR takes the smaller path so the matrix stops lying in the meantime; it does not preclude the other.

Related: #1036 (the matrix consumer), and the producer PRs in the four frontend repos.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->