### PR TITLE
ci: fail the walkthrough when it detects no installer screen at all

### DIFF
--- a/.github/workflows/installer-screenshots.yml
+++ b/.github/workflows/installer-screenshots.yml
@@ -175,6 +175,41 @@ jobs:
           fi
           jq -r '.screens | to_entries[] | "  \(.key): \(.value)"' "$json"
 
+          # ocr:true only proves tesseract RAN. It says nothing about whether
+          # anything was recognised, and on run 31171184497 that gap was the
+          # whole story: the step went green while the harness's own TAP output
+          # read
+          #
+          #   not ok - gnome: screen changes between steps
+          #     # 0/10 transitions changed >500px
+          #     # 1 distinct visual state(s) across 11 frames
+          #   # Results: 2 passed, 7 failed, 9 total
+          #   # screens reached: (none detected)
+          #
+          # and every screen row came back false. installer-walkthrough.py
+          # reports those failures and exits 0 unless --strict is passed, so
+          # the assertion above — mine — was a gate that could not fire on the
+          # only question the job exists to answer.
+          #
+          # A run that detected NO screen at all has not produced a parity
+          # report; it has produced an empty one, which is worse, because the
+          # matrix cannot tell "we looked and found nothing" from "we never
+          # looked". Blank frames on the GPU-less runner are a known and
+          # expected limitation for cosmic/niri/xfwl4 — but the correct
+          # response to a limitation is to say so out loud, not to publish a
+          # green tick over six false rows.
+          reached=$(jq -r '[.screens[] | select(. == true)] | length' "$json")
+          total=$(jq -r '.screens | length' "$json")
+          echo "screens detected: ${reached}/${total}"
+          if [[ "$reached" -eq 0 ]]; then
+            echo "::error::the walkthrough detected NONE of the ${total} spec'd"
+            echo "::error::screens. The installer UI was never reached, so this"
+            echo "::error::report would fill the parity matrix with six false"
+            echo "::error::rows. See the DIAGNOSIS line above and the captured"
+            echo "::error::PNGs in the installer-shots-${{ matrix.flavor }} artifact."
+            exit 1
+          fi
+
       # The walkthrough performed a real install onto install-disk.qcow2.
       # Boot that disk to verify the install flow actually produced a
       # bootable system — this is the end-to-end check on the ISO install


### PR DESCRIPTION
Run [31171184497](https://github.com/tuna-os/tunaOS/actions/runs/31171184497) went **green on both legs**. Its parity report is **empty**:

```
welcome: false   disk: false      encryption: false
summary: false   install: false   done: false
```

The harness said so plainly, in the same step that passed:

```
not ok - gnome: screen changes between steps
  # 0/10 transitions changed >500px
  # 1 distinct visual state(s) across 11 frames
# Results: 2 passed, 7 failed, 9 total
# screens reached: (none detected)
==> Walkthrough automation complete (exit 0)
```

Eleven frames, one visual state, nothing responded to input across ten attempts. Its own DIAGNOSIS: *the process is running but no installer window was ever mapped — most likely a greeter or bare desktop.*

### Why it was green

`installer-walkthrough.py` reports those failures and exits 0 unless `--strict` is passed. The assertion I added in #1039 checked only `ocr: true` — which proves tesseract **ran**, not that anything was **recognised**.

So the gate I wrote to stop this job publishing empty reports could not fire on the only question the job exists to answer. That is the same defect it was written to fix, one level up, and I built it.

### What this changes

The step now fails when zero of the six spec'd screens were detected, and prints `screens detected: N/6` either way.

A run that detects no screen has not produced a parity report — it has produced an empty one, which is worse, because the matrix cannot distinguish *"we looked and found nothing"* from *"we never looked"*. Blank frames on a GPU-less runner are a known limitation for the Smithay compositors; the right response to a limitation is to state it, not to publish a green tick over six false rows.

### What this does not do

**It does not fix the underlying problem.** The installer UI is not being reached — that is still open, and it is now the only thing between this job and a green that means something. Two candidates worth separating before anyone guesses:

- `No GL path (no /dev/dri/renderD128 or QEMU lacks virgl)` is logged, and is expected on a hosted runner. It explains cosmic. It is a weaker explanation for gnome, which should fall back to llvmpipe.
- The captured PNGs are in the `installer-shots-gnome` artifact. Eleven of them, all 23K, all one visual state. Looking at one answers "greeter, bare desktop, or installer that never mapped" immediately — the same way looking at the KDE screenshots settled the icon question in a minute.

Also worth recording: `Verify installed system boots` **failed** (`exit 2`, `desktop experience contract marker was not emitted`) and was masked by `continue-on-error: true`. That is not a surprise — `install-disk.qcow2` is 193K, because the install never ran. Nothing here has yet demonstrated phase 2.

### Verification

`yamllint` clean. The workflow does not run on PRs; the proof is that the next dispatch goes **red** with `screens detected: 0/6`, which is the correct outcome until the UI is reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->