### PR TITLE
feat(e2e): pixel gate — "DM active" must become "something actually drew"

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -89,6 +89,10 @@
 #   3  kickstart install failed
 #   4  installed system did not boot
 #   5  SSH check failed
+#   6  pixel gate failed — the installed system reached login but nothing
+#      provably rendered (blank/absent capture, or zero timelapse frames on
+#      a host where capture works). TUNAOS_PIXEL_GATE=0 downgrades to
+#      advisory. See scripts/lib/pixel-gate.sh for the decision table.
 #   77 missing dependency (qemu, ovmf, etc.) — distinguishable for CI skip
 
 set -euo pipefail
@@ -245,6 +249,8 @@ E2E_SSH_OPTS=(
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
 . "${SCRIPT_DIR}/lib/common.sh"
+# shellcheck source=lib/pixel-gate.sh
+. "${SCRIPT_DIR}/lib/pixel-gate.sh"
 # Extract VARIANT and FLAVOR from ISO filename for screenshot comparison and
 # for the fisherman recipe's image ref (used only as a fallback — callers
 # should set VARIANT/FLAVOR explicitly, e.g. luks-e2e.yml's env: block).
@@ -2394,6 +2400,38 @@ EOF
 			;;
 		*) echo "WARNING: no desktop contract marker on the installed system (DM likely never started)" >&2 ;;
 		esac
+
+		# ── Pixel gate: "DM active" must become "something actually drew" ──
+		# All the evidence above this line already exists on every run — the
+		# stddev-measured screenshot and the timelapse frames — but it was
+		# recorded fatal=0 and gated nothing, which is how a black console
+		# shipped under a green cell (run 29645108966). pixel_gate
+		# (scripts/lib/pixel-gate.sh) turns the measurable cases into a
+		# verdict and names the unmeasurable ones (virgl, no ImageMagick)
+		# instead of silently passing them.
+		#
+		# Stop the timelapse NOW rather than leaving it to cleanup_vm's EXIT
+		# trap: the gate needs frame-count.txt while the verdict is being
+		# decided. stop is idempotent (the pidfile is consumed; a second
+		# assemble recounts the same frames), so cleanup's later stop stays
+		# harmless.
+		local _frames="" _pixel_line="" _pixel_rc=0
+		if [[ -n "${TIMELAPSE_DIR:-}" ]]; then
+			bash "${SCRIPT_DIR}/record-timelapse.sh" stop "$TIMELAPSE_DIR" || true
+			_frames="$(cat "${TIMELAPSE_DIR}/frame-count.txt" 2>/dev/null || true)"
+		fi
+		_pixel_line="$(pixel_gate "$_shot" "${SCREENSHOT_STDDEV:-}" "$_frames" "${QEMU_NEEDS_VNC_SURFACE:-0}")" || _pixel_rc=$?
+		record_luks_evidence "$_pixel_line"
+		if [[ "$_pixel_rc" -ne 0 ]]; then
+			if [[ "${TUNAOS_PIXEL_GATE:-1}" == "1" ]]; then
+				echo "ERROR: pixel gate FAILED — the encrypted install unlocked and reached" >&2
+				echo "       login, but nothing provably rendered (${_pixel_line})." >&2
+				echo "       The screenshot and timelapse artifacts are the evidence;" >&2
+				echo "       TUNAOS_PIXEL_GATE=0 downgrades this to advisory." >&2
+				return 6
+			fi
+			echo "::warning::pixel gate failed but TUNAOS_PIXEL_GATE=0 — advisory only (${_pixel_line})"
+		fi
 
 		echo "==> LUKS passphrase gate PASSED for ${VARIANT:-}:${FLAVOR:-}"
 		return 0

--- a/scripts/lib/pixel-gate.sh
+++ b/scripts/lib/pixel-gate.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# pixel-gate.sh — decide whether the installed system PROVABLY drew pixels.
+#
+# Sourced by scripts/iso-e2e.sh; a separate lib file so bats can source the
+# real logic (tests/bats/test_pixel_gate.bats) instead of grepping for it.
+#
+# WHY. The strongest runtime gate on the installed system used to be
+# "display-manager.service is active", and the repo's own history shows that
+# passing over a black console (run 29645108966). The evidence to contradict
+# it has been captured all along — the timelapse recorder screendumps real
+# frames on every GPU-less runner (151-210 frames on passing cells) and the
+# installed-desktop screenshot is stddev-measured — but both were recorded
+# fatal=0 and gated nothing. This turns the measurable cases into a gate and
+# names the unmeasurable ones instead of silently passing them.
+#
+# pixel_gate <shot> <stddev> <frames> <virgl>
+#   shot    drawn | blank | unmeasured | absent — screenshot_sane's verdict
+#           on the installed-desktop capture (iso-e2e.sh computes it)
+#   stddev  the measured grayscale stddev, or empty when not measured
+#   frames  content of the timelapse frame-count.txt, or empty when absent
+#   virgl   1 when QEMU runs GL scanout (egl-headless), else 0
+#
+# Prints exactly one evidence line:
+#   TUNAOS_LUKS_E2E_PIXEL_GATE result=<r> frames=<n> stddev=<s> fatal=<0|1>
+# Returns 0 when the gate passes or is advisory, 1 on a fatal failure.
+#
+# The decision table, and why each row is what it is:
+#   virgl=1        → skipped_virgl, advisory. screendump answers "no surface"
+#                    under GL scanout (see iso-e2e.sh's screenshot() comment)
+#                    so neither frames nor the capture measure anything here.
+#                    Saying skipped beats a silent pass.
+#   shot=unmeasured→ unmeasured, advisory. A capture exists but ImageMagick
+#                    was absent, so no verdict was measured — recording that
+#                    refusal as "blank" would invent a product failure out of
+#                    a missing host package (iso-e2e.sh already refuses to).
+#   frames=0/empty → no_frames, FATAL. On the plain (non-virgl) path the
+#                    recorder uses the same monitor socket as the screenshot;
+#                    zero frames across an entire install means the one
+#                    channel that can contradict "DM active" never worked,
+#                    and an unverifiable cell must not be a green cell.
+#   shot=drawn     → pass, FATAL gate satisfied: something actually rendered.
+#   shot=blank     → blank, FATAL failure — this is the black console that
+#                    used to ship. The stddev rides along as the measurement.
+#   shot=absent    → absent, FATAL failure: on the plain path screendump
+#                    works whenever QEMU is alive, so no capture at all means
+#                    the surface was never there to photograph.
+#
+# `drawn` still only means SOMETHING rendered — a greeter that draws, or a
+# text login, clears the same stddev floor; the greeter-drew-but-no-session
+# hole stays open and documented (iso-e2e.sh). This gate closes the
+# black-console hole, which is the one that has actually shipped.
+pixel_gate() {
+	local shot="$1" stddev="$2" frames="$3" virgl="$4"
+	local result fatal rc
+
+	if [[ "$virgl" == "1" ]]; then
+		result="skipped_virgl" fatal=0 rc=0
+	elif [[ "$shot" == "unmeasured" ]]; then
+		result="unmeasured" fatal=0 rc=0
+	elif [[ -z "$frames" || "$frames" == "0" ]]; then
+		result="no_frames" fatal=1 rc=1
+	elif [[ "$shot" == "drawn" ]]; then
+		result="pass" fatal=1 rc=0
+	elif [[ "$shot" == "blank" ]]; then
+		result="blank" fatal=1 rc=1
+	else
+		result="absent" fatal=1 rc=1
+	fi
+
+	echo "TUNAOS_LUKS_E2E_PIXEL_GATE result=${result} frames=${frames:-0} stddev=${stddev:-na} fatal=${fatal}"
+	return "$rc"
+}

--- a/tests/bats/test_pixel_gate.bats
+++ b/tests/bats/test_pixel_gate.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# Behavioral tests for scripts/lib/pixel-gate.sh — the decision table that
+# turns the already-captured screenshot/timelapse evidence into a verdict —
+# plus wiring pins for how scripts/iso-e2e.sh consumes it.
+#
+# The gap this closes: the installed-boot fatal gates ended at
+# "display-manager.service active", and a black console shipped under a
+# green cell (run 29645108966) while 151-210 real timelapse frames and a
+# stddev-measured screenshot sat unasserted in the artifacts.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+LIB="${REPO_ROOT}/scripts/lib/pixel-gate.sh"
+E2E="${REPO_ROOT}/scripts/iso-e2e.sh"
+
+gate() {
+  # shellcheck disable=SC1090
+  run bash -c "source '$LIB'; pixel_gate \"\$@\"" _ "$@"
+}
+
+# ── decision table ─────────────────────────────────────────────────────────
+
+@test "drawn + frames captured = fatal pass" {
+  gate drawn 0.18 172 0
+  [ "$status" -eq 0 ]
+  [[ "$output" == "TUNAOS_LUKS_E2E_PIXEL_GATE result=pass frames=172 stddev=0.18 fatal=1" ]]
+}
+
+@test "blank capture is a fatal failure carrying its measurement" {
+  gate blank 0.0007 151 0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"result=blank"* ]]
+  [[ "$output" == *"stddev=0.0007"* ]]
+  [[ "$output" == *"fatal=1"* ]]
+}
+
+@test "no capture at all on a measurable host is a fatal failure" {
+  gate absent "" 160 0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"result=absent"* ]]
+  [[ "$output" == *"stddev=na"* ]]
+}
+
+@test "zero frames on a measurable host fails even when the still looks drawn" {
+  # On the plain path the recorder shares the screenshot's monitor socket;
+  # an install-long capture that produced nothing means the verification
+  # channel itself never worked, and an unverifiable cell must not be green.
+  gate drawn 0.2 0 0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"result=no_frames"* ]]
+  gate drawn 0.2 "" 0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"result=no_frames"* ]]
+}
+
+@test "virgl hosts are named as skipped, never silently passed or failed" {
+  # screendump has no surface under GL scanout — frames and captures measure
+  # nothing there, whatever their values.
+  gate absent "" "" 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"result=skipped_virgl"* ]]
+  [[ "$output" == *"fatal=0"* ]]
+}
+
+@test "a capture without ImageMagick to judge it stays advisory" {
+  # Recording that refusal as blank would invent a product failure out of a
+  # missing host package — iso-e2e.sh already refuses to; so does the gate.
+  gate unmeasured "" 143 0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"result=unmeasured"* ]]
+  [[ "$output" == *"fatal=0"* ]]
+}
+
+# ── wiring in iso-e2e.sh ───────────────────────────────────────────────────
+
+@test "iso-e2e sources the gate lib and records its evidence line" {
+  grep -qF '. "${SCRIPT_DIR}/lib/pixel-gate.sh"' "$E2E"
+  grep -qF 'record_luks_evidence "$_pixel_line"' "$E2E"
+}
+
+@test "iso-e2e stops the timelapse before judging, so the frame count is real" {
+  # The stop must happen in the gate path itself, not only in cleanup_vm's
+  # EXIT trap — cleanup runs after the verdict.
+  run grep -B3 'frame-count.txt' "$E2E"
+  [[ "$output" == *'record-timelapse.sh" stop'* ]]
+}
+
+@test "a fatal gate verdict exits 6 and is documented, with an explicit escape hatch" {
+  run grep -A6 'TUNAOS_PIXEL_GATE:-1' "$E2E"
+  [[ "$output" == *"return 6"* ]]
+  grep -qE '^#   6  pixel gate failed' "$E2E"
+  grep -qF 'TUNAOS_PIXEL_GATE=0' "$E2E"
+}
+
+@test "the existing INSTALLED_SCREENSHOT evidence line is unchanged" {
+  # The workflow greps are exact-match and anchored; the gate adds a NEW
+  # line rather than mutating this one (see the comment above it in
+  # iso-e2e.sh about why appending a field breaks every green cell).
+  grep -qF 'TUNAOS_LUKS_E2E_INSTALLED_SCREENSHOT rendered=${_shot} stddev=${SCREENSHOT_STDDEV:-na} fatal=0' "$E2E"
+}


### PR DESCRIPTION
## The hole

The installed-boot fatal gates end at "display-manager.service is active and a login target was reached" — and the repo's own comments record that passing over a black console (run 29645108966, `iso-e2e.sh`). The evidence to contradict it is already captured on every LUKS cell: the timelapse recorder screendumps **real frames** on GPU-less runners (151–210 frames on passing cells) and the installed-desktop screenshot is **stddev-measured** — but both were recorded `fatal=0` and gated nothing.

## The gate

**`scripts/lib/pixel-gate.sh`** (new; a lib so bats can source the real logic) — one decision table:

| condition | verdict |
|---|---|
| virgl host (GL scanout — screendump has no surface) | `skipped_virgl`, **advisory, explicitly named** — never a silent pass |
| capture exists but no ImageMagick to judge it | `unmeasured`, advisory (recording that refusal as "blank" would invent a product failure out of a missing host package — the existing iso-e2e principle) |
| zero timelapse frames on a measurable host | `no_frames`, **FATAL** — the recorder shares the screenshot's monitor socket; an install-long capture that produced nothing means the verification channel never worked, and an unverifiable cell must not be green |
| capture drawn (stddev > 0.02, reusing `screenshot_sane`) + frames | `pass` |
| capture blank | **FATAL** — the black console that actually shipped |
| no capture at all on the plain path | **FATAL** |

**Wiring in `scripts/iso-e2e.sh`** (LUKS passphrase gate):
- timelapse stopped **in the gate path** (idempotent; `cleanup_vm`'s EXIT-trap stop stays harmless) so `frame-count.txt` is real at verdict time
- emits a new `TUNAOS_LUKS_E2E_PIXEL_GATE result=… frames=… stddev=… fatal=…` evidence line; the existing `TUNAOS_LUKS_E2E_INSTALLED_SCREENSHOT … fatal=0` line is **byte-identical** (the workflow greps are exact-match and anchored — the comment above it explains why appending a field breaks every green cell)
- fatal verdict → new documented **exit code 6**; `TUNAOS_PIXEL_GATE=0` is the explicit escape hatch (advisory + `::warning::`)

Honestly scoped: `drawn` still only means *something* rendered — a greeter that draws, or a text login, clears the same stddev floor. The greeter-drew-but-no-session hole stays open and documented; this closes the black-console hole, which is the one that has shipped.

## Tests

`tests/bats/test_pixel_gate.bats` (10 tests): every row of the decision table exercised behaviorally by sourcing the lib, plus wiring pins (lib sourced, evidence recorded, timelapse stopped before judging, exit 6 documented with escape hatch, pre-existing evidence line unchanged).

Evidence: 10/10 pass; mutation-verified (weakening the `no_frames` row to advisory fails its test); `bash -n` + shellcheck clean (`pixel-gate.sh` clean at default severity; `iso-e2e.sh` default-severity finding count identical before/after — 35 pre-existing, none added; `--severity=error` clean); full bats suite vs clean origin/main: none new (one baseline failure now *passes* with shellcheck installed on the test host).

## What to expect in CI

Cells whose installed system reaches login but draws nothing (or whose capture channel is dead) will now exit 6 instead of green. On virgl/GPU hosts the gate self-identifies as `skipped_virgl` and stays advisory. If a wave of legitimate cells trips it, `TUNAOS_PIXEL_GATE=0` in the workflow env is the one-line pause while the cells are triaged.