### PR TITLE
fix(luks-e2e): guppy had skopeo where the install needs podman

### DIFF
--- a/Containerfile.gentoo
+++ b/Containerfile.gentoo
@@ -84,10 +84,28 @@ RUN emerge --verbose --deep --newuse @world
 #   ERROR: ENABLE_SSHD=1 grants liveuser NOPASSWD sudo, but this image has no sudo.
 #
 # guppy:xfce, LUKS run 31082460289 — after a complete, correct image build.
+#
+# app-containers/podman, third of the same kind, and the one that skopeo looks
+# like it covers but does not. guppy probes BACKEND=composefs-native, and the
+# composefs install path cannot take fisherman's bootcDirect shortcut — bootc
+# has to run in a container, which means podman in the live guest (see the
+# SWAP_DISK comment in scripts/iso-e2e.sh, written from a sailfin OOM of that
+# very process). skopeo is here for bootc's containers-image-proxy and answers a
+# different question, so the gap read as "image absent" rather than "no podman":
+# the offline store held ghcr.io/tuna-os/guppy:gnome and every probe of it was
+# `sudo: podman: command not found`, so the cell fell through to the SSH image
+# transfer that scripts/iso-e2e.sh documents as impossible and died on
+#
+#   scp: write remote "/home/liveuser/luks-image-guppy-gnome.tar": Failure
+#
+# 2h30m into the job. guppy:gnome, LUKS run 31134373523. Every other base has
+# podman — the rpm and apt ones from build_scripts/10-base-packages.sh,
+# Containerfile.arch and .debian by name — and Gentoo runs none of those, which
+# is why guppy was the only variant without it.
 RUN emerge --verbose --deep --newuse \
         app-arch/cpio btrfs-progs dev-vcs/git dosfstools sys-fs/xfsprogs \
         linux-firmware rust skopeo sys-kernel/gentoo-kernel-bin systemd \
-        sys-apps/flatpak app-admin/sudo \
+        sys-apps/flatpak app-admin/sudo app-containers/podman \
         net-vpn/tailscale gui-apps/wl-clipboard media-video/ffmpeg media-plugins/gst-plugins-meta && \
     curl -fsSL -o /tmp/just.tar.gz https://github.com/casey/just/releases/download/1.35.0/just-1.35.0-x86_64-unknown-linux-musl.tar.gz && \
     tar -xzf /tmp/just.tar.gz -C /usr/bin just && rm /tmp/just.tar.gz && \

--- a/docs/ci-troubleshooting.md
+++ b/docs/ci-troubleshooting.md
@@ -366,6 +366,67 @@ the guest ourselves costs the following boot nothing. If it survives `SIGKILL`
 the function now fails with that as the reason, and the passphrase gate's own
 launch names a QEMU it could not start instead of exiting silently.
 
+### 8. `guppy` shipped skopeo instead of podman, so its offline store read as empty (2026-08-07)
+
+**Affected:** both `guppy` cells (Gentoo). Measured on `guppy:gnome`, run
+31134373523 — 2h30m in, after a complete and correct image build, a green live
+squash and 13 passing live-ISO checks.
+
+**Symptom:**
+
+```
+--- names recorded in the offline store ---
+[{... "names":["ghcr.io/tuna-os/guppy:gnome"] ...}]
+==> Probing for ghcr.io/tuna-os/guppy:gnome...
+==> Probing for localhost/guppy:gnome...
+==> No local image in offline store — transferring from host via SSH
+...
+scp: write remote "/home/liveuser/luks-image-guppy-gnome.tar": Failure
+ERROR: image transfer to guest timed out or failed
+```
+
+**The contradiction is the whole clue.** The dump prints the store's own index,
+recording the exact ref the very next line fails to find. Fifteen lines above
+it, twice: `sudo: podman: command not found`.
+
+**Root cause, two layers.**
+
+*The image.* `Containerfile.gentoo` emerged `app-containers/skopeo` and never
+`app-containers/podman`. Skopeo looks like coverage — it is what bootc's
+containers-image-proxy shells out to — but it cannot *start* a container, and
+`guppy` probes `BACKEND=composefs-native`, whose install path cannot take
+fisherman's `bootcDirect` shortcut: bootc runs inside a container podman
+starts. Every other base has podman (the rpm and apt ones via
+`build_scripts/10-base-packages.sh`, `Containerfile.arch` and `.debian` by
+name) and Gentoo runs none of those scripts. Third time Gentoo was the last
+base without something — see `sudo` (§ `test_live_sudo_every_base.bats`) and
+flatpak before it.
+
+*The harness.* Both offline-store probes were answered **inside** the guest:
+`sudo podman image exists <ref>`, then `sudo jq -e ... images.json` as the
+fallback. guppy has neither binary, so both exited 127 and the harness
+concluded "image absent" — then fell through to the SSH image transfer that
+`scripts/iso-e2e.sh` documents at length as physically impossible (a ~4.9G tar
+into a tmpfs upperdir on a 4096M guest, #941). A missing tool read as a missing
+image.
+
+**Fix, matching the two layers.**
+
+- `Containerfile.gentoo` emerges `app-containers/podman`.
+- `customize-live.sh` asserts `command -v podman` next to its `sudo`
+  assertion, so the next base to omit it fails the ISO build in seconds rather
+  than hour three of a matrix cell.
+- The store index is read out of the guest once with `cat` and parsed on the
+  **host** (`store_records_image`), so the probe needs nothing from the guest
+  that the diagnostic dump has not already proven it can do. Matching is on
+  `names` only, never `names-history`: containers-storage will not resolve a
+  ref that was retagged away, so answering yes for one is the same dead end by
+  another road.
+- Podman-shaped diagnostics are gated on the guest actually having podman, so
+  a skopeo-only base says so once instead of printing `command not found` a
+  dozen times and leaving the cause to be inferred from an absent `Found`
+  line.
+
 ---
 
 ## Glossary of Components

--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -308,6 +308,30 @@ EOF
 	mkdir -p /etc/sudoers.d
 	echo 'liveuser ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/90-tunaos-live-e2e
 	chmod 0440 /etc/sudoers.d/90-tunaos-live-e2e
+
+	# Same shape, one binary over. The storage.conf and drop-in written above
+	# exist so that the live root's PODMAN can see the offline store, and a
+	# composefs image cannot be installed without one at all: fisherman's
+	# bootcDirect shortcut is unavailable there, so bootc runs inside a
+	# container podman starts.
+	#
+	# guppy had skopeo (bootc's containers-image-proxy) and no podman, which
+	# looks close enough to be missed. It is not: every store probe answered
+	# `sudo: podman: command not found`, the harness read a store that holds the
+	# image as empty, and the cell died 2h30m in on the SSH image transfer that
+	# is its last resort. guppy:gnome, LUKS run 31134373523.
+	#
+	# Fatal here rather than a warning, and only on ENABLE_SSHD media, for the
+	# same reason as sudo above: this is the dev/E2E ISO, the assumption is made
+	# right here, and 10 seconds of ISO build is a better place to learn it than
+	# hour three of a matrix cell.
+	if ! command -v podman >/dev/null 2>&1; then
+		echo "ERROR: this image has no podman, but the offline image store above" >&2
+		echo "       is configured for one and the composefs install path runs" >&2
+		echo "       bootc inside a container." >&2
+		echo "       Add it to this variant's Containerfile base package list." >&2
+		exit 1
+	fi
 fi
 
 # ── 3. Pre-install the installer Flatpak into the live squash ────────────────

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -1468,6 +1468,36 @@ qualify_imgref() {
 	fi
 }
 
+# Does the embedded offline store's image index record this exact ref?
+#
+# Takes the index as text rather than a path because it is read out of the guest
+# once, over SSH, and answered on the HOST. The guest side of that is `cat`;
+# everything that needs a parser runs here, where jq is a declared dependency.
+# The previous form asked the guest for `jq`, and a guest that ships neither jq
+# nor podman — guppy, whose Gentoo base emerges skopeo for bootc's
+# containers-image-proxy and neither of those two — could not answer either
+# probe, so a store holding the image read as empty.
+#
+# `names`, never `names-history`: containers-storage resolves a ref only while
+# it is a current name, and a ref that appears solely in the history was
+# retagged away. Answering yes for one would send bootc after an image it
+# cannot resolve, which is the same dead end by a different road.
+store_records_image() {
+	local images_json="$1" ref="$2"
+	[[ -n "$images_json" && -n "$ref" ]] || return 1
+	if command -v jq >/dev/null 2>&1; then
+		jq -e --arg ref "$ref" \
+			'.[]? | select(.names != null) | select(.names | index($ref))' \
+			>/dev/null 2>&1 <<<"$images_json"
+		return
+	fi
+	# No jq on this host either (a bare local run). Match the `names` arrays
+	# textually — `"names":` cannot match `"names-history":`, whose next
+	# character is `-` — so a missing jq degrades the probe instead of
+	# silently turning it off.
+	grep -o '"names":\[[^]]*\]' <<<"$images_json" | grep -Fq "\"${ref}\""
+}
+
 # Generic install path for live media built from images that ship no
 # fisherman — the reference cells (aurora, bluefin) and any stock bootc
 # image (tacklebox#178's ladder). Everything tunaOS-specific is skipped: no
@@ -1883,6 +1913,27 @@ run_install() {
 		return 3
 	fi
 
+	# Does this guest have podman at all? Not a rhetorical question: guppy's
+	# base (Containerfile.gentoo) emerges app-containers/skopeo — which is what
+	# bootc's containers-image-proxy actually shells out to — and never emerges
+	# app-containers/podman or app-misc/jq. So on guppy every `sudo podman ...`
+	# below answers
+	#
+	#   sudo: podman: command not found
+	#
+	# That is not a broken image; bootc reads containers-storage through skopeo
+	# and installs fine. But it silently defeated the store probe further down,
+	# which had only podman- and jq-shaped questions to ask. Ask once, here, so
+	# the dump names the situation instead of printing it a dozen times and
+	# leaving the reader to infer it from a missing "Found" line.
+	local guest_has_podman=0
+	if "${ssh_cmd[@]}" "command -v podman >/dev/null 2>&1" 2>/dev/null; then
+		guest_has_podman=1
+	else
+		echo "==> guest ships no podman (skopeo-only base) — skipping podman store queries;" \
+			"the offline store index is read host-side below"
+	fi
+
 	# ── Offline store diagnostics (debug: remove once stable) ─────────
 	echo "==> Offline store diagnostics:"
 	echo "--- store service status ---"
@@ -1898,17 +1949,21 @@ run_install() {
 	# from before the mount, causing image exists / pull to miss the
 	# additional store entirely (observed on Gentoo-based variants where
 	# the offline-store.service sometimes races with podman's init).
-	"${ssh_cmd[@]}" "sudo podman system renumber 2>&1 || true" || true
+	if [[ "$guest_has_podman" -eq 1 ]]; then
+		"${ssh_cmd[@]}" "sudo podman system renumber 2>&1 || true" || true
+	fi
 	echo "--- primary storage.conf ---"
 	"${ssh_cmd[@]}" "cat /etc/containers/storage.conf 2>&1 || echo '(not found)'" || true
 	echo "--- offline store layout ---"
 	"${ssh_cmd[@]}" "sudo ls -la /var/lib/superiso-store/ 2>&1 || true" || true
 	"${ssh_cmd[@]}" "sudo ls -la /var/lib/superiso-store/overlay-images/ 2>&1 || echo '(no overlay-images)'" || true
 	"${ssh_cmd[@]}" "sudo cat /var/lib/superiso-store/storage.lock 2>&1 || echo '(no storage.lock)'" || true
-	echo "--- effective storage driver ---"
-	"${ssh_cmd[@]}" "sudo podman info 2>&1 | grep -i graphdriver || echo 'podman info failed'" || true
-	echo "--- podman images (all) ---"
-	"${ssh_cmd[@]}" "sudo podman images 2>&1 || echo '(empty or error)'" || true
+	if [[ "$guest_has_podman" -eq 1 ]]; then
+		echo "--- effective storage driver ---"
+		"${ssh_cmd[@]}" "sudo podman info 2>&1 | grep -i graphdriver || echo 'podman info failed'" || true
+		echo "--- podman images (all) ---"
+		"${ssh_cmd[@]}" "sudo podman images 2>&1 || echo '(empty or error)'" || true
+	fi
 
 	# skipjack fails here in a way the dump above cannot explain: the store is
 	# mounted, storage.conf lists it in additionalimagestores, overlay-images/
@@ -1920,13 +1975,21 @@ run_install() {
 	# image store (driver mismatch, unreadable lock, version skew); images.json
 	# is ~1 KB and states the names actually recorded, which distinguishes
 	# "store ignored" from "image recorded under a name we never probe".
-	echo "--- why podman does or does not see the additional store ---"
-	"${ssh_cmd[@]}" "sudo podman --log-level=debug images 2>&1 \
-		| grep -iE 'additional|superiso|store|driver' | head -40 \
-		|| echo '(no matching debug lines)'" || true
+	if [[ "$guest_has_podman" -eq 1 ]]; then
+		echo "--- why podman does or does not see the additional store ---"
+		"${ssh_cmd[@]}" "sudo podman --log-level=debug images 2>&1 \
+			| grep -iE 'additional|superiso|store|driver' | head -40 \
+			|| echo '(no matching debug lines)'" || true
+	fi
+
+	# Read the store's index ONCE, and keep it: this is both the diagnostic dump
+	# and the input to the probe below, so what the log shows is exactly what
+	# the decision was made from.
+	local img_json="/var/lib/superiso-store/overlay-images/images.json"
+	local store_images_json=""
+	store_images_json="$("${ssh_cmd[@]}" "sudo cat ${img_json} 2>/dev/null" 2>/dev/null || true)"
 	echo "--- names recorded in the offline store ---"
-	"${ssh_cmd[@]}" "sudo cat /var/lib/superiso-store/overlay-images/images.json 2>&1 \
-		|| echo '(unreadable)'" || true
+	printf '%s\n' "${store_images_json:-(unreadable)}"
 
 	# Probe the guest's containers-storage for a locally-available image.
 	# Try podman image exists first (primary store), then fall back to
@@ -1937,14 +2000,26 @@ run_install() {
 	local found_local=0 found_ref=""
 	for candidate_ref in "$prod_ref" "$local_ref"; do
 		echo "==> Probing for ${candidate_ref}..."
-		if "${ssh_cmd[@]}" "sudo podman image exists '${candidate_ref}'" 2>/dev/null; then
+		if [[ "$guest_has_podman" -eq 1 ]] &&
+			"${ssh_cmd[@]}" "sudo podman image exists '${candidate_ref}'" 2>/dev/null; then
 			found_local=1
 			found_ref="$candidate_ref"
 			break
 		fi
-		# Fallback: check the offline store images.json directly.
-		local img_json="/var/lib/superiso-store/overlay-images/images.json"
-		if "${ssh_cmd[@]}" "sudo test -f ${img_json} && sudo jq -e --arg ref '${candidate_ref}' '.[] | select(.names != null) | select(.names | index(\$ref))' ${img_json} >/dev/null 2>&1" 2>/dev/null; then
+		# Fallback: the offline store's own index, parsed on the HOST.
+		#
+		# This used to run `sudo jq` in the guest, which asks the guest for a jq
+		# it may not have. guppy has neither jq nor podman (see the
+		# skopeo-only note above), so on that variant BOTH probes were
+		# unrunnable — each exiting 127 — and a store that records
+		# `ghcr.io/tuna-os/guppy:gnome` verbatim read as "image absent". The
+		# cell then spent four minutes on the SSH transfer the block below
+		# documents as impossible and died on `scp: write remote ...: Failure`,
+		# ~2.5 hours into the job. guppy:gnome, LUKS run 31134373523.
+		#
+		# The guest only has to supply `cat`, which the dump above proves it
+		# can; jq runs where jq is a declared dependency.
+		if store_records_image "$store_images_json" "$candidate_ref"; then
 			echo "==> Found ${candidate_ref} in offline store images.json (podman query missed it)"
 			# This used to deliberately NOT set found_local, on the theory that
 			# podman/bootc could not resolve the image from the additional

--- a/tests/bats/test_iso_e2e_offline_store_probe.bats
+++ b/tests/bats/test_iso_e2e_offline_store_probe.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+# The offline-store probe must not require tooling the GUEST may not ship.
+#
+# It used to ask two questions, `sudo podman image exists <ref>` and
+# `sudo jq -e ... images.json`, both answered inside the live VM. guppy answers
+# neither: Containerfile.gentoo emerges app-containers/skopeo for bootc's
+# containers-image-proxy and emerges neither podman nor jq, so both probes exit
+# 127 and a store that records `ghcr.io/tuna-os/guppy:gnome` verbatim read as
+# "image absent". The cell then fell through to the SSH image transfer that
+# scripts/iso-e2e.sh itself documents as impossible and died on
+#
+#   scp: write remote "/home/liveuser/luks-image-guppy-gnome.tar": Failure
+#
+# 2h30m into the job (guppy:gnome, LUKS run 31134373523).
+#
+# So the index is read out of the guest with `cat` and parsed on the host. These
+# tests drive the real helper out of the script.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/iso-e2e.sh"
+
+# The exact index guppy:gnome's store carried in run 31134373523, trimmed of the
+# big-data blobs. Single line, as containers-storage writes it.
+STORE_JSON='[{"id":"d94de71ea8e4b7d60214d57261db4d5aef501c39e3bc62dc45721fd8b2660271","digest":"sha256:15c4702d2d1d181ad9ff2811299dc09ca6e5fc364d7bab3791afaeb317d6c2bf","names":["ghcr.io/tuna-os/guppy:gnome"],"names-history":["ghcr.io/tuna-os/guppy:gnome"],"layer":"614327ceb146d4b2a99ac98d2458620c78e4a3f2700d42253fdf42906c84a0fd","created":"2026-08-07T02:31:35.482754018Z"}]'
+
+# Runs store_records_image as shipped, with PATH optionally stripped of jq so
+# the no-jq fallback is exercised for real rather than described.
+probe() {
+	local json="$1" ref="$2" no_jq="${3:-}"
+	NO_JQ="$no_jq" bash -c '
+		set -Eeuo pipefail
+		eval "$(sed -n "/^store_records_image()/,/^}/p" "$1")"
+		if [[ -n "${NO_JQ:-}" ]]; then
+			# A host without jq. Hiding the binary, not stubbing the call, so
+			# the fallback branch is reached the way it would be in the wild.
+			command() {
+				if [[ "$*" == "-v jq" ]]; then return 1; fi
+				builtin command "$@"
+			}
+		fi
+		store_records_image "$2" "$3"
+	' _ "$SCRIPT" "$json" "$ref"
+}
+
+@test "a ref recorded in the store index is found (jq present)" {
+	run probe "$STORE_JSON" "ghcr.io/tuna-os/guppy:gnome"
+	[ "$status" -eq 0 ]
+}
+
+@test "a ref recorded in the store index is found with no jq on the host" {
+	# The degraded path still has to answer, or a bare local run silently
+	# reverts to the transfer that cannot work.
+	run probe "$STORE_JSON" "ghcr.io/tuna-os/guppy:gnome" strip-jq
+	[ "$status" -eq 0 ]
+}
+
+@test "a ref the store does not record is not found" {
+	run probe "$STORE_JSON" "localhost/guppy:gnome"
+	[ "$status" -ne 0 ]
+	run probe "$STORE_JSON" "localhost/guppy:gnome" strip-jq
+	[ "$status" -ne 0 ]
+}
+
+@test "a near-miss ref does not match by substring" {
+	# `guppy:gnome` is a suffix of the recorded name, and a bare grep for it
+	# would say yes. bootc would then be handed a ref containers-storage
+	# cannot resolve.
+	run probe "$STORE_JSON" "guppy:gnome"
+	[ "$status" -ne 0 ]
+	run probe "$STORE_JSON" "guppy:gnome" strip-jq
+	[ "$status" -ne 0 ]
+}
+
+@test "a ref only in names-history does not count as recorded" {
+	# containers-storage resolves current names only; a retagged-away ref is a
+	# different dead end, not a shortcut.
+	local retagged
+	retagged='[{"id":"abc","names":["ghcr.io/tuna-os/guppy:base"],"names-history":["ghcr.io/tuna-os/guppy:gnome","ghcr.io/tuna-os/guppy:base"]}]'
+	run probe "$retagged" "ghcr.io/tuna-os/guppy:gnome"
+	[ "$status" -ne 0 ]
+	run probe "$retagged" "ghcr.io/tuna-os/guppy:gnome" strip-jq
+	[ "$status" -ne 0 ]
+}
+
+@test "an entry with a null names array does not abort the probe" {
+	# containers-storage writes names:null for an untagged image. jq's
+	# `.names | index(...)` errors on null, which would take the whole probe
+	# down with it and lose the tagged entry beside it.
+	local mixed
+	mixed='[{"id":"aaa","names":null},{"id":"bbb","names":["ghcr.io/tuna-os/guppy:gnome"]}]'
+	run probe "$mixed" "ghcr.io/tuna-os/guppy:gnome"
+	[ "$status" -eq 0 ]
+}
+
+@test "an unreadable/empty index is not found, and does not error out" {
+	run probe "" "ghcr.io/tuna-os/guppy:gnome"
+	[ "$status" -eq 1 ]
+	run probe "$STORE_JSON" ""
+	[ "$status" -eq 1 ]
+}
+
+@test "the probe does not ask the guest for jq or podman" {
+	# The regression itself: any guest-side `jq` in the probe re-introduces a
+	# dependency guppy cannot satisfy, and does it silently.
+	local body
+	body="$(sed -n '/^store_records_image()/,/^}/p' "$SCRIPT")"
+	[ -n "$body" ]
+	run grep -qE 'ssh_cmd|sudo ' <<<"$body"
+	[ "$status" -ne 0 ]
+	# ...and nowhere else in the script either: the guest-side `sudo jq` this
+	# replaced was the only one, so "no guest jq at all" is an assertion the
+	# script can actually hold. Comments stripped, or the note explaining the
+	# removal would satisfy the check it exists to make.
+	local code
+	code="$(sed 's/^[[:space:]]*#.*//' "$SCRIPT")"
+	run grep -nE 'sudo[^|]*\bjq\b' <<<"$code"
+	[ "$status" -ne 0 ]
+}
+
+@test "the store index is read from the guest with cat, not parsed there" {
+	run grep -qE 'store_images_json=.*sudo cat' "$SCRIPT"
+	[ "$status" -eq 0 ]
+}
+
+@test "podman-shaped store queries are gated on the guest having podman" {
+	# Otherwise the dump is a dozen 'sudo: podman: command not found' lines and
+	# the reader has to infer the cause from an absent 'Found' line.
+	run grep -q 'local guest_has_podman=0' "$SCRIPT"
+	[ "$status" -eq 0 ]
+	run grep -qE 'guest_has_podman.*-eq 1.*&&' "$SCRIPT"
+	[ "$status" -eq 0 ]
+	# The `podman image exists` probe specifically must be behind the gate.
+	run grep -B2 "sudo podman image exists" "$SCRIPT"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"guest_has_podman"* ]]
+}

--- a/tests/bats/test_live_podman_every_base.bats
+++ b/tests/bats/test_live_podman_every_base.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# Every base whose live media has to install must ship podman.
+#
+# Not a container-tooling nicety: a composefs-native image cannot take
+# fisherman's bootcDirect shortcut, so bootc runs inside a container podman
+# starts (the SWAP_DISK comment in scripts/iso-e2e.sh is written from a sailfin
+# OOM of exactly that process), and customize-live.sh writes
+# /etc/containers/storage.conf + a 99- drop-in whose entire purpose is to let
+# the live root's podman see the embedded offline store.
+#
+# guppy shipped app-containers/skopeo — bootc's containers-image-proxy, which
+# looks close enough to be mistaken for coverage — and no podman. Every store
+# probe answered `sudo: podman: command not found`, so a store recording
+# `ghcr.io/tuna-os/guppy:gnome` verbatim read as "image absent" and the cell
+# fell through to the SSH image transfer scripts/iso-e2e.sh documents as
+# impossible, dying 2h30m in on
+#
+#   scp: write remote "/home/liveuser/luks-image-guppy-gnome.tar": Failure
+#
+# guppy:gnome, LUKS run 31134373523. Same one-of-N-Containerfiles shape as sudo
+# (tests/bats/test_live_sudo_every_base.bats), flatpak, openssh in
+# 40-services.sh and the pcsc omit line — and Gentoo was the last base without
+# it for the third time. Asserting it per base is what stops the (N+1)th.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+
+# Bases that must name podman themselves, because they run none of the numbered
+# build_scripts. Excluded:
+#
+#   Containerfile.el10, Containerfile.ubuntu, Containerfile.debian — they source
+#   build_scripts/10-base-packages.sh, which installs podman on every branch it
+#   has (asserted separately below).
+#
+#   Containerfile.opensuse — sailfin's live guest demonstrably runs podman: run
+#   30730744132 killed it by name (`Out of memory: Killed process 2978
+#   (podman)`), so Tumbleweed supplies it through the base image or the
+#   enhanced_base pattern rather than an explicit line. If that ever stops being
+#   true, the customize-live.sh assertion below turns it into an ISO-build
+#   failure instead of an hour-three E2E death.
+EXPLICIT_PODMAN_BASES=(
+  Containerfile.gentoo
+  Containerfile.arch
+)
+
+# Bases that get podman from the shared numbered script instead.
+SHARED_SCRIPT_BASES=(
+  Containerfile.el10
+  Containerfile.ubuntu
+  Containerfile.debian
+)
+
+@test "the assertion that catches this is still in customize-live.sh" {
+  # Without it, a missing podman is silent until the install path reaches for
+  # it, which on the LUKS matrix is hours later and presents as an scp failure.
+  local f="${REPO_ROOT}/live-iso/common/src/customize-live.sh"
+  run grep -q 'command -v podman' "$f"
+  [ "$status" -eq 0 ]
+  run grep -q 'this image has no podman' "$f"
+  [ "$status" -eq 0 ]
+}
+
+@test "every base that must install podman by name does" {
+  local f code fail=0
+  for f in "${EXPLICIT_PODMAN_BASES[@]}"; do
+    code="$(sed 's/^[[:space:]]*#.*//' "${REPO_ROOT}/$f")"
+    # Gentoo needs the atom, Arch the bare name. Anchored so that a substring
+    # like `podman-compose`, `podman-docker` or a comment cannot satisfy it.
+    if ! grep -qE '(^|[[:space:]])(app-containers/)?podman([[:space:]]|\\|$)' <<<"$code"; then
+      echo "FAIL: ${f} never installs podman." >&2
+      echo "      A composefs install runs bootc in a container podman starts," >&2
+      echo "      and customize-live.sh configures the offline store for one," >&2
+      echo "      so the live media cannot install without it." >&2
+      fail=1
+    fi
+  done
+  [ "$fail" -eq 0 ]
+}
+
+@test "skopeo alone does not satisfy it" {
+  # The exact confusion that produced the bug: skopeo is what bootc's
+  # containers-image-proxy shells out to, so a base can look container-capable
+  # while being unable to start one.
+  local f code
+  for f in "${EXPLICIT_PODMAN_BASES[@]}"; do
+    code="$(sed 's/^[[:space:]]*#.*//' "${REPO_ROOT}/$f")"
+    if grep -qE '(^|[[:space:]])skopeo([[:space:]]|\\|$)' <<<"$code"; then
+      run grep -qE '(^|[[:space:]])(app-containers/)?podman([[:space:]]|\\|$)' <<<"$code"
+      [ "$status" -eq 0 ]
+    fi
+  done
+}
+
+@test "the shared base-package script installs podman on every branch" {
+  # These bases delegate, so the delegate has to hold. One branch omitting it
+  # is the same defect with a longer paper trail.
+  local f="${REPO_ROOT}/build_scripts/10-base-packages.sh"
+  local code
+  code="$(sed 's/^[[:space:]]*#.*//' "$f")"
+  # apt, hummingbird (dnf --skip-unavailable) and Fedora/EL each have their own
+  # package list in this script.
+  local count
+  count="$(grep -cE '^[[:space:]]*podman[[:space:]]*\\?$' <<<"$code")"
+  [ "$count" -ge 3 ]
+}
+
+@test "bases that delegate really do source the shared script" {
+  # Otherwise the exclusion above is a wish, not a fact.
+  local f fail=0
+  for f in "${SHARED_SCRIPT_BASES[@]}"; do
+    if ! grep -q '10-base-packages.sh' "${REPO_ROOT}/$f"; then
+      echo "FAIL: ${f} is listed as getting podman from" >&2
+      echo "      build_scripts/10-base-packages.sh but never runs it." >&2
+      fail=1
+    fi
+  done
+  [ "$fail" -eq 0 ]
+}


### PR DESCRIPTION
`guppy:gnome` died 2h30m into [LUKS run 31134373523](https://github.com/tuna-os/tunaOS/actions/runs/31134373523) on `scp: write remote ...: Failure`, fifteen lines after the diagnostic dump printed the offline store's own index recording the exact ref the next line failed to find:

```
--- names recorded in the offline store ---
[{... "names":["ghcr.io/tuna-os/guppy:gnome"] ...}]
==> Probing for ghcr.io/tuna-os/guppy:gnome...
==> Probing for localhost/guppy:gnome...
==> No local image in offline store — transferring from host via SSH
...
scp: write remote "/home/liveuser/luks-image-guppy-gnome.tar": Failure
```

Between those two lines, twice: `sudo: podman: command not found`.

Reported against #1033, which merged as a16671e before this could land on its branch; the defect is still on `main`, so this is a fresh PR off the merged base.

## The image half

`Containerfile.gentoo` emerged `app-containers/skopeo` and never podman. Skopeo looks like coverage — it is what bootc's containers-image-proxy shells out to — but it cannot *start* a container, and guppy probes `BACKEND=composefs-native`, whose install path cannot take fisherman's `bootcDirect` shortcut: bootc runs inside a container podman starts. That is not a new claim; the `SWAP_DISK` comment in `iso-e2e.sh` is written from a sailfin OOM of that very process.

Every other base has podman (the rpm and apt ones via `build_scripts/10-base-packages.sh`, `Containerfile.arch` and `.debian` by name) and Gentoo runs none of those scripts. Third time Gentoo was the last base without something, after `sudo` and flatpak.

## The harness half, which produced the wrong diagnosis

Both offline-store probes were answered **inside** the guest: `sudo podman image exists <ref>`, then `sudo jq -e ... images.json` as the fallback. guppy has neither binary, so both exited 127 and a store holding the image read as empty — after which the cell fell through to the SSH image transfer that `iso-e2e.sh` documents at length as physically impossible (a ~4.9G tar into a tmpfs upperdir on a 4096M guest, #941). A missing tool read as a missing image.

The index is now read out of the guest once with `cat` and parsed on the host:

```bash
store_records_image() {
	local images_json="$1" ref="$2"
	[[ -n "$images_json" && -n "$ref" ]] || return 1
	if command -v jq >/dev/null 2>&1; then
		jq -e --arg ref "$ref" \
			'.[]? | select(.names != null) | select(.names | index($ref))' \
			>/dev/null 2>&1 <<<"$images_json"
		return
	fi
	# No jq on this host either (a bare local run). Match the `names` arrays
	# textually — `"names":` cannot match `"names-history":` ...
	grep -o '"names":\[[^]]*\]' <<<"$images_json" | grep -Fq "\"${ref}\""
}
```

`names` only, never `names-history`: containers-storage will not resolve a ref that was retagged away, so answering yes for one is the same dead end by another road. `.[]?` and the `names != null` guard matter because an untagged entry writes `names:null`, and jq's `index` on null would take the whole probe down with the tagged entry beside it.

## Also

- `customize-live.sh` asserts `command -v podman` beside its existing `sudo` assertion, so the next base to omit it fails the ISO build in seconds instead of hour three of a matrix cell. Scoped to `ENABLE_SSHD=1` media for the same reason that one is.
- Podman-shaped diagnostics are gated on the guest having podman, so a skopeo-only base says so once instead of printing `command not found` a dozen times and leaving the cause to be inferred from an absent `Found` line.
- `Containerfile.opensuse` is deliberately *not* changed: sailfin's guest demonstrably runs podman (run 30730744132 OOM-killed it by name), so Tumbleweed supplies it without an explicit line. The new assertion catches it if that stops being true.

15 bats cases across two files, 10 mutation-verified against the merged tree. The per-base contract test is modelled on `test_live_sudo_every_base.bats`, including a case rejecting the specific confusion that caused this: a base naming `skopeo` and no podman.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->