### PR TITLE
fix(xfce): run the xfwm4 theme provisioning the build actually sources

### DIFF
--- a/build_scripts/desktop/xfce.sh
+++ b/build_scripts/desktop/xfce.sh
@@ -50,43 +50,11 @@ case "${1:-}" in
 			# so image contents follow the spec's Requires.
 			dnf_retry -y install xfce4-wayland
 
-			# xfwl4 reads xfwm4's theme DATA and aborts without it —
-			# a panic before the session exists, not a warning:
-			#
-			#   thread 'main' panicked at src/core/state.rs:260:74:
-			#   Failed to load initial config: Failed to find theme named Default
-			#
-			# It needs /usr/share/themes/Default/xfwm4/. themerc alone is not
-			# enough: load_title_textures() propagates with `?`, so the
-			# title/border/button images are load-bearing too.
-			#
-			# NOTHING on EL10 ships them. xfwm4 is X11 and has no EL10 build;
-			# the whole repo.tunaos.org/xfce tree owns exactly one path under
-			# /usr/share/themes/Default (xfce4-notifyd's gtk.css) and xfwl4's
-			# own package ships two files, neither a theme. install_available
-			# is best-effort by design, so it skipped silently and yellowfin:xfce
-			# booted to a console of that backtrace (run 31183217981).
-			#
-			# So vendor the theme from the xfwm4 release tarball, pinned and
-			# checksummed, and only when the packaged one is genuinely absent.
+			# The Default xfwm4 theme xfwl4 needs is provisioned by
+			# desktop/xfwm4-theme.sh, listed in xfce.yaml's post_install —
+			# NOT here. install-desktop.sh never sources this file for the
+			# manifest-driven flavors, so a fix placed here does not run.
 			install_available xfwm4
-			if [[ ! -f /usr/share/themes/Default/xfwm4/themerc ]]; then
-				_xfwm4_ver=4.20.0
-				_xfwm4_sha=a58b63e49397aa0d8d1dcf0636be93c8bb5926779aef5165e0852890190dcf06
-				_xfwm4_tar=/tmp/xfwm4-${_xfwm4_ver}.tar.bz2
-				curl -fsSLo "$_xfwm4_tar" \
-					"https://archive.xfce.org/src/xfce/xfwm4/${_xfwm4_ver%.*}/xfwm4-${_xfwm4_ver}.tar.bz2"
-				echo "${_xfwm4_sha}  ${_xfwm4_tar}" | sha256sum -c -
-				mkdir -p /usr/share/themes/Default/xfwm4
-				# --exclude the build files; keep xpm (the base layer
-				# load_compose_image reads) alongside png/svg (the overlays).
-				tar -xjf "$_xfwm4_tar" -C /usr/share/themes/Default/xfwm4 \
-					--strip-components=3 --exclude='Makefile*' \
-					"xfwm4-${_xfwm4_ver}/themes/default"
-				rm -f "$_xfwm4_tar"
-				# Fail loudly rather than leave the gate to find it later.
-				test -f /usr/share/themes/Default/xfwm4/themerc
-			fi
 
 			install_available \
 				xfce4-whiskermenu-plugin \

--- a/build_scripts/desktop/xfwm4-theme.sh
+++ b/build_scripts/desktop/xfwm4-theme.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# xfwl4 aborts at startup without xfwm4's theme DATA:
+#
+#   thread 'main' panicked at src/core/state.rs:260:74:
+#   Failed to load initial config: Failed to find theme named Default
+#
+# It needs /usr/share/themes/Default/xfwm4/. themerc alone is not enough:
+# load_title_textures() propagates its image loads with `?`, so the
+# xpm/png/svg assets are load-bearing too.
+#
+# Nothing on EL10 provides them. xfwm4 is X11 with no EL10 build; the whole
+# repo.tunaos.org/xfce tree owns exactly one path under
+# /usr/share/themes/Default (xfce4-notifyd's gtk.css), and xfwl4's own
+# package ships two files, neither a theme.
+#
+# This logic first shipped inside build_scripts/desktop/xfce.sh, where it
+# NEVER RAN: install-desktop.sh sources only the scripts a manifest names in
+# post_install:, and xfce.yaml named just tuna-flatpak-remote.sh. The build
+# failed on the same missing path with the fix "merged" — the same
+# looks-applied-but-isn't shape as the defect it was fixing. Hence a
+# standalone post_install script the manifest actually lists.
+
+set -euo pipefail
+
+if [[ -f /usr/share/themes/Default/xfwm4/themerc ]]; then
+	echo "xfwm4-theme: already present, nothing to do"
+	return 0 2>/dev/null || exit 0
+fi
+
+_xfwm4_ver=4.20.0
+_xfwm4_sha=a58b63e49397aa0d8d1dcf0636be93c8bb5926779aef5165e0852890190dcf06
+_xfwm4_tar="/tmp/xfwm4-${_xfwm4_ver}.tar.bz2"
+
+curl -fsSLo "$_xfwm4_tar" \
+	"https://archive.xfce.org/src/xfce/xfwm4/${_xfwm4_ver%.*}/xfwm4-${_xfwm4_ver}.tar.bz2"
+echo "${_xfwm4_sha}  ${_xfwm4_tar}" | sha256sum -c -
+
+mkdir -p /usr/share/themes/Default/xfwm4
+# Keep xpm (the base layer load_compose_image reads) alongside png/svg (the
+# overlays); drop only the build files.
+tar -xjf "$_xfwm4_tar" -C /usr/share/themes/Default/xfwm4 \
+	--strip-components=3 --exclude='Makefile*' \
+	"xfwm4-${_xfwm4_ver}/themes/default"
+rm -f "$_xfwm4_tar"
+
+# Fail loudly here rather than leave it to the desktop-experience gate.
+test -f /usr/share/themes/Default/xfwm4/themerc
+echo "xfwm4-theme: installed Default theme for xfwl4"

--- a/manifests/desktops/xfce.yaml
+++ b/manifests/desktops/xfce.yaml
@@ -187,6 +187,12 @@ versionlock:
 
 # Post-install scripts to source (relative to build_scripts/)
 post_install:
+  # xfwl4 panics without xfwm4's theme data and nothing on EL10 ships it.
+  # MUST be listed here: install-desktop.sh sources only the scripts a
+  # manifest names, so logic living in desktop/xfce.sh never runs for this
+  # flavor — which is exactly how the first attempt at this fix shipped
+  # without taking effect.
+  - xfwm4-theme.sh
   - tuna-flatpak-remote.sh
   # Curated Flatpak set (store + browser) + preinstall service — see the
   # script header; asserts live in verify-desktop-experience.sh.


### PR DESCRIPTION
## The bug in the previous fix

#1081 vendored xfwm4's Default theme into `build_scripts/desktop/xfce.sh`. The xfce leg of run 31218951003 — on `main` **with #1081 merged** — failed on the identical line:

```
missing required path: none of [/usr/share/themes/Default/xfwm4/themerc /usr/share/themes/Default/xfwm4] exist
Error: building at STEP "... install-desktop.sh xfce": exit status 1
```

Because `desktop/xfce.sh` is never executed for this flavor. `install-desktop.sh:655` sources only the scripts a manifest names:

```bash
readarray -t _TD_POST_SCRIPTS < <($YQ -r '.post_install[]' "${_TD_MANIFEST}")
for script in "${_TD_POST_SCRIPTS[@]}"; do
    source "${_TD_CTX}/build_scripts/desktop/${script}"
done
```

and `manifests/desktops/xfce.yaml` listed exactly one: `tuna-flatpak-remote.sh`.

Which is the same shape as the defect it was fixing — code that looks applied and isn't. Worth naming: the gate is the only reason this surfaced at all instead of shipping an image whose session panics at boot.

## The fix

- New `build_scripts/desktop/xfwm4-theme.sh` with the pinned, sha256-checksummed vendoring (idempotent: returns early when a packaged theme is already present).
- Listed in `xfce.yaml`'s `post_install`, ahead of the flatpak remote.
- The old site in `xfce.sh` keeps `install_available xfwm4` plus a comment explaining why the provisioning does **not** belong there, so it doesn't get re-added.

## Verification

- `bash -n` clean on both scripts.
- `yaml.safe_load` confirms the resolved list: `['xfwm4-theme.sh', 'tuna-flatpak-remote.sh', 'flatpak-preinstall.sh']`.
- The tarball extraction and sha256 were exercised against the real archive earlier: 182 files, `themerc` present.
- Not yet proven end-to-end — that needs an xfce ISO build, which is what this changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->