### PR TITLE
fix(gurnard): give pantheon a desktop contract instead of a silent exit 0

### DIFF
--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-desktop="${1:?usage: verify-desktop-experience.sh <gnome|kde|niri|cosmic|xfce> [--runtime]}"
+desktop="${1:?usage: verify-desktop-experience.sh <gnome|kde|niri|cosmic|xfce|pantheon> [--runtime]}"
 mode="${2:-build}"
 
 # At runtime the E2E gate greps ttyS0 for a contract marker; a silent early
@@ -263,6 +263,23 @@ xfce)
 	require_any_glob \
 		'/usr/libexec/xdg-desktop-portal-gtk' '/usr/lib/xdg-desktop-portal-gtk'
 	dm_pattern='^(gdm|gdm3|lightdm|greetd)\.service$'
+	;;
+pantheon)
+	# gurnard only: Pantheon comes exclusively from ppa:elementary-os/stable
+	# (manifests/desktops/pantheon.yaml). Until 2026-08-07 this case did not
+	# exist, so gurnard:pantheon sailed through the LUKS gates with
+	# desktop_contract=absent — a green cell whose desktop was never proven
+	# (run 31074188677, found by the full-matrix contract audit). The asserts
+	# mirror what the manifest actually installs, nothing invented: `gala` is
+	# the compositor package and its binary keeps that name, the session
+	# entry ships as pantheon.desktop, and the manifest pins
+	# display_manager: lightdm.
+	experience="tunaos/pantheon"
+	require_command gala
+	require_any_glob '/usr/share/xsessions/pantheon.desktop' \
+		'/usr/share/wayland-sessions/pantheon.desktop'
+	require_any_unit lightdm
+	dm_pattern='^lightdm\.service$'
 	;;
 *) exit 0 ;;
 esac

--- a/build_scripts/desktop/configure-desktop-runtime.sh
+++ b/build_scripts/desktop/configure-desktop-runtime.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-desktop="${1:?usage: configure-desktop-runtime.sh <gnome|kde|niri|cosmic|xfce>}"
+desktop="${1:?usage: configure-desktop-runtime.sh <gnome|kde|niri|cosmic|xfce|pantheon>}"
 
 # Desktop packages are installed in later Containerfile stages than the base
 # service setup. Enable their display manager only after its unit exists.
@@ -85,6 +85,16 @@ xfce)
 		dm=greetd
 	fi
 	;;
+pantheon)
+	# manifests/desktops/pantheon.yaml pins display_manager: lightdm and the
+	# elementary PPA's greeter (io.elementary.greeter) is a LightDM greeter.
+	# Until 2026-08-07 pantheon fell through to the `*) exit 0` below: no DM
+	# enable, no graphical.target default, and — the part the matrix could
+	# not see — no tunaos-desktop-contract.service, so gurnard:pantheon was
+	# green with desktop_contract=absent (run 31074188677). Landing here also
+	# puts pantheon in the contract family case further down.
+	dm=lightdm
+	;;
 *) exit 0 ;;
 esac
 
@@ -129,7 +139,7 @@ systemctl set-default graphical.target
 # snosi-derived installed-system TAP checks (harvested from the serial
 # console by scripts/iso-e2e.sh; the checks ExecStart is non-fatal).
 case "$desktop" in
-gnome | kde | niri | cosmic | xfce)
+gnome | kde | niri | cosmic | xfce | pantheon)
 	# Compile dconf databases before verify checks — desktop stages lay down
 	# keyfiles after the base stage's dconf update, so recompile here.
 	if command -v dconf &>/dev/null && compgen -G "/etc/dconf/db/*.d/*" >/dev/null 2>&1; then

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -129,12 +129,44 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
 
 @test "desktop experience contract covers every shipped DE" {
   local script="${REPO_ROOT}/build_scripts/checks/verify-desktop-experience.sh"
-  for de in gnome kde niri cosmic xfce; do
+  for de in gnome kde niri cosmic xfce pantheon; do
     grep -qE "^${de}\)|\| ${de}\)|${de} \|" "$script"
   done
   # Runtime DM validation must use the distro-agnostic alias, not raw unit
   # names (gdm vs gdm3 vs lightdm drift across variants).
   grep -qF 'display-manager.service' "$script"
+}
+
+@test "every desktop with a Containerfile runtime-config call is in the contract family" {
+  # configure-desktop-runtime.sh's DM case ends in `*) exit 0` — a desktop
+  # that reaches it gets NO display-manager enable, NO graphical.target
+  # default, and NO tunaos-desktop-contract.service, silently. That is not a
+  # hypothetical: pantheon fell through it from its introduction until
+  # 2026-08-07, so gurnard:pantheon passed every LUKS gate with
+  # desktop_contract=absent (run 31074188677) — a green cell whose desktop
+  # was never proven. Every desktop any Containerfile passes to the script
+  # must therefore appear BOTH in its DM case and in the contract-family
+  # case, so a new desktop stage cannot re-open the hole.
+  local runtime="${REPO_ROOT}/build_scripts/desktop/configure-desktop-runtime.sh"
+  local de fail=0
+  while read -r de; do
+    grep -qE "^${de}\)|\| ${de}\)|${de} \|" "$runtime" || {
+      echo "FAIL: ${de} is passed to configure-desktop-runtime.sh by a" >&2
+      echo "      Containerfile but has no DM branch — it exits 0 silently" >&2
+      fail=1
+    }
+    # The contract-family case is the single pipe-separated line; the DM
+    # branches are one-per-desktop. Require two distinct mentions so being
+    # in the DM case alone (or the family alone) is not enough.
+    [ "$(grep -cE "^${de}\)|\| ${de}\)|${de} \|" "$runtime")" -ge 2 ] || {
+      echo "FAIL: ${de} appears in only one of the two cases in" >&2
+      echo "      configure-desktop-runtime.sh (DM branch + contract family" >&2
+      echo "      are both required)" >&2
+      fail=1
+    }
+  done < <(grep -hoE 'configure-desktop-runtime\.sh [a-z]+' "${REPO_ROOT}"/Containerfile.* |
+    awk '{print $2}' | sort -u)
+  [ "$fail" -eq 0 ]
 }
 
 @test "disk gate requires the desktop contract marker" {


### PR DESCRIPTION
## What

First of the two fixes coming out of the full-matrix desktop-contract audit: gurnard:pantheon was green with `desktop_contract=absent` (run 31074188677) — every LUKS gate passed and nothing ever proved a desktop existed.

## Why

Structural, not a flake. `configure-desktop-runtime.sh`'s DM case ends in `*) exit 0`, and pantheon was never added to the case — so `configure-desktop-runtime.sh pantheon` (Containerfile.ubuntu's pantheon stage) was a **silent no-op**: no DM enable, no `graphical.target` default, and no `tunaos-desktop-contract.service`, which is the only thing that emits the marker the E2E passphrase gate waits 300s for. `verify-desktop-experience.sh` likewise had no pantheon case. The cell only rendered a desktop at all because lightdm's own packaging self-enables.

## How

Both halves, mirroring how every other desktop is wired:

- `configure-desktop-runtime.sh`: `pantheon) dm=lightdm` — the manifest (`manifests/desktops/pantheon.yaml`) pins `display_manager: lightdm` and the elementary PPA's `io.elementary.greeter` is a LightDM greeter — plus membership in the contract-family case so the contract service is installed and enabled.
- `verify-desktop-experience.sh`: a pantheon case asserting only what the manifest installs (per the file's own "never add a glob you have not seen resolve" doctrine): `gala` compositor, `pantheon.desktop` session entry, lightdm unit, and a runtime `dm_pattern` pinning lightdm.

## Testing

- The shipped-DE coverage test now includes pantheon.
- A new bats case pins the general invariant: **every desktop any Containerfile passes to `configure-desktop-runtime.sh` must appear in both its DM case and the contract family** — the desktop list is derived from the Containerfiles, not hardcoded, so the next desktop stage cannot fall through `exit 0` and ship an unproven desktop. Mutation-verified (dropping pantheon from the family line fails exactly this case; restored tree is green).
- Pre-existing environment-dependent bats failures are identical with and without this diff (checked by stashing).

Real proof is the next gurnard:pantheon cell: the build now runs the pantheon contract at image-build time, and the installed system emits `TUNAOS_DESKTOP_CONTRACT_*` for the gate to harvest — `desktop_contract=ok` instead of `absent`.

Part of making `desktop_contract=ok` a fatal gate matrix-wide: every cell must first prove it can emit the marker.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->