### PR TITLE
e2e: harvest the emergency shell's rdsosreport instead of timing out past it

### DIFF
--- a/scripts/luks-first-boot.py
+++ b/scripts/luks-first-boot.py
@@ -58,6 +58,36 @@ contract_wait = int(sys.argv[5]) if len(sys.argv) > 5 else 0
 CONTRACT_RE = re.compile(r"TUNAOS_DESKTOP_CONTRACT_(OK|FAIL)")
 contract_result = None
 
+# Dracut's emergency shell announces itself and then waits forever; the boot
+# will never reach userspace, and the ONLY diagnosis — rdsosreport.txt — lives
+# inside the guest and dies with it. guppy:xfce hit exactly this (run
+# 31182709691): "Failed to start Switch Root", emergency shell, and an
+# artifact that proves the failure happened while containing nothing about
+# why. The console is interactive at that prompt, so harvest the report
+# instead of timing out around it: press Enter for the maintenance shell,
+# cat the report and the journal tail to the serial (which tee already
+# captures into installed-serial.log), then bail with the existing exit 3.
+emergency_seen = False
+
+
+def harvest_emergency(ser):
+    print("\n>>> emergency shell detected; harvesting rdsosreport", flush=True)
+    ser.sendall(b"\n")
+    time.sleep(3)
+    ser.sendall(b"cat /run/initramfs/rdsosreport.txt 2>/dev/null || true\n")
+    time.sleep(5)
+    ser.sendall(b"journalctl -b --no-pager -n 120 2>/dev/null || true\n")
+    # Drain whatever the guest prints for a bounded window.
+    drain_until = time.time() + 30
+    while time.time() < drain_until:
+        try:
+            d = ser.recv(4096)
+            if d:
+                sys.stdout.buffer.write(d)
+                sys.stdout.flush()
+        except socket.timeout:
+            pass
+
 while time.time() < deadline:
     try:
         d = ser.recv(4096)
@@ -80,6 +110,14 @@ while time.time() < deadline:
         reached_login = True
         login_at = time.time()
         print("\n>>> userspace reached; letting first-boot enrollment run", flush=True)
+
+    # Initramfs gave up: userspace will never come. Capture the diagnosis the
+    # emergency shell offers, then stop burning the timeout — the exit path
+    # below reports "never reached userspace" exactly as before.
+    if not emergency_seen and not reached_login and "Entering emergency mode" in text:
+        emergency_seen = True
+        harvest_emergency(ser)
+        break
 
     # Scan the WHOLE buffer, not the 4000-byte window above: the contract
     # marker is a single line emitted once, and at 10s-ish poll granularity a

--- a/scripts/luks-first-boot.py
+++ b/scripts/luks-first-boot.py
@@ -86,6 +86,8 @@ def harvest_emergency(ser):
                 sys.stdout.buffer.write(d)
                 sys.stdout.flush()
         except socket.timeout:
+            # Expected: the guest is simply quiet right now. Keep polling until
+            # drain_until rather than cutting the harvest short.
             pass
 
 while time.time() < deadline:

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -980,3 +980,16 @@ setup_runtime_check_stubs() {
   grep -q 'recipe_image=""' "$SCRIPT"
   grep -q 'containers-storage:<targetImgref>' "$SCRIPT"
 }
+
+@test "first-boot harness harvests the emergency shell instead of timing out past it" {
+  # guppy:xfce (run 31182709691): "Failed to start Switch Root", dracut
+  # emergency shell, and an artifact that proved the failure happened while
+  # containing nothing about why — rdsosreport.txt lives inside the guest and
+  # died with it. The harness must detect the shell and cat the report to the
+  # serial it already captures. Pinned on the CODE strings (the send commands
+  # and the detection literal), not the rationale comments.
+  local harness="${REPO_ROOT}/scripts/luks-first-boot.py"
+  grep -qF '"Entering emergency mode" in text' "$harness"
+  grep -qF 'cat /run/initramfs/rdsosreport.txt 2>/dev/null' "$harness"
+  grep -qF 'journalctl -b --no-pager -n 120' "$harness"
+}


### PR DESCRIPTION
## What

guppy:xfce just reached the deepest point in its history (run 31182709691): the Gentoo image built through the forced systemd rebuild (#1054 proven — real compile output, all three `command -v` asserts green), fisherman installed, the disk encrypted, the passphrase unlocked — and then the initramfs failed **Switch Root** into a dracut emergency shell:

```
[FAILED] Failed to start Switch Root.
Entering emergency mode. Exit the shell to continue.
You might want to save "/run/initramfs/rdsosreport.txt" ...
```

The artifact proves the failure happened and contains nothing about *why*: `rdsosreport.txt` lives inside the guest and died with it, while the harness burned its 900s timeout around an interactive prompt that was literally offering the diagnosis.

## How

`luks-first-boot.py` now recognizes the shell's announcement: on `Entering emergency mode` before userspace, it presses Enter for the maintenance shell, cats `/run/initramfs/rdsosreport.txt` and `journalctl -b -n 120` to the serial (which `tee` already lands in `installed-serial.log`), drains for a bounded 30s, and exits through the existing never-reached-userspace path (exit 3). Healthy boots are untouched — the branch only fires on the emergency announcement.

## Testing

- Bats case pins the detection literal and both harvest commands on **code** strings, not the rationale comments. Mutation-verified: removing the rdsosreport cat fails the case; restored tree green.
- `py_compile` clean; test_iso_e2e.bats failure set identical to clean main (4 pre-existing env failures).

Next guppy dispatch self-diagnoses the Switch Root failure instead of producing another evidence-free artifact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->