### PR TITLE
ci: install imagemagick, keep the chown, and stop a missing tool crashing the harness

### DIFF
--- a/.github/workflows/installer-screenshots.yml
+++ b/.github/workflows/installer-screenshots.yml
@@ -88,7 +88,7 @@ jobs:
             just podman jq golang-go git \
             systemd-boot-efi xorriso mtools squashfs-tools dosfstools gdisk \
             qemu-system-x86 qemu-utils ovmf socat netpbm python3-pil \
-            tesseract-ocr
+            tesseract-ocr imagemagick
           sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
 
       - name: Log in to GHCR
@@ -142,9 +142,21 @@ jobs:
           # falls back to FLAVOR=de and both matrix legs write the same
           # walkthrough-de.json — a parity report that names neither frontend
           # it came from.
+          # `|| true` so a walkthrough failure still reaches the chown below.
+          # run-walkthrough.sh runs as root, so everything it writes —
+          # serial.log included — is root-owned; without the chown the
+          # if: always() debug upload dies with EACCES and destroys the one
+          # piece of evidence a failed run produces. Run 31168173594 did
+          # exactly that: the walkthrough failed, `set -e` skipped the chown,
+          # and the serial log could not be uploaded.
+          rc=0
           sudo -E FLAVOR="${{ matrix.flavor }}" \
-            bash scripts/run-walkthrough.sh "$ISO" walkthrough-out
-          sudo chown -R "$USER:$(id -gn)" walkthrough-out
+            bash scripts/run-walkthrough.sh "$ISO" walkthrough-out || rc=$?
+          sudo chown -R "$USER:$(id -gn)" walkthrough-out || true
+          if [[ "$rc" -ne 0 ]]; then
+            echo "::error::run-walkthrough.sh exited $rc"
+            exit "$rc"
+          fi
 
           # Fail loudly rather than publish a report with the screen rows
           # unfilled. installer-walkthrough.py degrades to "screen detection

--- a/scripts/installer-walkthrough.py
+++ b/scripts/installer-walkthrough.py
@@ -138,6 +138,37 @@ def vnc_capture(png):
     return os.path.exists(png) and os.path.getsize(png) > 0
 
 
+# PPM -> PNG converter, resolved once.
+#
+# The screendump path hardcoded `convert`, under a `check=False` that reads as
+# tolerance but is not: check=False only suppresses a NONZERO EXIT, while a
+# missing binary raises FileNotFoundError out of Popen before any exit code
+# exists. So an absent ImageMagick did not degrade — it crashed the harness
+# with a traceback on the very first frame (run 31168173594), after the VM had
+# booted and was sitting on the installer's first screen.
+#
+# ImageMagick 7 ships `magick`; 6 ships `convert`; netpbm's `pnmtopng` reads
+# PPM natively and is already a dependency of every caller. Prefer whichever
+# exists, and say so once rather than per frame.
+def _resolve_ppm_converter():
+    for exe in ("magick", "convert"):
+        if shutil.which(exe):
+            return lambda ppm, png, exe=exe: subprocess.run(
+                [exe, ppm, png], check=False)
+    if shutil.which("pnmtopng"):
+        def _pnmtopng(ppm, png):
+            with open(png, "wb") as out:
+                subprocess.run(["pnmtopng", ppm], stdout=out, check=False)
+        return _pnmtopng
+    return None
+
+
+_ppm_to_png = _resolve_ppm_converter()
+if _ppm_to_png is None:
+    note("no PPM converter found (magick / convert / pnmtopng) — screendump "
+         "frames cannot be saved; install imagemagick or netpbm")
+
+
 def shot(idx, label):
     png = os.path.abspath(f"{outdir}/walkthrough-{flavor}-{idx:02d}.png")
 
@@ -151,7 +182,8 @@ def shot(idx, label):
     hmp(f"screendump {ppm}")
     time.sleep(1.5)
     if os.path.exists(ppm):
-        subprocess.run(["convert", ppm, png], check=False)
+        if _ppm_to_png is not None:
+            _ppm_to_png(ppm, png)
         os.remove(ppm)
         print(f"captured step {idx}: {label} -> {png} (screendump)", flush=True)
         return png


### PR DESCRIPTION
### The ISO build works now

Run [31168173594](https://github.com/tuna-os/tunaOS/actions/runs/31168173594) — **both legs built their ISO successfully**, in about six minutes each, and booted the VM. #1046 and #1050 did their jobs.

The walkthrough then ran **for the first time**, and died 12 seconds in, on the very first frame:

```
==> Booting VM under kvm...
Waiting for installer boot (45 seconds)...
==> Driving installer via installer-walkthrough.py (flavor=gnome, steps=10)
FileNotFoundError: [Errno 2] No such file or directory: 'convert'
```

### Three fixes

**1. `imagemagick` was never installed.** `installer-walkthrough.py`'s screendump path shells out to `convert`. This workflow installs `netpbm`, which provides `pnmtopng` — not `convert`. `installer-smoke.yml` installs `imagemagick`.

Same shape as the `systemd-boot-efi` gap in #1050: this job's dependency list has been missing tools that only matter once it gets far enough to use them, and until this week it never got that far. Each fix reveals the next.

**2. The call sat under `check=False`, which reads as tolerance and is not.** `check=False` suppresses a *nonzero exit*; a missing binary raises `FileNotFoundError` out of `Popen` before an exit code exists. So an absent converter crashed the harness with a traceback rather than degrading — after the VM had booted and was sitting on the installer's first screen, which is the expensive part.

The converter is now resolved once: `magick`, then `convert`, then netpbm's `pnmtopng` (already a dependency of every caller), with a single clear note if none is present.

**3. The chown was unreachable on failure.** `run-walkthrough.sh` runs as root, so `serial.log` is root-owned. `set -e` skipped the chown when the script failed, and the `if: always()` debug upload then died with `EACCES: permission denied ... walkthrough-out/serial.log` — destroying the only evidence a failed run produces, precisely when it is needed. The exit code is now captured, the chown always runs, and the failure is re-raised afterwards.

That is the same "cleanup step only runs on success" pattern as the stale-artifact bug in `tuna-installer-kde`, one layer down.

### Recorded, not fixed

```
==> No GL path (no /dev/dri/renderD128 or QEMU lacks virgl).
    cosmic/niri/xfwl4 will not start; kde needs it too. Expect blank frames.
```

Expected on a hosted runner, and the reason `--strict` is limited to kde/cosmic/gnome elsewhere. Whether gnome renders without GL is the next question — and a real one about coverage rather than plumbing.

### Verification

`yamllint` clean; `installer-walkthrough.py` compiles, and `note()` is defined above its new first use. The workflow does not run on PRs, so the proof is another dispatch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->