### PR TITLE
walkthrough: stop the diagnosis naming a favourite cause it cannot know

### DIFF
--- a/scripts/installer-walkthrough.py
+++ b/scripts/installer-walkthrough.py
@@ -446,10 +446,31 @@ if have_ocr and not any(reached.values()) and rendered > 0:
     _moved = "nothing responded to input" if n_states <= 1 else (
         f"the screen changed {n_states - 1}x, but no change was an installer "
         f"screen (a greeter clock or desktop animation looks identical here)")
-    print(f"  # DIAGNOSIS: {flavor} — process is running (gate passed) but no "
-          f"installer screen was ever detected and {_moved}; the frames are "
-          f"most likely a login greeter or the bare desktop, with no installer "
-          f"window mapped. Check the captured PNGs before assuming a UI bug.",
+    # Deliberately lists the causes instead of naming a favourite.
+    #
+    # It used to end "most likely a login greeter or the bare desktop, with no
+    # installer window mapped". On run 31171184497 that was wrong on every
+    # count: the session was a fully drawn GNOME desktop, and the reason no
+    # installer screen appeared is that the gnome live adapter never launched
+    # one — it had no autostart entry at all, while kde, cosmic and xfce did.
+    # A confident wrong guess is worse than no guess: it sent the investigation
+    # looking for a greeter, then for a GTK renderer bug, before anyone read
+    # the five desktop adapters and saw the asymmetry.
+    #
+    # "process is running" is also weaker evidence than it sounds. That gate
+    # lives in installer-smoke.yml and does not run here, so on this harness it
+    # is an assumption, not a check.
+    print(f"  # DIAGNOSIS: {flavor} — no installer screen was ever detected "
+          f"and {_moved}. Causes, in the order they are worth checking:\n"
+          f"  #   1. the installer was never LAUNCHED — check that "
+          f"live-iso/common/src/desktop-{flavor}.sh arranges an autostart "
+          f"entry, a systemd user unit or a spawn-at-startup line\n"
+          f"  #   2. it launched and exited — check the user journal\n"
+          f"  #   3. its window is mapped but not drawing (no GL path)\n"
+          f"  #   4. the frames are a greeter, so the session never started\n"
+          f"  # These look identical in the numbers and completely different in "
+          f"the PNGs. Look at the captured frames first — an empty desktop with "
+          f"the app merely pinned to a dock or launcher is case 1, not a UI bug.",
           flush=True)
 
 # ── Result for the parity matrix ─────────────────────────────────────────


### PR DESCRIPTION
The DIAGNOSIS line ended:

> *most likely a login greeter or the bare desktop, with no installer window mapped*

On run 31171184497 that was wrong on every count. The session was a fully drawn GNOME desktop, and no installer screen appeared because **the gnome live adapter never launched one** — it had no autostart entry at all, while kde, cosmic and xfce did (#1056).

**A confident wrong guess is worse than no guess.** That sentence sent the investigation looking for a greeter, then for a GTK4 renderer bug, before anyone read the five desktop adapters and saw the asymmetry. Reading them took two minutes.

### What it says now

```
  # DIAGNOSIS: gnome — no installer screen was ever detected and nothing responded to input. Causes, in the order they are worth checking:
  #   1. the installer was never LAUNCHED — check that live-iso/common/src/desktop-gnome.sh arranges an autostart entry, a systemd user unit or a spawn-at-startup line
  #   2. it launched and exited — check the user journal
  #   3. its window is mapped but not drawing (no GL path)
  #   4. the frames are a greeter, so the session never started
  # These look identical in the numbers and completely different in the PNGs. Look at the captured frames first — an empty desktop with the app merely pinned to a dock or launcher is case 1, not a UI bug.
```

Ordered by what the numbers *cannot* distinguish and the pictures settle instantly, and it names the file to look in.

### Also dropped: "process is running (gate passed)"

That overstated what this harness knows. The process gate lives in `installer-smoke.yml` and does not run here — so on this harness it was an assumption presented as a check, which is how "the process is running but nothing is on screen" came to be believed on a run where nothing had been started.

### Verification

Compiles; the new message was rendered with the real f-string and the real `_moved` branch to confirm it reads correctly and wraps sanely (output above is the actual render, not a mock-up). Text-only change — no behavioural effect on frame capture, OCR, crediting or the emitted JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->