### PR TITLE
spec: make the screen keywords product-name-free

### DIFF
--- a/tests/installer-screens.yaml
+++ b/tests/installer-screens.yaml
@@ -25,7 +25,10 @@ screens:
   - id: welcome
     title: Welcome
     required: true
-    keywords: ["welcome", "get started", "let's get", "begin", "install tunaos"]
+    # "install tunaos" dropped: same product-name coupling as the disk and
+    # install lists. The four remaining keywords are what a welcome screen
+    # says regardless of what it is installing.
+    keywords: ["welcome", "get started", "let's get", "begin"]
 
   - id: disk
     title: Disk / target selection
@@ -43,9 +46,25 @@ screens:
     # "destination" is admitted as a bare-ish noun deliberately: it is the
     # entire heading on Niri, and it does not appear as a field label on any
     # other screen in any of the four frontends.
+    #
+    # PRODUCT-NAME-FREE from here on. The three keywords that embedded
+    # "tunaos" are gone: the frontends are being changed to show the VARIANT
+    # name the branding pipeline already computes (90-image-info.sh sets
+    # distro_name = PRETTY_NAME, which is why gnome says "Welcome to
+    # Skipjack"), so a keyword containing "tunaos" would stop matching the
+    # moment a frontend is branded correctly — the contract would punish the
+    # fix. Every keyword below is a heading or prompt that holds whatever the
+    # product is called.
+    #
+    # "be installed" rather than "will be installed" / "where tunaos will be
+    # installed": the product name sits INSIDE those phrases, so no
+    # product-free keyword can span it. XFCE's heading is "Where should
+    # <name> be installed?" and KDE's is "Choose the disk where <name> will
+    # be installed." — "be installed" is the longest contiguous run common to
+    # both that contains no product name. Verified against all four forks'
+    # source: it appears on their disk screens and on no other screen.
     keywords: ["select target disk", "select a disk", "choose the disk",
-               "available disks", "where tunaos will be installed",
-               "where should tunaos be installed", "destination"]
+               "available disks", "be installed", "destination"]
 
   - id: encryption
     title: Disk encryption (LUKS)
@@ -102,9 +121,14 @@ screens:
     # evidence available that an install is actually under way, which is the
     # principle this list already states ("progress screens say what they are
     # DOING").
+    #
+    # "installing tunaos" removed for the same reason as the disk keywords.
+    # The fisherman step lines carry this screen instead: every frontend
+    # streams the same backend, so "partitioning" and "installing image"
+    # appear on the progress screen of all five and on no other screen, and
+    # they do not contain a product name at all.
     keywords: ["installation progress", "copying files", "deploying",
-               "please wait", "writing image",
-               "installing tunaos", "installing\u2026",
+               "please wait", "writing image", "installing\u2026",
                "partitioning", "installing image"]
 
   - id: done


### PR DESCRIPTION
Prerequisite for rebranding the four forks to show the **variant** name.

### The inconsistency being fixed

gnome shows the variant — `90-image-info.sh` sets `distro_name = PRETTY_NAME`, which is why its welcome screen reads **"Welcome to Skipjack"**. The four TunaOS forks hardcode "TunaOS" in user-visible strings and read the product name from nothing:

| frontend | reads product name from | shows |
|---|---|---|
| gnome | recipe `distro_name` | **Skipjack** ✅ |
| kde | hardcoded | TunaOS |
| cosmic | hardcoded | TunaOS |
| niri | hardcoded | TunaOS |
| xfce | hardcoded | TunaOS |

So booting a Skipjack KDE ISO says *"Choose the disk where TunaOS will be installed"* while the GNOME one says *"Welcome to Skipjack"*.

### Why the contract has to change first

Four keywords embedded the product name and would have **stopped matching the moment a frontend was branded correctly**:

```
welcome  install tunaos
disk     where tunaos will be installed, where should tunaos be installed
install  installing tunaos
```

A contract that punishes the fix is worse than no contract. All four are gone.

### `be installed`

The product name sits *inside* the two disk phrases — `Where should <name> be installed?` (XFCE), `Choose the disk where <name> will be installed.` (KDE) — so no product-free keyword can span it. `be installed` is the longest contiguous run common to both that contains no name. Checked against all four forks' source: it appears on their disk screens and on no other screen.

### Verified with a variant name substituted

```
kde     choose the disk, be installed   'Choose the disk where Skipjack will be installed.'
niri    destination                     'Destination'
xfce    be installed                    'Where should Skipjack be installed?'
cosmic  select a disk                   'Select a disk'
gnome   select a disk                   'Select a disk'
```

All five still match, and no keyword contains a product name.

The install screen keeps the fisherman step lines — `partitioning`, `installing image` — which every frontend streams from the same backend and which never contained a product name.

### Follow-up

The four forks' rebranding lands separately, one PR per repo. Each vendors a copy of this spec in its parity report, so those copies need the same edit — the drift check in each repo's screenshot workflow will warn until they do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->