### PR TITLE
fix(live-iso): bound every network fetch in customize-live.sh

### DIFF
--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -452,11 +452,11 @@ if [[ -n "${INSTALLER_APP}" ]]; then
 		# tuna-os/tuna-installer, which mirrors the same app ID as a release
 		# asset.
 		INSTALLER_FLATPAK_FILE="/tmp/bootc-installer.flatpak"
-		if ! curl --retry 3 --fail --location \
+		if ! curl --retry 3 --fail --location --max-time 300 \
 			"https://github.com/projectbluefin/bootc-installer/releases/latest/download/org.bootcinstaller.Installer.flatpak" \
 			-o "${INSTALLER_FLATPAK_FILE}" 2>/dev/null; then
 			echo "projectbluefin/bootc-installer unavailable, falling back to tuna-os/tuna-installer..."
-			curl --retry 3 --fail --location \
+			curl --retry 3 --fail --location --max-time 300 \
 				"https://github.com/tuna-os/tuna-installer/releases/latest/download/org.bootcinstaller.Installer.flatpak" \
 				-o "${INSTALLER_FLATPAK_FILE}"
 		fi
@@ -465,7 +465,7 @@ if [[ -n "${INSTALLER_APP}" ]]; then
 		flatpak build-import-bundle "${INSTALLER_LOCAL_REPO}" "${INSTALLER_FLATPAK_FILE}"
 		rm -f "${INSTALLER_FLATPAK_FILE}"
 		flatpak remote-add --system --no-gpg-verify installer-local "file://${INSTALLER_LOCAL_REPO}"
-		flatpak install --system --noninteractive installer-local "${INSTALLER_APP}" ||
+		timeout 900 flatpak install --system --noninteractive installer-local "${INSTALLER_APP}" ||
 			{ [[ -f "${SCRIPT_DIR}/.enable-sshd" ]] &&
 				echo "WARN: installer flatpak install failed; continuing (dev/e2e ISO)" ||
 				exit 1; }
@@ -497,13 +497,22 @@ if [[ -n "${INSTALLER_APP}" ]]; then
 			flatpak remote-add --system --if-not-exists tuna-os \
 				/etc/flatpak/remotes.d/tuna-os.flatpakrepo || true
 		else
-			flatpak remote-add --system --if-not-exists tuna-os \
+			timeout 120 flatpak remote-add --system --if-not-exists tuna-os \
 				https://tunaos.org/flatpak/tuna-os.flatpakrepo ||
 				echo "WARN: could not add tuna-os remote (network?); continuing"
 		fi
-		flatpak install --system --noninteractive -y tuna-os "${INSTALLER_APP}" ||
+		# timeout: flatpak has no network deadline of its own, and a stalled
+		# fetch here is indistinguishable from progress in the build log,
+		# because tacklebox does not surface customize output. grouper:cosmic
+		# sat in [customize] for 3h52m until the 240-min job cap killed the
+		# run (31144135208) — twice, where every other flavor clears this
+		# phase in ~2 minutes. Bounded, a stall lands in the WARN arm below on
+		# dev/E2E media (which never run this flatpak anyway — the harness
+		# installs fisherman via FISHERMAN_OVERRIDE) instead of eating the
+		# job. On release media it stays fatal, exactly as before.
+		timeout 900 flatpak install --system --noninteractive -y tuna-os "${INSTALLER_APP}" ||
 			{ [[ -f "${SCRIPT_DIR}/.enable-sshd" ]] &&
-				echo "WARN: installer flatpak install failed; continuing (dev/e2e ISO)" ||
+				echo "WARN: installer flatpak install failed or timed out; continuing (dev/e2e ISO)" ||
 				exit 1; }
 	fi
 

--- a/tests/bats/test_customize_live.bats
+++ b/tests/bats/test_customize_live.bats
@@ -184,3 +184,53 @@ detect() {
   run grep -r 'Flatpak Preinstall org.tunaos.Installer' "${REPO_ROOT}/build_scripts/"
   [ "$status" -ne 0 ]
 }
+
+# ── Bounded network operations ──────────────────────────────────────────────
+#
+# tacklebox does not surface customize output, so a hung network fetch in this
+# script is indistinguishable from progress: the build log shows
+# "[customize] running 2 script(s)" and then nothing until the job cap. That
+# is precisely how grouper:cosmic burned two runs — 3h52m in [customize]
+# until the 240-minute cap killed the second (run 31144135208), where every
+# other flavor clears the phase in ~2 minutes. flatpak has no network
+# deadline of its own and curl's --retry does not bound a stalled transfer.
+#
+# These pin every network operation in the installer-flatpak block to a
+# deadline, so a stall becomes the WARN-and-continue arm (dev/E2E media) or a
+# visible failure (release media) rather than a silent 4-hour wedge.
+
+@test "both installer flatpak installs run under timeout" {
+	# Comments stripped: the rationale above names the commands in prose.
+	local body
+	body="$(grep -v '^[[:space:]]*#' "$SCRIPT")"
+	local n
+	n=$(grep -cE 'timeout [0-9]+ flatpak install --system --noninteractive' <<<"$body")
+	[ "$n" -eq 2 ] || {
+		echo "FAIL: expected 2 bounded flatpak installs, found ${n}." >&2
+		echo "      An unbounded flatpak install in a tacklebox customize" >&2
+		echo "      script hangs the whole ISO build with no output when its" >&2
+		echo "      fetch stalls (grouper:cosmic, run 31144135208)." >&2
+		return 1
+	}
+	# And no unbounded ones remain.
+	! grep -qE '^[[:space:]]*flatpak install' <<<"$body"
+}
+
+@test "the network remote-add and the release curls carry deadlines" {
+	local body
+	# Fold backslash continuations first: the remote-add command and its URL
+	# live on separate source lines, so a per-line grep can never see both.
+	body="$(sed ':a;/\\$/{N;s/\\\n//;ba}' "$SCRIPT" | grep -v '^[[:space:]]*#')"
+	# The tunaos.org remote-add fetches over the network; the file-based one
+	# two lines up needs no bound and must not be forced to carry one.
+	grep -qE 'timeout [0-9]+ flatpak remote-add.*tunaos\.org' <<<"$body"
+	# Every curl in the script must bound the transfer, not just retry it:
+	# --retry without --max-time retries only failures, not stalls.
+	local unbounded
+	unbounded=$(grep -E 'curl ' <<<"$body" | grep -v -- '--max-time' || true)
+	[ -z "$unbounded" ] || {
+		echo "FAIL: curl without --max-time can stall forever:" >&2
+		echo "$unbounded" >&2
+		return 1
+	}
+}


### PR DESCRIPTION
grouper:cosmic burned two runs wedged in tacklebox's `[customize]` phase — 1h40m the first time, then **3h52m until the 240-minute job cap** killed the second ([run 31144135208](https://github.com/tuna-os/tunaOS/actions/runs/31144135208)) — where every other flavor clears the phase in ~2 minutes:

```
03:31:37 >>> [customize] running 2 script(s) against localhost/grouper:cosmic
07:23:08 ##[error]The operation was canceled.
```

tacklebox does not surface customize output, so a hung network fetch in this script is **indistinguishable from progress**.

`customize-live.sh` had exactly three unbounded network operations, all in the installer-flatpak block: two `flatpak install`s (flatpak has no network deadline of its own), the tunaos.org `flatpak remote-add`, and curls whose `--retry` retries failures but does not bound a stalled transfer. Any of them can hang forever by construction. Bounded, a stall lands in the existing WARN-and-continue arm on dev/E2E media — which never run this flatpak anyway; the harness installs fisherman via `FISHERMAN_OVERRIDE` — and is a visible failure on release media, exactly as an unbounded failure already was.

**This is deliberately not a claim about where grouper:cosmic hangs** — the swallowed output means nobody knows yet. It is the property that makes the next hang cheap: if the flatpak block was the wedge, the next run proceeds past it within 15 minutes and the cell completes; if it still wedges, the flatpak block is excluded and the search narrows — after 15 minutes instead of 4 hours.

## Testing

2 bats cases in `test_customize_live.bats`, comment-stripped and continuation-folded so prose naming the commands cannot satisfy them (two of tonight's test bugs were exactly that). Mutation-verified: reverting only `customize-live.sh` fails both.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->