### PR TITLE
fix(nvidia): actually install the NVIDIA driver stack in *-nvidia overlays

### DIFF
--- a/build_scripts/checks/verify-nvidia.sh
+++ b/build_scripts/checks/verify-nvidia.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# verify-nvidia.sh — fatal build-time contract for *-nvidia overlay images.
+#
+# WHY THIS EXISTS. Every way an NVIDIA image fails on real hardware is
+# statically visible in the image, and for months the statically visible
+# truth was "there is no NVIDIA in the nvidia image": the overlay's
+# run_buildscripts_for found no overrides directory, silently skipped, and
+# published *-nvidia tags that were byte-for-byte their parent plus VS Code
+# hooks. No check could contradict it because nothing asserted a single
+# nvidia file. This script is the independent auditor of the install layer
+# (build_scripts/overlay/overrides/nvidia/20-nvidia.sh): it re-derives every
+# claim from the filesystem and the rpm database rather than trusting that
+# the install script ran.
+#
+# Assertion sources — measured, not guessed (repo rule: never assert a glob
+# you have not seen resolve). File paths below were read out of negativo17
+# fedora-nvidia 43 repodata filelists (2026-08-07), the exact repo the
+# install script points these images at:
+#   /usr/share/glvnd/egl_vendor.d/10_nvidia.json      (nvidia-driver-libs)
+#   /usr/share/vulkan/icd.d/nvidia_icd.*.json         (per-arch name)
+#   /usr/lib64/gbm/nvidia-drm_gbm.so                  (Wayland GBM backend)
+#   /usr/lib64/libEGL_nvidia.so.0, libGLX_nvidia.so.0
+#   /usr/lib/dracut/dracut.conf.d/99-nvidia.conf      (nvidia-kmod-common)
+# That packaging ships NO nvidia-suspend/resume/hibernate units (it ships
+# persistenced + powerd), so the suspend check is conditional: present units
+# must be enabled; absent units are reported, not failed.
+#
+# Scope: the dnf/rpm family only — the only family that declares -nvidia
+# flavors in .github/build-config.yml (yellowfin/albacore/skipjack on the
+# centos-10 akmods, bonito/bonito-rawhide on coreos-stable). If a non-rpm
+# variant ever grows an nvidia flavor this exits loudly rather than
+# pretending to have verified something it cannot.
+#
+# Test hooks (same pattern as TUNAOS_OS_RELEASE in verify-branding.sh):
+#   TUNAOS_NVIDIA_VERIFY_ROOT  prefix for every filesystem path, so bats can
+#                              run the real logic against a fixture tree.
+#   rpm/modinfo/systemctl are resolved via PATH, so tests stub them.
+
+set -euo pipefail
+
+NV_ROOT="${TUNAOS_NVIDIA_VERIFY_ROOT:-}"
+
+fails=0
+fail() {
+	echo "  FAIL: $*" >&2
+	fails=$((fails + 1))
+}
+pass() { echo "  ok: $*"; }
+
+if ! command -v rpm >/dev/null 2>&1; then
+	echo "ERROR: verify-nvidia.sh only knows the rpm family, and this image has no rpm." >&2
+	echo "       No non-rpm variant declares an nvidia flavor; if one now does," >&2
+	echo "       teach this contract that family first." >&2
+	exit 1
+fi
+
+echo "== packages =="
+for pkg in kmod-nvidia nvidia-driver nvidia-driver-cuda nvidia-container-toolkit; do
+	if v=$(rpm -q --queryformat '%{VERSION}' "$pkg" 2>/dev/null); then
+		pass "${pkg}=${v}"
+	else
+		fail "${pkg} is not installed"
+	fi
+done
+
+echo "== kernel/module coherence =="
+# The kmod must exist for the EXACT kernel this image ships — a kmod for any
+# other kernel is a black screen on real hardware while every package
+# transaction "succeeded".
+KERNEL_VRA="$(rpm -q kernel --queryformat '%{EVR}.%{ARCH}\n' 2>/dev/null | tail -1 || true)"
+MODULE_FILE=""
+if [[ -z "$KERNEL_VRA" ]]; then
+	fail "cannot determine kernel EVR (rpm -q kernel failed)"
+elif [[ ! -d "${NV_ROOT}/usr/lib/modules/${KERNEL_VRA}" ]]; then
+	fail "no module directory for the shipped kernel: /usr/lib/modules/${KERNEL_VRA}"
+else
+	MODULE_FILE="$(find "${NV_ROOT}/usr/lib/modules/${KERNEL_VRA}" -name 'nvidia*.ko*' -print 2>/dev/null | head -1 || true)"
+	if [[ -n "$MODULE_FILE" ]]; then
+		pass "nvidia kernel module present for ${KERNEL_VRA} (${MODULE_FILE#"${NV_ROOT}"})"
+	else
+		fail "no nvidia*.ko* under /usr/lib/modules/${KERNEL_VRA} — kmod built for a different kernel?"
+	fi
+fi
+
+echo "== version lock (kmod == userspace) =="
+KMOD_VERSION="$(rpm -q --queryformat '%{VERSION}' kmod-nvidia 2>/dev/null || true)"
+DRIVER_VERSION="$(rpm -q --queryformat '%{VERSION}' nvidia-driver 2>/dev/null || true)"
+if [[ -n "$KMOD_VERSION" && -n "$DRIVER_VERSION" ]]; then
+	if [[ "$KMOD_VERSION" == "$DRIVER_VERSION" ]]; then
+		pass "kmod-nvidia and nvidia-driver agree (${KMOD_VERSION})"
+	else
+		fail "version skew: kmod-nvidia=${KMOD_VERSION} but nvidia-driver=${DRIVER_VERSION}"
+	fi
+fi
+# File-level proof the .ko really is that version (catches a stale module
+# left behind by a partial overlay rebuild, which rpm -q cannot see).
+if [[ -n "$MODULE_FILE" && -n "$KMOD_VERSION" ]] && command -v modinfo >/dev/null 2>&1; then
+	MODINFO_VERSION="$(modinfo -F version "$MODULE_FILE" 2>/dev/null | head -1 || true)"
+	if [[ -z "$MODINFO_VERSION" ]]; then
+		fail "modinfo could not read a version from ${MODULE_FILE#"${NV_ROOT}"}"
+	elif [[ "$MODINFO_VERSION" == "$KMOD_VERSION" ]]; then
+		pass "module file version matches kmod rpm (${MODINFO_VERSION})"
+	else
+		fail "module file is ${MODINFO_VERSION} but kmod-nvidia rpm is ${KMOD_VERSION}"
+	fi
+fi
+
+echo "== nouveau is out of the way =="
+if grep -rqs 'blacklist nouveau' "${NV_ROOT}/usr/lib/modprobe.d" "${NV_ROOT}/etc/modprobe.d" 2>/dev/null; then
+	pass "nouveau blacklisted in modprobe.d"
+else
+	fail "no 'blacklist nouveau' under /usr/lib/modprobe.d or /etc/modprobe.d"
+fi
+if grep -rqs 'nvidia-drm.modeset=1' "${NV_ROOT}/usr/lib/bootc/kargs.d" 2>/dev/null; then
+	pass "nvidia-drm.modeset=1 karg declared in /usr/lib/bootc/kargs.d"
+else
+	fail "nvidia-drm.modeset=1 missing from /usr/lib/bootc/kargs.d — Wayland/KMS will not engage"
+fi
+
+echo "== GL/Vulkan/Wayland plumbing =="
+# Each pair is (dispatch JSON, the library it names). A JSON without its
+# library renders as "no NVIDIA GPU found" in every GL/Vulkan app.
+if compgen -G "${NV_ROOT}/usr/share/glvnd/egl_vendor.d/10_nvidia.json" >/dev/null; then
+	pass "glvnd EGL vendor JSON present"
+else
+	fail "missing /usr/share/glvnd/egl_vendor.d/10_nvidia.json"
+fi
+if compgen -G "${NV_ROOT}/usr/lib64/libEGL_nvidia.so.0" >/dev/null; then
+	pass "libEGL_nvidia.so.0 present"
+else
+	fail "missing /usr/lib64/libEGL_nvidia.so.0"
+fi
+if compgen -G "${NV_ROOT}/usr/share/vulkan/icd.d/nvidia_icd.*.json" >/dev/null; then
+	pass "Vulkan ICD JSON present"
+else
+	fail "missing /usr/share/vulkan/icd.d/nvidia_icd.*.json"
+fi
+if compgen -G "${NV_ROOT}/usr/lib64/libGLX_nvidia.so.0" >/dev/null; then
+	pass "libGLX_nvidia.so.0 present"
+else
+	fail "missing /usr/lib64/libGLX_nvidia.so.0"
+fi
+if compgen -G "${NV_ROOT}/usr/lib64/gbm/nvidia-drm_gbm.so" >/dev/null; then
+	pass "GBM backend nvidia-drm_gbm.so present"
+else
+	fail "missing /usr/lib64/gbm/nvidia-drm_gbm.so — Wayland compositors cannot use the driver"
+fi
+
+echo "== initramfs policy =="
+DRACUT_CONF="${NV_ROOT}/usr/lib/dracut/dracut.conf.d/99-nvidia.conf"
+if [[ ! -f "$DRACUT_CONF" ]]; then
+	fail "missing /usr/lib/dracut/dracut.conf.d/99-nvidia.conf (nvidia-kmod-common)"
+elif grep -q 'force_drivers' "$DRACUT_CONF"; then
+	pass "dracut force_drivers set for nvidia"
+else
+	fail "99-nvidia.conf does not force_drivers — black screen at boot on nvidia desktops"
+fi
+
+echo "== suspend units (conditional — see header) =="
+for unit in nvidia-suspend nvidia-resume nvidia-hibernate; do
+	if [[ -f "${NV_ROOT}/usr/lib/systemd/system/${unit}.service" ]]; then
+		if systemctl is-enabled "${unit}.service" >/dev/null 2>&1; then
+			pass "${unit}.service shipped and enabled"
+		else
+			fail "${unit}.service is shipped but not enabled"
+		fi
+	else
+		echo "  info: ${unit}.service not shipped by this driver packaging (expected on negativo17)"
+	fi
+done
+
+echo
+if [[ "$fails" -gt 0 ]]; then
+	echo "TUNAOS_NVIDIA_CONTRACT_FAIL failures=${fails}"
+	exit 1
+fi
+echo "TUNAOS_NVIDIA_CONTRACT_OK"

--- a/build_scripts/overlay/nvidia.sh
+++ b/build_scripts/overlay/nvidia.sh
@@ -22,6 +22,16 @@ fi
 copy_systemfiles_for nvidia
 run_buildscripts_for nvidia
 
+# Independent audit of what the overlay just did. run_buildscripts_for
+# returns 0 when its overrides directory is missing — exactly how driverless
+# "*-nvidia" images shipped for months — so the contract below is a bare call
+# under `set -e`: an nvidia overlay that did not actually install the driver
+# stack fails the build here rather than publishing. Installed into the image
+# too, so desktop-contract-sweep can re-run it against published tags.
+/run/context/build_scripts/checks/verify-nvidia.sh
+install -Dm0755 /run/context/build_scripts/checks/verify-nvidia.sh \
+	/usr/libexec/tunaos/verify-nvidia
+
 if command -v jq >/dev/null 2>&1; then
 	jq . /usr/share/ublue-os/image-info.json || true
 else

--- a/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# 20-nvidia.sh — install the NVIDIA driver stack on a *-nvidia overlay.
+#
+# WHY THIS FILE EXISTS (tunaOS was shipping driverless "nvidia" images):
+# build_scripts/overlay/nvidia.sh calls `run_buildscripts_for nvidia`, which
+# resolves ${BUILD_SCRIPTS_PATH}/overrides/nvidia (lib.sh) — a directory that
+# did not exist. run_buildscripts_for prints "No build script overrides for
+# 'nvidia', skipping." and returns 0, so every *-nvidia image was its parent
+# DE image plus three VS Code setup hooks: no kernel module, no userspace
+# driver, no kargs, no nouveau blacklist. The akmods-nvidia-open RPMs were
+# bind-mounted at /tmp/akmods-nvidia-open-rpms (Containerfile.overlay) and
+# never consumed. Nothing could catch it: no check mentioned nvidia at all.
+#
+# Ported from the proven prior art for the exact same akmods bundle:
+# _upstream-snapshots/bluefin-lts/build_scripts/overrides/gdx/20-nvidia.sh
+# (bluefin-lts GDX consumes ghcr.io/ublue-os/akmods-nvidia-open:centos-10,
+# which is what scripts/build-image-inner.sh passes for the EL10 variants;
+# bonito passes coreos-stable-<N>). Deliberate differences from the port:
+#
+#   * No `dnf config-manager` calls. The EL10 variants have dnf4
+#     (--set-enabled/--set-disabled) while bonito has dnf5 (setopt) — the two
+#     syntaxes are mutually incompatible, so repos are written with enabled=0
+#     baked into the file and enabled per-transaction with --enablerepo.
+#   * SELinux module install and ublue-nvctk-cdi enablement are guarded on
+#     the file/unit existing, because the ublue-os addons payload differs
+#     between the centos-10 and coreos-stable akmods bundles.
+#   * Suspend/resume/hibernate units are enabled IF the driver packaging
+#     ships them. Measured against negativo17 fedora-nvidia 43 (filelists,
+#     2026-08-07): that packaging ships nvidia-persistenced.service and
+#     nvidia-powerd.service but NO nvidia-suspend/resume/hibernate units, so
+#     on today's repo the loop is a documented no-op — it exists so a
+#     packaging change that adds them cannot ship them disabled.
+#
+# The kmod install below globs kmod-nvidia-${KERNEL_VRA}-*.rpm — an EXACT
+# kernel EVR.ARCH match. If the akmods bundle was built for a different
+# kernel than this image ships, dnf receives the unexpanded glob and fails
+# the build. That is deliberate: a kmod for the wrong kernel is a black
+# screen on real hardware, and a loud build failure is the only place to
+# learn it. build_scripts/checks/verify-nvidia.sh re-proves this and the
+# rest of the contract independently at the end of the overlay.
+
+set -xeuo pipefail
+
+# /*
+# Get Kernel Version
+# */
+KERNEL_NAME="kernel"
+KERNEL_VRA="$(rpm -q "$KERNEL_NAME" --queryformat '%{EVR}.%{ARCH}')"
+KERNEL_SUFFIX=""
+QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(|'"$KERNEL_SUFFIX"'-)(\d+\.\d+\.\d+)' | sed -E 's/kernel-(|'"$KERNEL_SUFFIX"'-)//' | tail -n 1)"
+
+### install Nvidia driver packages and dependencies
+# kmod-nvidia requires nvidia-kmod-common from negativo17's fedora-nvidia
+# repo. Detect the Fedora release embedded in the akmods RPMs and download
+# the matching repo file so DNF can resolve it. On the centos-10 akmods the
+# RPMs carry no .fcNN tag, so the pinned default applies — the same release
+# bluefin-lts pins for the same bundle.
+FEDORA_VERSION="${FEDORA_AKMODS_VERSION:-43}"
+AKMODS_FEDORA_VERSION="$(find /tmp/akmods-nvidia-open-rpms -name "*.rpm" -print | grep -oPm1 '(?<=\.fc)\d+' || true)"
+if [[ -n "${AKMODS_FEDORA_VERSION}" ]]; then
+	FEDORA_VERSION="${AKMODS_FEDORA_VERSION}"
+fi
+curl --retry 3 -fsSLo - "https://negativo17.org/repos/fedora-nvidia.repo" |
+	sed "s/\$releasever/${FEDORA_VERSION}/g" |
+	tee "/etc/yum.repos.d/fedora-nvidia.repo"
+# Disabled at rest; enabled per-transaction below (see header for why this
+# is not `dnf config-manager`).
+sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/fedora-nvidia.repo
+
+dnf -y install --enablerepo="fedora-nvidia" \
+	/tmp/akmods-nvidia-open-rpms/kmods/kmod-nvidia-"${KERNEL_VRA}"-*.rpm \
+	/tmp/akmods-nvidia-open-rpms/ublue-os/*.rpm
+
+# Get the kmod-nvidia version to ensure driver packages match
+KMOD_VERSION="$(rpm -q --queryformat '%{VERSION}' kmod-nvidia)"
+# Determine the expected package version format (epoch:version-release)
+NVIDIA_PKG_VERSION="3:${KMOD_VERSION}"
+
+# The nvidia-container-toolkit repo file ships in the ublue-os addons RPMs
+# installed above; enable it for this transaction only.
+dnf -y install --enablerepo="fedora-nvidia" --enablerepo="nvidia-container-toolkit" \
+	"libnvidia-fbc-${NVIDIA_PKG_VERSION}" \
+	"nvidia-driver-${NVIDIA_PKG_VERSION}" \
+	"nvidia-driver-cuda-${NVIDIA_PKG_VERSION}" \
+	"nvidia-settings-${NVIDIA_PKG_VERSION}" \
+	nvidia-container-toolkit
+# Leave the toolkit repo disabled at rest, matching the fedora-nvidia repo.
+if [[ -f /etc/yum.repos.d/nvidia-container-toolkit.repo ]]; then
+	sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/nvidia-container-toolkit.repo
+fi
+
+# Ensure the version of the Nvidia module matches the driver
+DRIVER_VERSION="$(rpm -q --queryformat '%{VERSION}' nvidia-driver)"
+if [ "$KMOD_VERSION" != "$DRIVER_VERSION" ]; then
+	echo "Error: kmod-nvidia version ($KMOD_VERSION) does not match nvidia-driver version ($DRIVER_VERSION)"
+	exit 1
+fi
+
+tee /usr/lib/modprobe.d/00-nouveau-blacklist.conf <<'EOF'
+blacklist nouveau
+options nouveau modeset=0
+EOF
+
+install -d /usr/lib/bootc/kargs.d
+tee /usr/lib/bootc/kargs.d/00-nvidia.toml <<'EOF'
+kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-drm.modeset=1"]
+EOF
+
+## nvidia post-install steps
+# Container toolkit CDI generation service + SELinux module, both from the
+# ublue-os addons payload — guarded because the payload differs between the
+# centos-10 and coreos-stable akmods bundles (see header).
+if [[ -f /usr/lib/systemd/system/ublue-nvctk-cdi.service ]]; then
+	systemctl enable ublue-nvctk-cdi.service
+fi
+if [[ -f /usr/share/selinux/packages/nvidia-container.pp ]]; then
+	semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
+fi
+
+# Suspend/resume/hibernate units: enable when the driver packaging ships
+# them. Measured no-op on negativo17 fedora-nvidia 43 today — see header.
+for _nv_unit in nvidia-suspend nvidia-resume nvidia-hibernate; do
+	if [[ -f "/usr/lib/systemd/system/${_nv_unit}.service" ]]; then
+		systemctl enable "${_nv_unit}.service"
+	fi
+done
+
+# Universal Blue specific Initramfs fixes
+# nvidia-modeset.conf may not exist on all architectures (e.g. arm64/SBSA)
+if [[ -f /etc/modprobe.d/nvidia-modeset.conf ]]; then
+	cp /etc/modprobe.d/nvidia-modeset.conf /usr/lib/modprobe.d/nvidia-modeset.conf
+fi
+# we must force driver load to fix black screen on boot for nvidia desktops.
+# 99-nvidia.conf ships in negativo17's nvidia-kmod-common (measured in its
+# filelists) — installed above as a nvidia-driver dependency chain member.
+if [[ ! -f /usr/lib/dracut/dracut.conf.d/99-nvidia.conf ]]; then
+	echo "ERROR: /usr/lib/dracut/dracut.conf.d/99-nvidia.conf is missing —" >&2
+	echo "       nvidia-kmod-common did not install; the initramfs would omit" >&2
+	echo "       the driver and real hardware would boot to a black screen." >&2
+	exit 1
+fi
+sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
+# as we need forced load, also must pre-load intel/amd iGPU else chromium web browsers fail to use hardware acceleration
+sed -i 's@ nvidia @ i915 amdgpu nvidia @g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
+
+# Make sure initramfs is rebuilt after nvidia drivers or kernel replacement
+/usr/bin/dracut --no-hostonly --kver "$QUALIFIED_KERNEL" --reproducible --tmpdir /boot --zstd -v --add ostree -f "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -1,0 +1,234 @@
+#!/usr/bin/env bats
+# The NVIDIA overlay must actually install a driver, and the contract must
+# actually verify one.
+#
+# Failure mode these tests pin: run_buildscripts_for (build_scripts/lib.sh)
+# resolves ${BUILD_SCRIPTS_PATH}/overrides/<what> and RETURNS 0 when the
+# directory is missing ("No build script overrides ... skipping"). For the
+# nvidia overlay that silent skip published *-nvidia images containing no
+# kernel module, no userspace driver, no kargs and no nouveau blacklist —
+# the akmods RPMs were bind-mounted and never consumed. A missing or
+# mis-named overrides/nvidia directory must be a TEST failure here, never a
+# silent no-op again.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+NVIDIA_DIR="${REPO_ROOT}/build_scripts/overlay/overrides/nvidia"
+INSTALL_SH="${NVIDIA_DIR}/20-nvidia.sh"
+VERIFY_SH="${REPO_ROOT}/build_scripts/checks/verify-nvidia.sh"
+OVERLAY_SH="${REPO_ROOT}/build_scripts/overlay/nvidia.sh"
+
+# ── wiring: the silent-skip hole stays closed ──────────────────────────────
+
+@test "nvidia overrides directory exists where run_buildscripts_for looks" {
+  # nvidia.sh executes with $0 = build_scripts/overlay/nvidia.sh, so lib.sh's
+  # BUILD_SCRIPTS_PATH is build_scripts/overlay and the resolved overrides
+  # path is build_scripts/overlay/overrides/nvidia. Anywhere else is skipped.
+  run test -d "$NVIDIA_DIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "nvidia overrides directory contains an executable matching run_buildscripts_for's find pattern" {
+  # run_buildscripts_for finds only `-maxdepth 1 -iname "*-*.sh" -type f`.
+  # A script named without a hyphen (e.g. nvidia.sh) would be skipped.
+  local found=0 f
+  for f in "$NVIDIA_DIR"/*-*.sh; do
+    [ -f "$f" ] || continue
+    [ -x "$f" ] || { echo "not executable: $f" >&2; continue; }
+    found=1
+  done
+  [ "$found" -eq 1 ]
+}
+
+@test "overlay nvidia.sh runs the overrides and then the fatal contract" {
+  run grep -F 'run_buildscripts_for nvidia' "$OVERLAY_SH"
+  [ "$status" -eq 0 ]
+  # Bare call (no `|| true`, no `-`): under set -e a failed contract fails
+  # the build.
+  run grep -E '^/run/context/build_scripts/checks/verify-nvidia\.sh$' "$OVERLAY_SH"
+  [ "$status" -eq 0 ]
+  # And the auditor ships in the image for the published-image sweep.
+  run grep -F '/usr/libexec/tunaos/verify-nvidia' "$OVERLAY_SH"
+  [ "$status" -eq 0 ]
+}
+
+# ── install layer: the load-bearing lines of 20-nvidia.sh ──────────────────
+
+@test "20-nvidia.sh installs the akmods kmod with an exact kernel EVR match" {
+  # The glob kmod-nvidia-${KERNEL_VRA}-*.rpm is the mechanism that makes a
+  # kernel/kmod mismatch a loud dnf failure instead of a black screen.
+  run grep -F '/tmp/akmods-nvidia-open-rpms/kmods/kmod-nvidia-"${KERNEL_VRA}"-*.rpm' "$INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F "KERNEL_VRA=\"\$(rpm -q \"\$KERNEL_NAME\" --queryformat '%{EVR}.%{ARCH}')\"" "$INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "20-nvidia.sh refuses version skew between kmod and userspace driver" {
+  run grep -F '"$KMOD_VERSION" != "$DRIVER_VERSION"' "$INSTALL_SH"
+  [ "$status" -eq 0 ]
+  # The mismatch branch must exit non-zero, not warn.
+  run grep -A2 -F '"$KMOD_VERSION" != "$DRIVER_VERSION"' "$INSTALL_SH"
+  [[ "$output" == *"exit 1"* ]]
+}
+
+@test "20-nvidia.sh blacklists nouveau and sets the modeset karg" {
+  run grep -F 'blacklist nouveau' "$INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'nvidia-drm.modeset=1' "$INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F '/usr/lib/bootc/kargs.d/00-nvidia.toml' "$INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "20-nvidia.sh avoids dnf config-manager (dnf4/dnf5 split across variants)" {
+  # EL10 variants carry dnf4 (--set-enabled), bonito carries dnf5 (setopt);
+  # either spelling breaks the other family. Repos are enabled per
+  # transaction instead.
+  # Match only code, not the header comment that documents this rule.
+  run grep -E '^[^#]*dnf config-manager' "$INSTALL_SH"
+  [ "$status" -ne 0 ]
+  run grep -F -- '--enablerepo="fedora-nvidia"' "$INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "20-nvidia.sh rebuilds the initramfs after installing the driver" {
+  run grep -E 'dracut .*--kver "\$QUALIFIED_KERNEL"' "$INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+# ── contract: verify-nvidia.sh behavioral tests against a fixture root ─────
+#
+# The script takes TUNAOS_NVIDIA_VERIFY_ROOT (same pattern as
+# TUNAOS_OS_RELEASE in verify-branding.sh) and resolves rpm/modinfo/
+# systemctl from PATH, so the real logic runs against a fake tree and stub
+# tools. Each mutation below was verified to fail before the corresponding
+# fixture piece existed.
+
+KVER="6.12.0-55.el10.x86_64"
+
+make_stub_tools() {
+  # rpm stub: answers -q kernel and -q <pkg> --queryformat %{VERSION}.
+  mkdir -p "${BATS_TEST_TMPDIR}/bin"
+  cat > "${BATS_TEST_TMPDIR}/bin/rpm" <<STUB
+#!/usr/bin/env bash
+args="\$*"
+case "\$args" in
+  *"-q kernel"*) echo "${KVER}"; exit 0 ;;
+  *kmod-nvidia*|*nvidia-driver-cuda*|*nvidia-container-toolkit*) printf '580.10.01'; exit 0 ;;
+  *nvidia-driver*) printf '580.10.01'; exit 0 ;;
+esac
+exit 1
+STUB
+  cat > "${BATS_TEST_TMPDIR}/bin/modinfo" <<'STUB'
+#!/usr/bin/env bash
+echo "580.10.01"
+STUB
+  cat > "${BATS_TEST_TMPDIR}/bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "${BATS_TEST_TMPDIR}/bin/"*
+}
+
+make_good_root() {
+  local r="${BATS_TEST_TMPDIR}/root"
+  mkdir -p \
+    "$r/usr/lib/modules/${KVER}/extra/nvidia" \
+    "$r/usr/lib/modprobe.d" \
+    "$r/usr/lib/bootc/kargs.d" \
+    "$r/usr/share/glvnd/egl_vendor.d" \
+    "$r/usr/share/vulkan/icd.d" \
+    "$r/usr/lib64/gbm" \
+    "$r/usr/lib/dracut/dracut.conf.d" \
+    "$r/usr/lib/systemd/system"
+  touch "$r/usr/lib/modules/${KVER}/extra/nvidia/nvidia.ko.xz"
+  echo "blacklist nouveau" > "$r/usr/lib/modprobe.d/00-nouveau-blacklist.conf"
+  echo 'kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-drm.modeset=1"]' \
+    > "$r/usr/lib/bootc/kargs.d/00-nvidia.toml"
+  echo '{}' > "$r/usr/share/glvnd/egl_vendor.d/10_nvidia.json"
+  echo '{}' > "$r/usr/share/vulkan/icd.d/nvidia_icd.x86_64.json"
+  touch "$r/usr/lib64/libEGL_nvidia.so.0" "$r/usr/lib64/libGLX_nvidia.so.0"
+  touch "$r/usr/lib64/gbm/nvidia-drm_gbm.so"
+  echo 'force_drivers+=" i915 amdgpu nvidia nvidia-drm "' \
+    > "$r/usr/lib/dracut/dracut.conf.d/99-nvidia.conf"
+  echo "$r"
+}
+
+run_verify() {
+  PATH="${BATS_TEST_TMPDIR}/bin:$PATH" \
+    TUNAOS_NVIDIA_VERIFY_ROOT="$1" \
+    run bash "$VERIFY_SH"
+}
+
+@test "verify-nvidia passes on a complete driver install" {
+  make_stub_tools
+  root="$(make_good_root)"
+  run_verify "$root"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TUNAOS_NVIDIA_CONTRACT_OK"* ]]
+}
+
+@test "verify-nvidia fails when the kmod is for a different kernel" {
+  make_stub_tools
+  root="$(make_good_root)"
+  rm "$root/usr/lib/modules/${KVER}/extra/nvidia/nvidia.ko.xz"
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"TUNAOS_NVIDIA_CONTRACT_FAIL"* ]]
+}
+
+@test "verify-nvidia fails on kmod/userspace version skew" {
+  make_stub_tools
+  # Re-stub rpm so nvidia-driver reports a different version. Order matters:
+  # the kmod-nvidia arm must match before the nvidia-driver arm, since
+  # "kmod-nvidia" contains "nvidia-driver" as a substring? It does not — but
+  # keep the arms explicit so the stub stays legible.
+  cat > "${BATS_TEST_TMPDIR}/bin/rpm" <<STUB
+#!/usr/bin/env bash
+args="\$*"
+case "\$args" in
+  *"-q kernel"*) echo "${KVER}"; exit 0 ;;
+  *kmod-nvidia*) printf '580.10.01'; exit 0 ;;
+  *nvidia-driver-cuda*|*nvidia-container-toolkit*) printf '580.10.01'; exit 0 ;;
+  *nvidia-driver*) printf '570.99.99'; exit 0 ;;
+esac
+exit 1
+STUB
+  chmod +x "${BATS_TEST_TMPDIR}/bin/rpm"
+  root="$(make_good_root)"
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"version skew"* ]]
+}
+
+@test "verify-nvidia fails when the Wayland GBM backend is missing" {
+  make_stub_tools
+  root="$(make_good_root)"
+  rm "$root/usr/lib64/gbm/nvidia-drm_gbm.so"
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"nvidia-drm_gbm.so"* ]]
+}
+
+@test "verify-nvidia fails when the modeset karg is absent" {
+  make_stub_tools
+  root="$(make_good_root)"
+  echo 'kargs = ["rd.driver.blacklist=nouveau"]' \
+    > "$root/usr/lib/bootc/kargs.d/00-nvidia.toml"
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"nvidia-drm.modeset=1"* ]]
+}
+
+@test "verify-nvidia fails when a shipped suspend unit is disabled" {
+  make_stub_tools
+  root="$(make_good_root)"
+  touch "$root/usr/lib/systemd/system/nvidia-suspend.service"
+  cat > "${BATS_TEST_TMPDIR}/bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  chmod +x "${BATS_TEST_TMPDIR}/bin/systemctl"
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"nvidia-suspend.service is shipped but not enabled"* ]]
+}


### PR DESCRIPTION
## The bug

Every `*-nvidia` image published from main is its parent DE image plus three VS Code setup hooks — **no driver at all**. The mechanism:

- `build_scripts/overlay/nvidia.sh` calls `run_buildscripts_for nvidia`
- `run_buildscripts_for` (lib.sh) resolves `${BUILD_SCRIPTS_PATH}/overrides/nvidia` = `build_scripts/overlay/overrides/nvidia`, **a directory that does not exist anywhere in the tree**, prints "No build script overrides for 'nvidia', skipping." and returns 0
- the akmods-nvidia-open RPMs are bind-mounted at `/tmp/akmods-nvidia-open-rpms` (Containerfile.overlay) and never consumed

So the images carry no kernel module, no userspace driver, no `nvidia-drm.modeset=1` karg, no nouveau blacklist — and nothing could catch it, because no check asserted a single nvidia file. On real NVIDIA hardware these images fall back to nouveau/simpledrm; on Wayland-only stacks that can mean no session at all.

## The fix

**Install layer** — `build_scripts/overlay/overrides/nvidia/20-nvidia.sh`, ported from the proven prior art for the exact same akmods bundle (`_upstream-snapshots/bluefin-lts/build_scripts/overrides/gdx/20-nvidia.sh`):
- kmod installed via an **exact kernel EVR.ARCH glob** — a kernel/kmod mismatch fails the build loudly instead of shipping a black screen
- userspace pinned to the kmod version, with an explicit skew check (`exit 1` on mismatch)
- nouveau blacklist, `kargs.d/00-nvidia.toml` (`rd.driver.blacklist=nouveau modprobe.blacklist=nouveau nvidia-drm.modeset=1`), dracut `force_drivers` (+ i915/amdgpu preload), initramfs rebuild

Deliberate divergences from the port, each explained in the file header:
- no `dnf config-manager` — the EL10 variants are dnf4 (`--set-disabled`) and bonito is dnf5 (`setopt`); repos are written `enabled=0` and enabled per-transaction with `--enablerepo`
- addons/SELinux/suspend-unit steps are existence-guarded (the centos-10 and coreos-stable akmods payloads differ)
- suspend/resume/hibernate enablement is a **measured no-op today**: negativo17 fedora-nvidia 43 ships `nvidia-persistenced.service` + `nvidia-powerd.service` and no suspend units (read from its repodata filelists, 2026-08-07); the loop exists so a packaging change cannot ship them disabled

**Audit layer** — `build_scripts/checks/verify-nvidia.sh`, a fatal build-time contract run as a bare call at the end of the nvidia overlay and installed to `/usr/libexec/tunaos/verify-nvidia` for the published-image sweep. It re-derives every claim independently of the install script:
- packages present (kmod-nvidia, nvidia-driver, nvidia-driver-cuda, nvidia-container-toolkit)
- a `nvidia*.ko*` exists for the **exact shipped kernel EVR**, and kmod rpm == userspace rpm == `modinfo` version of the actual module file
- nouveau blacklisted; modeset karg declared
- glvnd EGL vendor JSON, Vulkan ICD, `libEGL_nvidia.so.0`/`libGLX_nvidia.so.0`, and the Wayland GBM backend `nvidia-drm_gbm.so` all present — every path measured from negativo17 repodata per the repo rule against unmeasured globs
- dracut `force_drivers`; shipped suspend units must be enabled

**Tests** — `tests/bats/test_nvidia_overlay.bats` (14 tests) pins the failure mode itself: the overrides directory must exist exactly where `run_buildscripts_for` looks and contain an executable matching its `-iname "*-*.sh"` find pattern; nvidia.sh must run the fatal contract; and the contract logic runs behaviorally against a fixture root (`TUNAOS_NVIDIA_VERIFY_ROOT` + PATH-stubbed rpm/modinfo/systemctl) with mutation cases for missing kmod, version skew, missing GBM backend, missing karg, and a disabled suspend unit.

kde-nvidia / niri-nvidia override dirs referenced by nvidia.sh remain absent on purpose — they are optional per-DE hooks with no content yet; the shared `overrides/nvidia` layer is what installs the driver.

## Test evidence

- `bats tests/bats/test_nvidia_overlay.bats` — 14/14 pass
- mutation-verified: removing the overrides dir fails tests 1/2/4; unwiring the contract call fails test 3; each behavioral fixture mutation fails its test
- full suite `for f in tests/bats/*.bats; do bats $f; done` — identical failure set to clean origin/main (25 pre-existing environment failures, none new)

## Expected CI consequence worth knowing

bonito's `-nvidia` flavors build against akmods `coreos-stable-41` (`scripts/build-image-inner.sh`) while the image ships the Fedora 44 kernel. If those kernels disagree, the exact-EVR kmod install now **fails that build loudly** instead of shipping a driverless image silently. That is the gate working; the fix would be the akmods pin, not the gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->