### PR TITLE
fix(guppy): build systemd-cryptenroll, cryptsetup and dmsetup into the image

### DIFF
--- a/Containerfile.gentoo
+++ b/Containerfile.gentoo
@@ -54,7 +54,7 @@ RUN NPROC="$(nproc)" && \
     printf '[gentoobinhost]\npriority = 9999\nsync-uri = https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64/\n' \
       >/etc/portage/binrepos.conf/gentoobinhost.conf && \
     getuto && \
-    echo "sys-apps/systemd boot" >> /etc/portage/package.use/systemd && \
+    echo "sys-apps/systemd boot cryptsetup tpm" >> /etc/portage/package.use/systemd && \
     echo "media-video/pipewire extra -ffmpeg" >> /etc/portage/package.use/pipewire && \
     echo "media-libs/gst-plugins-bad -vulkan" >> /etc/portage/package.use/gst-plugins-bad && \
     echo "sys-libs/minizip-ng compat" >> /etc/portage/package.use/minizip-ng && \
@@ -102,11 +102,41 @@ RUN emerge --verbose --deep --newuse @world
 # podman — the rpm and apt ones from build_scripts/10-base-packages.sh,
 # Containerfile.arch and .debian by name — and Gentoo runs none of those, which
 # is why guppy was the only variant without it.
+#
+# sys-fs/cryptsetup and sys-fs/lvm2, fourth of the same kind, found the same
+# way: with podman in place the guppy cells got past the store probe for the
+# first time and died one line into the install instead —
+#
+#   fisherman: fatal: missing required host tool: "systemd-cryptenroll" not
+#   found in PATH — install the "systemd" package on the host
+#
+# guppy:gnome, LUKS run 31144015274, 3h20m in. "Install systemd" is the right
+# advice on every OTHER base, where the systemd package unconditionally ships
+# the binary. Gentoo only builds systemd-cryptenroll when systemd has
+# USE=cryptsetup, which neither the desktop/systemd profile nor the make.conf
+# USE line enables — hence `boot cryptsetup tpm` in package.use above (tpm so
+# the enroll tool can at least attempt the TPM2 path the recipe asks for; it
+# falls back to passphrase everywhere today). cryptsetup and lvm2 are named
+# here explicitly because fisherman's LUKS path needs the cryptsetup and
+# dmsetup binaries themselves right after the enroll tool — the bootc-install
+# refactor comments further down have said "Gentoo emerges neither" for a
+# while; this is the run that made it cost a cell.
 RUN emerge --verbose --deep --newuse \
         app-arch/cpio btrfs-progs dev-vcs/git dosfstools sys-fs/xfsprogs \
         linux-firmware rust skopeo sys-kernel/gentoo-kernel-bin systemd \
         sys-apps/flatpak app-admin/sudo app-containers/podman \
+        sys-fs/cryptsetup sys-fs/lvm2 \
         net-vpn/tailscale gui-apps/wl-clipboard media-video/ffmpeg media-plugins/gst-plugins-meta && \
+    # make.conf runs emerge with --binpkg-respect-use=n, so the binhost's
+    # systemd (built WITHOUT cryptsetup) satisfies the install above even with
+    # the package.use entry in place, and the flag silently does nothing. Force
+    # the one package whose USE actually matters to build from source. The
+    # assertion afterwards is the point: a binary this image exists to provide
+    # must fail the BUILD when absent, not a matrix cell three hours later.
+    emerge --oneshot --verbose --usepkg=n sys-apps/systemd && \
+    command -v systemd-cryptenroll && \
+    command -v cryptsetup && \
+    command -v dmsetup && \
     curl -fsSL -o /tmp/just.tar.gz https://github.com/casey/just/releases/download/1.35.0/just-1.35.0-x86_64-unknown-linux-musl.tar.gz && \
     tar -xzf /tmp/just.tar.gz -C /usr/bin just && rm /tmp/just.tar.gz && \
     curl -fsSL -o /tmp/glow.tar.gz https://github.com/charmbracelet/glow/releases/download/v1.5.1/glow_Linux_x86_64.tar.gz && \

--- a/tests/bats/test_containerfile_context.bats
+++ b/tests/bats/test_containerfile_context.bats
@@ -104,8 +104,12 @@ strip_comments() { grep -v '^[[:space:]]*#' || true; }
     body="$(context_stage "${REPO_ROOT}/$f" | strip_comments)"
     has=0
     grep -q 'COPY[[:space:]]\+image-versions.yaml' <<<"$body" && has=1
+    # Strip comments, same as `has` above: Containerfile.gentoo's podman
+    # comment NAMES 10-base-packages.sh in prose ("the rpm and apt ones from
+    # build_scripts/10-base-packages.sh") and the unstripped grep read that
+    # as the script being run, failing every PR after #1038 merged.
     needs=0
-    grep -q '10-base-packages.sh' "${REPO_ROOT}/$f" && needs=1
+    strip_comments <"${REPO_ROOT}/$f" | grep -q '10-base-packages.sh' && needs=1
     if [ "$has" -ne "$needs" ]; then
       echo "FAIL: ${f} carries image-versions.yaml=${has} but runs 10-base-packages.sh=${needs}" >&2
       return 1

--- a/tests/bats/test_get_base_image.bats
+++ b/tests/bats/test_get_base_image.bats
@@ -226,6 +226,53 @@ setup() {
   done
 }
 
+@test "the Gentoo base builds systemd-cryptenroll, and proves it at build time" {
+  # Same fisherman gate as the apt case above, different mechanism: on Gentoo
+  # the binary is not a packaging split but a USE flag. The desktop/systemd
+  # profile does not enable cryptsetup for sys-apps/systemd, so the profile
+  # default silently omits systemd-cryptenroll — guppy:gnome died on it one
+  # line into the install, 3h20m into LUKS run 31144015274, with every earlier
+  # stage finally green.
+  #
+  # Two halves, both required:
+  #   * the package.use entry granting systemd USE=cryptsetup, AND
+  #   * a source rebuild of systemd with --usepkg=n. make.conf runs emerge
+  #     with --binpkg-respect-use=n, so without the forced source build the
+  #     binhost's systemd (built without cryptsetup) satisfies the dep and the
+  #     USE entry does nothing. The flag alone LOOKS like the fix and is not.
+  local path="${REPO_ROOT}/Containerfile.gentoo" body
+  body="$(grep -v '^[[:space:]]*#' "$path")"
+  grep -qE 'sys-apps/systemd[^"]*cryptsetup' <<<"$body" || {
+    echo "FAIL: no package.use entry granting sys-apps/systemd USE=cryptsetup" >&2
+    return 1
+  }
+  grep -qE 'emerge[^&]*--usepkg=n[^&]*sys-apps/systemd' <<<"$body" || {
+    echo "FAIL: systemd is never source-rebuilt; --binpkg-respect-use=n means" >&2
+    echo "      the binhost's cryptsetup-less binpkg satisfies the dep and the" >&2
+    echo "      USE entry is a no-op" >&2
+    return 1
+  }
+  # fisherman needs the cryptsetup and dmsetup binaries right behind the
+  # enroll tool; lvm2 is what ships dmsetup on Gentoo.
+  grep -qE 'sys-fs/cryptsetup' <<<"$body" || {
+    echo "FAIL: sys-fs/cryptsetup is not emerged" >&2
+    return 1
+  }
+  grep -qE 'sys-fs/lvm2' <<<"$body" || {
+    echo "FAIL: sys-fs/lvm2 (dmsetup) is not emerged" >&2
+    return 1
+  }
+  # And the build must assert all three, so the next USE-flag regression fails
+  # in the image build, not a matrix cell hours later.
+  local tool
+  for tool in systemd-cryptenroll cryptsetup dmsetup; do
+    grep -qF "command -v ${tool}" <<<"$body" || {
+      echo "FAIL: the build never asserts ${tool} is present" >&2
+      return 1
+    }
+  done
+}
+
 @test "every base can bring up a network, and both service paths enable it" {
   # An image with a NIC and no address presents as an SSH failure, not a
   # network one: sshd starts and generates host keys, QEMU's user networking


### PR DESCRIPTION
With podman in place (#1038), the guppy cells got past the offline-store probe for the first time and died one line into the install instead:

```
fisherman: fatal: missing required host tool: "systemd-cryptenroll" not found in PATH — install the "systemd" package on the host
```

guppy:gnome, [LUKS run 31144015274](https://github.com/tuna-os/tunaOS/actions/runs/31144015274), 3h20m in — kde and xfce identically. Everything before it finally worked: the override installed, 13/13 live smoke checks, podman answered the store probe, `Found local image ghcr.io/tuna-os/guppy:gnome in offline store`.

## The image half

"Install the systemd package" is the right advice on every other base, where systemd unconditionally ships the binary. On Gentoo it is a USE flag: systemd only builds `systemd-cryptenroll` with `USE=cryptsetup`, which neither the desktop/systemd profile nor make.conf's USE line enables.

The subtle half is that the package.use entry **alone does nothing**: make.conf runs emerge with `--binpkg-respect-use=n`, so the binhost's systemd — built without cryptsetup — still satisfies the dependency and the flag is silently ignored. systemd is therefore source-rebuilt with `--usepkg=n` after the binpkg pass; it is the one package here whose USE actually matters, so everything else stays on the fast binhost path.

`sys-fs/cryptsetup` and `sys-fs/lvm2` (dmsetup) come too: fisherman's LUKS path needs both binaries right behind the enroll tool, and this file's own bootc-install comments have said "Gentoo emerges neither" for a while — this is the run that made that cost a cell. `USE=tpm` alongside, so the enroll tool can attempt the TPM2 path the recipe requests rather than failing it structurally (it falls back to passphrase everywhere today).

The build now asserts all three binaries exist (`command -v` in the same RUN), matching the invariant the apt bases already enforce: a missing host tool must fail the image build in minutes, not a matrix cell three hours later.

Fifth instance of "Gentoo is the last base without something", after sudo, flatpak, podman and the network manager.

## Testing

Extends `test_get_base_image.bats` with the Gentoo counterpart of the apt cryptenroll case, pinning both halves — the USE entry AND the forced source rebuild, because the first without the second looks like the fix and is not — plus the three build-time assertions. Mutation-verified: reverting only the Containerfile fails the new case at its first check.

Not verified here: the image build itself (a systemd source build on the runner, est. +5–10 min on the Gentoo cell's ~2.5h). The proof is the next guppy cell reaching `Running fisherman` and getting past the host-tool gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->