### PR TITLE
fix(xfce): run the greeter provisioning the build actually sources

### DIFF
--- a/build_scripts/desktop/xfce-greeter.sh
+++ b/build_scripts/desktop/xfce-greeter.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# XFCE greeter provisioning: the display manager, gtkgreet + cage, the
+# wayland-sessions fallback, and the greetd config that points at them.
+#
+# THIS MUST BE A post_install SCRIPT, not part of desktop/xfce.sh.
+# install-desktop.sh sources only the scripts a manifest names
+# (install-desktop.sh:655), so everything in desktop/xfce.sh is dead code for
+# the manifest-driven flavors. Not a theory: with the theme half moved out in
+# #1085, the xfce build reached the NEXT gate and died on
+#
+#   missing required command: gtkgreet
+#
+# in run 31224115663 — because `install_available gtkgreet` was still in the
+# file that never runs. Two gates, one root cause, the second hidden behind
+# the first.
+#
+# Sourced, not executed: no `exit` here, it would abort the whole desktop
+# install. Indentation is carried over verbatim from the original block so
+# the heredocs inside stay intact.
+
+		# Display manager: neither branch pulls one in. Probe lightdm first
+		# (XFCE's usual DM), fall back to greetd; the enable logic below
+		# picks whichever landed.
+		install_available \
+			lightdm \
+			lightdm-gtk-greeter \
+			greetd \
+			greetd-selinux
+
+		# greetd ships no graphical greeter: its stock config runs
+		# `agreety --cmd /bin/sh`, i.e. a text prompt into a bare shell with
+		# no session picker. cosmic/niri never hit this because
+		# cosmic-greeter/dms-greeter ship their own config.toml — XFCE has no
+		# such package, so without this block an installed XFCE system boots
+		# to a shell. It still reaches graphical.target with
+		# display-manager.service active, so the desktop-contract gate cannot
+		# see the difference; only this config can.
+		#
+		# gtkgreet is GTK3 like the XFCE session, so it inherits the same
+		# GTK/icon/cursor/font theme — greeter and desktop match by
+		# construction. It pulls cage (its kiosk host) via Requires.
+		install_available gtkgreet
+
+		# Session entry: the adapted xfce4-session ships a wayland-sessions
+		# desktop file running `startxfce4 --wayland`. Only write a fallback
+		# if no packaged Wayland session landed (keeps DMs from showing an
+		# empty session list on EL10 if packaging regresses).
+		if [[ $IS_FEDORA != true ]] && ! compgen -G "/usr/share/wayland-sessions/*.desktop" >/dev/null; then
+			mkdir -p /usr/share/wayland-sessions
+			cat >/usr/share/wayland-sessions/xfce-wayland.desktop <<'EOF'
+[Desktop Entry]
+Name=Xfce Session (Wayland)
+Comment=XFCE desktop on Wayland (xfwl4)
+Exec=startxfce4 --wayland
+Type=Application
+DesktopNames=XFCE
+EOF
+		fi
+
+		# Point greetd at gtkgreet. Only rewrite the config when gtkgreet
+		# actually landed — if packaging regressed, leaving greetd's own
+		# config in place fails loudly at a text prompt rather than silently
+		# launching a greeter that is not installed.
+		if command -v gtkgreet &>/dev/null && command -v cage &>/dev/null; then
+			# gtkgreet is a plain Wayland client and cannot own a VT, so cage
+			# hosts it. -s keeps VT switching available (without it a greeter
+			# crash locks you out of the machine entirely).
+			mkdir -p /etc/greetd
+			cat >/etc/greetd/config.toml <<'EOF'
+[terminal]
+vt = 1
+
+[default_session]
+command = "cage -s -- gtkgreet -l -s /etc/greetd/gtkgreet.css"
+user = "greetd"
+EOF
+
+			# Greeter styling. Kept deliberately small: gtkgreet is GTK3, so
+			# it already picks up the session's GTK theme, icons, cursor and
+			# font — this only supplies the pieces a theme cannot know about
+			# (the layer-shell background behind the login window).
+			cat >/etc/greetd/gtkgreet.css <<'EOF'
+/* TunaOS XFCE greeter.
+ *
+ * gtkgreet inherits the system GTK3 theme, which is the whole reason it is
+ * the XFCE greeter: the login screen and the session it launches are styled
+ * by the same theme. Only the layer-shell background and the login window's
+ * framing are set here — everything else is intentionally left to the theme
+ * so retheming the desktop retheme the greeter too.
+ */
+window {
+	background-image: linear-gradient(to bottom, #2b3d4f, #1b2733);
+	background-color: #1b2733;
+}
+
+/* The login box: lift it off the background, otherwise the themed widgets
+ * float on the gradient with no visual container. */
+box#window-box {
+	background-color: @theme_bg_color;
+	border-radius: 8px;
+	padding: 24px;
+}
+EOF
+			# greetd runs the greeter as its own unprivileged user; it must be
+			# able to read both files.
+			chmod 0644 /etc/greetd/config.toml /etc/greetd/gtkgreet.css
+		fi
+
+		# Enable lightdm or greetd for display management
+		if command -v lightdm &>/dev/null; then
+			systemctl enable lightdm
+		elif command -v greetd &>/dev/null; then
+			systemctl enable greetd
+		fi

--- a/build_scripts/desktop/xfce.sh
+++ b/build_scripts/desktop/xfce.sh
@@ -66,100 +66,11 @@ case "${1:-}" in
 				catfish
 		fi
 
-		# Display manager: neither branch pulls one in. Probe lightdm first
-		# (XFCE's usual DM), fall back to greetd; the enable logic below
-		# picks whichever landed.
-		install_available \
-			lightdm \
-			lightdm-gtk-greeter \
-			greetd \
-			greetd-selinux
-
-		# greetd ships no graphical greeter: its stock config runs
-		# `agreety --cmd /bin/sh`, i.e. a text prompt into a bare shell with
-		# no session picker. cosmic/niri never hit this because
-		# cosmic-greeter/dms-greeter ship their own config.toml — XFCE has no
-		# such package, so without this block an installed XFCE system boots
-		# to a shell. It still reaches graphical.target with
-		# display-manager.service active, so the desktop-contract gate cannot
-		# see the difference; only this config can.
-		#
-		# gtkgreet is GTK3 like the XFCE session, so it inherits the same
-		# GTK/icon/cursor/font theme — greeter and desktop match by
-		# construction. It pulls cage (its kiosk host) via Requires.
-		install_available gtkgreet
-
-		# Session entry: the adapted xfce4-session ships a wayland-sessions
-		# desktop file running `startxfce4 --wayland`. Only write a fallback
-		# if no packaged Wayland session landed (keeps DMs from showing an
-		# empty session list on EL10 if packaging regresses).
-		if [[ $IS_FEDORA != true ]] && ! compgen -G "/usr/share/wayland-sessions/*.desktop" >/dev/null; then
-			mkdir -p /usr/share/wayland-sessions
-			cat >/usr/share/wayland-sessions/xfce-wayland.desktop <<'EOF'
-[Desktop Entry]
-Name=Xfce Session (Wayland)
-Comment=XFCE desktop on Wayland (xfwl4)
-Exec=startxfce4 --wayland
-Type=Application
-DesktopNames=XFCE
-EOF
-		fi
-
-		# Point greetd at gtkgreet. Only rewrite the config when gtkgreet
-		# actually landed — if packaging regressed, leaving greetd's own
-		# config in place fails loudly at a text prompt rather than silently
-		# launching a greeter that is not installed.
-		if command -v gtkgreet &>/dev/null && command -v cage &>/dev/null; then
-			# gtkgreet is a plain Wayland client and cannot own a VT, so cage
-			# hosts it. -s keeps VT switching available (without it a greeter
-			# crash locks you out of the machine entirely).
-			mkdir -p /etc/greetd
-			cat >/etc/greetd/config.toml <<'EOF'
-[terminal]
-vt = 1
-
-[default_session]
-command = "cage -s -- gtkgreet -l -s /etc/greetd/gtkgreet.css"
-user = "greetd"
-EOF
-
-			# Greeter styling. Kept deliberately small: gtkgreet is GTK3, so
-			# it already picks up the session's GTK theme, icons, cursor and
-			# font — this only supplies the pieces a theme cannot know about
-			# (the layer-shell background behind the login window).
-			cat >/etc/greetd/gtkgreet.css <<'EOF'
-/* TunaOS XFCE greeter.
- *
- * gtkgreet inherits the system GTK3 theme, which is the whole reason it is
- * the XFCE greeter: the login screen and the session it launches are styled
- * by the same theme. Only the layer-shell background and the login window's
- * framing are set here — everything else is intentionally left to the theme
- * so retheming the desktop retheme the greeter too.
- */
-window {
-	background-image: linear-gradient(to bottom, #2b3d4f, #1b2733);
-	background-color: #1b2733;
-}
-
-/* The login box: lift it off the background, otherwise the themed widgets
- * float on the gradient with no visual container. */
-box#window-box {
-	background-color: @theme_bg_color;
-	border-radius: 8px;
-	padding: 24px;
-}
-EOF
-			# greetd runs the greeter as its own unprivileged user; it must be
-			# able to read both files.
-			chmod 0644 /etc/greetd/config.toml /etc/greetd/gtkgreet.css
-		fi
-
-		# Enable lightdm or greetd for display management
-		if command -v lightdm &>/dev/null; then
-			systemctl enable lightdm
-		elif command -v greetd &>/dev/null; then
-			systemctl enable greetd
-		fi
+		# The greeter stack (DM probe, gtkgreet + cage, wayland-sessions
+		# fallback, greetd config) moved to desktop/xfce-greeter.sh, listed
+		# in xfce.yaml's post_install. It does NOT belong here:
+		# install-desktop.sh never sources this file for manifest-driven
+		# flavors, so a fix placed here does not run.
 
 		exit 0
 	fi

--- a/manifests/desktops/xfce.yaml
+++ b/manifests/desktops/xfce.yaml
@@ -187,6 +187,12 @@ versionlock:
 
 # Post-install scripts to source (relative to build_scripts/)
 post_install:
+  # The greeter stack (greetd/lightdm probe, gtkgreet + cage, the
+  # wayland-sessions fallback and greetd's config). Lived in
+  # desktop/xfce.sh, which install-desktop.sh never sources — so
+  # verify-desktop-experience.sh failed with "missing required command:
+  # gtkgreet" in run 31224115663, the gate immediately after the theme one.
+  - xfce-greeter.sh
   # xfwl4 panics without xfwm4's theme data and nothing on EL10 ships it.
   # MUST be listed here: install-desktop.sh sources only the scripts a
   # manifest names, so logic living in desktop/xfce.sh never runs for this


### PR DESCRIPTION
## Two gates, one root cause

#1085 moved the xfwm4 theme out of `build_scripts/desktop/xfce.sh` — a file `install-desktop.sh` never sources for manifest-driven flavors. **It worked**: run 31224115663's log shows

```
Running post-install: xfwm4-theme.sh
xfwm4-theme: installed Default theme for xfwl4
```

and no `missing required path`. But getting past that gate let the build reach the *next* one, in the same dead file:

```
+ /run/context/build_scripts/checks/verify-desktop-experience.sh xfce
missing required command: gtkgreet
```

`install_available gtkgreet`, the lightdm/greetd probe, the wayland-sessions fallback and greetd's `config.toml` were all still there. The second failure was hidden behind the first.

## The fix

Move the whole greeter block to `build_scripts/desktop/xfce-greeter.sh` and list it in `xfce.yaml`'s `post_install`, ahead of the theme script.

Two details that matter:
- **Indentation carried over verbatim.** De-indenting first broke the heredoc terminators inside the block (`syntax error near unexpected token 'fi'`). Bash doesn't care about the extra tabs; the heredocs do.
- **The trailing `exit 0` is dropped.** These scripts are `source`d, so an `exit` would abort the entire desktop install rather than just this section.

The old site keeps a pointer explaining why the provisioning does *not* belong there.

## Verification

- `bash -n` clean on both `xfce-greeter.sh` and the trimmed `xfce.sh`.
- `yaml.safe_load` resolves `post_install` to `['xfce-greeter.sh', 'xfwm4-theme.sh', 'tuna-flatpak-remote.sh', 'flatpak-preinstall.sh']`.
- The moved block still contains `install_available gtkgreet`, `/etc/greetd/config.toml` and `systemctl enable greetd`.
- Not proven end-to-end — that needs an xfce ISO build, which is what this changes.

Both gates did their job here. Without them this would have shipped an XFCE image whose login screen is a bare shell, with `display-manager.service` active and every metric green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNgsizQRcVzS3KiJ5BduiC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->