### PR TITLE
fix(grouper): xfce DM selection must defer to the apt family's debconf claim

### DIFF
--- a/build_scripts/desktop/configure-desktop-runtime.sh
+++ b/build_scripts/desktop/configure-desktop-runtime.sh
@@ -79,7 +79,26 @@ cosmic)
 	fi
 	;;
 xfce)
-	if systemctl list-unit-files lightdm.service --no-legend 2>/dev/null | grep -q '^lightdm.service'; then
+	# Debian-family packaging records the DM debconf chose in
+	# /etc/X11/default-display-manager, and BOTH gdm3 and lightdm consult it
+	# at startup — each refuses to run when the file names the other. That
+	# turned "prefer lightdm when its unit exists" into a broken desktop on
+	# grouper:xfce (run 31181743606): the manifest installs gdm3, Ubuntu's
+	# xfce4 metapackage pulls lightdm in via Recommends, this branch enabled
+	# the lightdm it found, and the installed system's serial shows lightdm
+	# crash-looping six times against default-display-manager=gdm3 while
+	# gdm3 — the DM debconf actually configured — sat unenabled. The
+	# contract service correctly reported DEPEND-failed, so the cell read
+	# desktop_contract=absent while the LUKS gates stayed green.
+	#
+	# Defer to the file: it is the apt-family equivalent of the
+	# display-manager.service alias claim the cosmic branch above defers to
+	# — the distro's packaging has already decided, and enabling anything
+	# else just loses a fight at boot. The unit-existence fallbacks remain
+	# for bases that never write the file.
+	if [[ -r /etc/X11/default-display-manager ]]; then
+		dm="$(basename "$(cat /etc/X11/default-display-manager)")"
+	elif systemctl list-unit-files lightdm.service --no-legend 2>/dev/null | grep -q '^lightdm.service'; then
 		dm=lightdm
 	else
 		dm=greetd

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -169,6 +169,37 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
   [ "$fail" -eq 0 ]
 }
 
+@test "xfce DM selection defers to the apt family's default-display-manager claim" {
+  # Debian-family DMs (gdm3, lightdm) consult /etc/X11/default-display-manager
+  # at startup and refuse to run when it names the other. Preferring
+  # lightdm-if-present enabled a Recommends-pulled, debconf-rejected lightdm
+  # on grouper:xfce — six crash-loops in the installed serial, gdm3 unenabled,
+  # desktop_contract=absent under green LUKS gates (run 31181743606). The
+  # branch must read the distro's own claim first; unit-existence fallbacks
+  # only apply when no claim exists.
+  #
+  # Comments stripped before every grep: the rationale comments in the script
+  # name the same file, and a test the comment can satisfy pins nothing.
+  local runtime="${REPO_ROOT}/build_scripts/desktop/configure-desktop-runtime.sh"
+  local code
+  code="$(grep -v '^[[:space:]]*#' "$runtime")"
+  grep -qF 'cat /etc/X11/default-display-manager' <<<"$code" || {
+    echo "FAIL: xfce DM selection no longer reads default-display-manager;" >&2
+    echo "      a Recommends-pulled lightdm will again beat the debconf DM" >&2
+    return 1
+  }
+  # The claim must be consulted BEFORE the lightdm unit-existence preference.
+  local xfce_branch claim_line lightdm_line
+  xfce_branch="$(awk '/^xfce\)/{f=1} f{print} f&&/;;/{exit}' "$runtime" | grep -v '^[[:space:]]*#')"
+  claim_line="$(grep -n 'default-display-manager' <<<"$xfce_branch" | head -1 | cut -d: -f1)"
+  lightdm_line="$(grep -n 'list-unit-files lightdm' <<<"$xfce_branch" | head -1 | cut -d: -f1)"
+  [ -n "$claim_line" ] && [ -n "$lightdm_line" ] && [ "$claim_line" -lt "$lightdm_line" ] || {
+    echo "FAIL: the default-display-manager claim must be checked before the" >&2
+    echo "      lightdm unit-existence fallback in the xfce branch" >&2
+    return 1
+  }
+}
+
 @test "disk gate requires the desktop contract marker" {
   # The gate wakes on either marker (both prove the contract service ran)
   # but only OK passes; FAIL surfaces its reason lines and exits nonzero.


### PR DESCRIPTION
## What

Second and final fix from the full-matrix desktop-contract audit: grouper:xfce was the last green cell with an unproven desktop (`desktop_contract=absent`). The fresh evidence run (31181743606, dispatched from main today) put the fault on the installed system's serial in plain text:

```
[FAILED] Failed to start lightdm.service - Light Display Manager.   (six restart attempts)
[DEPEND] Dependency failed for tunaos-desktop-contract … TunaOS xfce desktop experience.
```

## Why

- `xfce.yaml`'s apt section installs **gdm3** as the display manager.
- Ubuntu's `xfce4` metapackage pulls **lightdm** in via Recommends.
- `configure-desktop-runtime.sh`'s xfce branch preferred lightdm whenever its unit existed — so it enabled the Recommends-pulled lightdm.
- Debian-family DMs consult `/etc/X11/default-display-manager` at startup and refuse to run when it names another DM. The file said gdm3, so the enabled lightdm crash-looped while gdm3 — the DM debconf actually configured — sat unenabled.
- The contract service (Requires=display-manager.service) correctly went DEPEND-failed → `desktop_contract=absent` under green LUKS gates, exactly what the audit flagged.

(The earlier hypothesis — greetd's alias-only enable — died on contact with the artifact. The serial names lightdm.)

## How

Defer to `/etc/X11/default-display-manager` when it exists: it is the apt-family equivalent of the `display-manager.service` alias claim the cosmic branch already defers to — the distro's packaging has decided, and enabling anything else just loses a fight at boot. The unit-existence fallbacks remain for bases that never write the file.

## Testing

- New bats case pins both the read and its ordering (claim before the lightdm fallback), with **comments stripped before every grep** — the rationale comments name the same path, and a test the comment can satisfy pins nothing. Mutation-verified: removing the claim read fails the case while all comment mentions remain; restored tree is green.
- Pre-existing environment-dependent bats failures identical to clean main.

Real proof: the next grouper:xfce cell should boot gdm3, run the contract service, and read `desktop_contract=ok`. With gurnard:pantheon's fix (#1058) already merged, this is the last blocker before flipping `desktop_contract=ok` to a fatal gate matrix-wide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->