### PR TITLE
walkthrough: try the default action before tabbing anywhere

### DIFF
--- a/scripts/installer-walkthrough.py
+++ b/scripts/installer-walkthrough.py
@@ -286,7 +286,18 @@ if p:
 # advances.
 activation = "ret"
 switched = False
-tabs = 2
+# Start at 0: try the DEFAULT ACTION before tabbing anywhere.
+#
+# This used to start at 2, so the harness never once pressed Enter on the
+# focused widget — it always tabbed twice first. On a wizard whose primary
+# action has focus that skips straight past it, and on GNOME's welcome screen
+# tab order is install -> bluetooth -> recovery -> poweroff -> credits, so
+# sweeping outward walks toward Credits and away from Install. Run
+# 31183217981 opened the Credits modal and never left the welcome screen.
+#
+# Costs one step when the app sets no default focus — the existing widen loop
+# picks up from 1 exactly as before — and saves the run when it does.
+tabs = 0
 MAX_TABS = 8
 for i in range(1, steps + 1):
     send_keys(*(["tab"] * tabs), activation)
@@ -297,7 +308,7 @@ for i in range(1, steps + 1):
         frames.append(p)
         moved = bool(prev) and changed_pixels(prev, p) > DIFF_PIXELS
         if moved:
-            tabs = 2          # new page, start over from the usual position
+            tabs = 0          # new page: try its default action first, again
         elif prev:
             if not switched and activation == "ret":
                 activation = "spc"


### PR DESCRIPTION
The focus sweep started at `tabs = 2`, so **the harness never once pressed Enter on the focused widget** — it always tabbed twice first.

On a wizard whose primary action has focus, that skips straight past it. On GNOME's welcome screen the tab order is install → bluetooth → recovery → poweroff → **credits**, so sweeping outward walks *toward* Credits and away from Install.

Run [31183217981](https://github.com/tuna-os/tunaOS/actions/runs/31183217981) did exactly that: the Credits modal opened, every later keystroke went to the dialog, and the run never left the welcome screen. Frame 08 is the Credits list sitting over the welcome page, and the report credited `welcome` and nothing else.

### The change

Start at 0, then widen as before. The sweep still reaches every position it used to:

```
old tab counts tried: 2 3 4 5 6 7 8 8 8 8
new tab counts tried: 0 1 2 3 4 5 6 7 8 8
new covers everything old did: True
new additionally tries: [0, 1]
```

Costs one extra step on an app that sets no default focus; saves the run on one that does. The post-advance reset goes to 0 for the same reason — each new page gets its own default action tried first.

### Pairs with

tuna-os/bootc-installer#4 makes the GNOME welcome screen focus its install row, so Enter starts the install rather than doing whatever is first in tab order. Either change helps alone; together the harness stops needing to guess.

### What this does not fix, stated plainly

A sweep that *does* reach a dialog-opening control still gets stuck, because **"a modal opened" and "the page advanced" are the same pixel event** — `moved` cannot tell them apart, so `tabs` resets and the loop never reaches the widen/escalate branches that exist to break a stall.

I wrote a revisit-detection heuristic for that and replayed it against the real captured frames before shipping:

```
gnome  :  9 frames -> 6 new states, 0 escape(s) would fire
cosmic :  9 frames -> 4 new states, 0 escape(s) would fire
```

Zero. The top-bar clock makes every frame novel, so "have I seen this screen before" never triggers. It is not in this PR. A working version needs OCR text rather than pixel comparison — worth doing, but not worth pretending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->