### PR TITLE
fix(guppy): defer systemd USE=cryptsetup until cryptsetup is installed

### DIFF
--- a/Containerfile.gentoo
+++ b/Containerfile.gentoo
@@ -54,7 +54,17 @@ RUN NPROC="$(nproc)" && \
     printf '[gentoobinhost]\npriority = 9999\nsync-uri = https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64/\n' \
       >/etc/portage/binrepos.conf/gentoobinhost.conf && \
     getuto && \
-    echo "sys-apps/systemd boot cryptsetup tpm" >> /etc/portage/package.use/systemd && \
+    # boot only, here. The cryptsetup and tpm flags systemd also needs are
+    # granted AFTER @world, in the tooling layer below: with them visible to
+    # the first @world resolve, portage schedules the systemd source rebuild
+    # and the initial cryptsetup install in ONE transaction and dies on
+    #   * Error: circular dependencies:
+    #   (sys-fs/cryptsetup, binary) depends on (virtual/libudev) (runtime)
+    #    (sys-apps/systemd, ebuild) depends on (sys-fs/cryptsetup) (buildtime)
+    # (all three guppy cells, run 31158591954, ~4 min in). Once cryptsetup is
+    # installed the buildtime edge is satisfied by the live system instead of
+    # the transaction, and the same flags resolve without a cycle.
+    echo "sys-apps/systemd boot" >> /etc/portage/package.use/systemd && \
     echo "media-video/pipewire extra -ffmpeg" >> /etc/portage/package.use/pipewire && \
     echo "media-libs/gst-plugins-bad -vulkan" >> /etc/portage/package.use/gst-plugins-bad && \
     echo "sys-libs/minizip-ng compat" >> /etc/portage/package.use/minizip-ng && \
@@ -114,19 +124,29 @@ RUN emerge --verbose --deep --newuse @world
 # advice on every OTHER base, where the systemd package unconditionally ships
 # the binary. Gentoo only builds systemd-cryptenroll when systemd has
 # USE=cryptsetup, which neither the desktop/systemd profile nor the make.conf
-# USE line enables — hence `boot cryptsetup tpm` in package.use above (tpm so
+# USE line enables — hence the `cryptsetup tpm` grant mid-layer below (tpm so
 # the enroll tool can at least attempt the TPM2 path the recipe asks for; it
-# falls back to passphrase everywhere today). cryptsetup and lvm2 are named
-# here explicitly because fisherman's LUKS path needs the cryptsetup and
-# dmsetup binaries themselves right after the enroll tool — the bootc-install
-# refactor comments further down have said "Gentoo emerges neither" for a
-# while; this is the run that made it cost a cell.
+# falls back to passphrase everywhere today). The grant happens here and not
+# in the package.use layer above because systemd[cryptsetup] build-depends on
+# the cryptsetup this very list installs — flag first meant a circular-
+# dependency abort at @world (run 31158591954, see the package.use comment).
+# cryptsetup and lvm2 are named here explicitly because fisherman's LUKS path
+# needs the cryptsetup and dmsetup binaries themselves right after the enroll
+# tool — the bootc-install refactor comments further down have said "Gentoo
+# emerges neither" for a while; this is the run that made it cost a cell.
+# tpm2-tss is named so the tpm dep is already installed (as a binpkg) when the
+# forced source rebuild runs, keeping --usepkg=n's blast radius to systemd
+# itself.
 RUN emerge --verbose --deep --newuse \
         app-arch/cpio btrfs-progs dev-vcs/git dosfstools sys-fs/xfsprogs \
         linux-firmware rust skopeo sys-kernel/gentoo-kernel-bin systemd \
         sys-apps/flatpak app-admin/sudo app-containers/podman \
-        sys-fs/cryptsetup sys-fs/lvm2 \
+        sys-fs/cryptsetup sys-fs/lvm2 app-crypt/tpm2-tss \
         net-vpn/tailscale gui-apps/wl-clipboard media-video/ffmpeg media-plugins/gst-plugins-meta && \
+    # Now — and only now — grant systemd the flags that need those packages
+    # installed first (see the cycle comment above). Overwrite, not append:
+    # this line replaces the boot-only grant from the base layer.
+    echo "sys-apps/systemd boot cryptsetup tpm" > /etc/portage/package.use/systemd && \
     # make.conf runs emerge with --binpkg-respect-use=n, so the binhost's
     # systemd (built WITHOUT cryptsetup) satisfies the install above even with
     # the package.use entry in place, and the flag silently does nothing. Force

--- a/tests/bats/test_get_base_image.bats
+++ b/tests/bats/test_get_base_image.bats
@@ -271,6 +271,19 @@ setup() {
       return 1
     }
   done
+  # Ordering is load-bearing, not style. systemd[cryptsetup] build-depends on
+  # sys-fs/cryptsetup, so granting the flag before the first @world resolve
+  # puts the systemd source rebuild and the initial cryptsetup install in one
+  # transaction — portage aborts on the circular dependency and every guppy
+  # cell dies four minutes in (run 31158591954). The grant must sit BELOW the
+  # @world emerge, where the already-installed cryptsetup satisfies the edge.
+  local above_world
+  above_world="$(sed '/--newuse @world/q' "$path" | grep -v '^[[:space:]]*#')"
+  if grep -E 'sys-apps/systemd[^"]*cryptsetup' <<<"$above_world"; then
+    echo "FAIL: systemd USE=cryptsetup is visible to the @world emerge —" >&2
+    echo "      that recreates the circular-dependency abort of run 31158591954" >&2
+    return 1
+  fi
 }
 
 @test "every base can bring up a network, and both service paths enable it" {


### PR DESCRIPTION
## What

Fixes the new guppy build failure that #1042 introduced: all three guppy cells died ~4 minutes into `Build dev ISO` (run 31158591954) with portage's circular-dependency abort, where pre-#1042 builds ran 2.5–3h to completion.

## Why

#1042 granted `sys-apps/systemd boot cryptsetup tpm` in the base package.use layer, which the first `emerge @world` reads. That schedules the systemd **source rebuild** and the **initial** `sys-fs/cryptsetup` install in one transaction, and portage aborts:

```
 * Error: circular dependencies:
(sys-fs/cryptsetup, binary scheduled for merge) depends on
 (virtual/libudev, binary scheduled for merge) (runtime_slot_op)
  (sys-apps/systemd, ebuild scheduled for merge) (runtime)
   (sys-fs/cryptsetup, binary scheduled for merge) (buildtime_slot_op)
- sys-apps/systemd-260.1-r2 (Change USE: -cryptsetup)
```

systemd[cryptsetup] build-depends on cryptsetup; cryptsetup runtime-depends on libudev (systemd). The cycle only exists while both are scheduled in the *same* transaction.

## How

Ordering, not flags:

- Base layer grants `boot` only, so `@world` resolves exactly as it did before #1042 (with a comment explaining why the other two flags are absent there).
- The tooling layer installs `sys-fs/cryptsetup`, `sys-fs/lvm2` and (new) `app-crypt/tpm2-tss` as binpkgs, **then** overwrites the grant to `boot cryptsetup tpm` and runs the forced `emerge --oneshot --usepkg=n sys-apps/systemd` source rebuild. The buildtime edge is now satisfied by the installed cryptsetup, so the identical flags resolve without a cycle. `tpm2-tss` is named explicitly so `--usepkg=n` doesn't widen to source-building the TPM stack.
- The three `command -v systemd-cryptenroll/cryptsetup/dmsetup` build-time asserts from #1042 are unchanged — a regression still fails the image build, not a matrix cell hours later.

## Testing

- `tests/bats/test_get_base_image.bats` now also pins the ordering: any systemd cryptsetup grant textually above the `@world` emerge fails the suite. Mutation-verified (re-adding the flag to the base layer trips exactly that assertion; restored file is green).
- Full bats sweep: the only failures are the environment-dependent ones that fail identically on clean main (checked by stashing the diff).

The real proof is the next guppy dispatch: the failing run died before any long build, so a fixed build should get back to the 2.5–3h profile and then through fisherman's `systemd-cryptenroll` gate that #1042 was for.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->