### PR TITLE
fix(gurnard): pantheon shipped no session entry — install pantheon-xsession-settings

### DIFF
--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -276,8 +276,15 @@ pantheon)
 	# display_manager: lightdm.
 	experience="tunaos/pantheon"
 	require_command gala
-	require_any_glob '/usr/share/xsessions/pantheon.desktop' \
-		'/usr/share/wayland-sessions/pantheon.desktop'
+	# Session entries measured from the PPA deb itself (pantheon-xsession-
+	# settings 8.1.0+r419, dpkg -c, 2026-08-07): xsessions/pantheon.desktop
+	# and wayland-sessions/pantheon-wayland.desktop. The first run of this
+	# contract (31187758113) failed here and the failure was REAL: no package
+	# in the manifest shipped any session entry at all — the greeter had
+	# nothing to launch. pantheon-xsession-settings is that package; the
+	# manifest now installs it.
+	require_any_glob '/usr/share/xsessions/pantheon*.desktop' \
+		'/usr/share/wayland-sessions/pantheon*.desktop'
 	require_any_unit lightdm
 	dm_pattern='^lightdm\.service$'
 	;;

--- a/manifests/desktops/pantheon.yaml
+++ b/manifests/desktops/pantheon.yaml
@@ -43,6 +43,16 @@ packages:
     # Core apps
     - io.elementary.terminal
     - io.elementary.settings-daemon
+    # The session entry itself. Nothing else in this list ships ANY session
+    # desktop file — the first pantheon contract run (31187758113) failed on
+    # exactly that, and it was a real gap, not a bad assert: without
+    # xsessions/pantheon.desktop the greeter has no Pantheon session to
+    # launch. Measured from the PPA deb (8.1.0+r419, dpkg -c): this package
+    # ships /usr/share/xsessions/pantheon.desktop,
+    # /usr/share/wayland-sessions/pantheon-wayland.desktop and the
+    # gnome-session definitions, and Depends: gnome-session-bin, gala,
+    # pantheon-shell, xwayland — the session stack arrives with it.
+    - pantheon-xsession-settings
     # Display manager itself comes from the Ubuntu archive, not the PPA.
     - lightdm
     # Portals and secrets — the gap that made sailfin:gnome ship without a


### PR DESCRIPTION
## What

The first-ever run of the pantheon desktop contract (#1058's proof cell, run 31187758113) failed the image build:

```
missing required path: none of [/usr/share/xsessions/pantheon.desktop /usr/share/wayland-sessions/pantheon.desktop] exist
```

## Why this is a product bug, not a bad assert

Nothing in the pantheon manifest ships **any** session desktop file. gala, wingpanel, the greeter, the settings daemon — all installed; the entry the greeter needs to actually *launch a Pantheon session* — absent. The cell's prior green (before the contract existed) was an installed system whose login screen had nothing to log into. This is exactly the class of gap the watertightness work exists to catch, and the contract caught it on its first outing — at image build time, in 13 minutes, instead of after a 50-minute install.

## How (measured, not guessed)

From the elementary PPA itself (noble `Packages` index + `dpkg -c` of `pantheon-xsession-settings_8.1.0+r419+pkg132~ubuntu8.1_all.deb`):

```
/usr/share/xsessions/pantheon.desktop
/usr/share/wayland-sessions/pantheon-wayland.desktop
/usr/share/gnome-session/sessions/pantheon{,-wayland}.session
Depends: gnome-session-bin, gala (>= 0.3.2~), pantheon-shell, xwayland
```

- The manifest gains `pantheon-xsession-settings`, which brings the session entry and — via its Depends — the session stack.
- The contract glob widens to `pantheon*.desktop` in both session dirs, matching the measured wayland name (`pantheon-wayland.desktop`), with the deb listing cited inline.

## Testing

- Full bats file green minus the two environment failures identical on clean main; manifest YAML validated.
- Real proof is the re-dispatched gurnard:pantheon cell after merge: build passes the contract, greeter gets a session, installed boot reads `desktop_contract=ok`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->