### PR TITLE
fix(nvidia): align the overlay kernel with the akmods kmod by construction

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -69,6 +69,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: base-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 2
         build_image: true
         build_iso: false
@@ -122,11 +129,25 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: gnome-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
       - id: gnome-nvidia-hwe
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 4
         build_image: true
         build_iso: false
@@ -137,6 +158,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: cosmic-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
@@ -147,6 +175,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: kde-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
@@ -157,6 +192,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: niri-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
@@ -176,11 +218,12 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
-        # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
-        platforms:
-          - linux/amd64
-          - linux/amd64/v2
+        # x86_64 only. The xfce-wayland repo constraint (no aarch64) applied
+        # already; the nvidia overlay narrows further — no amd64/v2, because
+        # Kitten v2 kernels are ARCH=x86_64_v2 and the akmods kmods are
+        # x86_64 builds, so the exact-EVR kmod install can never match there
+        # (overrides/nvidia/10-kernel-swap.sh hard-fails off x86_64).
+        platforms: ["linux/amd64"]
 
   - id: albacore
     emoji: "🐟"
@@ -204,6 +247,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: base-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 2
         build_image: true
         build_iso: false
@@ -257,11 +307,25 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: gnome-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
       - id: gnome-nvidia-hwe
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 4
         build_image: true
         build_iso: false
@@ -272,6 +336,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: cosmic-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
@@ -282,6 +353,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: kde-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
@@ -292,6 +370,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: niri-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
@@ -311,11 +396,12 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
-        # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
-        platforms:
-          - linux/amd64
-          - linux/amd64/v2
+        # x86_64 only. The xfce-wayland repo constraint (no aarch64) applied
+        # already; the nvidia overlay narrows further — no amd64/v2, because
+        # Kitten v2 kernels are ARCH=x86_64_v2 and the akmods kmods are
+        # x86_64 builds, so the exact-EVR kmod install can never match there
+        # (overrides/nvidia/10-kernel-swap.sh hard-fails off x86_64).
+        platforms: ["linux/amd64"]
 
   - id: skipjack
     emoji: "🍣"
@@ -340,6 +426,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: base-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 2
         build_image: true
         build_iso: false
@@ -392,6 +485,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: gnome-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
@@ -402,6 +502,13 @@ variants:
       # %{major_version}), verified live in the published spec, not just
       # by the PR having merged.
       - id: gnome-nvidia-hwe
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 4
         build_image: true
         build_iso: false
@@ -412,6 +519,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: cosmic-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
@@ -422,6 +536,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: kde-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
@@ -432,6 +553,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: niri-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
@@ -465,6 +593,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: base-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 2
         build_image: true
         build_iso: false
@@ -512,26 +647,61 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: gnome-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
       - id: cosmic-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
       - id: kde-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
       - id: niri-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
       - id: xfce-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
@@ -683,6 +853,13 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: base-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 2
         build_image: true
         build_iso: false
@@ -718,26 +895,61 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: gnome-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
       - id: cosmic-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
       - id: kde-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
       - id: niri-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true
         build_qcow2: false
       - id: xfce-nvidia
+        # x86_64 only: the akmods-nvidia-open kmods are x86_64 builds, so on
+        # any other platform the exact-EVR kmod install can never match and
+        # the overlay hard-fails (overrides/nvidia/10-kernel-swap.sh) rather
+        # than shipping a driverless "nvidia" image. Also excludes amd64/v2:
+        # Kitten v2 kernels are ARCH=x86_64_v2, which no published kmod
+        # matches. Same shape as bluefin's x86_64-only GDX.
+        platforms: ["linux/amd64"]
         stage: 3
         build_image: true
         build_iso: true

--- a/Containerfile.overlay
+++ b/Containerfile.overlay
@@ -72,8 +72,21 @@ RUN \
   --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=akmods_nvidia_open,src=/rpms,dst=/tmp/akmods-nvidia-open-rpms \
+  --mount=type=bind,from=akmods_nvidia_open,src=/kernel-rpms,dst=/tmp/kernel-rpms \
   --mount=type=bind,from=context,source=/,target=/run/context \
     bash -c 'if [ "${OVERLAY_TYPE}" = "hwe" ]; then /run/context/build_scripts/overlay/hwe.sh; elif [ "${OVERLAY_TYPE}" = "cachyos" ]; then /run/context/build_scripts/overlay/cachyos.sh; elif [ "${OVERLAY_TYPE}" = "asahi" ]; then /run/context/build_scripts/overlay/asahi.sh; else /run/context/build_scripts/overlay/nvidia.sh; fi'
+# The second akmods mount above is the kmod↔kernel alignment mechanism: every
+# ublue akmods image ships BOTH /rpms (the kmods) and /kernel-rpms (the exact
+# kernel those kmods were built against — akmods' Containerfile.in copies
+# both into the final scratch stage). The nvidia overlay swaps the image's
+# kernel to that one (overrides/nvidia/10-kernel-swap.sh) BEFORE installing
+# the kmod, so the exact-EVR install cannot miss: equality by construction,
+# the same shape bluefin-lts uses (its base build runs kernel-swap.sh from
+# the akmods kernel-rpms mount). First-contact evidence for why hoping the
+# base kernel matches does not work: yellowfin ships AlmaLinux Kitten
+# 6.12.0-250.el10 while akmods-nvidia-open:centos-10 carried kmods for a
+# different CentOS kernel, and the kde-nvidia proof build died on the glob
+# (run 31189433990).
 
 # ==============================================================================
 # Desktop target — single parameterized stage replaces the per-DE copy-paste.

--- a/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
+++ b/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# 10-kernel-swap.sh — align the image kernel with the akmods kmod BEFORE the
+# NVIDIA driver install (20-nvidia.sh) runs.
+#
+# WHY. 20-nvidia.sh installs kmod-nvidia-${KERNEL_VRA}-*.rpm — an exact
+# kernel EVR.ARCH glob, kept deliberately strict. First contact proved the
+# strictness right and the alignment missing: yellowfin's base ships
+# AlmaLinux Kitten's kernel (6.12.0-250.el10) while the
+# akmods-nvidia-open:centos-10 bundle carries kmods for the CentOS kernel it
+# was actually built against, so the glob matched nothing and the build died
+# (kde-nvidia proof run 31189433990). Hoping two independently-published
+# kernels agree is not a mechanism.
+#
+# bluefin-lts solves this BY CONSTRUCTION: its base build erases the image
+# kernel and installs the one from the akmods /kernel-rpms mount
+# (build_scripts/scripts/kernel-swap.sh in the snapshot), so kmod and kernel
+# can never diverge. This is that mechanism, scoped to the nvidia overlay —
+# and made even tighter: /tmp/kernel-rpms here is mounted from the SAME
+# akmods-nvidia-open image as the kmods (every ublue akmods image ships both
+# /rpms and /kernel-rpms — akmods' Containerfile.in copies both into the
+# final stage), so the kernel installed here is the one the kmod was built
+# against by definition, not by tag coincidence.
+#
+# Numbered 10- so run_buildscripts_for's human-numeric sort runs it before
+# 20-nvidia.sh.
+
+set -xeuo pipefail
+
+# Test hooks (same pattern as TUNAOS_NVIDIA_VERIFY_ROOT in verify-nvidia.sh):
+# the mount points are parameters so bats can run the real logic against
+# fixture directories with rpm/dnf/curl/uname stubbed on PATH.
+AKMODS_DIR="${TUNAOS_AKMODS_DIR:-/tmp/akmods-nvidia-open-rpms}"
+KERNEL_RPMS_DIR="${TUNAOS_KERNEL_RPMS_DIR:-/tmp/kernel-rpms}"
+
+# x86_64 only, as a belt behind the build-config platform gate: the akmods
+# kmods are x86_64 builds, so an arm64 or x86_64_v2 overlay could only ship
+# a mislabeled driverless image — the exact bug this layer exists to end.
+# bluefin scopes its GDX the same way (x86_64-only overrides/publishing).
+if [[ "$(uname -m)" != "x86_64" ]]; then
+	echo "ERROR: the NVIDIA overlay only supports x86_64 (akmods kmods are x86_64" >&2
+	echo "       builds; kernel ARCH on this platform can never match them)." >&2
+	echo "       Remove this platform from the *-nvidia flavor in" >&2
+	echo "       .github/build-config.yml instead of building a driverless image." >&2
+	exit 1
+fi
+
+# Diagnostic FIRST, unconditionally: when the next mismatch happens, the log
+# must say what WAS in the bundle. The first failure's log did not, and that
+# cost a diagnosis step.
+echo "==> akmods bundle contents (${AKMODS_DIR}):"
+find "$AKMODS_DIR" -name '*.rpm' | sort
+echo "==> akmods kernel cache contents (${KERNEL_RPMS_DIR}):"
+find "$KERNEL_RPMS_DIR" -name '*.rpm' | sort
+
+KERNEL_NAME="kernel"
+
+# The kernel the akmods bundle was built for, read from the cache the kmods
+# shipped with (same detection as bluefin-lts kernel-swap.sh). The `|| true`
+# is load-bearing: on an empty cache `ls` exits non-zero, pipefail makes the
+# whole substitution non-zero, and `set -e` would kill the script HERE —
+# before the diagnosis below could name the empty cache.
+CACHED_VERSION=$(cd "$KERNEL_RPMS_DIR" && { ls kernel-[0-9]*.rpm 2>/dev/null || true; } | head -1 | sed -E 's/^kernel-//;s/\.rpm$//')
+if [[ -z "$CACHED_VERSION" ]]; then
+	echo "ERROR: could not detect a kernel version in ${KERNEL_RPMS_DIR} (listing above)" >&2
+	exit 1
+fi
+
+INSTALLED_VERSION="$(rpm -q "$KERNEL_NAME" --queryformat '%{EVR}.%{ARCH}\n' | tail -1)"
+echo "==> image kernel: ${INSTALLED_VERSION}; akmods kernel: ${CACHED_VERSION}"
+
+if [[ "$INSTALLED_VERSION" == "$CACHED_VERSION" ]]; then
+	echo "==> kernels already aligned; no swap needed"
+else
+	echo "==> swapping image kernel to the akmods-matched ${CACHED_VERSION}"
+	# Always remove these packages as kernel cache provides signed versions
+	# (bluefin-lts kernel-swap.sh, verbatim reasoning).
+	PKGS=("${KERNEL_NAME}" "${KERNEL_NAME}-core" "${KERNEL_NAME}-modules" "${KERNEL_NAME}-modules-core" "${KERNEL_NAME}-modules-extra" "${KERNEL_NAME}-uki-virt")
+	for pkg in "${PKGS[@]}"; do
+		rpm --erase "$pkg" --nodeps || true
+	done
+
+	# Install every core kernel piece the cache provides for this version.
+	# Enumerated from the cache rather than hardcoded: the uki-virt/devel
+	# split varies between kernel-cache builds, and a name the cache does not
+	# carry would fail the transaction on a file that was never promised.
+	RPM_FILES=()
+	for pkg in "${PKGS[@]}"; do
+		if [[ -f "${KERNEL_RPMS_DIR}/${pkg}-${CACHED_VERSION}.rpm" ]]; then
+			RPM_FILES+=("${KERNEL_RPMS_DIR}/${pkg}-${CACHED_VERSION}.rpm")
+		fi
+	done
+	if [[ "${#RPM_FILES[@]}" -eq 0 ]]; then
+		echo "ERROR: no installable kernel rpms for ${CACHED_VERSION} in ${KERNEL_RPMS_DIR}" >&2
+		exit 1
+	fi
+	dnf -y install "${RPM_FILES[@]}"
+fi
+
+# Lock what we just aligned — a later transaction pulling a different kernel
+# would silently undo the whole point of this script.
+dnf versionlock add \
+	"$KERNEL_NAME" \
+	"$KERNEL_NAME"-core \
+	"$KERNEL_NAME"-modules \
+	"$KERNEL_NAME"-modules-core \
+	"$KERNEL_NAME"-modules-extra 2>/dev/null || true
+
+# akmods secureboot key, so the signed kmod/kernel verify on SB machines
+# (bluefin-lts kernel-swap.sh does the same). Path is a test hook like the
+# mounts above.
+CERTS_DIR="${TUNAOS_AKMODS_CERT_DIR:-/etc/pki/akmods/certs}"
+mkdir -p "$CERTS_DIR"
+curl --retry 3 -fsSLo "${CERTS_DIR}/akmods-ublue.der" \
+	"https://github.com/ublue-os/akmods/raw/main/certs/public_key.der"

--- a/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
@@ -50,24 +50,47 @@ KERNEL_SUFFIX=""
 QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(|'"$KERNEL_SUFFIX"'-)(\d+\.\d+\.\d+)' | sed -E 's/kernel-(|'"$KERNEL_SUFFIX"'-)//' | tail -n 1)"
 
 ### install Nvidia driver packages and dependencies
-# kmod-nvidia requires nvidia-kmod-common from negativo17's fedora-nvidia
-# repo. Detect the Fedora release embedded in the akmods RPMs and download
-# the matching repo file so DNF can resolve it. On the centos-10 akmods the
-# RPMs carry no .fcNN tag, so the pinned default applies — the same release
-# bluefin-lts pins for the same bundle.
-FEDORA_VERSION="${FEDORA_AKMODS_VERSION:-43}"
+# kmod-nvidia requires nvidia-kmod-common (and the userspace below requires
+# the whole driver set) from negativo17, which publishes parallel trees per
+# family. Derive the family from the akmods RPM dist tags so kmod and
+# userspace come from the same world:
+#   *.elNN → epel-nvidia.repo (epel-NN). Measured for epel-10: the repo
+#            exists and carries the full set this script installs
+#            (nvidia-driver{,-cuda}, nvidia-settings, libnvidia-fbc,
+#            nvidia-kmod-common, all .el10 builds). The centos-10 akmods
+#            RPMs are .el10-tagged — first contact showed
+#            ublue-os-nvidia-addons-0.14-1.el10.noarch.rpm in the bundle —
+#            so the EL10 variants land here, not on Fedora userspace.
+#   *.fcNN → fedora-nvidia.repo (fedora-NN) — bluefin-lts's arm, right for
+#            bonito's coreos-stable akmods.
+# Fallback when neither tag is readable: fedora-43, bluefin-lts's pinned
+# default, kept so an unexpected bundle still names a real repo.
+AKMODS_EL_VERSION="$(find /tmp/akmods-nvidia-open-rpms -name "*.rpm" -print | grep -oPm1 '(?<=\.el)\d+' || true)"
 AKMODS_FEDORA_VERSION="$(find /tmp/akmods-nvidia-open-rpms -name "*.rpm" -print | grep -oPm1 '(?<=\.fc)\d+' || true)"
-if [[ -n "${AKMODS_FEDORA_VERSION}" ]]; then
-	FEDORA_VERSION="${AKMODS_FEDORA_VERSION}"
+if [[ -n "${AKMODS_EL_VERSION}" ]]; then
+	NVIDIA_REPO_ID="epel-nvidia"
+	NVIDIA_RELEASEVER="${AKMODS_EL_VERSION}"
+elif [[ -n "${AKMODS_FEDORA_VERSION}" ]]; then
+	NVIDIA_REPO_ID="fedora-nvidia"
+	NVIDIA_RELEASEVER="${AKMODS_FEDORA_VERSION}"
+else
+	NVIDIA_REPO_ID="fedora-nvidia"
+	NVIDIA_RELEASEVER="${FEDORA_AKMODS_VERSION:-43}"
 fi
-curl --retry 3 -fsSLo - "https://negativo17.org/repos/fedora-nvidia.repo" |
-	sed "s/\$releasever/${FEDORA_VERSION}/g" |
-	tee "/etc/yum.repos.d/fedora-nvidia.repo"
+echo "==> NVIDIA userspace repo: ${NVIDIA_REPO_ID} releasever=${NVIDIA_RELEASEVER}"
+curl --retry 3 -fsSLo - "https://negativo17.org/repos/${NVIDIA_REPO_ID}.repo" |
+	sed "s/\$releasever/${NVIDIA_RELEASEVER}/g" |
+	tee "/etc/yum.repos.d/${NVIDIA_REPO_ID}.repo"
 # Disabled at rest; enabled per-transaction below (see header for why this
 # is not `dnf config-manager`).
-sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/fedora-nvidia.repo
+sed -i 's/^enabled=1/enabled=0/' "/etc/yum.repos.d/${NVIDIA_REPO_ID}.repo"
 
-dnf -y install --enablerepo="fedora-nvidia" \
+# Say what the bundle holds right where the exact-EVR glob consumes it —
+# 10-kernel-swap.sh printed the full listing, but this is the line a
+# truncated log gets read from (the first mismatch's log showed only the
+# unexpanded glob, which cost a diagnosis step).
+ls -l /tmp/akmods-nvidia-open-rpms/kmods/ || true
+dnf -y install --enablerepo="${NVIDIA_REPO_ID}" \
 	/tmp/akmods-nvidia-open-rpms/kmods/kmod-nvidia-"${KERNEL_VRA}"-*.rpm \
 	/tmp/akmods-nvidia-open-rpms/ublue-os/*.rpm
 
@@ -78,13 +101,13 @@ NVIDIA_PKG_VERSION="3:${KMOD_VERSION}"
 
 # The nvidia-container-toolkit repo file ships in the ublue-os addons RPMs
 # installed above; enable it for this transaction only.
-dnf -y install --enablerepo="fedora-nvidia" --enablerepo="nvidia-container-toolkit" \
+dnf -y install --enablerepo="${NVIDIA_REPO_ID}" --enablerepo="nvidia-container-toolkit" \
 	"libnvidia-fbc-${NVIDIA_PKG_VERSION}" \
 	"nvidia-driver-${NVIDIA_PKG_VERSION}" \
 	"nvidia-driver-cuda-${NVIDIA_PKG_VERSION}" \
 	"nvidia-settings-${NVIDIA_PKG_VERSION}" \
 	nvidia-container-toolkit
-# Leave the toolkit repo disabled at rest, matching the fedora-nvidia repo.
+# Leave the toolkit repo disabled at rest, matching the driver repo above.
 if [[ -f /etc/yum.repos.d/nvidia-container-toolkit.repo ]]; then
 	sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/nvidia-container-toolkit.repo
 fi

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -86,7 +86,9 @@ OVERLAY_SH="${REPO_ROOT}/build_scripts/overlay/nvidia.sh"
   # Match only code, not the header comment that documents this rule.
   run grep -E '^[^#]*dnf config-manager' "$INSTALL_SH"
   [ "$status" -ne 0 ]
-  run grep -F -- '--enablerepo="fedora-nvidia"' "$INSTALL_SH"
+  # The repo is derived (epel-nvidia vs fedora-nvidia) and enabled
+  # per-transaction through the variable, never hardcoded.
+  run grep -F -- '--enablerepo="${NVIDIA_REPO_ID}"' "$INSTALL_SH"
   [ "$status" -eq 0 ]
 }
 
@@ -231,4 +233,159 @@ STUB
   run_verify "$root"
   [ "$status" -ne 0 ]
   [[ "$output" == *"nvidia-suspend.service is shipped but not enabled"* ]]
+}
+
+# ── kernel alignment (10-kernel-swap.sh) ───────────────────────────────────
+#
+# First contact (kde-nvidia proof run 31189433990): the exact-EVR gate fired
+# because yellowfin's Kitten kernel and the akmods kmod kernel disagreed.
+# The fix is bluefin-lts's mechanism — swap the image kernel to the one in
+# the akmods /kernel-rpms cache, mounted from the SAME image as the kmods —
+# so equality holds by construction. These tests run the real script against
+# fixtures (TUNAOS_AKMODS_DIR / TUNAOS_KERNEL_RPMS_DIR / TUNAOS_AKMODS_CERT_DIR)
+# with rpm/dnf/curl/uname stubbed on PATH.
+
+SWAP_SH="${NVIDIA_DIR}/10-kernel-swap.sh"
+AKMODS_KVER="6.12.0-247.el10.x86_64"
+
+@test "kernel-swap exists, is executable, and sorts before the driver install" {
+  [ -x "$SWAP_SH" ]
+  # run_buildscripts_for sorts human-numerically; 10- must precede 20-.
+  local first
+  first="$(find "$NVIDIA_DIR" -maxdepth 1 -iname '*-*.sh' -type f | sort | head -1)"
+  [ "$(basename "$first")" = "10-kernel-swap.sh" ]
+}
+
+@test "Containerfile.overlay mounts the akmods kernel cache alongside the kmods" {
+  # Both mounts must come from the SAME akmods stage — that identity is the
+  # by-construction guarantee.
+  grep -qF 'from=akmods_nvidia_open,src=/rpms,dst=/tmp/akmods-nvidia-open-rpms' "${REPO_ROOT}/Containerfile.overlay"
+  grep -qF 'from=akmods_nvidia_open,src=/kernel-rpms,dst=/tmp/kernel-rpms' "${REPO_ROOT}/Containerfile.overlay"
+}
+
+make_swap_stubs() {
+  # $1 = EVR.ARCH that stubbed `rpm -q kernel` reports as installed
+  mkdir -p "${BATS_TEST_TMPDIR}/bin"
+  cat > "${BATS_TEST_TMPDIR}/bin/uname" <<'STUB'
+#!/usr/bin/env bash
+echo x86_64
+STUB
+  cat > "${BATS_TEST_TMPDIR}/bin/rpm" <<STUB
+#!/usr/bin/env bash
+echo "rpm \$*" >> "${BATS_TEST_TMPDIR}/tool.log"
+case "\$*" in
+  *"-q kernel"*) echo "$1"; exit 0 ;;
+esac
+exit 0
+STUB
+  cat > "${BATS_TEST_TMPDIR}/bin/dnf" <<STUB
+#!/usr/bin/env bash
+echo "dnf \$*" >> "${BATS_TEST_TMPDIR}/tool.log"
+exit 0
+STUB
+  cat > "${BATS_TEST_TMPDIR}/bin/curl" <<STUB
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "${BATS_TEST_TMPDIR}/bin/"*
+}
+
+make_swap_fixture() {
+  mkdir -p "${BATS_TEST_TMPDIR}/akmods/kmods" "${BATS_TEST_TMPDIR}/kernel-rpms"
+  touch "${BATS_TEST_TMPDIR}/akmods/kmods/kmod-nvidia-${AKMODS_KVER}-580.10.01-1.el10.x86_64.rpm"
+  for p in kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra; do
+    touch "${BATS_TEST_TMPDIR}/kernel-rpms/${p}-${AKMODS_KVER}.rpm"
+  done
+}
+
+run_swap() {
+  PATH="${BATS_TEST_TMPDIR}/bin:$PATH" \
+    TUNAOS_AKMODS_DIR="${BATS_TEST_TMPDIR}/akmods" \
+    TUNAOS_KERNEL_RPMS_DIR="${BATS_TEST_TMPDIR}/kernel-rpms" \
+    TUNAOS_AKMODS_CERT_DIR="${BATS_TEST_TMPDIR}/certs" \
+    run bash "$SWAP_SH"
+}
+
+@test "kernel-swap prints both bundle listings before touching anything" {
+  make_swap_stubs "$AKMODS_KVER"
+  make_swap_fixture
+  run_swap
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"akmods bundle contents"* ]]
+  [[ "$output" == *"kmod-nvidia-${AKMODS_KVER}"* ]]
+  [[ "$output" == *"akmods kernel cache contents"* ]]
+  [[ "$output" == *"kernel-core-${AKMODS_KVER}.rpm"* ]]
+}
+
+@test "kernel-swap is a no-op when the image kernel already matches" {
+  make_swap_stubs "$AKMODS_KVER"
+  make_swap_fixture
+  run_swap
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no swap needed"* ]]
+  # No erase and no kernel install happened.
+  ! grep -q 'rpm --erase' "${BATS_TEST_TMPDIR}/tool.log"
+  ! grep -q 'dnf -y install' "${BATS_TEST_TMPDIR}/tool.log"
+}
+
+@test "kernel-swap replaces a mismatched kernel with the akmods one" {
+  make_swap_stubs "6.12.0-250.el10.x86_64"  # the first-contact Kitten kernel
+  make_swap_fixture
+  run_swap
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"swapping image kernel"* ]]
+  grep -q -- '--erase kernel' "${BATS_TEST_TMPDIR}/tool.log"
+  grep -q "dnf -y install .*kernel-core-${AKMODS_KVER}.rpm" "${BATS_TEST_TMPDIR}/tool.log"
+}
+
+@test "kernel-swap fails loudly when the cache holds no kernel at all" {
+  make_swap_stubs "$AKMODS_KVER"
+  make_swap_fixture
+  rm "${BATS_TEST_TMPDIR}/kernel-rpms/"*
+  run_swap
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not detect a kernel version"* ]]
+}
+
+@test "kernel-swap refuses to run on non-x86_64" {
+  make_swap_stubs "$AKMODS_KVER"
+  make_swap_fixture
+  cat > "${BATS_TEST_TMPDIR}/bin/uname" <<'STUB'
+#!/usr/bin/env bash
+echo aarch64
+STUB
+  chmod +x "${BATS_TEST_TMPDIR}/bin/uname"
+  run_swap
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"only supports x86_64"* ]]
+}
+
+@test "20-nvidia.sh derives the userspace repo family from the akmods dist tag" {
+  # .elNN → epel-nvidia, .fcNN → fedora-nvidia, fallback fedora-43. The el
+  # arm must be checked FIRST (an .el10 bundle must never land on Fedora
+  # userspace — first contact showed the centos-10 bundle is .el10-tagged).
+  grep -qF 'AKMODS_EL_VERSION=' "$INSTALL_SH"
+  grep -qF 'NVIDIA_REPO_ID="epel-nvidia"' "$INSTALL_SH"
+  run awk '/AKMODS_EL_VERSION.\}. \]\]/{print NR; exit}' "$INSTALL_SH"
+  local el_line="$output"
+  run awk '/AKMODS_FEDORA_VERSION.\}. \]\]/{print NR; exit}' "$INSTALL_SH"
+  [ -n "$el_line" ] && [ -n "$output" ] && [ "$el_line" -lt "$output" ]
+  # Both driver transactions must enable the derived repo, not a hardcoded one.
+  run grep -c -- '--enablerepo="${NVIDIA_REPO_ID}"' "$INSTALL_SH"
+  [ "$output" -eq 2 ]
+}
+
+@test "every *-nvidia flavor in build-config is linux/amd64 only" {
+  command -v python3 >/dev/null || skip "python3 not installed"
+  python3 -c "import yaml" 2>/dev/null || skip "pyyaml not installed"
+  run python3 -c "
+import yaml
+d = yaml.safe_load(open('${REPO_ROOT}/.github/build-config.yml'))
+bad = [(v['id'], f['id'], f.get('platforms'))
+       for v in d['variants'] for f in v['flavors']
+       if 'nvidia' in f['id'] and f.get('platforms') != ['linux/amd64']]
+assert not bad, bad
+print('ok')
+"
+  [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Follow-up to #1061 after first contact: the yellowfin kde-nvidia proof build (run 31189433990) failed **exactly where the new gate said it should** — the exact-EVR kmod install found no `kmod-nvidia-6.12.0-250.el10.x86_64-*.rpm`, because the image ships AlmaLinux Kitten's kernel while `akmods-nvidia-open:centos-10` carries kmods for the CentOS kernel it was built against. The gate stays exactly as strict; this PR adds the alignment it was waiting for.

## The mechanism (option 1 — bluefin-lts's, verified in the snapshot)

bluefin-lts guarantees kmod↔kernel equality **by construction**: its base build erases the image kernel and installs the one from the akmods `/kernel-rpms` mount (`build_scripts/scripts/kernel-swap.sh`, run from `overrides/base/10-packages-image-base.sh:13`). This PR ports that, scoped to the nvidia overlay, and makes it one notch tighter:

- **`Containerfile.overlay`** now bind-mounts `/kernel-rpms` **from the same `akmods_nvidia_open` stage as the kmods** (measured: every ublue akmods image ships both `/rpms` and `/kernel-rpms` — akmods' `Containerfile.in:184-187` copies both into the final stage). Same-image sourcing means the kernel installed is the one the kmod was built against *by definition*, not by tag coincidence.
- **`overrides/nvidia/10-kernel-swap.sh`** (new; sorts before `20-nvidia.sh`): no-op when already aligned; otherwise erase + install the cache kernel (pieces enumerated from the cache, not hardcoded), versionlock, akmods secureboot key — bluefin-lts's steps with its reasoning quoted.

## The rest of the coordinator-flagged items

- **Diagnostics before any install, unconditionally**: full rpm listings of both mounts at the top of 10-kernel-swap.sh, plus `ls` of the kmods dir immediately above the exact-EVR install line in 20-nvidia.sh. The first failure's log showed only the unexpanded glob — what the bundle actually held was unknowable, and that cost a diagnosis step.
- **The el10 userspace default was wrong, now derived**: `AKMODS_FEDORA_VERSION` came up empty (no `.fcNN` — the centos-10 bundle is `.el10`-tagged, e.g. `ublue-os-nvidia-addons-0.14-1.el10.noarch.rpm`) so the repo defaulted to *fedora-43 userspace on an EL10 image*. Measured fix: negativo17 publishes **`epel-nvidia` / epel-10** with the full driver set as `.el10` builds (`nvidia-driver{,-cuda}`, `nvidia-settings`, `libnvidia-fbc`, `nvidia-kmod-common` — read from its repodata). 20-nvidia.sh now derives: `.elNN` → epel-nvidia (checked first), `.fcNN` → fedora-nvidia (bluefin-lts's arm, right for bonito's coreos-stable akmods), fallback fedora-43. Both driver transactions use the derived repo id.
- **arm64/v2 scoped out at the matrix**, following bluefin's x86_64-only GDX shape: every `*-nvidia` flavor in `.github/build-config.yml` is now `platforms: ["linux/amd64"]` (incl. dropping `amd64/v2` from yellowfin/albacore xfce-nvidia — Kitten v2 kernels are `ARCH=x86_64_v2`, which no published kmod matches). `10-kernel-swap.sh` carries a hard non-x86_64 refusal as the belt behind the matrix gate — a skip would just re-ship the original mislabeled-driverless-image bug.
- **Pre-existing failure attribution checked**: last night's scheduled yellowfin run 31145192523 (pre-#1061) failed in its **`base / linux-arm64`** job itself, taking all 7 arm64 legs down (hwe included) — a different, pre-existing arm64-lane problem, not this layer.

## Tests

`test_nvidia_overlay.bats`: 14 → **23 tests**. New: swap-script ordering under `run_buildscripts_for`'s sort; same-stage kernel-rpms mount; behavioral fixture runs of the real swap logic (diagnostic-first, no-op when aligned, replaces when mismatched — **mutation-verified**, empty-cache loud failure, non-x86_64 refusal); repo-family derivation with the `.el` arm ordered before `.fc`; yaml-parsed assertion that every `*-nvidia` flavor is amd64-only. The empty-cache test caught a real bug before shipping: under `pipefail` the version probe died silently at its assignment instead of reaching its own error message — now annotated and fixed.

Evidence: 23/23 pass; shellcheck clean (default severity, the level the bats lint tests use); yamllint clean on build-config; full bats suite identical to current main's failure set (2 pre-existing env failures, renumbered only).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->