### PR TITLE
installer: ship our own credits instead of Bluefin's

### DIFF
--- a/system_files/etc/bootc-installer/recipe.json
+++ b/system_files/etc/bootc-installer/recipe.json
@@ -3,6 +3,7 @@
   "distro_name": "TunaOS",
   "welcome_title": "Welcome to TunaOS",
   "distro_logo": "resource:///org/bootcinstaller/Installer/images/tunaos.png",
+  "credits_data": "/run/host/usr/share/bootc-installer/credits.json",
   "imgref": "ghcr.io/tuna-os/tunaos:latest",
   "local_imgref": "containers-storage:ghcr.io/tuna-os/tunaos:latest",
   "bootloader": "systemd",

--- a/system_files/usr/share/bootc-installer/credits.json
+++ b/system_files/usr/share/bootc-installer/credits.json
@@ -1,0 +1,47 @@
+{
+  "header": {
+    "title": "TunaOS",
+    "subtitle": "An immutable, container-native Linux for workstations.",
+    "quote": "Every image here is somebody else's work, rebuilt.",
+    "quote_author": "TunaOS"
+  },
+  "sections": [
+    {
+      "title": "TunaOS",
+      "subtitle": "Maintained at github.com/tuna-os",
+      "members": [
+        {
+          "handle": "hanthor",
+          "title": "Maintainer",
+          "nickname": "tuna-os"
+        }
+      ]
+    },
+    {
+      "title": "Built On",
+      "subtitle": "Projects TunaOS depends on and does not claim credit for",
+      "members": [
+        {
+          "handle": "projectbluefin/bootc-installer",
+          "title": "The installer this one is built from",
+          "nickname": "Project Bluefin"
+        },
+        {
+          "handle": "bootc-dev/bootc",
+          "title": "Bootable containers",
+          "nickname": "bootc"
+        },
+        {
+          "handle": "ublue-os",
+          "title": "Cloud-native desktop images",
+          "nickname": "Universal Blue"
+        }
+      ]
+    }
+  ],
+  "footer": {
+    "quote": "Thanks to everyone whose work this is standing on.",
+    "quote_author": "",
+    "closing": "github.com/tuna-os"
+  }
+}

--- a/tests/bats/test_installer_credits.bats
+++ b/tests/bats/test_installer_credits.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# The Credits dialog must credit TunaOS, not Bluefin.
+#
+# WHY THIS EXISTS. bootc-installer's credits dialog resolves, in order:
+#   1. recipe["credits_data"] — a GResource (/org/...) or filesystem path
+#   2. its built-in /org/bootcinstaller/Installer/data/credits.json
+#   3. a dev-mode file next to the module
+#
+# TunaOS never set (1), so it silently got (2) — which names Bluefin's
+# maintainers and their roles. A Skipjack live ISO showed a correctly branded
+# welcome screen above a Credits dialog listing "Bluefin Maintainer" and
+# "Bluefin Maintainer Emeritus" (seen in tunaOS#1056's live-ISO screenshot).
+#
+# The mechanism was never broken and is documented in upstream's
+# docs/live-iso.md. We simply had not used it. This asserts we do, and that
+# what we point at actually exists — the same failure the variant logo had,
+# where the recipe named a resource that resolved for no variant at all.
+
+RECIPE="${BATS_TEST_DIRNAME}/../../system_files/etc/bootc-installer/recipe.json"
+REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+
+@test "recipe sets credits_data" {
+  run python3 -c "
+import json,sys
+r=json.load(open('${RECIPE}'))
+v=r.get('credits_data','')
+print(v)
+sys.exit(0 if v else 1)
+"
+  [ "$status" -eq 0 ] || {
+    echo "recipe.json has no credits_data, so the Credits dialog falls back" >&2
+    echo "to bootc-installer's built-in file, which credits Bluefin." >&2
+    false
+  }
+}
+
+@test "the credits file credits_data points at is shipped in the image" {
+  run python3 -c "
+import json,os,sys
+r=json.load(open('${RECIPE}'))
+v=r.get('credits_data','')
+if v.startswith('/org/'):
+    print('GResource path, not checkable here:', v); sys.exit(0)
+# Filesystem paths are read from inside the flatpak, where the host's / is at
+# /run/host. Strip that to find the file in this repo's system_files tree.
+local = os.path.join('${REPO_ROOT}', 'system_files', v.replace('/run/host/','').lstrip('/'))
+if not os.path.exists(local):
+    print('credits_data points at', v, '-> expected', local, 'which does not exist')
+    sys.exit(1)
+json.load(open(local))
+print('ok:', local)
+"
+  [ "$status" -eq 0 ] || {
+    echo "$output" >&2
+    false
+  }
+}
+
+@test "our credits file does not credit Bluefin's maintainers as ours" {
+  # The point of the exercise. Naming upstream projects in a 'Built On'
+  # section is correct and wanted; listing Bluefin's people under our own
+  # maintainer headings is not.
+  run python3 -c "
+import json,sys
+r=json.load(open('${RECIPE}'))
+v=r.get('credits_data','')
+if v.startswith('/org/'): sys.exit(0)
+import os
+local=os.path.join('${REPO_ROOT}','system_files',v.replace('/run/host/','').lstrip('/'))
+d=json.load(open(local))
+bad=[]
+for s in d.get('sections',[]):
+    title=(s.get('title') or '').lower()
+    for m in s.get('members',[]):
+        role=(m.get('title') or '').lower()
+        if 'maintainer' in role and 'bluefin' in role:
+            bad.append(f\"{s.get('title')}/{m.get('handle')}: {m.get('title')}\")
+if bad:
+    print('Bluefin maintainer roles under our credits:'); [print(' ',b) for b in bad]
+    sys.exit(1)
+print('ok')
+"
+  [ "$status" -eq 0 ] || {
+    echo "$output" >&2
+    false
+  }
+}


### PR DESCRIPTION
A Skipjack live ISO renders a correctly branded welcome screen and, one click away, a Credits dialog listing **"Bluefin Maintainer"** and **"Bluefin Maintainer Emeritus"**. Visible in #1056's live-ISO screenshot.

### Correction to the premise

The credits were **already brandable**. bootc-installer resolves them from `recipe["credits_data"]` — a GResource (`/org/...`) or filesystem path — and only then falls back to its built-in file. Upstream documents the key in `docs/live-iso.md` and sets it in its own `recipe.json`.

Nothing was broken. **We had simply never set it**, so we inherited Bluefin's people under our own branding.

### The change

`recipe.json` now points at `/run/host/usr/share/bootc-installer/credits.json` — the same `/run/host` prefix the tour images in that file already use for host paths read from inside the flatpak — and `system_files` ships it.

**On the contents, deliberately conservative:** I credited `hanthor` as maintainer, which the commit history and `CPE_NAME` support, and **invented nobody**. The second section credits the projects TunaOS is built on — projectbluefin/bootc-installer, bootc, Universal Blue — as *projects* rather than people. Naming upstream is right; claiming upstream's contributors is the thing this PR exists to stop. Add real people when there are real people to add.

### The gate

`tests/bats/test_installer_credits.bats`: the key is set, what it points at is actually shipped and parses, and no member under our own sections carries a Bluefin maintainer role.

That second assertion matters because it's the failure the logo had in #1059 — a recipe naming a resource that resolved for nobody, degrading silently.

### Separate defect found, not fixed here

The recipe's **four tour slides all reference** `/run/host/usr/share/bootc-installer/images/tunaos-install.png`, and **nothing in this repo installs it** — not `system_files`, not any build script:

```
MISSING /run/host/usr/share/bootc-installer/images/tunaos-install.png
```

Same silent shape as the variant logo. It needs an actual image asset, which I'm not going to fabricate — `tuna-os/branding` is where the variant marks live. Worth its own issue.

### Companion

tuna-os/bootc-installer#3 makes the fallback loud upstream: when `credits_data` is unset and `distro_name` isn't Bluefin, it logs a warning naming the key. Not an error — falling back is correct behaviour, and an installer must never fail over its credits dialog. The point is that the branding layer gets told instead of finding out from a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->