### PR TITLE
smoke: collect the evidence that explains a live ISO stuck at a greeter

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -234,6 +234,29 @@ jobs:
             echo "=== rendering capability in the live session ==="
             $SSH 'ls -l /dev/dri/ 2>/dev/null; echo "--- eglinfo/vulkaninfo ---"; (eglinfo 2>&1 | head -20) || true; (vulkaninfo --summary 2>&1 | head -20) || true' 2>/dev/null || true
             echo
+            echo "=== who the display manager is, and which greetd config it reads ==="
+            # Added because run 31183217981's cosmic leg sat on the
+            # cosmic-greeter LOGIN SCREEN — liveuser, password prompt — so the
+            # installer never launched. desktop-cosmic.sh writes
+            # /etc/greetd/config.toml with [initial_session] user=liveuser
+            # command=cosmic-session, which should bypass any greeter, and the
+            # symptom says it did not take. The evidence to tell WHY was not
+            # collected: greetd logs to the journal, not to ttyS0, and the
+            # serial log we upload has nothing about the session at all.
+            #
+            # install-desktop.sh documents the shape that would explain it —
+            # cosmic-greeter.service IS greetd, wrapped, started as
+            #   ExecStart=greetd --config /etc/greetd/cosmic-greeter.toml
+            # i.e. a DIFFERENT file from the one the live adapter writes. That
+            # is a hypothesis, not a finding: this run reported the display
+            # manager as greetd.service, not cosmic-greeter.service. Rather
+            # than change autologin on a guess, collect what settles it.
+            $SSH 'echo "-- display-manager.service ->"; readlink -f /etc/systemd/system/display-manager.service 2>/dev/null; \
+                  echo "-- greetd config files present --"; ls -l /etc/greetd/ 2>/dev/null; \
+                  echo "-- ExecStart of the active DM --"; systemctl cat "$(basename "$(readlink -f /etc/systemd/system/display-manager.service 2>/dev/null)" 2>/dev/null)" 2>/dev/null | grep -E "^ExecStart|^\[" | head -20; \
+                  echo "-- /etc/greetd/config.toml as installed --"; cat /etc/greetd/config.toml 2>/dev/null; \
+                  echo "-- greetd journal --"; sudo journalctl -u greetd -u cosmic-greeter --no-pager 2>/dev/null | tail -40' 2>/dev/null || true
+            echo
             echo "=== windows the compositor actually has ==="
             # -x matches comm exactly, so this cannot self-match the way a
             # bare `pgrep -f` does — but the fallbacks below it were reporting


### PR DESCRIPTION
Run [31183217981](https://github.com/tuna-os/tunaOS/actions/runs/31183217981)'s cosmic leg sat on the **cosmic-greeter login screen** — liveuser, password prompt, power menu — so the installer never launched. The desktop screenshot shows it plainly; nothing in the artifacts says why.

### What we know, and what we don't

`desktop-cosmic.sh` writes `/etc/greetd/config.toml` with:

```toml
[initial_session]
user = "liveuser"
command = "cosmic-session"
```

which should bypass any greeter. The symptom says it didn't take. But the evidence to distinguish **"the config was never read"** from **"the session started and died"** was never collected — greetd logs to the journal, and the serial log we upload carries nothing about the session at all.

`install-desktop.sh` already documents a shape that would explain it:

> cosmic-greeter is not a rival display manager to greetd — it IS greetd, wrapped:
> `ExecStart=greetd --config /etc/greetd/cosmic-greeter.toml`

A **different file** from the one the live adapter writes. That's a good hypothesis — and this run partly contradicts it: the run reported the display manager as `greetd.service`, not `cosmic-greeter.service`.

### Why this PR is diagnostics and not a fix

I could change the autologin config on the strength of that hypothesis. I'd rather not: I've drawn two confident wrong conclusions today from exactly this kind of plausible-but-unverified reasoning — the "black window" that turned out to be an empty workspace preview, and the icon theme that was fine all along. Both cost more time than looking would have.

So this collects what settles it: the resolved `display-manager.service` target, the contents of `/etc/greetd/`, the active unit's `ExecStart`, the installed `config.toml`, and the `greetd`/`cosmic-greeter` journals. The next run answers the question, and then the fix can be one line aimed at the right file.

### Safety

Diagnostics only, no behaviour change. The step is already `if: always()` and every command is `|| true`, so it cannot turn a passing leg red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->