### PR TITLE
ci: give the host the ISO-build toolchain it now needs, and more time

### DIFF
--- a/.github/workflows/installer-screenshots.yml
+++ b/.github/workflows/installer-screenshots.yml
@@ -43,7 +43,10 @@ jobs:
   walkthrough:
     name: ${{ inputs.variant || 'skipjack' }}:${{ matrix.flavor }} installer flow
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    # Must exceed the sum of the step ceilings below (70 ISO + 30 walkthrough
+    # + 20 install-verify), or the job clock kills a step that is still inside
+    # its own budget — which reads as a hang rather than as the timeout it is.
+    timeout-minutes: 130
     strategy:
       fail-fast: false
       matrix:
@@ -68,11 +71,22 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm || true
 
+      # The second line is the ISO-BUILD toolchain, and it is required now that
+      # tacklebox runs as a host binary rather than in a container: the
+      # container carried these tools, the runner does not. Without them the
+      # build runs all the way to the end and then dies with
+      #
+      #   Error: no systemd-boot EFI binary on host ...; install
+      #   systemd-boot-efi or systemd-boot-unsigned
+      #
+      # This is the same list installer-smoke.yml installs, and for the same
+      # reason — it has always built its ISOs from source.
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
             just podman jq golang-go git \
+            systemd-boot-efi xorriso mtools squashfs-tools dosfstools gdisk \
             qemu-system-x86 qemu-utils ovmf socat netpbm python3-pil \
             tesseract-ocr
           sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
@@ -103,8 +117,13 @@ jobs:
       # whole thing in another sudo dropped the environment, which is why the
       # variable had to be re-stated inline. installer-smoke.yml calls `just
       # iso` unsudoed for exactly this reason.
+      # 45 was not enough once tacklebox moved to the host: the gnome leg of run
+      # 31162836652 was killed mid-build at exactly 45 minutes, having got
+      # past every previous failure point. The cosmic leg finished its build in
+      # ~7 minutes, so this is headroom for the large images, not a general
+      # slowdown.
       - name: Build live ISO (from published GHCR image)
-        timeout-minutes: 45
+        timeout-minutes: 70
         env:
           GITHUB_REPOSITORY_OWNER: tuna-os
           TACKLEBOX_FROM_SOURCE: "1"


### PR DESCRIPTION
Follow-up to #1046, which cleared the DNS wall.

### The DNS failure is gone

Run [31162836652](https://github.com/tuna-os/tunaOS/actions/runs/31162836652)'s **cosmic leg ran the full ISO build for the first time in the workflow's recorded history**:

```
08:44:39  [customize] running 2 script(s) against ghcr.io/tuna-os/skipjack:cosmic
08:46:31  [customize] committed localhost/tbox-live-custom:0cbd73be5b64ca3f
08:47:21  [initramfs] rebuilt, added: tbox-live tbox-root
08:47:54  Finished environment: skipjack-cosmic (kernel=6.12.0-243.el10.x86_64)
08:48:52  [offline-store] raw store size: 5.6G
08:49:08  [offline-store] squashfs size: 2.3G
```

No `mirrors.centos.org` error anywhere. The nested-podman diagnosis held.

### Two new failures, both mine

**1. Missing host toolchain.** The build then died on its last step:

```
Error: no systemd-boot EFI binary on host (and image ghcr.io/tuna-os/skipjack:cosmic
wasn't probed); install systemd-boot-efi or systemd-boot-unsigned
```

A direct and foreseeable consequence of moving tacklebox out of its container — the container carried the ISO-build toolchain; the runner does not. `installer-smoke.yml` has always installed `systemd-boot-efi xorriso mtools squashfs-tools dosfstools gdisk` for precisely this reason, having always built from source. I copied one line from that workflow when I should have copied its dependency list too.

**2. Step timeout.** The gnome leg was killed at exactly 45 minutes — the step ceiling — still building, having got past every previous failure point. The from-source path compiles tacklebox and loses the prebuilt container's layer caching, so the large images need more room. Raised to 70.

The job budget goes to 130 with it, so it exceeds the sum of the step ceilings (70 + 30 + 20). Otherwise the job clock kills a step that is still inside its own budget, which reads as a hang rather than as the timeout it is. cosmic built in ~7 minutes, so this is headroom for the big images, not a general slowdown.

### What is still unproven

The walkthrough has still never run, so the `ocr: true` assertion and the screen rows remain unobserved. That is the next question, not this one.

### Verification

`yamllint` clean. This workflow does not run on PRs; the proof is another `workflow_dispatch` after merge, which I'll run and report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->