### PR TITLE
fix(nvidia): the kmod RPM records /lib/modules, not /usr/lib/modules

### DIFF
--- a/build_scripts/checks/verify-nvidia.sh
+++ b/build_scripts/checks/verify-nvidia.sh
@@ -80,19 +80,34 @@ else
 	# module every kernel ships, and modinfo rightly found no driver version
 	# in it. A name glob also passes on an image with no kmod at all, which
 	# inverts the check's whole purpose.
+	# UsrMove: the kmod RPM RECORDS its payload under /lib/modules — measured
+	# from the actual akmods bundle (rpm -qlp on
+	# kmod-nvidia-6.12.0-254.el10.x86_64-610.43.03-1.el10.x86_64.rpm prints
+	# ./lib/modules/<kver>/extra/nvidia/nvidia*.ko.xz) — while the files
+	# resolve on disk through the /lib -> /usr/lib symlink. Demanding the
+	# /usr-prefixed form in the rpm -ql output is how proof build #3 (run
+	# 31202648166) failed with a fully installed, version-locked driver.
+	# Match the kernel-dir substring either way, then resolve the on-disk
+	# location with a /usr fallback for roots without the symlink.
 	MODULE_FILE="$(rpm -ql kmod-nvidia 2>/dev/null |
 		grep -E '\.ko(\.[a-z0-9]+)?$' |
-		grep -F "/usr/lib/modules/${KERNEL_VRA}/" |
+		grep -F "lib/modules/${KERNEL_VRA}/" |
 		head -1 || true)"
+	if [[ -n "$MODULE_FILE" && ! -e "${NV_ROOT}${MODULE_FILE}" && -e "${NV_ROOT}/usr${MODULE_FILE}" ]]; then
+		MODULE_FILE="/usr${MODULE_FILE}"
+	fi
 	if [[ -n "$MODULE_FILE" && -e "${NV_ROOT}${MODULE_FILE}" ]]; then
 		MODULE_FILE="${NV_ROOT}${MODULE_FILE}"
 		pass "kmod-nvidia ships a module for ${KERNEL_VRA} (${MODULE_FILE#"${NV_ROOT}"})"
 	elif [[ -n "$MODULE_FILE" ]]; then
 		MODULE_FILE=""
-		fail "kmod-nvidia's module list names files absent on disk under /usr/lib/modules/${KERNEL_VRA}"
+		fail "kmod-nvidia's module list names files absent on disk under lib/modules/${KERNEL_VRA}"
 	else
+		# Evidence with the failure: what rpm actually owns, so the next
+		# mismatch names itself instead of costing a diagnosis round.
+		rpm -ql kmod-nvidia 2>/dev/null | head -10 | sed 's/^/    rpm -ql: /' || true
 		MODULE_FILE=""
-		fail "kmod-nvidia owns no .ko under /usr/lib/modules/${KERNEL_VRA} — kmod built for a different kernel?"
+		fail "kmod-nvidia owns no .ko under lib/modules/${KERNEL_VRA} — kmod built for a different kernel?"
 	fi
 fi
 

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -118,7 +118,12 @@ case "\$args" in
   # -ql answers with the module files the kmod OWNS — the probe the contract
   # uses since the wmi-ec-backlight false match (run 31196251408): a name
   # glob found a mainline nvidia-prefixed module and failed modinfo on it.
-  *"-ql kmod-nvidia"*) echo "/usr/lib/modules/${KVER}/extra/nvidia/nvidia.ko.xz"; exit 0 ;;
+  # The REAL recorded form, measured from the akmods bundle (rpm -qlp): the
+  # kmod RPM records /lib/modules/... (UsrMove), while the files resolve to
+  # /usr/lib/modules on disk. The fixture must model that mismatch — a stub
+  # answering /usr/lib/... is how the probe's /usr-demanding filter passed
+  # 23/23 locally while failing on the real image (run 31202648166).
+  *"-ql kmod-nvidia"*) echo "/lib/modules/${KVER}/extra/nvidia/nvidia.ko.xz"; exit 0 ;;
   *kmod-nvidia*|*nvidia-driver-cuda*|*nvidia-container-toolkit*) printf '580.10.01'; exit 0 ;;
   *nvidia-driver*) printf '580.10.01'; exit 0 ;;
 esac


### PR DESCRIPTION
## What

Proof build #3 (run 31202648166) failed on exactly one line, with a fully installed, version-locked driver behind it:

```
FAIL: kmod-nvidia owns no .ko under /usr/lib/modules/6.12.0-254.el10.x86_64
```

## Why — measured, not guessed

I extracted the actual kmod RPM from `ghcr.io/ublue-os/akmods-nvidia-open:centos-10` and listed its header and payload:

```
NAME: kmod-nvidia                       (the -ql package resolution in #1070 was right)
./lib/modules/6.12.0-254.el10.x86_64/extra/nvidia/nvidia.ko.xz
./lib/modules/6.12.0-254.el10.x86_64/extra/nvidia/nvidia-drm.ko.xz
…
```

UsrMove: the rpmdb records `/lib/modules/...`; the files resolve on disk through the `/lib → /usr/lib` symlink. The probe filtered `rpm -ql` output for the `/usr`-prefixed form and matched nothing.

## How

- Match the kernel-dir substring in either recorded form (`lib/modules/<kver>/`), then resolve the on-disk path with a `/usr` fallback for roots without the symlink.
- The owns-nothing failure arm now prints the head of `rpm -ql` — the next mismatch names itself instead of costing a diagnosis round.
- The fixture stub answers `-ql` with the **measured** `/lib/modules` form while the fixture root stores files under `usr/lib/modules` — modelling the exact mismatch that let the previous probe pass 23/23 locally while failing on the real image.

## Testing

23/23; mutation-verified (restoring the `/usr`-demanding filter fails the complete-install test; restored tree green).

Proof build #4 after merge should print `TUNAOS_NVIDIA_CONTRACT_OK` — every other line of the contract was already green on run #3.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->