### PR TITLE
contract: stop a login greeter being credited with the finished screen

### DIFF
--- a/tests/bats/test_screens_not_greeter.bats
+++ b/tests/bats/test_screens_not_greeter.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# No screen in the contract may be credited by a LOGIN GREETER.
+#
+# WHY THIS EXISTS. Run 31183217981's cosmic leg never got past
+# cosmic-greeter — the installer was not running at all — and the parity
+# report still said `done: true`. The greeter's power menu offers Restart,
+# Power Off and Suspend, and "restart" and "reboot" were `done` keywords.
+#
+# That is the worst phantom row the matrix can publish: it reports a finished
+# installation on a machine where the installer never started, which is the
+# exact case the operator most needs to see.
+#
+# Every existing comment in installer-screens.yaml warns about one keyword
+# that matched the wrong SCREEN. This warns about keywords that match
+# something which is not a screen of ours at all.
+
+SPEC="${BATS_TEST_DIRNAME}/../installer-screens.yaml"
+
+# Text a stock greeter puts on screen. Deliberately generous — cosmic-greeter,
+# GDM and SDDM between them show a clock, the username, a password prompt, and
+# session/power/accessibility controls.
+GREETER_TEXT="friday august 7 1:55 pm liveuser password login log in
+sign in session select session suspend hibernate restart reboot power off
+shut down shutdown accessibility keyboard layout settings users guest
+authentication failed caps lock is on"
+
+@test "no screen keyword is satisfied by a login greeter" {
+  run python3 - "$SPEC" <<'PY'
+import sys, yaml
+greeter = """friday august 7 1:55 pm liveuser password login log in
+sign in session select session suspend hibernate restart reboot power off
+shut down shutdown accessibility keyboard layout settings users guest
+authentication failed caps lock is on"""
+spec = yaml.safe_load(open(sys.argv[1]))
+bad = []
+for screen in spec["screens"]:
+    for kw in screen["keywords"]:
+        if kw.lower() in greeter:
+            bad.append(f"{screen['id']}: {kw!r}")
+if bad:
+    print("keywords a login greeter satisfies:")
+    for b in bad:
+        print("  " + b)
+    sys.exit(1)
+print("ok")
+PY
+  [ "$status" -eq 0 ] || {
+    echo "$output" >&2
+    false
+  }
+}
+
+@test "done is still reachable from real finished-screen text" {
+  # The converse. Tightening the keywords until a greeter cannot match is easy;
+  # the risk is tightening until the real screens cannot match either. These
+  # are the actual strings the frontends render.
+  run python3 - "$SPEC" <<'PY'
+import sys, yaml
+real = [
+    ("kde", "Finished Installation complete TunaOS has been installed. "
+            "Remove the installation media and restart to boot into your new system."),
+    ("gnome-upstream", "Skipjack is installed"),
+]
+spec = yaml.safe_load(open(sys.argv[1]))
+done = [s for s in spec["screens"] if s["id"] == "done"][0]["keywords"]
+missing = []
+for name, text in real:
+    if not any(k.lower() in text.lower() for k in done):
+        missing.append(name)
+if missing:
+    print("done screen no longer credited for: " + ", ".join(missing))
+    sys.exit(1)
+print("ok")
+PY
+  [ "$status" -eq 0 ] || {
+    echo "$output" >&2
+    false
+  }
+}

--- a/tests/installer-screens.yaml
+++ b/tests/installer-screens.yaml
@@ -134,4 +134,23 @@ screens:
   - id: done
     title: Finished / reboot
     required: false
-    keywords: ["complete", "finished", "reboot", "restart", "success"]
+    # NOT "reboot" or "restart", and NOT bare "complete"/"finished"/"success".
+    #
+    # A LOGIN GREETER satisfies those. cosmic-greeter's power menu offers
+    # Restart, Power Off and Suspend, so run 31183217981 — which never got past
+    # the greeter, with the installer not running at all — was still credited
+    # with reaching the FINISHED screen. That is the worst phantom row
+    # available: it reports an install that completed on a machine where the
+    # installer never started.
+    #
+    # Every keyword below needs a sentence a greeter has no reason to contain.
+    # Checked against the frontends' real done-screen text: KDE renders
+    # "Installation complete" and "TunaOS has been installed. Remove the
+    # installation media and restart to boot into your new system"; upstream
+    # bootc-installer renders "<product> is installed" (done.py). Note
+    # "restart to boot" is admitted where bare "restart" is not — the phrase
+    # cannot appear in a power menu.
+    keywords: ["installation complete", "installation finished",
+               "is installed", "has been installed",
+               "remove the installation media",
+               "restart to boot", "reboot into"]


### PR DESCRIPTION
Run [31183217981](https://github.com/tuna-os/tunaOS/actions/runs/31183217981)'s cosmic leg **never got past cosmic-greeter** — the installer was not running at all — and the parity report still said:

```json
"screens": { "welcome": false, ..., "done": true }
```

cosmic-greeter's power menu offers **Restart**, Power Off and Suspend, and `restart`/`reboot` were `done` keywords.

So a machine where the installer never started was credited with reaching the **finished** screen. That is the worst phantom row this matrix can publish: it reports a completed installation in exactly the case an operator most needs to see failed.

### The change

Every `done` keyword now requires a sentence a greeter has no reason to contain. Verified in both directions against real text:

| | credited by |
|---|---|
| greeter power menu | **nothing** |
| KDE done screen | `installation complete`, `has been installed`, `remove the installation media`, `restart to boot` |
| upstream bootc-installer (`done.py`) | `is installed` |

`restart to boot` is admitted where bare `restart` is not — the phrase cannot occur in a power menu.

### The gate

`tests/bats/test_screens_not_greeter.bats` generalises the lesson rather than patching the instance. Every existing comment in `installer-screens.yaml` warns about a keyword that matched the wrong **screen**; this asserts that no keyword — on *any* screen, not just `done` — is satisfied by a login greeter's vocabulary at all. Currently clean across all six.

The second test is the converse, and matters as much: tightening until a greeter cannot match is easy, and the risk is tightening until the real screens stop matching too. It pins `done` against KDE's and upstream's actual rendered strings.

### Knock-on

The four frontends vendor their own copy of this spec and will report drift until refreshed. Their drift checks are warnings, not failures, so nothing breaks in the meantime — but they should be refreshed, and the kde/cosmic branding PRs are still open and could carry it.

### Context

This is the fourth phantom row found today, and the first that credits a screen from something which is not one of our screens at all — the previous three were keywords matching the wrong screen within the installer. Worth noting because the fix is a different shape: not "make the keyword more specific" but "assert the vocabulary cannot come from outside the app".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->