### PR TITLE
fix(nvidia): probe the kmod's own module files, not a name glob

### DIFF
--- a/build_scripts/checks/verify-nvidia.sh
+++ b/build_scripts/checks/verify-nvidia.sh
@@ -74,11 +74,25 @@ if [[ -z "$KERNEL_VRA" ]]; then
 elif [[ ! -d "${NV_ROOT}/usr/lib/modules/${KERNEL_VRA}" ]]; then
 	fail "no module directory for the shipped kernel: /usr/lib/modules/${KERNEL_VRA}"
 else
-	MODULE_FILE="$(find "${NV_ROOT}/usr/lib/modules/${KERNEL_VRA}" -name 'nvidia*.ko*' -print 2>/dev/null | head -1 || true)"
-	if [[ -n "$MODULE_FILE" ]]; then
-		pass "nvidia kernel module present for ${KERNEL_VRA} (${MODULE_FILE#"${NV_ROOT}"})"
+	# Ask rpm which module files the kmod package OWNS — never glob by name.
+	# The first proof build (run 31196251408) failed on exactly that: the
+	# nvidia*.ko* glob matched nvidia-wmi-ec-backlight.ko.xz, a mainline
+	# module every kernel ships, and modinfo rightly found no driver version
+	# in it. A name glob also passes on an image with no kmod at all, which
+	# inverts the check's whole purpose.
+	MODULE_FILE="$(rpm -ql kmod-nvidia 2>/dev/null |
+		grep -E '\.ko(\.[a-z0-9]+)?$' |
+		grep -F "/usr/lib/modules/${KERNEL_VRA}/" |
+		head -1 || true)"
+	if [[ -n "$MODULE_FILE" && -e "${NV_ROOT}${MODULE_FILE}" ]]; then
+		MODULE_FILE="${NV_ROOT}${MODULE_FILE}"
+		pass "kmod-nvidia ships a module for ${KERNEL_VRA} (${MODULE_FILE#"${NV_ROOT}"})"
+	elif [[ -n "$MODULE_FILE" ]]; then
+		MODULE_FILE=""
+		fail "kmod-nvidia's module list names files absent on disk under /usr/lib/modules/${KERNEL_VRA}"
 	else
-		fail "no nvidia*.ko* under /usr/lib/modules/${KERNEL_VRA} — kmod built for a different kernel?"
+		MODULE_FILE=""
+		fail "kmod-nvidia owns no .ko under /usr/lib/modules/${KERNEL_VRA} — kmod built for a different kernel?"
 	fi
 fi
 

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -115,6 +115,10 @@ make_stub_tools() {
 args="\$*"
 case "\$args" in
   *"-q kernel"*) echo "${KVER}"; exit 0 ;;
+  # -ql answers with the module files the kmod OWNS — the probe the contract
+  # uses since the wmi-ec-backlight false match (run 31196251408): a name
+  # glob found a mainline nvidia-prefixed module and failed modinfo on it.
+  *"-ql kmod-nvidia"*) echo "/usr/lib/modules/${KVER}/extra/nvidia/nvidia.ko.xz"; exit 0 ;;
   *kmod-nvidia*|*nvidia-driver-cuda*|*nvidia-container-toolkit*) printf '580.10.01'; exit 0 ;;
   *nvidia-driver*) printf '580.10.01'; exit 0 ;;
 esac


### PR DESCRIPTION
## What

The second NVIDIA proof build (run 31196251408) was one assert away from green — and the assert was wrong, not the image. The contract's own output tells the story:

```
ok: kmod-nvidia=610.43.03
ok: nvidia-driver=610.43.03
ok: nvidia kernel module present for 6.12.0-254.el10.x86_64 (…/nvidia-wmi-ec-backlight.ko.xz)
ok: kmod-nvidia and nvidia-driver agree (610.43.03)
FAIL: modinfo could not read a version from …/nvidia-wmi-ec-backlight.ko.xz
```

The kernel swap worked (#1067 proven: image runs the akmods kernel, equality by construction), the driver installed, versions agree, all GL/Vulkan/GBM plumbing present. But the coherence probe's `nvidia*.ko*` **name glob** matched `nvidia-wmi-ec-backlight.ko.xz` — a mainline module every kernel ships — and the version lock rightly found no driver version in it. Worse than the false FAIL: the same glob would **pass the presence check on an image with no kmod at all**, inverting the check's purpose.

## How

Ask rpm which module files `kmod-nvidia` *owns* (`rpm -ql`), require one to exist on disk under the shipped kernel's directory, and run the modinfo version lock against that file. Three outcomes, each named: module present (pass); rpm names files missing on disk (stale/partial overlay — fail); rpm owns nothing under the kernel dir (kmod for a different kernel — fail).

## Testing

- Fixture rpm stub gains the `-ql` arm; 23/23 green.
- The removed-module mutation case still fails, now through the absent-on-disk arm.
- Mutation-verified: making `-ql` fail flips the complete-install test red; restored tree 23/23.

The third proof build after merge should print `TUNAOS_NVIDIA_CONTRACT_OK` end to end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->