### PR TITLE
fix(flatpak): reach the baseline on script-driven desktop stages too

### DIFF
--- a/build_scripts/desktop/configure-desktop-runtime.sh
+++ b/build_scripts/desktop/configure-desktop-runtime.sh
@@ -159,6 +159,32 @@ systemctl set-default graphical.target
 # console by scripts/iso-e2e.sh; the checks ExecStart is non-fatal).
 case "$desktop" in
 gnome | kde | niri | cosmic | xfce | pantheon)
+	# ── Flatpak baseline, BEFORE the contract that asserts it ─────────────
+	# The baseline (Flathub remote + curated preinstall declarations +
+	# preinstall service) normally arrives through install-desktop.sh's
+	# post_install hooks — but not every desktop stage is manifest-driven.
+	# Containerfile.ubuntu's niri and xfce stages run their per-DE scripts
+	# (niri.sh/xfce.sh) plus THIS script and never touch install-desktop.sh,
+	# so grouper:xfce failed its own contract at build time:
+	#
+	#   missing required path: /etc/flatpak/remotes.d/flathub.flatpakrepo
+	#   (run 31192228329)
+	#
+	# The assert was right — the image genuinely lacked the remote. Laying
+	# the baseline down HERE, inside the same block that runs the contract,
+	# makes that drift impossible: any desktop path that verifies the
+	# experience has just installed the baseline it verifies, and a stage
+	# that skips both this script and install-desktop.sh is refused by
+	# tests/bats/test_containerfile_context_scripts.bats. Both scripts are
+	# idempotent (the remote fetch is guarded by the baked file, the
+	# preinstall writer dedups, the service enable re-runs clean), so the
+	# manifest-driven stages that already ran them lose nothing.
+	export DESKTOP_FLAVOR="$desktop"
+	# shellcheck source=/dev/null
+	source /run/context/build_scripts/desktop/tuna-flatpak-remote.sh
+	# shellcheck source=/dev/null
+	source /run/context/build_scripts/desktop/flatpak-preinstall.sh
+
 	# Compile dconf databases before verify checks — desktop stages lay down
 	# keyfiles after the base stage's dconf update, so recompile here.
 	if command -v dconf &>/dev/null && compgen -G "/etc/dconf/db/*.d/*" >/dev/null 2>&1; then

--- a/tests/bats/test_containerfile_context_scripts.bats
+++ b/tests/bats/test_containerfile_context_scripts.bats
@@ -170,3 +170,67 @@ per_de_scripts() {
   run bash -c "$(declare -f containerfile_code executed_script_refs); REPO_ROOT='${REPO_ROOT}'; executed_script_refs"
   [[ "$output" != *"build_scripts/lib.sh"* ]]
 }
+
+# ── Every desktop stage must lead to the flatpak baseline ──────────────────
+#
+# The baseline (Flathub remote + curated preinstall + preinstall service) has
+# exactly two carriers: install-desktop.sh's manifest post_install hooks, and
+# configure-desktop-runtime.sh's contract-family block. A desktop stage that
+# runs a per-DE session script WITHOUT either carrier ships a desktop whose
+# own build contract fails — grouper:xfce did exactly that (run 31192228329:
+# "missing required path: /etc/flatpak/remotes.d/flathub.flatpakrepo")
+# because Containerfile.ubuntu's xfce stage ran xfce.sh + the contract but
+# the baseline only existed in manifest post_install. Stage lists are DERIVED
+# from the Containerfiles, not hardcoded, so a new stage cannot dodge this.
+
+# Print "file:stage_start_line" for every stage in $1 that invokes a per-DE
+# SESSION script (a desktop id's own .sh) without install-desktop.sh or
+# configure-desktop-runtime.sh in the same stage.
+stages_missing_baseline() {
+  sed 's/^[[:space:]]*#.*//' "$1" | awk -v file="$1" '
+    /^FROM /            { if (bad && !ok) print file ":" start; start=NR; bad=0; ok=0 }
+    /\/run\/context\/build_scripts\/desktop\/(gnome|kde|cosmic|niri|xfce|pantheon)\.sh/ { bad=1 }
+    /install-desktop\.sh|configure-desktop-runtime\.sh/ { ok=1 }
+    END                 { if (bad && !ok) print file ":" start }
+  '
+}
+
+@test "every desktop stage runs install-desktop.sh or configure-desktop-runtime.sh" {
+  local fail=0 f
+  for f in "${REPO_ROOT}"/Containerfile.*; do
+    [[ "$f" == *Containerfile.overlay || "$f" == *Containerfile.final || "$f" == *Containerfile.custom ]] && continue
+    while IFS= read -r hit; do
+      [ -n "$hit" ] || continue
+      echo "FAIL: desktop stage without a baseline/contract carrier at $hit" >&2
+      fail=1
+    done < <(stages_missing_baseline "$f")
+  done
+  [ "$fail" -eq 0 ]
+}
+
+@test "the script-driven stages actually exist and rely on configure-desktop-runtime" {
+  # Sanity for the test above: Containerfile.ubuntu's niri and xfce stages
+  # are the known script-driven pair. If they migrate to install-desktop.sh
+  # this test documents the change; if they lose configure-desktop-runtime
+  # the test above turns red.
+  run grep -A1 'desktop/xfce.sh base' "${REPO_ROOT}/Containerfile.ubuntu"
+  [[ "$output" == *"configure-desktop-runtime.sh xfce"* ]]
+  run grep -A1 'desktop/niri.sh base' "${REPO_ROOT}/Containerfile.ubuntu"
+  [[ "$output" == *"configure-desktop-runtime.sh niri"* ]]
+}
+
+@test "configure-desktop-runtime lays down the flatpak baseline before verifying it" {
+  local script="${REPO_ROOT}/build_scripts/desktop/configure-desktop-runtime.sh"
+  local remote_line preinstall_line verify_line
+  remote_line=$(grep -n 'source /run/context/build_scripts/desktop/tuna-flatpak-remote.sh' "$script" | head -1 | cut -d: -f1)
+  preinstall_line=$(grep -n 'source /run/context/build_scripts/desktop/flatpak-preinstall.sh' "$script" | head -1 | cut -d: -f1)
+  verify_line=$(grep -n '/run/context/build_scripts/checks/verify-desktop-experience.sh "\$desktop"' "$script" | head -1 | cut -d: -f1)
+  [ -n "$remote_line" ] && [ -n "$preinstall_line" ] && [ -n "$verify_line" ]
+  # Install first, verify second — the contract asserts what was just laid down.
+  [ "$remote_line" -lt "$verify_line" ]
+  [ "$preinstall_line" -lt "$verify_line" ]
+  # DESKTOP_FLAVOR must be exported first: flatpak-preinstall.sh names its
+  # preinstall file after it.
+  run grep -B10 'source /run/context/build_scripts/desktop/flatpak-preinstall.sh' "$script"
+  [[ "$output" == *'export DESKTOP_FLAVOR="$desktop"'* ]]
+}


### PR DESCRIPTION
Follow-up to #1062, whose own assert found its coverage gap: the grouper:xfce proof cell (run 31192228329) failed the image build inside `configure-desktop-runtime.sh`'s contract call with

```
missing required path: /etc/flatpak/remotes.d/flathub.flatpakrepo
```

The assert was right — the image genuinely lacked the remote. **Blocks the grouper:xfce proof cell for the desktop_contract fatal flip.**

## The audit

The baseline (Flathub remote + curated preinstall declarations + preinstall service) rode only `install-desktop.sh`'s manifest post_install hooks. Auditing every Containerfile's desktop stages for their build path:

| family | desktop stages | path |
|---|---|---|
| el10 / debian / arch / opensuse / gentoo | all | `install-desktop.sh` (manifest-driven) ✔ |
| ubuntu | gnome, kde, cosmic, pantheon | `install-desktop.sh` **+** `configure-desktop-runtime.sh` ✔ |
| ubuntu | **niri** (`niri.sh base`, :488), **xfce** (`xfce.sh base`, :498) | per-DE script + `configure-desktop-runtime.sh` only — **no post_install hooks ever run** |

## The fix (the drift-impossible option)

`configure-desktop-runtime.sh`'s contract-family block now **sources `tuna-flatpak-remote.sh` and `flatpak-preinstall.sh` itself, before the `verify-desktop-experience.sh` call that asserts their output** — any desktop path that verifies the experience has just installed the baseline it verifies. Both scripts are idempotent (remote fetch guarded by the baked file, preinstall writer dedups, service enable re-runs clean), so the five ubuntu stages that run both `install-desktop.sh` *and* this script lose nothing, and no other family behaves differently. `DESKTOP_FLAVOR` is exported first since the preinstall file is named after it.

Who runs the baseline on the *other* script-driven families: there are none — the audit above shows every non-ubuntu stage is manifest-driven, and the new test refuses any future exception.

## Drift protection (derived, not hardcoded)

`tests/bats/test_containerfile_context_scripts.bats` +3 tests:
1. **Every stage that invokes a per-DE session script** (`gnome|kde|cosmic|niri|xfce|pantheon`.sh) **must carry `install-desktop.sh` or `configure-desktop-runtime.sh` in the same stage** — stages derived by splitting each Containerfile on `FROM` boundaries, so a new script-driven stage cannot dodge the baseline or the contract.
2. The known script-driven pair (ubuntu niri/xfce) pinned as relying on configure-desktop-runtime.
3. Ordering inside `configure-desktop-runtime.sh`: both baseline sources precede the contract call, `DESKTOP_FLAVOR` exported before the preinstall source.

## Evidence

- 8/8 in the extended file; the existing `flatpak baseline` drift test still green.
- Mutation-verified: blanking the xfce stage's `configure-desktop-runtime.sh` call fails tests 1+2 with the file:line of the offending stage; blanking the preinstall `source` fails test 3.
- shellcheck clean (default severity — the level the in-bats lint tests use); full bats suite identical failure set to current main (2 pre-existing env failures).
- Note: main's pantheon contract work landed meanwhile — pantheon is in the contract-family block and the session-script regex, so gurnard's stages are covered by the same derived test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->