### PR TITLE
fix(nvidia): remove the stale kernel tree the swap leaves behind; prove initramfs parity

### DIFF
--- a/build_scripts/checks/verify-nvidia.sh
+++ b/build_scripts/checks/verify-nvidia.sh
@@ -185,6 +185,55 @@ else
 	fail "99-nvidia.conf does not force_drivers — black screen at boot on nvidia desktops"
 fi
 
+echo "== exactly one kernel tree =="
+# The kernel swap must leave exactly ONE /usr/lib/modules entry. rpm --erase
+# keeps a directory alive when it holds generated (unowned) files, and a
+# stale half-alive tree is a landmine for every consumer that scans
+# /usr/lib/modules: the yellowfin:kde-nvidia live ISO resolved its kernel
+# version against the leftover 6.12.0-250 husk (no vmlinuz, no initramfs,
+# empty modules.dep), generated an initrd with tacklebox hooks and zero
+# drivers, and hung in dracut with no sr0 ever appearing (run 31208526159)
+# — while the swapped kernel's own initramfs, one directory over, carried
+# every driver the boot needed.
+_tree_count=0
+_tree_name=""
+for _tree in "${NV_ROOT}"/usr/lib/modules/*/; do
+	[[ -d "$_tree" ]] || continue
+	_tree_count=$((_tree_count + 1))
+	_tree_name="$(basename "$_tree")"
+done
+if [[ "$_tree_count" -eq 1 && "$_tree_name" == "$KERNEL_VRA" ]]; then
+	pass "single kernel module tree (${_tree_name})"
+elif [[ "$_tree_count" -eq 1 ]]; then
+	fail "single module tree ${_tree_name} does not match the installed kernel ${KERNEL_VRA}"
+else
+	fail "${_tree_count} kernel module trees under /usr/lib/modules — a stale tree breaks kernel/initrd selection downstream (expected exactly ${KERNEL_VRA})"
+fi
+
+echo "== initramfs boot-driver parity =="
+# The rebuilt initramfs must serve BOTH boots: the live ISO (virtio-scsi CD:
+# virtio_scsi + sr_mod + cdrom + isofs, squashfs/overlay/loop for the live
+# root) and the installed disk (virtio_blk). Names measured with lsinitrd on
+# the PASSING parent image (yellowfin:kde, 705 modules) and confirmed
+# present in the nvidia image's swapped-kernel initramfs (720 modules) —
+# this is a parity floor, not a wish list; dm_crypt is deliberately absent
+# because the parent's initramfs does not carry it either.
+INITRAMFS="${NV_ROOT}/usr/lib/modules/${KERNEL_VRA}/initramfs.img"
+if [[ ! -s "$INITRAMFS" ]]; then
+	fail "missing or empty initramfs for the installed kernel: /usr/lib/modules/${KERNEL_VRA}/initramfs.img"
+elif ! command -v lsinitrd >/dev/null 2>&1; then
+	fail "lsinitrd is unavailable — cannot prove the initramfs carries the boot drivers"
+else
+	_initrd_list="$(lsinitrd "$INITRAMFS" 2>/dev/null || true)"
+	for _drv in sr_mod cdrom isofs squashfs virtio_scsi virtio_blk overlay loop; do
+		if grep -qE "/${_drv}\.ko" <<<"$_initrd_list"; then
+			pass "initramfs carries ${_drv}"
+		else
+			fail "initramfs is missing ${_drv} — the live ISO or installed boot cannot mount its root"
+		fi
+	done
+fi
+
 echo "== suspend units (conditional — see header) =="
 for unit in nvidia-suspend nvidia-resume nvidia-hibernate; do
 	if [[ -f "${NV_ROOT}/usr/lib/systemd/system/${unit}.service" ]]; then

--- a/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
+++ b/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
@@ -31,6 +31,7 @@ set -xeuo pipefail
 # fixture directories with rpm/dnf/curl/uname stubbed on PATH.
 AKMODS_DIR="${TUNAOS_AKMODS_DIR:-/tmp/akmods-nvidia-open-rpms}"
 KERNEL_RPMS_DIR="${TUNAOS_KERNEL_RPMS_DIR:-/tmp/kernel-rpms}"
+MODULES_ROOT="${TUNAOS_MODULES_ROOT:-/usr/lib/modules}"
 
 # x86_64 only, as a belt behind the build-config platform gate: the akmods
 # kmods are x86_64 builds, so an arm64 or x86_64_v2 overlay could only ship
@@ -94,6 +95,32 @@ else
 		exit 1
 	fi
 	dnf -y install "${RPM_FILES[@]}"
+
+	# Remove the OLD kernel's module directory outright. `rpm --erase` above
+	# removes only rpm-OWNED files; generated ones (initramfs.img, depmod
+	# output) are unowned, so /usr/lib/modules/<old-ver> survives as a husk —
+	# and later scriptlets from the driver install cheerfully repopulate its
+	# metadata. That husk is what broke the yellowfin:kde-nvidia live ISO
+	# (run 31208526159): with TWO module dirs present, the ISO build resolved
+	# its kernel version against the stale one, generated an initrd from a
+	# tree holding no drivers at all, and paired it with the new kernel — the
+	# serial showed the swapped kernel booting, tacklebox hooks present in
+	# the initrd, and no sr0/cdrom ever appearing. Measured on the published
+	# images: the parent ships ONE modules dir whose initramfs carries
+	# sr_mod/cdrom/isofs/virtio_scsi (705 modules); the nvidia image's own
+	# 6.12.0-254 initramfs carries the same set plus nvidia (720 modules) —
+	# the delta was never the dracut rebuild, only the stale
+	# 6.12.0-250 husk (no vmlinuz, no initramfs, empty modules.dep) sitting
+	# beside it. verify-nvidia.sh now fails the build if more than one
+	# module tree survives to the end.
+	for _mod_dir in "${MODULES_ROOT}"/*/; do
+		[[ -d "$_mod_dir" ]] || continue
+		_mod_ver="$(basename "$_mod_dir")"
+		if [[ "$_mod_ver" != "$CACHED_VERSION" ]]; then
+			echo "==> removing stale kernel module tree ${_mod_dir}"
+			rm -rf "$_mod_dir"
+		fi
+	done
 fi
 
 # Lock what we just aligned — a later transaction pulling a different kernel

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -137,6 +137,14 @@ STUB
 #!/usr/bin/env bash
 exit 0
 STUB
+  # lsinitrd stub: emits the boot-driver set the parity check demands
+  # (paths as the real lsinitrd prints them, measured on yellowfin:kde).
+  cat > "${BATS_TEST_TMPDIR}/bin/lsinitrd" <<STUB
+#!/usr/bin/env bash
+for d in sr_mod cdrom isofs squashfs virtio_scsi virtio_blk overlay loop; do
+  echo "usr/lib/modules/${KVER}/kernel/drivers/misc/\${d}.ko.xz"
+done
+STUB
   chmod +x "${BATS_TEST_TMPDIR}/bin/"*
 }
 
@@ -152,6 +160,7 @@ make_good_root() {
     "$r/usr/lib/dracut/dracut.conf.d" \
     "$r/usr/lib/systemd/system"
   touch "$r/usr/lib/modules/${KVER}/extra/nvidia/nvidia.ko.xz"
+  echo initrd > "$r/usr/lib/modules/${KVER}/initramfs.img"
   echo "blacklist nouveau" > "$r/usr/lib/modprobe.d/00-nouveau-blacklist.conf"
   echo 'kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-drm.modeset=1"]' \
     > "$r/usr/lib/bootc/kargs.d/00-nvidia.toml"
@@ -308,10 +317,14 @@ make_swap_fixture() {
 }
 
 run_swap() {
+  # TUNAOS_MODULES_ROOT is not optional here: the stale-tree cleanup would
+  # otherwise iterate the TEST HOST's real /usr/lib/modules.
+  mkdir -p "${BATS_TEST_TMPDIR}/modules"
   PATH="${BATS_TEST_TMPDIR}/bin:$PATH" \
     TUNAOS_AKMODS_DIR="${BATS_TEST_TMPDIR}/akmods" \
     TUNAOS_KERNEL_RPMS_DIR="${BATS_TEST_TMPDIR}/kernel-rpms" \
     TUNAOS_AKMODS_CERT_DIR="${BATS_TEST_TMPDIR}/certs" \
+    TUNAOS_MODULES_ROOT="${BATS_TEST_TMPDIR}/modules" \
     run bash "$SWAP_SH"
 }
 
@@ -397,4 +410,73 @@ assert not bad, bad
 print('ok')
 "
   [ "$status" -eq 0 ]
+}
+
+# ── stale kernel trees and initramfs parity (run 31208526159) ──────────────
+#
+# rpm --erase keeps a module directory alive when it holds generated
+# (unowned) files, and later driver scriptlets repopulate its metadata. The
+# yellowfin:kde-nvidia live ISO resolved its kernel version against that
+# husk, generated an initrd with tacklebox hooks and ZERO drivers, and hung
+# in dracut with no sr0 — while the swapped kernel's own initramfs, one
+# directory over, carried every driver the boot needed (measured: parent
+# 705 modules, nvidia 720, both including sr_mod/cdrom/isofs/virtio_scsi).
+
+@test "kernel-swap removes the stale kernel tree the erase leaves behind" {
+  make_swap_stubs "6.12.0-250.el10.x86_64"
+  make_swap_fixture
+  # The husk: generated files survive the rpm erase.
+  mkdir -p "${BATS_TEST_TMPDIR}/modules/6.12.0-250.el10.x86_64/kernel"
+  touch "${BATS_TEST_TMPDIR}/modules/6.12.0-250.el10.x86_64/modules.dep"
+  mkdir -p "${BATS_TEST_TMPDIR}/modules/${AKMODS_KVER}"
+  run_swap
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"removing stale kernel module tree"* ]]
+  [ ! -d "${BATS_TEST_TMPDIR}/modules/6.12.0-250.el10.x86_64" ]
+  [ -d "${BATS_TEST_TMPDIR}/modules/${AKMODS_KVER}" ]
+}
+
+@test "kernel-swap leaves the module root alone when already aligned" {
+  make_swap_stubs "$AKMODS_KVER"
+  make_swap_fixture
+  mkdir -p "${BATS_TEST_TMPDIR}/modules/${AKMODS_KVER}"
+  run_swap
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"removing stale kernel module tree"* ]]
+  [ -d "${BATS_TEST_TMPDIR}/modules/${AKMODS_KVER}" ]
+}
+
+@test "verify-nvidia fails when a stale second kernel tree survives" {
+  make_stub_tools
+  root="$(make_good_root)"
+  mkdir -p "$root/usr/lib/modules/6.12.0-250.el10.x86_64"
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"kernel module trees under /usr/lib/modules"* ]]
+}
+
+@test "verify-nvidia fails when the initramfs lacks a boot-critical driver" {
+  make_stub_tools
+  root="$(make_good_root)"
+  # lsinitrd that forgot the CD/SCSI path — the exact live-ISO hang shape.
+  cat > "${BATS_TEST_TMPDIR}/bin/lsinitrd" <<STUB
+#!/usr/bin/env bash
+for d in squashfs virtio_blk overlay loop; do
+  echo "usr/lib/modules/${KVER}/kernel/drivers/misc/\${d}.ko.xz"
+done
+STUB
+  chmod +x "${BATS_TEST_TMPDIR}/bin/lsinitrd"
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"initramfs is missing sr_mod"* ]]
+  [[ "$output" == *"initramfs is missing virtio_scsi"* ]]
+}
+
+@test "verify-nvidia fails when the installed kernel has no initramfs at all" {
+  make_stub_tools
+  root="$(make_good_root)"
+  rm "$root/usr/lib/modules/${KVER}/initramfs.img"
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"missing or empty initramfs"* ]]
 }


### PR DESCRIPTION
Follow-up to #1067/#1072 after the NVIDIA layer's first full proof (run 31208526159: build_push green — kernel swap, driver, version lock, plumbing all passed the fatal contract; image on GHCR). The one failure was the live-ISO QEMU smoke: dracut timeout on `devexists-/run/tacklebox-live-done`, tacklebox hooks in the initrd, swapped kernel booting, **no sr0/cdrom lines at all**.

## Measured diagnosis (both published images pulled and lsinitrd'd — the hypothesis was wrong in an interesting way)

| image | /usr/lib/modules | initramfs of its kernel |
|---|---|---|
| `yellowfin:kde` (parent, smoke **passes**) | **one** tree (6.12.0-250) | 705 modules, **has** sr_mod/cdrom/isofs/virtio_scsi/squashfs/overlay/loop/virtio_blk |
| `yellowfin:kde-nvidia` (smoke **fails**) | **two** trees | 6.12.0-254's initramfs: same full set **plus nvidia** (720 modules) — the dracut rebuild was already driver-parity |

The second tree is the smoking gun: a `6.12.0-250` **husk** — no vmlinuz, no initramfs, empty `modules.dep`, overlay-build timestamps. `rpm --erase` removes only rpm-*owned* files; generated ones (initramfs.img, depmod output) are unowned, so the old kernel's directory survives the swap and later driver scriptlets repopulate its metadata. Any consumer that resolves a kernel version by scanning `/usr/lib/modules` can land on the husk — the ISO build did, generated an initrd from a tree holding **no drivers at all** (hooks included, since dracut modules aren't kernel modules), and paired it with the new kernel. QEMU's CD is `virtio-scsi-pci` + `scsi-cd` (`iso-e2e.sh:840-842`): no virtio_scsi/sr_mod in the initrd → no sr0, tbox-root waits forever. Single-tree parent → same QEMU config passes.

## The fix (both halves, per the constraint that the initramfs serve BOTH boots)

- **`10-kernel-swap.sh`**: after the swap, remove every module tree that is not the cache kernel's (swap branch only; aligned images untouched). Module root is a test hook (`TUNAOS_MODULES_ROOT`) — load-bearing in bats, where the cleanup would otherwise iterate the test host's real `/usr/lib/modules`.
- **`verify-nvidia.sh`**, two new fatal sections:
  - **exactly one kernel tree**, matching the installed kernel EVR — this alone would have caught the bug at image-build time, before any ISO existed;
  - **initramfs boot-driver parity**: `lsinitrd` of the installed kernel's initramfs must carry `sr_mod cdrom isofs squashfs virtio_scsi virtio_blk overlay loop` — the measured parity floor from the passing parent, covering the live-ISO boot (virtio-scsi CD + squashfs/overlay live root) and the installed boot (virtio_blk). `dm_crypt` deliberately excluded: the parent's initramfs doesn't carry it either (measured), so it's not part of parity.

Preference check: the dracut invocation itself already mirrors the base's (`26-packages-post.sh:88` — same `--no-hostonly --reproducible --zstd --add ostree` shape), and measurement confirms its output was never the problem, so no dracut changes; the image's own configuration remains the single source.

## Tests

`test_nvidia_overlay.bats`: 23 → **28**. Behavioral fixtures: stale tree removed on swap / root untouched when aligned; verify fails on a second tree, on an lsinitrd missing sr_mod+virtio_scsi (named individually), and on a missing initramfs. **Mutation-verified**: neutering the `rm -rf` fails the removal test; shrinking the parity list fails the driver test. Good-root fixture gained an initramfs + an lsinitrd stub emitting the measured driver paths.

Evidence: 28/28 pass; shellcheck clean; full bats suite failure-set identical to the previously recorded baseline (diff rc=0).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->