### PR TITLE
contract(codec): a failing h264 probe must name its evidence

### DIFF
--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -479,14 +479,42 @@ else
 		# and keep "ffmpeg would not run" distinct from "ffmpeg runs but
 		# cannot decode", because their fixes live in different places
 		# (packaging deps vs codec sourcing).
+		# Both failure branches dump the evidence that names the cause,
+		# because this check fired on guppy:xfce (run 31201546516) with a
+		# freshly source-built ffmpeg 8.1.2 whose USE line showed x264 —
+		# a build where the native h264 decoder should be unconditional —
+		# while the same check passes inside the July guppy:gnome image
+		# and against Alpine's 8.1.2. Three container reproductions of the
+		# tooling stage could not replicate it (portage tree drift), so
+		# the next failing run must answer for itself: WHICH ffmpeg ran,
+		# what its configure line disabled, what it printed to stderr
+		# (previously discarded), and what the decoder list actually held.
+		_ffmpeg_diag() {
+			{
+				echo "codec_diag: ffmpeg=$(command -v ffmpeg)"
+				ffmpeg -version 2>&1 | head -2 | sed 's/^/codec_diag: /'
+				ffmpeg -version 2>&1 | tr ' ' '\n' | grep -- '--disable-\(everything\|decoders\|decoder=[a-z0-9_]*\)' | sed 's/^/codec_diag: configure /'
+				echo "codec_diag: decoders_stdout_bytes=${#_ffmpeg_decoders}"
+				echo "codec_diag: decoders_stderr: ${_ffmpeg_stderr:-<empty>}"
+				grep -i 'h26' <<<"$_ffmpeg_decoders" | head -5 | sed 's/^/codec_diag: h26x /'
+			} >&2 || true
+		}
 		_ffmpeg_decoders=""
-		if ! _ffmpeg_decoders="$(ffmpeg -hide_banner -decoders 2>/dev/null)"; then
+		_ffmpeg_stderr=""
+		_ffmpeg_rc=0
+		_ffmpeg_stderr_file="$(mktemp)"
+		_ffmpeg_decoders="$(ffmpeg -hide_banner -decoders 2>"$_ffmpeg_stderr_file")" || _ffmpeg_rc=$?
+		_ffmpeg_stderr="$(head -c 2048 "$_ffmpeg_stderr_file")"
+		rm -f "$_ffmpeg_stderr_file"
+		if ((_ffmpeg_rc != 0)); then
 			echo "ffmpeg is installed but would not run (broken dependencies?) — cannot verify codecs" >&2
+			_ffmpeg_diag
 			if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
 				exit 1
 			fi
 		elif ! grep -q ' h264 ' <<<"$_ffmpeg_decoders"; then
 			echo "ffmpeg cannot decode h264 — a free/crippled libavcodec is installed" >&2
+			_ffmpeg_diag
 			if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
 				exit 1
 			fi

--- a/tests/bats/test_codec_baseline.bats
+++ b/tests/bats/test_codec_baseline.bats
@@ -59,8 +59,10 @@ CONTRACT="${REPO_ROOT}/build_scripts/checks/verify-desktop-experience.sh"
   # The plugin file existing is satisfiable by a free-codec libavcodec — the
   # exact v2 failure — so the contract must interrogate ffmpeg itself. The
   # probe must use the capture-first form: the output is captured into a
-  # variable, then grepped.
-  run grep -F '_ffmpeg_decoders="$(ffmpeg -hide_banner -decoders 2>/dev/null)"' "$CONTRACT"
+  # variable, then grepped. stderr goes to a file, not /dev/null — discarding
+  # it is how guppy:xfce (run 31201546516) failed this check with no evidence
+  # of what ffmpeg actually said.
+  run grep -F '_ffmpeg_decoders="$(ffmpeg -hide_banner -decoders 2>"$_ffmpeg_stderr_file")"' "$CONTRACT"
   [ "$status" -eq 0 ]
   run grep -F "grep -q ' h264 ' <<<\"\$_ffmpeg_decoders\"" "$CONTRACT"
   [ "$status" -eq 0 ]
@@ -115,4 +117,73 @@ GEN
   # New (captured) form: passes.
   run bash -c "set -o pipefail; d=\"\$('${BATS_TEST_TMPDIR}/fake-decoders')\"; grep -q ' h264 ' <<<\"\$d\""
   [ "$status" -eq 0 ]
+}
+
+# ── Failure-evidence dump ────────────────────────────────────────────────────
+# When the h264 probe fires, the contract must name its evidence: which ffmpeg
+# ran, its configure line's decoder kill-switches, what it wrote to stderr,
+# and what the decoder list held. guppy:xfce (run 31201546516) failed this
+# check against a source-built ffmpeg whose USE line said the decoder should
+# exist, and three container reproductions could not replicate it — the next
+# failing run has to answer for itself.
+
+# Extract the codec-baseline block and run it against a fake ffmpeg on PATH.
+run_codec_block() {
+  local bin="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "$bin"
+  cp "${BATS_TEST_TMPDIR}/fake-ffmpeg" "${bin}/ffmpeg"
+  chmod +x "${bin}/ffmpeg"
+  local block
+  block="$(awk '/── Codec baseline ──/,/── KDE version-skew guard/' "$CONTRACT" | sed '$d')"
+  PATH="${bin}:/usr/bin:/bin" bash -c "
+    set -euo pipefail
+    require_any_glob() { :; }
+    require_command() { :; }
+    IS_HUMMINGBIRD=false
+    ${block}
+  "
+}
+
+@test "a decoder-less ffmpeg fails AND dumps codec_diag evidence" {
+  cat > "${BATS_TEST_TMPDIR}/fake-ffmpeg" <<'FAKE'
+#!/usr/bin/env bash
+case "$*" in
+*-decoders*) echo " V....D vp9    Google VP9"; echo "warning: h264 decoder disabled at configure time" >&2 ;;
+*-version*)  echo "ffmpeg version 9.9-test"; echo "built with test"; echo "configuration: --disable-decoder=h264" ;;
+esac
+FAKE
+  run run_codec_block
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"cannot decode h264"* ]]
+  [[ "$output" == *"codec_diag: ffmpeg="* ]]
+  [[ "$output" == *"codec_diag: configure --disable-decoder=h264"* ]]
+  [[ "$output" == *"codec_diag: decoders_stderr: warning: h264 decoder disabled at configure time"* ]]
+  [[ "$output" == *"ffmpeg version 9.9-test"* ]]
+}
+
+@test "an ffmpeg that will not run fails on its own branch with evidence" {
+  cat > "${BATS_TEST_TMPDIR}/fake-ffmpeg" <<'FAKE'
+#!/usr/bin/env bash
+case "$*" in
+*-decoders*) echo "error while loading shared libraries: libavcodec.so.62" >&2; exit 127 ;;
+*-version*)  echo "ffmpeg version 9.9-test"; echo "built with test" ;;
+esac
+FAKE
+  run run_codec_block
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"would not run"* ]]
+  [[ "$output" == *"codec_diag: decoders_stderr: error while loading shared libraries"* ]]
+}
+
+@test "a healthy ffmpeg passes silently — no codec_diag noise on green" {
+  cat > "${BATS_TEST_TMPDIR}/fake-ffmpeg" <<'FAKE'
+#!/usr/bin/env bash
+case "$*" in
+*-decoders*) echo " V....D h264                 H.264 / AVC" ;;
+*-version*)  echo "ffmpeg version 9.9-test" ;;
+esac
+FAKE
+  run run_codec_block
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"codec_diag"* ]]
 }


### PR DESCRIPTION
## What

guppy:xfce ([run 31201546516](https://github.com/tuna-os/tunaOS/actions/runs/31201546516)) failed the codec baseline — `ffmpeg cannot decode h264` — against a freshly source-built ffmpeg 8.1.2 whose USE line (x264, vpx, dav1d, opus…) says the native decoder should be unconditional. The same check passes inside the July `guppy:gnome` image and against Alpine's 8.1.2, and three container reproductions of the tooling stage could not replicate the failure (portage tree drift defeats byte-faithful replay).

The check as written discarded every piece of evidence that would settle it: ffmpeg's stderr went to `/dev/null`, and the failure message asserted a diagnosis ("free/crippled libavcodec") it had not measured.

## Changes

- `build_scripts/checks/verify-desktop-experience.sh`: both codec-baseline failure branches now print `codec_diag:` lines to stderr — which ffmpeg binary ran, the version banner, any `--disable-everything`/`--disable-decoders`/`--disable-decoder=` configure switches, decoder-list size and its h26x neighborhood, and (newly captured instead of discarded) ffmpeg's stderr. The green path is behaviorally unchanged and prints nothing.
- The probe's stderr lands in a `mktemp` file read once and removed; capture-first-then-grep is unchanged (the SIGPIPE pin still holds).
- `tests/bats/test_codec_baseline.bats`: the capture-form pin follows the new redirect; three new behavioral fixtures drive a fake ffmpeg through both failure branches (asserting the evidence lines, including the previously-discarded stderr) and the green path (asserting silence).

## Testing

- `test_codec_baseline.bats`: 11/11 pass.
- Full suite failure set identical to clean main (24 pre-existing, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->