### PR TITLE
fix(codecs): the h264 probe was a SIGPIPE false-negative machine, not a codec gap

### DIFF
--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -402,6 +402,8 @@ else
 	#      rpm/openSUSE/Gentoo  /usr/lib64/gstreamer-1.0/libgstlibav.so
 	#      Arch                 /usr/lib/gstreamer-1.0/libgstlibav.so
 	#      Debian/Ubuntu        /usr/lib/<triplet>/gstreamer-1.0/libgstlibav.so
+	#      (the apt path MEASURED on ubuntu:noble — gstreamer1.0-libav ships
+	#      /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstlibav.so)
 	# 2. `ffmpeg -decoders` actually lists h264 — the plugin above routes
 	#    into libavcodec, so a free-codec libavcodec (the exact v2 failure)
 	#    is caught here even though the plugin file exists.
@@ -411,7 +413,25 @@ else
 		'/usr/lib/*/gstreamer-1.0/libgstlibav.so'
 	require_command ffmpeg
 	if command -v ffmpeg >/dev/null 2>&1; then
-		if ! ffmpeg -hide_banner -decoders 2>/dev/null | grep -q ' h264 '; then
+		# NEVER pipe ffmpeg straight into `grep -q` here. grep -q exits at the
+		# first match, ffmpeg is still writing its ~30 KB decoder list, gets
+		# SIGPIPE, exits 141 — and under this script's `set -o pipefail` the
+		# pipeline reports failure WITH the decoder present. That is not a
+		# race in practice: measured on ubuntu:noble (ffmpeg 6.1.1, h264
+		# decoder confirmed in the output), the piped form returned 141 on
+		# five out of five runs and failed gurnard:pantheon's proof build
+		# (run 31196812732) with a message blaming a "crippled libavcodec"
+		# the image did not have. Capture first, then grep the variable —
+		# and keep "ffmpeg would not run" distinct from "ffmpeg runs but
+		# cannot decode", because their fixes live in different places
+		# (packaging deps vs codec sourcing).
+		_ffmpeg_decoders=""
+		if ! _ffmpeg_decoders="$(ffmpeg -hide_banner -decoders 2>/dev/null)"; then
+			echo "ffmpeg is installed but would not run (broken dependencies?) — cannot verify codecs" >&2
+			if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
+				exit 1
+			fi
+		elif ! grep -q ' h264 ' <<<"$_ffmpeg_decoders"; then
 			echo "ffmpeg cannot decode h264 — a free/crippled libavcodec is installed" >&2
 			if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
 				exit 1

--- a/tests/bats/test_codec_baseline.bats
+++ b/tests/bats/test_codec_baseline.bats
@@ -100,8 +100,18 @@ done
 GEN
   chmod +x "${BATS_TEST_TMPDIR}/fake-decoders"
   # Old (piped) form under pipefail: fails despite the decoder being there.
-  run bash -c "set -o pipefail; '${BATS_TEST_TMPDIR}/fake-decoders' | grep -q ' h264 '"
-  [ "$status" -eq 141 ]
+  #
+  # The exact code depends on the SIGPIPE disposition the harness inherited,
+  # so this asserts "nonzero", not "141". With SIGPIPE at its default the
+  # writer dies of the signal and bash reports 141 (128+13) — that is the
+  # container-build case the contract actually runs in. When some ancestor
+  # already set SIGPIPE to SIG_IGN, children inherit the ignore, writes fail
+  # with EPIPE instead, and the pipeline reports 1 — that is the GitHub
+  # Actions case, whose Node-based runner ignores SIGPIPE. Same bug either
+  # way: the pipeline fails WITH the decoder present. Pinning 141 made this
+  # test itself a false failure on CI.
+  run bash -c "set -o pipefail; '${BATS_TEST_TMPDIR}/fake-decoders' 2>/dev/null | grep -q ' h264 '"
+  [ "$status" -ne 0 ]
   # New (captured) form: passes.
   run bash -c "set -o pipefail; d=\"\$('${BATS_TEST_TMPDIR}/fake-decoders')\"; grep -q ' h264 ' <<<\"\$d\""
   [ "$status" -eq 0 ]

--- a/tests/bats/test_codec_baseline.bats
+++ b/tests/bats/test_codec_baseline.bats
@@ -57,10 +57,52 @@ CONTRACT="${REPO_ROOT}/build_scripts/checks/verify-desktop-experience.sh"
 
 @test "contract proves h264 decode through ffmpeg, not just plugin presence" {
   # The plugin file existing is satisfiable by a free-codec libavcodec — the
-  # exact v2 failure — so the contract must interrogate ffmpeg itself.
-  run grep -E 'ffmpeg -hide_banner -decoders.*grep -q .{0,3}h264' "$CONTRACT"
+  # exact v2 failure — so the contract must interrogate ffmpeg itself. The
+  # probe must use the capture-first form: the output is captured into a
+  # variable, then grepped.
+  run grep -F '_ffmpeg_decoders="$(ffmpeg -hide_banner -decoders 2>/dev/null)"' "$CONTRACT"
+  [ "$status" -eq 0 ]
+  run grep -F "grep -q ' h264 ' <<<\"\$_ffmpeg_decoders\"" "$CONTRACT"
   [ "$status" -eq 0 ]
   # And a missing decoder must be fatal (exit 1 in that branch), not a warning.
   run grep -A3 'ffmpeg cannot decode h264' "$CONTRACT"
   [[ "$output" == *"exit 1"* ]]
+  # ffmpeg-would-not-run is a DIFFERENT diagnosis with a different fix
+  # (packaging deps, not codec sourcing) — it must have its own fatal branch,
+  # never fold into "crippled libavcodec".
+  run grep -A3 'ffmpeg is installed but would not run' "$CONTRACT"
+  [[ "$output" == *"exit 1"* ]]
+}
+
+@test "the h264 probe never pipes ffmpeg straight into grep -q" {
+  # The piped form is a false-negative machine, not a style nit: grep -q
+  # exits at the first match, ffmpeg is still writing its ~30 KB decoder
+  # list, takes SIGPIPE (exit 141), and under the contract's pipefail the
+  # pipeline reports failure WITH the decoder present. Measured on
+  # ubuntu:noble (ffmpeg 6.1.1): 141 on five of five runs; it failed
+  # gurnard:pantheon's proof build (run 31196812732) blaming a "crippled
+  # libavcodec" the image did not have.
+  run grep -E 'ffmpeg -hide_banner -decoders[^|]*\|[[:space:]]*grep' "$CONTRACT"
+  [ "$status" -ne 0 ]
+}
+
+@test "the SIGPIPE mechanism is real, and the captured form is immune" {
+  # Behavioral proof with a generator standing in for ffmpeg: the match line
+  # first, then (after grep -q has certainly exited) more output than a pipe
+  # buffer holds, so the writer hits the closed pipe deterministically.
+  cat > "${BATS_TEST_TMPDIR}/fake-decoders" <<'GEN'
+#!/usr/bin/env bash
+echo " VFS..D h264                 H.264 / AVC"
+sleep 0.3
+for _ in $(seq 1 3000); do
+  echo " V....D someothercodec       filler line to overrun the pipe buffer"
+done
+GEN
+  chmod +x "${BATS_TEST_TMPDIR}/fake-decoders"
+  # Old (piped) form under pipefail: fails despite the decoder being there.
+  run bash -c "set -o pipefail; '${BATS_TEST_TMPDIR}/fake-decoders' | grep -q ' h264 '"
+  [ "$status" -eq 141 ]
+  # New (captured) form: passes.
+  run bash -c "set -o pipefail; d=\"\$('${BATS_TEST_TMPDIR}/fake-decoders')\"; grep -q ' h264 ' <<<\"\$d\""
+  [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Follow-up to #1063. The gurnard:pantheon proof cell (run 31196812732) failed the codec baseline with `ffmpeg cannot decode h264 — a free/crippled libavcodec is installed`. **Both halves of that message were wrong**, and the diagnosis below is measured in a container, not inferred.

## Measured on ubuntu:noble (installed exactly as the image installs — `apt-get --no-install-recommends ffmpeg gstreamer1.0-libav libavcodec-extra`, the `10-base-packages.sh:56-62` apt list)

1. **The apt family's content was already right.** ffmpeg `6.1.1-3ubuntu5` installs from the archive and its decoder table contains ` VFS..D h264`; `gstreamer1.0-libav` ships `/usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstlibav.so` — the multiarch glob the contract asserts, now measured rather than assumed. **No package addition needed anywhere.**
2. **The probe itself was the bug.** `ffmpeg -hide_banner -decoders 2>/dev/null | grep -q ' h264 '` returned **141 on five out of five runs**: `grep -q` exits at the first match, ffmpeg is still writing its ~30 KB decoder list, takes SIGPIPE — and under the contract's `set -o pipefail` the pipeline reports failure *with the decoder present*. Deterministic on noble; a latent time-bomb on every other family, since the same probe runs on all of them.

## The fix (probe only, no content change)

- **Capture-first:** decoder list into a variable, then grep the variable. Measured passing on the same noble container.
- **Three-way diagnosis** (the coordinator's absent-vs-crippled distinction, because the fixes live in different places):
  - ffmpeg absent → `require_command` (unchanged, its own accurate message)
  - ffmpeg present but won't run → new fatal branch (`broken dependencies?` — packaging problem)
  - ffmpeg runs but lists no h264 → the crippled-libavcodec message, now reachable only when true
- **Per-family scoping audit** (assert-what-you-ship): every family's baseline installs the ffmpeg CLI — apt via `10-base-packages.sh`, EL10/Fedora via the #1063 codec transactions, Arch/openSUSE/Gentoo via their Containerfiles — so the unconditional `require_command ffmpeg` matches shipped content on all six; the three `libgstlibav.so` globs each map to a family that installs the plugin. The assert was family-blind only in its probe mechanics, not its scoping.

## Tests (`tests/bats/test_codec_baseline.bats`, 6 → 8)

- probe test now pins the capture-first form **and** the separate would-not-run fatal branch
- new test **bans the piped form outright** (`ffmpeg …-decoders … | grep` may not reappear)
- new behavioral test **reproduces the SIGPIPE mechanism** with a generator (old form exits 141 under pipefail, captured form exits 0) — the *why* survives in executable form

Evidence: 8/8 pass; mutation-verified (restoring a piped probe fails both pins); shellcheck clean; full bats suite identical failure set to current main (2 pre-existing env failures).

This unblocks both proof cells — gurnard:pantheon directly, and grouper:xfce which would have hit the identical false negative on the same apt-family ffmpeg after #1068's re-dispatch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->