### PR TITLE
fix(xfce): install the xfwm4 Default theme xfwl4 panics without

### DIFF
--- a/build_scripts/desktop/xfce.sh
+++ b/build_scripts/desktop/xfce.sh
@@ -50,11 +50,45 @@ case "${1:-}" in
 			# so image contents follow the spec's Requires.
 			dnf_retry -y install xfce4-wayland
 
-			# xfwl4 reads xfwm4's themes and refuses to start without them
-			# (hanthor/xfwl4 README); the meta package does not require
-			# xfwm4, so pull it (plus nice-to-haves) if they resolve.
+			# xfwl4 reads xfwm4's theme DATA and aborts without it —
+			# a panic before the session exists, not a warning:
+			#
+			#   thread 'main' panicked at src/core/state.rs:260:74:
+			#   Failed to load initial config: Failed to find theme named Default
+			#
+			# It needs /usr/share/themes/Default/xfwm4/. themerc alone is not
+			# enough: load_title_textures() propagates with `?`, so the
+			# title/border/button images are load-bearing too.
+			#
+			# NOTHING on EL10 ships them. xfwm4 is X11 and has no EL10 build;
+			# the whole repo.tunaos.org/xfce tree owns exactly one path under
+			# /usr/share/themes/Default (xfce4-notifyd's gtk.css) and xfwl4's
+			# own package ships two files, neither a theme. install_available
+			# is best-effort by design, so it skipped silently and yellowfin:xfce
+			# booted to a console of that backtrace (run 31183217981).
+			#
+			# So vendor the theme from the xfwm4 release tarball, pinned and
+			# checksummed, and only when the packaged one is genuinely absent.
+			install_available xfwm4
+			if [[ ! -f /usr/share/themes/Default/xfwm4/themerc ]]; then
+				_xfwm4_ver=4.20.0
+				_xfwm4_sha=a58b63e49397aa0d8d1dcf0636be93c8bb5926779aef5165e0852890190dcf06
+				_xfwm4_tar=/tmp/xfwm4-${_xfwm4_ver}.tar.bz2
+				curl -fsSLo "$_xfwm4_tar" \
+					"https://archive.xfce.org/src/xfce/xfwm4/${_xfwm4_ver%.*}/xfwm4-${_xfwm4_ver}.tar.bz2"
+				echo "${_xfwm4_sha}  ${_xfwm4_tar}" | sha256sum -c -
+				mkdir -p /usr/share/themes/Default/xfwm4
+				# --exclude the build files; keep xpm (the base layer
+				# load_compose_image reads) alongside png/svg (the overlays).
+				tar -xjf "$_xfwm4_tar" -C /usr/share/themes/Default/xfwm4 \
+					--strip-components=3 --exclude='Makefile*' \
+					"xfwm4-${_xfwm4_ver}/themes/default"
+				rm -f "$_xfwm4_tar"
+				# Fail loudly rather than leave the gate to find it later.
+				test -f /usr/share/themes/Default/xfwm4/themerc
+			fi
+
 			install_available \
-				xfwm4 \
 				xfce4-whiskermenu-plugin \
 				thunar-volman \
 				thunar-archive-plugin \


### PR DESCRIPTION
## What

The desktop-experience gate added in #1077 now hard-fails the EL10 xfce build:

```
missing required path: none of [/usr/share/themes/Default/xfwm4/themerc /usr/share/themes/Default/xfwm4] exist
```

That is the gate working — the path really is absent, and it is why `yellowfin:xfce` booted to a console of

```
thread 'main' panicked at src/core/state.rs:260:74:
Failed to load initial config: Failed to find theme named Default
```

instead of a desktop (installer-smoke run 31183217981).

## Why nothing provided it

- `xfwm4` is X11 and has no EL10 build, so `install_available xfwm4` skipped silently — best-effort by design.
- The whole `repo.tunaos.org/xfce/10-stream-x86_64` tree owns exactly one path under `/usr/share/themes/Default`: `xfce4-notifyd`'s `gtk.css`.
- `xfwl4`'s own package ships two files, `/usr/bin/xfwl4` and `/usr/share/xfce4/xfwl4/defaults`. No theme.

## The fix

Vendor the theme from the pinned, sha256-checksummed xfwm4 4.20.0 release tarball, and only when a packaged one is genuinely missing (so a future EL10 `xfwm4` build takes precedence).

`themerc` alone is not sufficient: `load_title_textures()` in `src/core/drawing/decorations.rs` propagates its image loads with `?`, and `load_compose_image()` reads the `.xpm` base layer plus `svg/png/gif/jpg/bmp` overlays — so the whole asset set is load-bearing. The extraction keeps all of it and drops only `Makefile*`.

## Verification

- `bash -n build_scripts/desktop/xfce.sh` clean.
- Extraction command run against the real tarball: 182 files, `themerc` present.
- Tarball sha256 `a58b63e4…dcf06` recorded from the fetched artifact; a mismatch aborts the build.
- `test -f …/themerc` after extraction fails the build loudly rather than deferring to the gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->