### PR TITLE
feat(flatpak): Flathub everywhere, curated preinstall set (store + browser), and a contract that keeps both

### DIFF
--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -393,6 +393,41 @@ else
 		fi
 	fi
 
+	# ── Flatpak baseline (store + browser + a remote that can serve them) ──
+	# Asserts exactly what the build now lays down, nothing aspirational:
+	# tuna-flatpak-remote.sh bakes the Flathub remote on every base, and
+	# flatpak-preinstall.sh declares the curated set (io.github.kolunmi.Bazaar
+	# as the store, org.mozilla.firefox as the browser — Bluefin's choices)
+	# and enables flatpak-preinstall.service where the base's flatpak ships
+	# it. Guarded on flatpak existing so a hypothetical flatpak-less image is
+	# out of scope rather than red. The per-app grep list below is kept in
+	# lockstep with flatpak-preinstall.sh by
+	# tests/bats/test_build_scripts_remaining.bats — change both together.
+	if command -v flatpak >/dev/null 2>&1; then
+		require_glob '/etc/flatpak/remotes.d/flathub.flatpakrepo'
+		require_glob '/usr/share/flatpak/preinstall.d/*.preinstall'
+		for _fp_app in io.github.kolunmi.Bazaar org.mozilla.firefox; do
+			if ! grep -rqs "^\[Flatpak Preinstall ${_fp_app}\]" /usr/share/flatpak/preinstall.d; then
+				echo "missing flatpak preinstall declaration: ${_fp_app}" >&2
+				if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
+					exit 1
+				fi
+			fi
+		done
+		# Where the unit exists, declarations without the service are inert —
+		# that combination shipped: preinstall files with nothing to run them.
+		if [[ -f /usr/lib/systemd/system/flatpak-preinstall.service ]]; then
+			if ! systemctl is-enabled flatpak-preinstall.service >/dev/null 2>&1; then
+				echo "flatpak-preinstall.service is shipped but not enabled — the declared flatpaks would never install" >&2
+				if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
+					exit 1
+				fi
+			fi
+		else
+			echo "info: this base's flatpak ships no flatpak-preinstall.service; declarations are documentation until it does"
+		fi
+	fi
+
 	# ── Branding & Asset Contract ──
 	# Wallpapers: shipping only upstream artwork means a user sees upstream background on login.
 	if ! compgen -G "/usr/share/backgrounds/tunaos*" >/dev/null &&

--- a/build_scripts/desktop/flatpak-preinstall.sh
+++ b/build_scripts/desktop/flatpak-preinstall.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# flatpak-preinstall.sh — declare the curated Flatpak set for this desktop
+# and make sure the mechanism that installs it actually runs.
+#
+# Sourced by install-desktop.sh via each desktop manifest's post_install
+# list, AFTER any desktop-specific script that writes its own preinstall
+# file (kcm-ublue.sh writes bazaar.preinstall on dnf KDE images), so the
+# already-declared guard below keeps entries unique across files.
+#
+# WHY. TunaOS images shipped with no browser and — outside dnf KDE and the
+# zirconium niri payload — no software store: gnome-software is deliberately
+# excluded (manifests/desktops/gnome.yaml), Bazaar's preinstall was written
+# only by kcm-ublue.sh (which skips every non-dnf base), and nothing ever
+# enabled flatpak-preinstall.service, so even the files that existed were
+# inert wherever the distro preset didn't enable the unit. The upstream
+# curated experiences this project mirrors do both: Bluefin and Aurora ship
+# io.github.kolunmi.Bazaar via /usr/share/flatpak/preinstall.d AND
+# `systemctl enable flatpak-preinstall.service` (their 17-cleanup.sh), and
+# Bluefin's default browser is the org.mozilla.firefox Flatpak (its GNOME
+# favorite-apps pins org.mozilla.firefox.desktop and its setup hook installs
+# the Firefox flatpak's systemconfig extension).
+#
+# The curated set is deliberately small and identical across desktops:
+#   io.github.kolunmi.Bazaar   the software store (every desktop; replaces
+#                              the excluded gnome-software / hidden discover)
+#   org.mozilla.firefox        the browser (every desktop; Bluefin's choice)
+# Per-desktop additions belong in the same mechanism: add_app lines guarded
+# by _FP_DESKTOP, with a matching assert in verify-desktop-experience.sh —
+# assert exactly what is added, nothing aspirational.
+#
+# Test hooks: TUNAOS_PREINSTALL_DIR and TUNAOS_SYSTEMD_SYSTEM_DIR redirect
+# the paths (same pattern as 40-services.sh); systemctl resolves via PATH.
+
+set -euo pipefail
+
+_FP_DIR="${TUNAOS_PREINSTALL_DIR:-/usr/share/flatpak/preinstall.d}"
+_FP_UNIT_DIR="${TUNAOS_SYSTEMD_SYSTEM_DIR:-/usr/lib/systemd/system}"
+_FP_DESKTOP="${_TD_DESKTOP:-${DESKTOP_FLAVOR:-desktop}}"
+_FP_FILE="${_FP_DIR}/tunaos-${_FP_DESKTOP}.preinstall"
+
+mkdir -p "$_FP_DIR"
+
+_fp_declared() {
+	grep -rqs "^\[Flatpak Preinstall $1\]" "$_FP_DIR"
+}
+
+_fp_add_app() {
+	local app="$1"
+	if _fp_declared "$app"; then
+		echo "flatpak-preinstall: ${app} already declared, skipping"
+		return 0
+	fi
+	{
+		echo "[Flatpak Preinstall ${app}]"
+		echo "Branch=stable"
+		echo "IsRuntime=false"
+		echo
+	} >>"$_FP_FILE"
+	echo "flatpak-preinstall: declared ${app} for ${_FP_DESKTOP}"
+}
+
+_fp_add_app io.github.kolunmi.Bazaar
+_fp_add_app org.mozilla.firefox
+
+# A preinstall file with nothing to run it is decoration. flatpak ships the
+# unit on current Fedora/EL; where a base does not ship it yet, say so
+# loudly in the build log instead of failing a family this cannot serve —
+# verify-desktop-experience.sh applies the same conditional contract, so a
+# base that gains the unit later cannot ship it disabled.
+if [[ -f "${_FP_UNIT_DIR}/flatpak-preinstall.service" ]]; then
+	systemctl enable flatpak-preinstall.service
+	echo "flatpak-preinstall: flatpak-preinstall.service enabled"
+else
+	echo "WARNING: flatpak-preinstall.service is not shipped by this base's flatpak;" >&2
+	echo "         the preinstall declarations in ${_FP_DIR} will not self-install." >&2
+fi

--- a/build_scripts/desktop/tuna-flatpak-remote.sh
+++ b/build_scripts/desktop/tuna-flatpak-remote.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
-# tuna-flatpak-remote.sh — register the tuna-os Flatpak remote in the image.
+# tuna-flatpak-remote.sh — register the Flatpak remotes in the image.
 #
 # Sourced by install-desktop.sh via a manifest's post_install list. Only the
-# remote lands in OS images; the installer frontends themselves are baked
+# remotes land in OS images; the installer frontends themselves are baked
 # into live ISOs at ISO-build time (live-iso/common/src/customize-live.sh via
 # tacklebox live_customize) — installed systems don't ship an OS installer.
+#
+# TWO remotes, and the second closes a real gap. Flathub used to be baked
+# only by 26-packages-post.sh, which the marlin (Containerfile.arch), guppy
+# (Containerfile.gentoo) and sailfin (Containerfile.opensuse) builds never
+# run — so those installed systems had only the tuna-os remote, no Flathub,
+# and everything Flathub-sourced (Bazaar via flatpak-preinstall.sh, anything
+# a user tries to install) silently had no source. This script runs through
+# install-desktop.sh's post_install on EVERY base (the apt path falls
+# through to the shared tail since tunaOS#959), which makes it the one place
+# that covers all variants. Idempotent next to 26-packages-post.sh: on bases
+# that run both, the file is already present and the fetch is skipped.
 
 set -euo pipefail
 
@@ -13,3 +24,12 @@ curl --retry 3 --fail -sSL \
 	-o /etc/flatpak/remotes.d/tuna-os.flatpakrepo \
 	"https://tunaos.org/flatpak/tuna-os.flatpakrepo"
 chmod 0644 /etc/flatpak/remotes.d/tuna-os.flatpakrepo
+
+# Flathub: skip the download when 26-packages-post.sh already baked it (rpm
+# and apt bases); fetch it on the bases that never run that script.
+if [[ ! -s /etc/flatpak/remotes.d/flathub.flatpakrepo ]]; then
+	curl --retry 3 --fail -sSL \
+		-o /etc/flatpak/remotes.d/flathub.flatpakrepo \
+		"https://dl.flathub.org/repo/flathub.flatpakrepo"
+	chmod 0644 /etc/flatpak/remotes.d/flathub.flatpakrepo
+fi

--- a/manifests/desktops/cosmic-arch.yaml
+++ b/manifests/desktops/cosmic-arch.yaml
@@ -72,3 +72,6 @@ versionlock: []
 # Post-install scripts to source (relative to build_scripts/)
 post_install:
   - tuna-flatpak-remote.sh
+  # Curated Flatpak set (store + browser) + preinstall service — see the
+  # script header; asserts live in verify-desktop-experience.sh.
+  - flatpak-preinstall.sh

--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -235,3 +235,6 @@ post_install:
   # cosmic-greeter is not packaged, it is the difference between a login screen
   # and greetd's stock `agreety --cmd /bin/sh` text prompt into a bare shell.
   - greetd-gtkgreet.sh
+  # Curated Flatpak set (store + browser) + preinstall service — see the
+  # script header; asserts live in verify-desktop-experience.sh.
+  - flatpak-preinstall.sh

--- a/manifests/desktops/gnome-arch.yaml
+++ b/manifests/desktops/gnome-arch.yaml
@@ -52,3 +52,6 @@ versionlock: []
 # Post-install scripts to source (relative to build_scripts/)
 post_install:
   - tuna-flatpak-remote.sh
+  # Curated Flatpak set (store + browser) + preinstall service — see the
+  # script header; asserts live in verify-desktop-experience.sh.
+  - flatpak-preinstall.sh

--- a/manifests/desktops/gnome-debian.yaml
+++ b/manifests/desktops/gnome-debian.yaml
@@ -22,3 +22,13 @@ packages:
     # gschema overrides for autologin/no-sleep; Debian ships the tool in the
     # dev-bin package (Fedora's glib2 includes it in the main package).
     - libglib2.0-dev-bin
+
+# Post-install scripts to source (relative to build_scripts/desktop/).
+# This manifest had no post_install at all, so flounder's GNOME images also
+# never got the tuna-os Flatpak remote — both remotes now come from
+# tuna-flatpak-remote.sh like every other desktop manifest.
+post_install:
+  - tuna-flatpak-remote.sh
+  # Curated Flatpak set (store + browser) + preinstall service — see the
+  # script header; asserts live in verify-desktop-experience.sh.
+  - flatpak-preinstall.sh

--- a/manifests/desktops/gnome.yaml
+++ b/manifests/desktops/gnome.yaml
@@ -307,3 +307,6 @@ versionlock:
 post_install:
   - tuna-flatpak-remote.sh
   - gnome-extensions.sh
+  # Curated Flatpak set (store + browser) + preinstall service — see the
+  # script header; asserts live in verify-desktop-experience.sh.
+  - flatpak-preinstall.sh

--- a/manifests/desktops/kde-arch.yaml
+++ b/manifests/desktops/kde-arch.yaml
@@ -61,3 +61,6 @@ disable_desktop_files:
 post_install:
   - tuna-flatpak-remote.sh
   - kcm-ublue.sh
+  # Curated Flatpak set (store + browser) + preinstall service — see the
+  # script header; asserts live in verify-desktop-experience.sh.
+  - flatpak-preinstall.sh

--- a/manifests/desktops/kde-debian.yaml
+++ b/manifests/desktops/kde-debian.yaml
@@ -30,3 +30,6 @@ disable_desktop_files:
 # Post-install scripts to source (relative to build_scripts/)
 post_install:
   - tuna-flatpak-remote.sh
+  # Curated Flatpak set (store + browser) + preinstall service — see the
+  # script header; asserts live in verify-desktop-experience.sh.
+  - flatpak-preinstall.sh

--- a/manifests/desktops/kde.yaml
+++ b/manifests/desktops/kde.yaml
@@ -224,3 +224,6 @@ disable_desktop_files:
 post_install:
   - tuna-flatpak-remote.sh
   - kcm-ublue.sh
+  # Curated Flatpak set (store + browser) + preinstall service — see the
+  # script header; asserts live in verify-desktop-experience.sh.
+  - flatpak-preinstall.sh

--- a/manifests/desktops/niri-arch.yaml
+++ b/manifests/desktops/niri-arch.yaml
@@ -100,3 +100,6 @@ post_install:
   # on `command -v gtkgreet && command -v cage`, so it is a no-op if that
   # packaging ever regresses rather than writing a config for a missing greeter.
   - greetd-gtkgreet.sh
+  # Curated Flatpak set (store + browser) + preinstall service — see the
+  # script header; asserts live in verify-desktop-experience.sh.
+  - flatpak-preinstall.sh

--- a/manifests/desktops/niri.yaml
+++ b/manifests/desktops/niri.yaml
@@ -257,3 +257,6 @@ post_install:
   # dms-greeter); on openSUSE it is the difference between a login screen and
   # greetd's stock text prompt into a bare shell.
   - greetd-gtkgreet.sh
+  # Curated Flatpak set (store + browser) + preinstall service — see the
+  # script header; asserts live in verify-desktop-experience.sh.
+  - flatpak-preinstall.sh

--- a/manifests/desktops/pantheon.yaml
+++ b/manifests/desktops/pantheon.yaml
@@ -59,3 +59,6 @@ packages:
 
 post_install:
   - tuna-flatpak-remote.sh
+  # Curated Flatpak set (store + browser) + preinstall service — see the
+  # script header; asserts live in verify-desktop-experience.sh.
+  - flatpak-preinstall.sh

--- a/manifests/desktops/xfce-arch.yaml
+++ b/manifests/desktops/xfce-arch.yaml
@@ -69,3 +69,6 @@ versionlock: []
 # Post-install scripts to source (relative to build_scripts/)
 post_install:
   - tuna-flatpak-remote.sh
+  # Curated Flatpak set (store + browser) + preinstall service — see the
+  # script header; asserts live in verify-desktop-experience.sh.
+  - flatpak-preinstall.sh

--- a/manifests/desktops/xfce.yaml
+++ b/manifests/desktops/xfce.yaml
@@ -188,3 +188,6 @@ versionlock:
 # Post-install scripts to source (relative to build_scripts/)
 post_install:
   - tuna-flatpak-remote.sh
+  # Curated Flatpak set (store + browser) + preinstall service — see the
+  # script header; asserts live in verify-desktop-experience.sh.
+  - flatpak-preinstall.sh

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -201,6 +201,51 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
   [ "$fail" -eq 0 ]
 }
 
+@test "flatpak baseline: manifests, preinstall script and contract cannot drift" {
+  # Same discipline as the contract-required-application table above: every
+  # piece of curated Flatpak content is (a) laid down by a post_install
+  # script every desktop manifest lists, and (b) asserted by the build
+  # contract — change any one of the three and this test names the others.
+  local contract="${REPO_ROOT}/build_scripts/checks/verify-desktop-experience.sh"
+  local preinstall="${REPO_ROOT}/build_scripts/desktop/flatpak-preinstall.sh"
+  local remote="${REPO_ROOT}/build_scripts/desktop/tuna-flatpak-remote.sh"
+  local fail=0
+
+  # (a) every desktop manifest runs both post_install scripts.
+  local m
+  for m in "${REPO_ROOT}"/manifests/desktops/*.yaml; do
+    for script in tuna-flatpak-remote.sh flatpak-preinstall.sh; do
+      if ! grep -qE "^\s*-\s+${script}\s*$" "$m"; then
+        echo "FAIL: $(basename "$m") post_install never runs ${script}" >&2
+        fail=1
+      fi
+    done
+  done
+
+  # (b) the remote script bakes Flathub, and the contract requires it.
+  grep -qF 'flathub.flatpakrepo' "$remote" || { echo "FAIL: tuna-flatpak-remote.sh no longer bakes flathub" >&2; fail=1; }
+  grep -qF "require_glob '/etc/flatpak/remotes.d/flathub.flatpakrepo'" "$contract" || { echo "FAIL: contract does not require the flathub remote" >&2; fail=1; }
+  grep -qF "require_glob '/usr/share/flatpak/preinstall.d/*.preinstall'" "$contract" || { echo "FAIL: contract does not require a preinstall declaration" >&2; fail=1; }
+
+  # (c) the app set is identical in the script that declares it and the
+  # contract that asserts it — extracted from both, compared as sets.
+  local declared asserted
+  declared="$(grep -oE '^_fp_add_app [A-Za-z0-9._-]+' "$preinstall" | awk '{print $2}' | sort)"
+  asserted="$(grep -oE 'for _fp_app in [A-Za-z0-9._ -]+;' "$contract" | sed 's/for _fp_app in //; s/;$//' | tr ' ' '\n' | sed '/^$/d' | sort)"
+  [ -n "$declared" ] || { echo "FAIL: no _fp_add_app lines found in flatpak-preinstall.sh" >&2; fail=1; }
+  if [ "$declared" != "$asserted" ]; then
+    echo "FAIL: preinstall set drifted — script declares [$declared] but contract asserts [$asserted]" >&2
+    fail=1
+  fi
+
+  # (d) the service that makes declarations real is enabled by the script
+  # and enforced by the contract wherever the unit exists.
+  grep -qF 'systemctl enable flatpak-preinstall.service' "$preinstall" || { echo "FAIL: flatpak-preinstall.sh does not enable the service" >&2; fail=1; }
+  grep -qF 'flatpak-preinstall.service is shipped but not enabled' "$contract" || { echo "FAIL: contract does not enforce the preinstall service" >&2; fail=1; }
+
+  [ "$fail" -eq 0 ]
+}
+
 @test "greetd greeter degrades to software rendering without a render node" {
   # cage is wlroots-based: on a VM with virtio-gpu but no virgl there is a DRM
   # card and NO render node, GL init fails, cage exits and greetd restart-loops

--- a/tests/bats/test_flatpak_preinstall.bats
+++ b/tests/bats/test_flatpak_preinstall.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# Behavioral tests for build_scripts/desktop/flatpak-preinstall.sh.
+#
+# The script is sourced by install-desktop.sh in production; here it runs
+# standalone against redirected paths (TUNAOS_PREINSTALL_DIR /
+# TUNAOS_SYSTEMD_SYSTEM_DIR — same hook pattern as 40-services.sh) with
+# systemctl stubbed on PATH, so the real logic is exercised, not grepped.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/build_scripts/desktop/flatpak-preinstall.sh"
+
+setup() {
+  PRE_DIR="${BATS_TEST_TMPDIR}/preinstall.d"
+  UNIT_DIR="${BATS_TEST_TMPDIR}/systemd"
+  mkdir -p "$UNIT_DIR" "${BATS_TEST_TMPDIR}/bin"
+  cat > "${BATS_TEST_TMPDIR}/bin/systemctl" <<EOF
+#!/usr/bin/env bash
+echo "systemctl \$*" >> "${BATS_TEST_TMPDIR}/systemctl.log"
+exit 0
+EOF
+  chmod +x "${BATS_TEST_TMPDIR}/bin/systemctl"
+}
+
+run_script() {
+  PATH="${BATS_TEST_TMPDIR}/bin:$PATH" \
+    TUNAOS_PREINSTALL_DIR="$PRE_DIR" \
+    TUNAOS_SYSTEMD_SYSTEM_DIR="$UNIT_DIR" \
+    DESKTOP_FLAVOR="gnome" \
+    run bash "$SCRIPT"
+}
+
+@test "declares the store and the browser for the desktop" {
+  touch "${UNIT_DIR}/flatpak-preinstall.service"
+  run_script
+  [ "$status" -eq 0 ]
+  grep -q '^\[Flatpak Preinstall io.github.kolunmi.Bazaar\]' "${PRE_DIR}/tunaos-gnome.preinstall"
+  grep -q '^\[Flatpak Preinstall org.mozilla.firefox\]' "${PRE_DIR}/tunaos-gnome.preinstall"
+}
+
+@test "is idempotent — a second run adds no duplicate declarations" {
+  touch "${UNIT_DIR}/flatpak-preinstall.service"
+  run_script
+  [ "$status" -eq 0 ]
+  run_script
+  [ "$status" -eq 0 ]
+  [ "$(grep -c 'Flatpak Preinstall io.github.kolunmi.Bazaar' "${PRE_DIR}/tunaos-gnome.preinstall")" -eq 1 ]
+}
+
+@test "respects an entry another script already declared (kcm-ublue's bazaar.preinstall)" {
+  mkdir -p "$PRE_DIR"
+  printf '[Flatpak Preinstall io.github.kolunmi.Bazaar]\nBranch=stable\nIsRuntime=false\n' \
+    > "${PRE_DIR}/bazaar.preinstall"
+  touch "${UNIT_DIR}/flatpak-preinstall.service"
+  run_script
+  [ "$status" -eq 0 ]
+  # Bazaar stays declared once, in the pre-existing file; firefox is added.
+  [ "$(grep -rc 'Flatpak Preinstall io.github.kolunmi.Bazaar' "$PRE_DIR" | awk -F: '{s+=$2} END {print s}')" -eq 1 ]
+  grep -q 'Flatpak Preinstall org.mozilla.firefox' "${PRE_DIR}/tunaos-gnome.preinstall"
+}
+
+@test "enables flatpak-preinstall.service when the unit is shipped" {
+  touch "${UNIT_DIR}/flatpak-preinstall.service"
+  run_script
+  [ "$status" -eq 0 ]
+  grep -q 'systemctl enable flatpak-preinstall.service' "${BATS_TEST_TMPDIR}/systemctl.log"
+}
+
+@test "warns instead of failing when the base ships no preinstall unit" {
+  run_script
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"flatpak-preinstall.service is not shipped"* ]]
+  [ ! -f "${BATS_TEST_TMPDIR}/systemctl.log" ]
+}
+
+@test "a failing enable fails the build instead of being swallowed" {
+  touch "${UNIT_DIR}/flatpak-preinstall.service"
+  cat > "${BATS_TEST_TMPDIR}/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "${BATS_TEST_TMPDIR}/bin/systemctl"
+  run_script
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## The gaps

A user's first ten minutes on most TunaOS images: no browser, no app store, and on three variants no way to even install one.

1. **No Flathub remote on marlin/guppy/sailfin.** The remote was baked only by `26-packages-post.sh`, which `Containerfile.arch`, `Containerfile.gentoo` and `Containerfile.opensuse` never run. Those installed systems had only the tuna-os remote (installer apps), so anything Flathub-sourced silently had no source.
2. **No store and no browser on most desktops.** `gnome-software` is deliberately excluded (`gnome.yaml` — kept that way), but nothing replaced it outside dnf KDE (`kcm-ublue.sh` skips every non-dnf base) and the zirconium niri payload. No image shipped any browser. And nothing ever enabled `flatpak-preinstall.service`, so even the preinstall files that existed were inert wherever the distro preset left the unit disabled — Bluefin and Aurora both enable it explicitly in their `17-cleanup.sh`.
3. **Nothing asserted any of it.**

## The changes

- **`build_scripts/desktop/tuna-flatpak-remote.sh`** now also bakes `/etc/flatpak/remotes.d/flathub.flatpakrepo` when `26-packages-post.sh` didn't. It runs through `install-desktop.sh`'s post_install on **every** base (the apt path falls through to the shared tail since tunaOS#959), making it the one place that covers all variants.
- **`build_scripts/desktop/flatpak-preinstall.sh`** (new, in every desktop manifest's post_install, last): declares the curated set —
  - `io.github.kolunmi.Bazaar` — the store both Bluefin and Aurora preinstall (`system_files/shared/usr/share/flatpak/preinstall.d/bazaar.preinstall` in both clones)
  - `org.mozilla.firefox` — Bluefin's browser (its GNOME favorite-apps pins `org.mozilla.firefox.desktop`; its setup hook installs the Firefox flatpak systemconfig extension)

  It dedups against entries other scripts already declared (kcm-ublue's `bazaar.preinstall`), and enables `flatpak-preinstall.service` where the base's flatpak ships the unit (loud warning where it doesn't).
- **`manifests/desktops/*.yaml`**: all 13 desktop manifests list the new script. `gnome-debian.yaml` had **no post_install at all** — flounder's GNOME images also never got the tuna-os remote; fixed by the same edit.
- **`build_scripts/checks/verify-desktop-experience.sh`** (build-mode tail, fatal, wherever flatpak is installed): requires the Flathub remote file, at least one preinstall declaration, the exact curated app set, and — where the unit exists — `flatpak-preinstall.service` enabled. Asserts exactly what this PR adds, nothing aspirational.

## Drift protection + tests

- `tests/bats/test_build_scripts_remaining.bats` gains a drift test (same pattern as the contract-required-application table at ~L165): every manifest runs both scripts; the remote script and contract agree about Flathub; the app set in `flatpak-preinstall.sh` and the set the contract asserts are **extracted from both files and compared as sets**; service enablement present on both sides.
- `tests/bats/test_flatpak_preinstall.bats` (new, 6 tests) runs the real script against redirected paths (`TUNAOS_PREINSTALL_DIR`/`TUNAOS_SYSTEMD_SYSTEM_DIR`, stubbed systemctl): declaration, idempotence, dedup, enablement, no-unit warning path, failing-enable-fails-build.

**Evidence:** 6/6 + 1/1 new tests pass; mutation-verified (dropping the script from a manifest and renaming an app both fail the drift test with named diagnostics); full bats suite identical to clean origin/main (25 pre-existing env failures, none new; two shifted test numbers only); all manifests re-parse as YAML; yamllint shows only pre-existing warnings.

## Product decisions to veto if wrong

- **Browser = `org.mozilla.firefox` flatpak on every desktop** (including KDE — Aurora *excludes* the Firefox RPM and its clone shows no browser preinstall, so this is Bluefin's choice applied uniformly).
- **Store = Bazaar on every desktop**, including XFCE/COSMIC/pantheon (on sailfin:cosmic this sits alongside the packaged `cosmic-store`; dedup keeps it one Bazaar, but two stores will coexist there).
- Preinstall only *declares*; installation happens on first boot via `flatpak-preinstall.service` where flatpak ships it (current Fedora/EL do). Bases whose flatpak lacks the unit get a loud build-log warning, not a failure — the contract enforces enablement the moment the unit appears.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->