### PR TITLE
fix(guppy): the forced systemd rebuild must also disable getbinpkg

### DIFF
--- a/Containerfile.gentoo
+++ b/Containerfile.gentoo
@@ -150,10 +150,19 @@ RUN emerge --verbose --deep --newuse \
     # make.conf runs emerge with --binpkg-respect-use=n, so the binhost's
     # systemd (built WITHOUT cryptsetup) satisfies the install above even with
     # the package.use entry in place, and the flag silently does nothing. Force
-    # the one package whose USE actually matters to build from source. The
-    # assertion afterwards is the point: a binary this image exists to provide
-    # must fail the BUILD when absent, not a matrix cell three hours later.
-    emerge --oneshot --verbose --usepkg=n sys-apps/systemd && \
+    # the one package whose USE actually matters to build from source.
+    #
+    # BOTH binpkg switches must be off. --usepkg=n alone does not do it:
+    # make.conf also sets --getbinpkg (and FEATURES=getbinpkg), and with
+    # getbinpkg still active emerge fetched the binhost package and "rebuilt"
+    # systemd in two seconds flat — the merge log's `<<< dir
+    # /usr/lib/systemd/boot` (removed, never replaced) is the binhost's
+    # flagless build erasing even the stage3's boot support, and all three
+    # guppy cells then died on the cryptenroll assert 2h45m in (run
+    # 31164551903). The assertion afterwards is the point: a binary this
+    # image exists to provide must fail the BUILD when absent, not a matrix
+    # cell three hours later.
+    emerge --oneshot --verbose --usepkg=n --getbinpkg=n sys-apps/systemd && \
     command -v systemd-cryptenroll && \
     command -v cryptsetup && \
     command -v dmsetup && \

--- a/tests/bats/test_get_base_image.bats
+++ b/tests/bats/test_get_base_image.bats
@@ -252,6 +252,16 @@ setup() {
     echo "      USE entry is a no-op" >&2
     return 1
   }
+  # --usepkg=n alone is not a source build: make.conf's --getbinpkg (and
+  # FEATURES=getbinpkg) still lets emerge take the binhost package, which is
+  # exactly what happened in run 31164551903 — a two-second "rebuild" that
+  # installed the flagless binpkg and failed the cryptenroll assert 2h45m in.
+  grep -qE 'emerge[^&]*--usepkg=n[^&]*--getbinpkg=n[^&]*sys-apps/systemd' <<<"$body" || {
+    echo "FAIL: the forced systemd rebuild does not pass --getbinpkg=n;" >&2
+    echo "      make.conf's getbinpkg lets the binhost binpkg satisfy it and" >&2
+    echo "      the source build never happens (run 31164551903)" >&2
+    return 1
+  }
   # fisherman needs the cryptsetup and dmsetup binaries right behind the
   # enroll tool; lvm2 is what ships dmsetup on Gentoo.
   grep -qE 'sys-fs/cryptsetup' <<<"$body" || {


### PR DESCRIPTION
## What

Third and (evidence says) final piece of the guppy `systemd-cryptenroll` saga. Run 31164551903 — the first past #1047's cycle fix — reached the forced systemd rebuild for the first time, and the rebuild turned out not to be one. All three guppy cells failed the `command -v systemd-cryptenroll` build assert 2h45m in.

## Why

The merge log is unambiguous:

- systemd "rebuilt" **two seconds** after dependency resolution, with zero compile output — that's a binary package merge, not a source build.
- The unmerge shows `<<< dir /usr/lib/systemd/boot` removed and never replaced: the binhost's flagless binpkg overwrote the stage3 systemd, erasing even its `boot` support.

`make.conf` sets `--getbinpkg` in `EMERGE_DEFAULT_OPTS` (and `FEATURES=getbinpkg`). **`--usepkg=n` does not override `--getbinpkg`** — getbinpkg alone is enough for emerge to take the binary package, so the `--usepkg=n` "source rebuild" from #1042 silently installed the binhost package built without `boot cryptsetup tpm`, and the package.use grant did nothing. The build-time assert then failed exactly as designed — better than a matrix cell three hours later, which is what it was for.

## How

One flag: `emerge --oneshot --verbose --usepkg=n --getbinpkg=n sys-apps/systemd`. With both binpkg switches off the oneshot genuinely builds systemd from source with `USE="boot cryptsetup tpm"`; its deps (cryptsetup, lvm2, tpm2-tss) are already installed as binpkgs by the preceding list emerge (#1047), so the source build's blast radius stays at systemd itself. Comment updated with the evidence.

## Testing

- `tests/bats/test_get_base_image.bats` now pins both switches on the same emerge invocation. Mutation-verified: dropping `--getbinpkg=n` from the Containerfile fails exactly that assertion; restored file is green (18/18).
- Real proof is the next guppy dispatch: the oneshot should now take minutes (ninja output in the log), `command -v systemd-cryptenroll` should print a path, and the cells proceed to the LUKS install that #1042 unblocked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->