### PR TITLE
fix(apt): lightdm needs tmpfiles.d on bootc, and a dead DM must not silence its own diagnostician

### DIFF
--- a/build_scripts/desktop/configure-desktop-runtime.sh
+++ b/build_scripts/desktop/configure-desktop-runtime.sh
@@ -154,6 +154,31 @@ if ! systemctl enable "${dm}.service"; then
 fi
 systemctl set-default graphical.target
 
+# Debian's lightdm expects /var state that a bootc install never has. The
+# package ships /var/cache/lightdm, /var/lib/lightdm-data and
+# /var/log/lightdm as dpkg directories and creates /var/lib/lightdm in its
+# postinst (adduser --home) — and ships NO tmpfiles.d entries at all
+# (measured on ubuntu:noble, dpkg -L lightdm; gdm3 self-creates its dirs at
+# runtime, which is why grouper:gnome never hit this). ostree/bootc installs
+# start with a fresh machine-local /var, so every one of those directories
+# is missing on first boot; lightdm dies, Restart=always loops it, and both
+# proof cells (gurnard:pantheon 31204811851, grouper:xfce 31204818233)
+# showed six FAILED lines and desktop_contract=absent. Give the dirs the
+# mechanism the package forgot: tmpfiles.d, ownership and modes as measured
+# from the installed package.
+if systemctl list-unit-files lightdm.service --no-legend 2>/dev/null | grep -q '^lightdm.service'; then
+	cat >/usr/lib/tmpfiles.d/tunaos-lightdm-state.conf <<'EOF'
+# lightdm ships these as dpkg dirs / postinst artifacts, with no tmpfiles.d
+# of its own — on a bootc system machine-local /var starts empty and the DM
+# crash-loops without them. Ownership/modes measured on ubuntu:noble.
+d /var/lib/lightdm 0750 lightdm lightdm -
+d /var/lib/lightdm-data 0755 lightdm lightdm -
+d /var/cache/lightdm 0755 root root -
+d /var/log/lightdm 0755 root root -
+EOF
+	echo "configure-desktop-runtime: wrote tmpfiles.d for lightdm /var state (bootc fresh-/var)"
+fi
+
 # Every desktop family ships an explicit runtime contract plus the
 # snosi-derived installed-system TAP checks (harvested from the serial
 # console by scripts/iso-e2e.sh; the checks ExecStart is non-fatal).
@@ -222,11 +247,22 @@ gnome | kde | niri | cosmic | xfce | pantheon)
 		BRANDING_EXTRA="ExecStart=-/usr/libexec/tunaos/verify-branding-niri ${IMAGE_NAME:-$desktop} --runtime"
 		;;
 	esac
+	# Wants=, NOT Requires=. With Requires=, a failed display manager takes
+	# the contract down as DEPEND — which silences the one service built to
+	# diagnose that exact failure: verify-desktop-experience --runtime has a
+	# dm_inactive branch that ships `systemctl show` and the DM's journal
+	# tail to the serial console. Both proof cells of run pair
+	# 31204811851/31204818233 crash-looped lightdm and produced
+	# desktop_contract=absent with zero journal evidence, because the
+	# diagnostician was skipped alongside its patient. Wants= keeps the
+	# pull-in and the After= ordering; a dead DM now yields
+	# TUNAOS_DESKTOP_CONTRACT_FAIL reason=dm_inactive plus the journal,
+	# instead of silence.
 	cat >/usr/lib/systemd/system/tunaos-desktop-contract.service <<EOF
 [Unit]
 Description=Verify TunaOS ${desktop} desktop experience
 After=display-manager.service
-Requires=display-manager.service
+Wants=display-manager.service
 
 [Service]
 Type=oneshot

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -1374,3 +1374,34 @@ STUB
   [ "$installs" -ge 3 ]
   [ "$declares" -ge "$installs" ]
 }
+
+@test "the desktop contract Wants (not Requires) the display manager" {
+  # Requires= made a failed DM take the contract down as DEPEND — silencing
+  # the dm_inactive branch that ships the DM's journal to the serial, which
+  # is the only diagnosis channel the E2E has. Both proof cells of run pair
+  # 31204811851/31204818233 crash-looped lightdm and left zero journal
+  # evidence for exactly this reason. Comments stripped: the rationale names
+  # both directives.
+  local runtime="${REPO_ROOT}/build_scripts/desktop/configure-desktop-runtime.sh" code
+  code="$(grep -v '^[[:space:]]*#' "$runtime")"
+  grep -qF 'Wants=display-manager.service' <<<"$code"
+  ! grep -qF 'Requires=display-manager.service' <<<"$code"
+}
+
+@test "lightdm gets tmpfiles.d for its /var state on bootc systems" {
+  # Debian's lightdm ships /var dirs via dpkg/postinst and no tmpfiles.d
+  # (measured on ubuntu:noble); a bootc install starts with fresh /var and
+  # the DM crash-loops (runs 31204811851, 31204818233). All four measured
+  # dirs must be declared, with the lightdm-owned pair owned by lightdm.
+  local runtime="${REPO_ROOT}/build_scripts/desktop/configure-desktop-runtime.sh" code
+  code="$(grep -v '^[[:space:]]*#' "$runtime")"
+  grep -qF 'tunaos-lightdm-state.conf' <<<"$code"
+  local d
+  for d in /var/lib/lightdm /var/lib/lightdm-data /var/cache/lightdm /var/log/lightdm; do
+    grep -qE "^d ${d} " "$runtime" || {
+      echo "FAIL: tmpfiles entry for ${d} missing" >&2
+      return 1
+    }
+  done
+  grep -qE '^d /var/lib/lightdm 0750 lightdm lightdm' "$runtime"
+}


### PR DESCRIPTION
## What

Both fatal-flip proof cells (gurnard:pantheon run 31204811851, grouper:xfce run 31204818233) reached the installed boot with every earlier gate green — codec fix proven, flatpak baseline running, session package present — and then **lightdm crash-looped six times**, leaving `desktop_contract=absent` and zero journal evidence. (The new pixel gate from #1064 also correctly went fatal on the unrendered system.) Two faults, one story:

## 1. The diagnostician was skipped alongside its patient

`tunaos-desktop-contract.service` had `Requires=display-manager.service` — so a failed DM took the contract down as DEPEND, silencing the exact service built to diagnose DM failures (`verify-desktop-experience --runtime`'s `dm_inactive` branch ships `systemctl show` + the DM's journal tail to the serial). Changed to `Wants=`: same pull-in, same `After=` ordering, but a dead DM now yields `TUNAOS_DESKTOP_CONTRACT_FAIL reason=dm_inactive` **plus the journal** instead of silence.

## 2. The likely killer — measured, not guessed

On `ubuntu:noble` (dpkg -L, ls, tmpfiles inspection):

- lightdm ships `/var/cache/lightdm`, `/var/lib/lightdm-data`, `/var/log/lightdm` as dpkg directories and creates `/var/lib/lightdm` (0750 lightdm:lightdm) in postinst — and ships **no tmpfiles.d at all**.
- A bootc install starts with a fresh machine-local `/var`: all four directories are missing on first boot.
- gdm3 self-creates its dirs at runtime — which is exactly why grouper:gnome has always been green while the lightdm cells fail. flatpak ships its own `tmpfiles.d/flatpak.conf`.

The fix writes the tmpfiles.d the package forgot (`tunaos-lightdm-state.conf`, ownership/modes as measured) on any apt image carrying `lightdm.service`.

Also confirmed from the unit file: lightdm's own `ExecStartPre` enforces the `/etc/X11/default-display-manager` claim, validating #1065's mechanism, and `Restart=always` explains the six-loop signature.

## Testing

Two bats cases, comment-stripped, both mutation-verified (a `Requires=` regression fails the Wants pin; corrupting a tmpfiles entry fails the state pin). Suite failure set identical to clean main.

Real proof: re-dispatched proof cells after merge — if the tmpfiles hypothesis is right, lightdm starts and both cells read `desktop_contract=ok`; if anything else is still wrong, the Wants= change guarantees the journal arrives with the failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->