### PR TITLE
live: force software GL for sessions on machines with no 3D

### DIFF
--- a/system_files/usr/lib/systemd/user-environment-generators/60-tunaos-software-gl
+++ b/system_files/usr/lib/systemd/user-environment-generators/60-tunaos-software-gl
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Force software GL for the user session when the machine has no 3D.
+#
+# WHY THIS EXISTS, from measured evidence rather than folklore:
+#
+# installer-smoke run 31218951003 booted cosmic and kde on the SAME virtual
+# GPU. Both serial logs report, character for character:
+#
+#   [drm] features: -virgl +edid -resource_blob -host_visible
+#   [drm] features: -context_init
+#   [drm] number of cap sets: 0
+#
+# cosmic rendered a full desktop. kde produced nine 282-byte black frames,
+# with zero OOM kills and sddm.service active. Same hardware, opposite
+# outcome — so "these compositors cannot render without virgl" was never
+# true. cosmic-comp falls back to software on its own; kwin_wayland does not.
+#
+# greetd-gtkgreet.sh already does exactly this for the GREETER, which is why
+# the login screen renders on machines where the session does not. This is
+# that same fix, moved to where every Wayland session picks it up.
+#
+# A render node is the honest test for 3D: virtio-gpu without virgl exposes
+# card* but no renderD*. Where a render node exists this generator prints
+# nothing at all, so hardware with working GL is untouched.
+
+if compgen -G '/dev/dri/renderD*' >/dev/null 2>&1; then
+	exit 0
+fi
+
+# Mesa's generic software-rasteriser switch — honoured by kwin_wayland,
+# mutter, and anything else going through libGL/EGL.
+echo "LIBGL_ALWAYS_SOFTWARE=1"
+# wlroots compositors (niri, xfwl4) select their renderer separately.
+echo "WLR_RENDERER=pixman"
+# kwin's own escape hatch: QPainter compositing instead of OpenGL. Set
+# alongside, not instead of, the Mesa switch — kwin consults this before it
+# ever reaches GL.
+echo "KWIN_COMPOSE=Q"


### PR DESCRIPTION
## The measurement that settles it

Run 31218951003 booted **cosmic and kde on the same virtual GPU**. Both serial logs report, character for character:

```
[drm] features: -virgl +edid -resource_blob -host_visible
[drm] features: -context_init
[drm] number of cap sets: 0
```

- **cosmic**: rendered a full desktop (nine ~1 MB frames).
- **kde**: nine **282-byte black** frames. `grep -c "Out of memory: Killed"` = **0**. `sddm.service` active, branding check passing.

Same hardware, opposite outcome. So *"these compositors cannot render without virgl"* — the premise behind the old `STRICT` carve-out, the harness's blank-screen hint, and several of my own claims today — was never true. `cosmic-comp` falls back to software on its own; `kwin_wayland` does not.

## The fix already existed, in the wrong place

`build_scripts/desktop/greetd-gtkgreet.sh:96-99` does exactly this for the **greeter**:

```bash
if ! compgen -G '/dev/dri/renderD*' >/dev/null 2>&1; then
	export WLR_RENDERER=pixman
	export LIBGL_ALWAYS_SOFTWARE=1
fi
```

That is precisely why the login screen renders on machines where the session does not — the greeter got the fallback and the session never did.

This moves it to a systemd **user-environment generator**, so every Wayland session inherits it: kwin, mutter, niri, xfwl4, cosmic-comp.

## Why a generator and not a static file

The condition is a property of the *machine*, not the image, so it cannot be decided at build time. A generator runs per-session and is the mechanism systemd provides for exactly this.

Guarded on the absence of a render node — the honest test for 3D, since virtio-gpu without virgl exposes `card*` but no `renderD*` (reasoning already documented in `greetd-gtkgreet.sh`). **Where a render node exists it prints nothing**, so real hardware is untouched.

`KWIN_COMPOSE=Q` is set alongside the Mesa switch rather than instead of it: kwin consults its own variable before it ever reaches GL.

## Verification

- `bash -n` clean.
- Executed directly on a host with no render node: emits all three variables, exit 0.
- The guard's early-exit path is the same `compgen` test already proven in the greeter.
- Not yet proven end-to-end on kde — that needs a smoke run, which is what this changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->