### PR TITLE
installer: point the variant mark at a resource that exists

### DIFF
--- a/build_scripts/90-image-info.sh
+++ b/build_scripts/90-image-info.sh
@@ -185,13 +185,37 @@ if [[ -f "${RECIPE_FILE}" ]]; then
 	if [[ "${IMAGE_FLAVOR}" == "niri" || "${IMAGE_FLAVOR}" == *"niri"* ]]; then DESKTOP_PRETTY_NAME="Niri"; fi
 	if [[ "${IMAGE_FLAVOR}" == "xfce" || "${IMAGE_FLAVOR}" == *"xfce"* ]]; then DESKTOP_PRETTY_NAME="XFCE"; fi
 
+	# Pick the variant mark that ACTUALLY EXISTS in the installer's GResource.
+	#
+	# This line used to build 'images/${IMAGE_NAME}.png' unconditionally. Every
+	# TunaOS mark in that bundle is an .svg — only bluefin, bluefin-lts and
+	# dakota are .png — so the path never resolved. bootc-installer's
+	# apply_icon() catches the failure and logs a warning, so the welcome
+	# screen silently showed GTK's broken-image placeholder above a correctly
+	# branded "Welcome to Skipjack". Seen on the live-ISO screenshot for
+	# tuna-os/tunaOS#1056.
+	#
+	# The set below is upstream's, from bootc_installer/bootc-installer.gresource.xml:
+	#   images/tunaos.svg  bonito.svg  skipjack.svg  albacore.svg  yellowfin.svg
+	# grouper, marlin, redfin and sailfin have no mark of their own, and would
+	# hit exactly the same broken placeholder — they fall back to the TunaOS
+	# mark, which is branding rather than breakage.
+	case "${IMAGE_NAME}" in
+	tunaos | bonito | skipjack | albacore | yellowfin)
+		DISTRO_LOGO_RES="resource:///org/bootcinstaller/Installer/images/${IMAGE_NAME}.svg"
+		;;
+	*)
+		DISTRO_LOGO_RES="resource:///org/bootcinstaller/Installer/images/tunaos.svg"
+		;;
+	esac
+
 	python3 -c "
 import json
 with open('${RECIPE_FILE}', 'r') as f:
     recipe = json.load(f)
 recipe['distro_name'] = '${IMAGE_PRETTY_NAME}'
 recipe['welcome_title'] = 'Welcome to ${IMAGE_PRETTY_NAME}'
-recipe['distro_logo'] = 'resource:///org/bootcinstaller/Installer/images/${IMAGE_NAME}.png'
+recipe['distro_logo'] = '${DISTRO_LOGO_RES}'
 recipe['tour']['welcome']['title'] = 'Welcome to ${IMAGE_PRETTY_NAME}'
 recipe['tour']['welcome']['description'] = '${IMAGE_PRETTY_NAME} is an immutable, container-native Linux operating system built for enterprise workstations and developers.'
 

--- a/tests/bats/test_installer_branding.bats
+++ b/tests/bats/test_installer_branding.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# The installer's variant mark must point at a resource that EXISTS.
+#
+# WHY THIS EXISTS. build_scripts/90-image-info.sh rewrites
+# /etc/bootc-installer/recipe.json per variant, and it used to set
+#
+#   distro_logo = resource:///org/bootcinstaller/Installer/images/<variant>.png
+#
+# unconditionally. Every TunaOS mark in bootc-installer's GResource is an .svg
+# — only bluefin, bluefin-lts and dakota are .png — so that path resolved for
+# nobody. bootc-installer's apply_icon() catches the failure and logs a
+# warning, so the welcome screen showed GTK's broken-image placeholder above a
+# correctly branded "Welcome to Skipjack", and every gate stayed green: the
+# process was running, the window was mapped, the title was right.
+#
+# Only looking at the picture found it (tuna-os/tunaOS#1056's live-ISO
+# screenshot). This is the cheap regression check that does not need a picture.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../build_scripts/90-image-info.sh"
+
+# Upstream's set, from bootc_installer/bootc-installer.gresource.xml. If
+# upstream adds a mark for grouper/marlin/redfin/sailfin, add it here AND to
+# the case statement in 90-image-info.sh — this list existing separately is
+# the price of not being able to read the GResource at image-build time.
+KNOWN_MARKS="tunaos bonito skipjack albacore yellowfin"
+
+@test "distro_logo uses .svg, never .png" {
+  # .png would silently resolve to nothing for every TunaOS variant.
+  run grep -n "Installer/images/.*\.png" "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "every variant maps to a mark that exists upstream" {
+  # Mirrors the case statement. A variant that falls through must land on the
+  # TunaOS mark, not on its own name.
+  for variant in tunaos bonito skipjack albacore yellowfin grouper marlin redfin sailfin; do
+    local mark
+    case "$variant" in
+      tunaos | bonito | skipjack | albacore | yellowfin) mark="$variant" ;;
+      *) mark="tunaos" ;;
+    esac
+    # shellcheck disable=SC2076
+    [[ " ${KNOWN_MARKS} " == *" ${mark} "* ]] || {
+      echo "variant ${variant} maps to ${mark}, which upstream does not ship" >&2
+      false
+    }
+  done
+}
+
+@test "the fallback branch is present so unmarked variants are not broken" {
+  # grouper, marlin, redfin and sailfin have no mark of their own. Without the
+  # fallback they get the same broken placeholder this file exists to prevent.
+  run grep -c "images/tunaos.svg" "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+}


### PR DESCRIPTION
The gnome live ISO shows GTK's **broken-image placeholder** above a correctly branded "Welcome to Skipjack" — visible in #1056's live-ISO screenshot.

### Cause

`90-image-info.sh` built the logo path as:

```
resource:///org/bootcinstaller/Installer/images/${IMAGE_NAME}.png
```

Every TunaOS mark in bootc-installer's GResource is an **`.svg`**. Only bluefin, bluefin-lts and dakota are `.png`:

```xml
<file alias="images/bluefin.png">...</file>
<file alias="images/bluefin-lts.png">...</file>
<file alias="images/dakota.png">...</file>
<file preprocess="xml-stripblanks" alias="images/tunaos.svg">...</file>
<file preprocess="xml-stripblanks" alias="images/bonito.svg">...</file>
<file preprocess="xml-stripblanks" alias="images/skipjack.svg">...</file>
<file preprocess="xml-stripblanks" alias="images/albacore.svg">...</file>
<file preprocess="xml-stripblanks" alias="images/yellowfin.svg">...</file>
```

So the path resolved for **no TunaOS variant at all**. `apply_icon()` catches the failure and logs a warning, so it degraded to a broken image rather than an error — and every gate stayed green, because each one was true: the process was running, the window was mapped, the title was right.

### Fix

`.svg`, with a fallback. Upstream ships marks for tunaos, bonito, skipjack, albacore and yellowfin only — **grouper, marlin, redfin and sailfin have none** and would hit the identical placeholder, so they fall back to the TunaOS mark. That is branding rather than breakage.

| variant | mark |
|---|---|
| skipjack | `skipjack.svg` |
| yellowfin | `yellowfin.svg` |
| albacore, bonito, tunaos | own `.svg` |
| grouper, marlin, redfin, sailfin | `tunaos.svg` (fallback) |

### The gate

`tests/bats/test_installer_branding.bats`: no `.png` under `Installer/images`, every variant maps to a mark upstream actually ships, and the fallback branch exists. The known-marks list is duplicated there deliberately — the GResource cannot be read at image-build time, so the list existing in two places is the price, and the test is what makes drift between them loud.

### Not fixed here, because it is not ours

The welcome screen's action row reads **"Install Bluefin"** on every downstream, TunaOS included. It is hardcoded:

```blueprint
Adw.ActionRow row_install {
  title: _("Install Bluefin");
```

`bootc_installer/gtk/default-welcome.blp:23`, and never set at runtime — unlike `welcome_title`, which the recipe does drive (hence "Welcome to Skipjack" being right on the same screen). `done.py` already has the pattern it should use: `recipe.get("distro_name", "the operating system")`. Worth an upstream issue against projectbluefin/bootc-installer; no recipe change can work around it.

### Verification

The mapping was evaluated for all nine variants and cross-checked against upstream's `gresource.xml` — all five named marks are present, and the four unmarked variants land on `tunaos.svg`. Two of the three bats assertions were reproduced in plain bash here (bats is not installed); the `Unit Tests` job globs `tests/bats/*.bats`, so all three run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->