### PR TITLE
ci: make the installer walkthrough's parity report actually reach anyone

### DIFF
--- a/.github/workflows/installer-screenshots.yml
+++ b/.github/workflows/installer-screenshots.yml
@@ -1,7 +1,10 @@
 name: Installer Walkthrough Screenshots
 
 # Boots a freshly built live ISO in QEMU, drives the bootc-install GUI with
-# scripts/run-walkthrough.sh (sendkey choreography + screendumps), and commits
+# scripts/run-walkthrough.sh (which delegates the driving to
+# scripts/installer-walkthrough.py — the fixed sendkey choreography this
+# comment used to describe was removed after it labelled three welcome-screen
+# frames as disk_select and confirm), and commits
 # the resulting flow screenshots to docs/images/installer/ — replacing the
 # repo's installer imagery with real captures on a schedule.
 #
@@ -70,7 +73,8 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
             just podman jq golang-go git \
-            qemu-system-x86 qemu-utils ovmf socat netpbm python3-pil
+            qemu-system-x86 qemu-utils ovmf socat netpbm python3-pil \
+            tesseract-ocr
           sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
 
       - name: Log in to GHCR
@@ -92,8 +96,30 @@ jobs:
             echo "::error::No ISO found for ${VARIANT}-${{ matrix.flavor }}"
             exit 1
           fi
-          sudo bash scripts/run-walkthrough.sh "$ISO" walkthrough-out
+          # FLAVOR must be set AND must survive sudo (-E), or run-walkthrough.sh
+          # falls back to FLAVOR=de and both matrix legs write the same
+          # walkthrough-de.json — a parity report that names neither frontend
+          # it came from.
+          sudo -E FLAVOR="${{ matrix.flavor }}" \
+            bash scripts/run-walkthrough.sh "$ISO" walkthrough-out
           sudo chown -R "$USER:$(id -gn)" walkthrough-out
+
+          # Fail loudly rather than publish a report with the screen rows
+          # unfilled. installer-walkthrough.py degrades to "screen detection
+          # skipped" when tesseract is missing and still exits 0, so a missing
+          # dependency looked exactly like a passing run — which is how this
+          # job produced ocr:false reports for months while green.
+          json="walkthrough-out/walkthrough-${{ matrix.flavor }}.json"
+          if [[ ! -f "$json" ]]; then
+            echo "::error::$json was not written"
+            exit 1
+          fi
+          if [[ "$(jq -r .ocr "$json")" != "true" ]]; then
+            echo "::error::walkthrough ran without OCR — every screen row in"
+            echo "::error::this report is unfilled. tesseract-ocr missing?"
+            exit 1
+          fi
+          jq -r '.screens | to_entries[] | "  \(.key): \(.value)"' "$json"
 
       # The walkthrough performed a real install onto install-disk.qcow2.
       # Boot that disk to verify the install flow actually produced a
@@ -137,7 +163,12 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: installer-shots-${{ matrix.flavor }}
-          path: staged/*.png
+          # The parity report ships alongside the PNGs. It was being written
+          # into walkthrough-out/ and then uploaded by nothing, so the file
+          # tunaOS's own installer matrix consumes never left the runner.
+          path: |
+            staged/*.png
+            walkthrough-out/walkthrough-*.json
           if-no-files-found: error
           retention-days: 14
 

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -1,7 +1,8 @@
 # Installer GUI smoke (tunaOS#678 phase 1): per-desktop proof that the
 # live ISO autologins and the installer frontend actually starts.
 #
-# For each flavor: build the dev ISO (SSH enabled), boot it under OVMF,
+# For each flavor (gnome and the four forks): build the dev ISO (SSH enabled),
+# boot it under OVMF,
 # wait for TUNAOS_LIVE_READY, then over SSH assert the installer process
 # is running (flatpak run org.tunaos.Installer* / bootc-installer) and
 # capture a desktop screenshot as reviewable evidence.
@@ -21,7 +22,12 @@ on:
       flavors:
         description: "Comma-separated flavors"
         required: false
-        default: "kde,cosmic,niri,xfce"
+        # gnome included: it is the flow the four forks are asked to match, and
+        # it was the only frontend with no per-DE smoke leg at all. The APP
+        # mapping below already falls through to org.bootcinstaller.Installer
+        # for it, and the walkthrough's --strict list already names it — only
+        # this default kept it from ever running.
+        default: "gnome,kde,cosmic,niri,xfce"
         type: string
   schedule:
     # Weekly, after the Tuesday image builds settle.
@@ -39,7 +45,7 @@ jobs:
     steps:
       - id: gen
         env:
-          FLAVORS: ${{ inputs.flavors || 'kde,cosmic,niri,xfce' }}
+          FLAVORS: ${{ inputs.flavors || 'gnome,kde,cosmic,niri,xfce' }}
           VARIANT: ${{ inputs.variant || 'yellowfin' }}
         run: |
           M=$(jq -cn --arg v "$VARIANT" --arg f "$FLAVORS" \


### PR DESCRIPTION
`docs/INSTALLER-FRONTENDS.md` has been sitting on `_pending_` rows. The job meant to fill them — `installer-screenshots.yml` — has been producing nothing, silently, on every green run.

Three independent defects, any one of which was sufficient:

**1. `tesseract-ocr` was never installed.**
Deps are `qemu-system-x86 qemu-utils ovmf socat netpbm python3-pil`. `installer-walkthrough.py` does `shutil.which("tesseract")` and, when it's absent, prints `tesseract not installed — screen detection skipped`, writes `"ocr": false`, and **exits 0**. Every run published a report with all six screen rows unfilled, and a green tick. `installer-smoke.yml` has always installed it; this job never did.

**2. `FLAVOR` was never passed.**
The step calls `sudo bash scripts/run-walkthrough.sh "$ISO" walkthrough-out`. `run-walkthrough.sh` defaults to `FLAVOR="${FLAVOR:-de}"`, and `sudo` drops the environment regardless — so both matrix legs wrote `walkthrough-de.json`, a parity report naming neither frontend it came from. Now `sudo -E FLAVOR=…`.

**3. The report was never uploaded.**
It is written into `walkthrough-out/` while the artifact step uploads only `staged/*.png`. The file tunaOS's own installer matrix consumes never left the runner.

### The assertion that stops this recurring

A missing dependency must not look like a passing run — that is precisely the failure above. The walkthrough step now fails if the report is absent or reports `ocr: false`, and prints the screen rows it did fill.

### Also: gnome joins the smoke matrix

`installer-smoke.yml` ran `kde,cosmic,niri,xfce`. gnome is the flow the four forks are being asked to match, and was the only frontend with no per-DE smoke leg at all. Nothing else needed changing — the `APP` mapping already falls through to `org.bootcinstaller.Installer` for it, and the walkthrough's `--strict` list already names it. Only the default flavor list kept it from ever running.

### What this does not do

This is the reporting layer, not coverage. `installer-smoke.yml` still stops at *"the installer starts and reaches screens"* and never completes an install; `installer-screenshots.yml` still installs and boot-verifies only gnome and cosmic, and that verification is still `continue-on-error`. Closing that — phase 2, per-DE GUI-driven install through to a bootable system — is a separate change, and it has to answer the `--strict` constraint first: niri and xfwl4 are Smithay compositors that cannot render without virgl, so a GPU-less runner shows legitimately blank frames.

### Verification

`yamllint` clean on both files (only pre-existing long-line warnings, none on added lines). The behavioural claims are read from the scripts in this repo: `installer-walkthrough.py:358` for the `which("tesseract")` degrade, `:373` for the skip message, `:438` for the output filename, and `run-walkthrough.sh:196` for the `FLAVOR` default. Neither workflow runs on PRs, so CI here cannot exercise them — the real test is the next scheduled run or a `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->