### PR TITLE
ci: build the walkthrough ISO from source, so the job can reach green

### DIFF
--- a/.github/workflows/installer-screenshots.yml
+++ b/.github/workflows/installer-screenshots.yml
@@ -80,13 +80,36 @@ jobs:
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
 
+      # TACKLEBOX_FROM_SOURCE=1 is what every other ISO-building workflow in
+      # this repo already sets — reusable-build-artifacts, live-iso-bootc,
+      # luks-e2e, publish-iso-groups and installer-smoke. This job was the only
+      # one that did not, and it is the reason it has never once gone green.
+      #
+      # Without it, tunaos_run_tacklebox() runs tacklebox INSIDE a podman
+      # container (scripts/lib/common.sh). Tacklebox then issues its own
+      # `podman run` for the live-customize step, so that step is
+      # podman-in-podman — and the nested container's DNS does not resolve:
+      #
+      #   Error: Failed to download metadata for repo 'baseos': Cannot prepare
+      #   internal mirrorlist: Curl error (6): Could not resolve hostname for
+      #   https://mirrors.centos.org/... [Could not resolve host: mirrors.centos.org]
+      #
+      # With it, tacklebox is built and run as a HOST binary at the SHA pinned
+      # in image-versions.yaml, so live-customize is an ordinary host container
+      # with working DNS. golang-go is already in this job's dependency list.
+      #
+      # The outer `sudo` goes with it. The Justfile's `iso` recipe already does
+      # `sudo -E bash ./scripts/build-iso-tacklebox.sh` itself; wrapping the
+      # whole thing in another sudo dropped the environment, which is why the
+      # variable had to be re-stated inline. installer-smoke.yml calls `just
+      # iso` unsudoed for exactly this reason.
       - name: Build live ISO (from published GHCR image)
         timeout-minutes: 45
         env:
           GITHUB_REPOSITORY_OWNER: tuna-os
+          TACKLEBOX_FROM_SOURCE: "1"
         run: |
-          sudo GITHUB_REPOSITORY_OWNER=tuna-os \
-            just iso "${VARIANT}" "${{ matrix.flavor }}" ghcr "${{ matrix.flavor }}"
+          just iso "${VARIANT}" "${{ matrix.flavor }}" ghcr "${{ matrix.flavor }}"
 
       - name: Run installer walkthrough
         timeout-minutes: 30


### PR DESCRIPTION
`installer-screenshots.yml` has never gone green. Every recorded run has failed — **seven for seven**, back to 2026-07-06 — and always at the same place, about six minutes in, long before the walkthrough it exists to run:

```
Error: Failed to download metadata for repo 'baseos': Cannot prepare internal
mirrorlist: Curl error (6): Could not resolve hostname for
https://mirrors.centos.org/... [Could not resolve host: mirrors.centos.org]
```

### Cause: nesting

With `TACKLEBOX_FROM_SOURCE` unset, `tunaos_run_tacklebox()` (`scripts/lib/common.sh`) runs tacklebox **inside a podman container**. Tacklebox then issues its own `podman run` for the live-customize step — so that step is podman-in-podman, and the inner container's DNS does not resolve.

### Why this is the fix and not a guess

Every other ISO-building workflow in this repo already sets `TACKLEBOX_FROM_SOURCE=1`:

- `reusable-build-artifacts.yml`
- `live-iso-bootc.yml`
- `luks-e2e.yml`
- `publish-iso-groups.yml`
- `installer-smoke.yml`

This job was the only one that did not. And `installer-smoke.yml` builds ISOs on the same runner image with the same toolchain, gets 19 minutes in — well past where this one dies — with its **niri leg passing outright** on the most recent scheduled run. That is direct evidence the source path builds ISOs and the container path does not.

Setting it makes tacklebox a host binary at the SHA pinned in `image-versions.yaml`, so live-customize becomes an ordinary host container with working DNS. `golang-go` is already in this job's dependency list.

**The outer `sudo` goes with it.** The Justfile's `iso` recipe already runs `sudo -E bash ./scripts/build-iso-tacklebox.sh` itself. Wrapping the whole thing in a second `sudo` dropped the environment — which is why `GITHUB_REPOSITORY_OWNER` had to be restated inline, and why an exported `TACKLEBOX_FROM_SOURCE` would not have survived. `installer-smoke.yml` calls `just iso` unsudoed for exactly this reason.

### A correction of priority

This also corrects the framing of #1039. I described that job there as "producing nothing, silently, on every green run" — it has never been green. The three reporting defects fixed there are real, and `tesseract-ocr` is confirmed installed now, but they were latent behind this: report plumbing cannot matter while the ISO build dies first. Details in [this comment](https://github.com/tuna-os/tunaOS/pull/1039#issuecomment-5214379887).

### One thing I checked rather than assumed

The ISO-locating step (`find . -maxdepth 1 -name "${VARIANT}-${FLAVOR}-*.iso"`) looked wrong against tacklebox's output path — but `build-iso-tacklebox.sh:175` copies the result to the repo root as `${VARIANT}-${FLAVOR}-${VERSION_ID}-${ARCH}.iso`, so it is correct. No change needed.

### Verification

`yamllint` clean. This workflow does not run on PRs, so CI here cannot exercise it — the proof is a `workflow_dispatch` after merge, which I'll run and report. Expect the ISO build to get past six minutes; the next real question is whether the walkthrough's new `ocr: true` assertion passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->