### PR TITLE
fix(codecs): H.264/H.265 decode on every family, with a contract that proves it

### DIFF
--- a/Containerfile.arch
+++ b/Containerfile.arch
@@ -133,8 +133,15 @@ RUN KERNEL_PKG="linux"; \
         gst-plugins-base \
         gst-plugins-good \
         gst-plugins-bad \
-        gst-plugins-ugly && \
+        gst-plugins-ugly \
+        gst-libav && \
     pacman -Scc --noconfirm
+# gst-libav above is not optional garnish: the ugly set only carries the
+# x264 ENcoder — H.264/H.265 DEcode in GStreamer apps goes through
+# libgstlibav.so (measured: Arch's gst-libav ships
+# /usr/lib/gstreamer-1.0/libgstlibav.so). Without it marlin played no
+# mainstream video. Asserted by verify-desktop-experience.sh's codec
+# baseline.
 
 # NOTE: this MUST precede the dracut step below. dracut-config.sh derives the
 # driver set from prepare-root.conf — written at the end of this block — so

--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -162,10 +162,17 @@ elif [[ $IS_FEDORA == true ]]; then
 		"https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${FEDORA_VER}.noarch.rpm" \
 		"https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${FEDORA_VER}.noarch.rpm" || true
 
-	# Multimedia + common desktop packages in one transaction
+	# Multimedia + common desktop packages in one transaction.
+	# gstreamer1-plugin-libav is Fedora's own package (measured in the F44
+	# repodata); with RPM Fusion's full ffmpeg installed alongside it, its
+	# libgstlibav.so resolves the full libavcodec sonames — that pairing is
+	# what gives GStreamer apps H.264/H.265 decode. gstreamer1-plugins-ugly
+	# is the RPM Fusion build. The build contract asserts the result
+	# (verify-desktop-experience.sh codec baseline).
 	dnf -y install \
 		gstreamer1-plugins-good \
 		gstreamer1-plugins-ugly \
+		gstreamer1-plugin-libav \
 		gstreamer1-plugins-bad-free \
 		lame \
 		ffmpeg \
@@ -204,39 +211,54 @@ else
 	fi
 	dnf config-manager --set-enabled epel
 
-	# Multimedia codecs
+	# Multimedia codecs — negativo17 epel-multimedia (same as upstream
+	# bluefin-lts), on BOTH x86_64 legs.
+	#
+	# The v2 leg used to get `ffmpeg-free` and nothing else patent-encumbered
+	# ("no epel-multimedia for x86_64_v2"), which shipped flagship images
+	# that could not decode H.264/H.265 at all. The actual obstacle was only
+	# the repo file's $basearch: negativo17 publishes no x86_64_v2 tree
+	# (measured: .../epel-10/x86_64_v2/repodata/repomd.xml is 404 while the
+	# x86_64 path is 200), so on a v2 image the baseurl resolved to a 404 and
+	# skip_if_unavailable made the whole repo vanish. The v2 leg has always
+	# installed plain-x86_64 payloads regardless — ffmpeg-free exists only as
+	# EPEL's x86_64 build — so pin the basearch and install the same full set
+	# everywhere. If the depsolver ever disagrees on v2, the build fails
+	# loudly, which beats silently shipping a no-H.264 image.
+	#
+	# Written with curl+sed rather than `dnf config-manager` so the repo
+	# state is identical text on every EL10 base and there is no dnf4/dnf5
+	# syntax split to carry.
+	curl --retry 3 -fsSL https://negativo17.org/repos/epel-multimedia.repo \
+		-o /etc/yum.repos.d/epel-multimedia.repo
+	# Disabled at rest; enabled per-transaction below (previous behavior).
+	sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/epel-multimedia.repo
+	# Disable fastestmirror for this repo to avoid corrupted mirrors
+	sed -i '/^\[epel-multimedia\]$/a fastestmirror=0' /etc/yum.repos.d/epel-multimedia.repo
 	if is_x86_64_v2; then
-		echo "no epel-multimedia for x86_64_v2"
-		dnf -y install \
-			ffmpeg-free \
-			@multimedia \
-			gstreamer1-plugins-bad-free \
-			gstreamer1-plugins-bad-free-libs \
-			gstreamer1-plugins-good \
-			gstreamer1-plugins-base \
-			lame \
-			lame-libs \
-			libjxl
-	else
-		# Use negativo17 epel-multimedia repo (same as upstream bluefin-lts)
-		dnf config-manager --add-repo=https://negativo17.org/repos/epel-multimedia.repo
-		dnf config-manager --set-disabled epel-multimedia
-		# Disable fastestmirror for this repo to avoid corrupted mirrors
-		dnf config-manager --setopt="epel-multimedia.fastestmirror=0" --save
-
-		dnf_retry -y install --enablerepo=epel-multimedia \
-			ffmpeg \
-			libavcodec \
-			@multimedia \
-			gstreamer1-plugins-bad-free \
-			gstreamer1-plugins-bad-free-libs \
-			gstreamer1-plugins-good \
-			gstreamer1-plugins-base \
-			lame \
-			lame-libs \
-			libjxl \
-			ffmpegthumbnailer
+		sed -i 's|/\$basearch/|/x86_64/|' /etc/yum.repos.d/epel-multimedia.repo
 	fi
+
+	# gstreamer1-plugins-ugly and gstreamer1-plugin-libav are the two that
+	# make GStreamer applications (totem, thumbnailers, anything WebKit)
+	# actually decode H.264/H.265 — libgstlibav.so routes through the full
+	# negativo17 libavcodec installed here. Both names measured present in
+	# the epel-10 repodata. The build contract asserts the result
+	# (verify-desktop-experience.sh codec baseline).
+	dnf_retry -y install --enablerepo=epel-multimedia \
+		ffmpeg \
+		libavcodec \
+		@multimedia \
+		gstreamer1-plugins-bad-free \
+		gstreamer1-plugins-bad-free-libs \
+		gstreamer1-plugins-good \
+		gstreamer1-plugins-base \
+		gstreamer1-plugins-ugly \
+		gstreamer1-plugin-libav \
+		lame \
+		lame-libs \
+		libjxl \
+		ffmpegthumbnailer
 
 	if [[ $IS_ALMALINUX == true ]] && [ "$MAJOR_VERSION_NUMBER" -ge 9 ]; then
 		dnf swap -y coreutils-single coreutils

--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -236,6 +236,7 @@ else
 	# Disable fastestmirror for this repo to avoid corrupted mirrors
 	sed -i '/^\[epel-multimedia\]$/a fastestmirror=0' /etc/yum.repos.d/epel-multimedia.repo
 	if is_x86_64_v2; then
+		# shellcheck disable=SC2016  # $basearch is a dnf repo variable, not a shell one
 		sed -i 's|/\$basearch/|/x86_64/|' /etc/yum.repos.d/epel-multimedia.repo
 	fi
 

--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -365,6 +365,36 @@ else
 		fi
 	fi
 
+	# ── Codec baseline ──
+	# "Codecs installed" was promised on every family and verified on none —
+	# the EL10 x86_64_v2 leg shipped ffmpeg-free only (no H.264/H.265 at
+	# all) and marlin shipped gst-plugins-ugly without gst-libav (x264
+	# ENcoder present, no mainstream DEcoder), and both were green. Two
+	# file-level proofs, both cheap and network-free:
+	#
+	# 1. The GStreamer libav plugin exists — the piece that lets totem,
+	#    thumbnailers and WebKit decode through libavcodec. One measured
+	#    path per packaging family (repo rule: no unmeasured globs):
+	#      rpm/openSUSE/Gentoo  /usr/lib64/gstreamer-1.0/libgstlibav.so
+	#      Arch                 /usr/lib/gstreamer-1.0/libgstlibav.so
+	#      Debian/Ubuntu        /usr/lib/<triplet>/gstreamer-1.0/libgstlibav.so
+	# 2. `ffmpeg -decoders` actually lists h264 — the plugin above routes
+	#    into libavcodec, so a free-codec libavcodec (the exact v2 failure)
+	#    is caught here even though the plugin file exists.
+	require_any_glob \
+		'/usr/lib64/gstreamer-1.0/libgstlibav.so' \
+		'/usr/lib/gstreamer-1.0/libgstlibav.so' \
+		'/usr/lib/*/gstreamer-1.0/libgstlibav.so'
+	require_command ffmpeg
+	if command -v ffmpeg >/dev/null 2>&1; then
+		if ! ffmpeg -hide_banner -decoders 2>/dev/null | grep -q ' h264 '; then
+			echo "ffmpeg cannot decode h264 — a free/crippled libavcodec is installed" >&2
+			if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
+				exit 1
+			fi
+		fi
+	fi
+
 	# ── KDE version-skew guard (pattern from ublue-os/aurora's 20-tests.sh) ──
 	# Mid-compose repo skew can ship kwin/kscreen from a newer Plasma than
 	# plasma-desktop; the session then crashes at login while every package

--- a/tests/bats/test_codec_baseline.bats
+++ b/tests/bats/test_codec_baseline.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# Codec baseline: what the build installs and what the contract asserts must
+# name the same pieces, per packaging family.
+#
+# The gap these pin: the EL10 x86_64_v2 leg shipped ffmpeg-free only (no
+# H.264/H.265 decode at all) and marlin shipped gst-plugins-ugly without
+# gst-libav (x264 ENcoder, no mainstream DEcoder) — both green, because
+# nothing anywhere verified a codec. See the "Codec baseline" section of
+# build_scripts/checks/verify-desktop-experience.sh.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+BASE_PKGS="${REPO_ROOT}/build_scripts/10-base-packages.sh"
+CONTRACT="${REPO_ROOT}/build_scripts/checks/verify-desktop-experience.sh"
+
+@test "EL10 leg installs the gstreamer decode pair from epel-multimedia" {
+  # Extract the dnf transaction that carries the epel-multimedia enablerepo
+  # and check the two decode-critical names ride in it.
+  run awk '/--enablerepo=epel-multimedia/,/^$/' "$BASE_PKGS"
+  [[ "$output" == *"gstreamer1-plugin-libav"* ]]
+  [[ "$output" == *"gstreamer1-plugins-ugly"* ]]
+}
+
+@test "EL10 x86_64_v2 no longer falls back to ffmpeg-free" {
+  # The crippled v2-only branch is gone; the v2 accommodation is a basearch
+  # pin on the same repo, not a different (free-codec) package set. Match
+  # code only — the history lives on in comments.
+  run grep -E '^[^#]*ffmpeg-free' "$BASE_PKGS"
+  [ "$status" -ne 0 ]
+  run grep -F 's|/\$basearch/|/x86_64/|' "$BASE_PKGS"
+  [ "$status" -eq 0 ]
+  # ...and that pin is applied under the v2 detector, not unconditionally.
+  run grep -B2 -F 's|/\$basearch/|/x86_64/|' "$BASE_PKGS"
+  [[ "$output" == *"is_x86_64_v2"* ]]
+}
+
+@test "Fedora leg installs gstreamer1-plugin-libav alongside RPM Fusion ffmpeg" {
+  # Both must appear inside the same Fedora branch (between the IS_FEDORA
+  # test and the following elif).
+  run awk '/IS_FEDORA == true/,/^else$/' "$BASE_PKGS"
+  [[ "$output" == *"gstreamer1-plugin-libav"* ]]
+  [[ "$output" == *"gstreamer1-plugins-ugly"* ]]
+}
+
+@test "Arch base installs gst-libav" {
+  run grep -E '^\s*gst-libav' "${REPO_ROOT}/Containerfile.arch"
+  [ "$status" -eq 0 ]
+}
+
+@test "contract asserts the libav plugin at each family's measured path" {
+  for g in \
+    '/usr/lib64/gstreamer-1.0/libgstlibav.so' \
+    '/usr/lib/gstreamer-1.0/libgstlibav.so' \
+    '/usr/lib/*/gstreamer-1.0/libgstlibav.so'; do
+    grep -qF "'$g'" "$CONTRACT" || { echo "missing contract glob: $g" >&2; return 1; }
+  done
+}
+
+@test "contract proves h264 decode through ffmpeg, not just plugin presence" {
+  # The plugin file existing is satisfiable by a free-codec libavcodec — the
+  # exact v2 failure — so the contract must interrogate ffmpeg itself.
+  run grep -E 'ffmpeg -hide_banner -decoders.*grep -q .{0,3}h264' "$CONTRACT"
+  [ "$status" -eq 0 ]
+  # And a missing decoder must be fatal (exit 1 in that branch), not a warning.
+  run grep -A3 'ffmpeg cannot decode h264' "$CONTRACT"
+  [[ "$output" == *"exit 1"* ]]
+}


### PR DESCRIPTION
## The gaps (both green until now — nothing anywhere verified a codec)

1. **EL10 x86_64_v2 could not decode H.264/H.265 at all.** `10-base-packages.sh` installed `ffmpeg-free` and nothing patent-encumbered on the v2 leg ("no epel-multimedia for x86_64_v2"). The actual obstacle turned out to be only the negativo17 repo file's `$basearch`: **measured**, `.../multimedia/epel-10/x86_64_v2/repodata/repomd.xml` is 404 while the `x86_64` path is 200 — so on a v2 image the baseurl 404'd and `skip_if_unavailable=1` silently vanished the repo.
2. **marlin had no mainstream video decoder in GStreamer.** `Containerfile.arch` installed `gst-plugins-ugly` (x264 **en**coder) but not `gst-libav` (the **de**coder plugin).

## The changes

- **EL10, both legs unified** (`build_scripts/10-base-packages.sh`): the epel-multimedia repo file is fetched with curl+sed (written `enabled=0`, `fastestmirror=0`, enabled per-transaction — no `dnf config-manager`, so no dnf4/dnf5 split), and on v2 the baseurl's `$basearch` is pinned to `x86_64`. The v2 leg has always installed plain-x86_64 payloads anyway (`ffmpeg-free` exists only as EPEL's x86_64 build), so the same full set now installs on both legs, plus the decode pair: `gstreamer1-plugins-ugly` + `gstreamer1-plugin-libav` (both names **measured in the epel-10 repodata**, which also ships `/usr/lib64/gstreamer-1.0/libgstlibav.so` per its filelists). If the depsolver ever disagrees on v2, the build fails loudly — better than silently shipping a no-H.264 flagship.
- **Fedora**: adds `gstreamer1-plugin-libav` (Fedora's own package, **measured in F44 repodata**); with RPM Fusion's full ffmpeg installed alongside, its `libgstlibav.so` resolves the full libavcodec sonames.
- **Arch**: adds `gst-libav` (**measured**: Arch package ships `/usr/lib/gstreamer-1.0/libgstlibav.so`).
- **Contract** (`verify-desktop-experience.sh`, fatal, build-mode tail): `libgstlibav.so` must exist at the family's measured path (`/usr/lib64/...`, `/usr/lib/...`, or the Debian multiarch triplet), **and** `ffmpeg -hide_banner -decoders` must list `h264` — plugin-file presence alone is satisfiable by a free-codec libavcodec (the exact v2 failure), so the contract interrogates ffmpeg itself. apt/openSUSE/Gentoo already ship the full stack (gstreamer1.0-libav in 10-base-packages, packman in Containerfile.opensuse, USE flags + gst-plugins-meta in Containerfile.gentoo); for them the assert is regression protection.

## Tests

`tests/bats/test_codec_baseline.bats` (6 tests): decode pair rides the epel-multimedia transaction; the v2 branch is a basearch pin, not a free-codec fallback (`ffmpeg-free` banned from code); Fedora and Arch carry their additions; the contract asserts every measured glob plus the fatal h264 probe.

Evidence: 6/6 pass; mutation-verified both directions (dropping `gstreamer1-plugin-libav` from the install list fails the install-side tests, weakening the h264 probe to h265 fails the contract-side test); full bats suite identical to clean origin/main (25 pre-existing env failures, none new).

## Decisions to veto if wrong

- **v2 gets full negativo17 x86_64 codecs via a basearch pin.** Rationale above; the alternative was documenting the gap as a permanent waiver. If AlmaLinux Kitten's v2 rpm arch policy rejects x86_64 payloads from this repo, the v2 cells go red on the dnf transaction — visible, revertible to the old `ffmpeg-free` branch.
- The h264 probe is decode-capability only; hardware-accel (VA-API) is deliberately out of scope here.
- Note: this PR and #1062 both touch `verify-desktop-experience.sh` in different regions (this one before the KDE skew guard, #1062 before the branding section); whichever merges second may need a trivial rebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->