### PR TITLE
walkthrough: press escape when a modal has swallowed the focus sweep

### DIFF
--- a/scripts/installer-walkthrough.py
+++ b/scripts/installer-walkthrough.py
@@ -299,6 +299,9 @@ switched = False
 # picks up from 1 exactly as before — and saves the run when it does.
 tabs = 0
 MAX_TABS = 8
+# Set once the escape hatch below has been spent; cleared by any real
+# advance so a long run can escape more than one modal.
+escaped = False
 for i in range(1, steps + 1):
     send_keys(*(["tab"] * tabs), activation)
     time.sleep(3)
@@ -309,6 +312,7 @@ for i in range(1, steps + 1):
         moved = bool(prev) and changed_pixels(prev, p) > DIFF_PIXELS
         if moved:
             tabs = 0          # new page: try its default action first, again
+            escaped = False   # re-arm the modal escape for the next stall
         elif prev:
             if not switched and activation == "ret":
                 activation = "spc"
@@ -320,6 +324,32 @@ for i in range(1, steps + 1):
                 tabs += 1
                 print(f"  # no change — widening focus search to {tabs} tabs",
                       flush=True)
+            elif not escaped:
+                # A modal swallows the whole sweep. Starting the tab count at
+                # 0 (above) stops the harness WALKING into GNOME's Credits
+                # dialog, but nothing stops a dialog that opens for any other
+                # reason — and once inside, every escalation is spent on the
+                # modal's own widgets while the wizard behind it never moves.
+                #
+                # Run 31216208138's gnome leg is the shape: frame 02 is the
+                # Credits modal, frame 03 is byte-identical to it, and the
+                # remaining five steps produced no new screen. The harness
+                # reported "6/8 transitions changed >500px" — opening and
+                # scrolling a dialog counts as movement — so the stall was
+                # invisible in every metric except the pictures.
+                #
+                # Escape is the one key that means "close this" in both GTK
+                # and Qt, and it does nothing to a wizard page that has no
+                # dialog open, so it is safe to spend a step on. Once only
+                # per stall: re-armed by the next real advance, so a run
+                # cannot sit in an Escape loop.
+                escaped = True
+                tabs = 0
+                print("  # focus sweep exhausted — sending 'esc' in case a "
+                      "modal (Credits, About, a file chooser) is on top",
+                      flush=True)
+                send_keys("esc")
+                time.sleep(2)
             elif os.path.exists(vnc_sock) and shutil.which("vncdo") and shutil.which("socat"):
                 # Fallback to mouse click on primary button location via VNC if keyboard navigation stalls
                 # Primary action buttons ("Get Started", "Next", "Continue") sit near bottom right / center bottom


### PR DESCRIPTION
## The evidence

`installer-smoke` run 31216208138, gnome leg. `walkthrough-gnome.json`:

```json
"frames": 9, "advanced_transitions": 6, "visual_states": 7,
"screens": { "welcome": true, "disk": false, "encryption": false,
             "summary": false, "install": false, "done": false }
```

Frame 02 is the **Credits modal**. Frame 03 is byte-identical to it (both 73001 bytes). The remaining five steps produced nothing new — one screen out of six.

Every metric read healthy: the TAP line says `6/8 transitions changed >500px` and `7 distinct visual state(s)`. Opening a dialog and scrolling it *is* movement. The stall was invisible in everything except the pictures.

## Why #1079 was not enough

#1079 starts the tab count at 0 so the harness tries the default action before sweeping toward Credits. That stops it **walking into** the dialog. It does nothing for a harness already inside one: `moved` goes true when the modal opens, `tabs` resets, and the entire escalation — `ret`→`spc`, then eight widening tabs — is spent on the modal's own widgets while the wizard behind it never moves.

## The fix

Once the sweep is exhausted, spend one step on `esc`:

- It means "close this" in both GTK and Qt.
- It is a no-op on a wizard page with no dialog on top, so the step is cheap when the diagnosis is wrong.
- Fired **once per stall**, re-armed by the next real advance — a run cannot sit in an Escape loop.

It sits between the tab-widening branch and the existing VNC mouse-click fallback, so the cheaper keyboard remedy runs first.

## Verification

- `python3 -m py_compile scripts/installer-walkthrough.py` clean.
- `esc` is a valid QKeyCode for the HMP `sendkey` this harness already uses for `tab`/`ret`/`spc`.
- Not verified end-to-end yet: that needs an installer-smoke run, which is what this changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->