### PR TITLE
xfce: fail the build when xfwl4's theme data is missing

### DIFF
--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -262,6 +262,36 @@ xfce)
 	require_command thunar
 	require_any_glob \
 		'/usr/libexec/xdg-desktop-portal-gtk' '/usr/lib/xdg-desktop-portal-gtk'
+
+	# xfwl4 reads xfwm4's THEME DATA and panics without it — not a warning, a
+	# hard abort before the session exists:
+	#
+	#   xfwl4::backend::udev: Using renderD128 as primary GPU
+	#   smithay::wayland::socket: Created new socket name="wayland-1"
+	#   thread 'main' panicked at src/core/state.rs:260:74:
+	#   Failed to load initial config: Failed to find theme named Default
+	#
+	# yellowfin:xfce in installer-smoke run 31183217981 booted to a console of
+	# that backtrace: no desktop, no installer, nothing to screenshot. It reads
+	# like the GPU-less runner limitation and is not — the same log line says a
+	# render node WAS found.
+	#
+	# xfce.sh already pulls xfwm4 for this reason, but through
+	# install_available, which is best-effort by design and skips silently when
+	# the package does not resolve on a base. So the theme data can be absent
+	# with nothing in the build log to say so, and the first symptom is a
+	# compositor panic on a user's machine. Assert it here instead: an image
+	# whose compositor cannot start is not a shippable image.
+	#
+	# Guarded on xfwl4 being present because the X11 branch (xfwm4 as the WM on
+	# bases without the Wayland stack) pulls the same package as a dependency
+	# and would never reach this state.
+	if command -v xfwl4 >/dev/null 2>&1; then
+		require_any_glob \
+			'/usr/share/themes/Default/xfwm4/themerc' \
+			'/usr/share/themes/Default/xfwm4'
+	fi
+
 	dm_pattern='^(gdm|gdm3|lightdm|greetd)\.service$'
 	;;
 pantheon)


### PR DESCRIPTION
`yellowfin:xfce` in installer-smoke run [31183217981](https://github.com/tuna-os/tunaOS/actions/runs/31183217981) booted to a text console showing a Rust backtrace. No desktop, no installer, nothing to screenshot:

```
xfwl4::backend::udev: Using renderD128 as primary GPU
smithay::wayland::socket: Created new socket name="wayland-1"
xfwl4::core::config::xfwl4_config: Failed to reload defaults: /usr/local/share/xfce4/xfwl4/defaults does not exist
thread 'main' panicked at src/core/state.rs:260:74:
Failed to load initial config: Failed to find theme named Default
```

### Why this nearly got written off

It looks exactly like the known hosted-runner limitation — no virgl, so the Smithay compositors can't render, blank frames expected, don't chase it. **It isn't.** The same log line says `Using renderD128 as primary GPU`. A render node was found. xfwl4 got as far as creating its Wayland socket, then aborted on missing xfwm4 theme data.

I only caught it because I opened the PNG instead of reading the exit code. It's the fourth time today the picture disagreed with the plausible explanation.

### The silent part

`build_scripts/desktop/xfce.sh` already pulls `xfwm4` for precisely this reason:

```bash
# xfwl4 reads xfwm4's themes and refuses to start without them
# (hanthor/xfwl4 README); the meta package does not require
# xfwm4, so pull it (plus nice-to-haves) if they resolve.
install_available xfwm4 ...
```

`install_available` is best-effort by design and skips silently when a package doesn't resolve on a base. So the theme data can be absent with **nothing in the build log saying so**, and the first symptom is a compositor panic on a user's machine.

### The change

The desktop-experience contract now asserts it. That contract already requires a session file, a display manager, `thunar` and a portal — it did not require the one thing whose absence stops the desktop existing at all.

Guarded on `xfwl4` being present, so the X11 branch (where `xfwm4` is the window manager and pulls its own themes as a dependency) is unaffected.

**This does not fix the packaging gap**, which is tunaos-packages#123. It stops that gap shipping silently — an image whose compositor cannot start is not a shippable image, and this moves discovery from first boot to image build.

### Verification

`bash -n` and `shellcheck -S error` clean. The guard was exercised both ways against the real `require_any_glob`:

```
case A: xfwl4 present, theme MISSING -> correctly fails the build
case B: xfwl4 present, theme PRESENT -> correctly passes
xfwl4 absent                          -> guard does not run (X11 branch unaffected)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->