### PR TITLE
fix(overlay): re-lay system_files — an overlay never rebuilds its parent

### DIFF
--- a/Containerfile.overlay
+++ b/Containerfile.overlay
@@ -107,6 +107,31 @@ RUN if command -v pacman &>/dev/null; then \
         pacman -S --needed --noconfirm sudo fuse-overlayfs; \
     fi
 
+# Re-lay the repo's system_files, for the same reason 90-image-info.sh is
+# re-run below: an overlay flavor does NOT rebuild its parent. It chains on
+# the PUBLISHED parent tag (Justfile: `localhost/<variant>:<parent>` when
+# present, else `<parent>-testing` from ghcr), so every file the base stage
+# copies is frozen at whatever that published image happened to carry —
+# while the desktop scripts, live-ISO adapters and contracts that read those
+# files are always current-tree.
+#
+# Measured, not assumed: ghcr.io/tuna-os/yellowfin:niri-testing
+# (IMAGE_VERSION niri-3505bf2) ships /usr/bin/niri but has no
+# /usr/share/niri/ directory and no /usr/share/backgrounds/tunaos/ — its
+# commit is not a descendant of 453f15b7, which added both. So the
+# niri-nvidia and niri-hwe LUKS cells (run 31226672079) died in live
+# customize on "config.kdl missing; cannot arrange installer autostart",
+# while plain niri passed: the dev ISO rebuilds THAT one from the current
+# tree. Same staleness applies to hwe/cachyos/asahi overlays, and to every
+# system_files asset, not just niri's.
+#
+# Ordering: before 90-image-info.sh, which reads assets this copy provides
+# (the logo it asserts lives at /usr/share/pixmaps/tunaos.svg, from
+# system_files).
+RUN --mount=type=tmpfs,dst=/tmp \
+    --mount=type=bind,from=context,source=/,target=/run/context \
+    /run/context/build_scripts/00-copy-files.sh
+
 # The published base may predate 90-image-info.sh (identity/logo/image-info),
 # so re-run it on the overlay to guarantee the branding contract passes
 # regardless of base freshness.

--- a/tests/bats/test_overlay_refreshes_system_files.bats
+++ b/tests/bats/test_overlay_refreshes_system_files.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# An overlay flavor never rebuilds its parent — so it must re-lay the tree's
+# system_files itself.
+#
+# `just build <variant> <flavor>-nvidia` (and -hwe/-cachyos/-asahi) chains on
+# the PUBLISHED parent tag rather than rebuilding it: the Justfile takes
+# localhost/<variant>:<parent> when it happens to be in storage, and otherwise
+# falls back to <parent>-testing from ghcr. That fallback is deliberate (it is
+# what unbroke all 24 NVIDIA LUKS cells in run 29978067348), but it means every
+# file the base stage copies is frozen at whatever the published parent
+# carried, while the desktop scripts, live-ISO adapters and contracts reading
+# those files are always current-tree.
+#
+# What that cost, measured: ghcr.io/tuna-os/yellowfin:niri-testing
+# (IMAGE_VERSION niri-3505bf2) ships /usr/bin/niri but has no /usr/share/niri/
+# directory and no /usr/share/backgrounds/tunaos/ — its commit is not a
+# descendant of 453f15b7, which added both. The niri-nvidia and niri-hwe LUKS
+# cells (run 31226672079) therefore died in live customize with
+# "config.kdl missing; cannot arrange installer autostart", while plain niri
+# passed because the dev ISO rebuilds that one from the current tree.
+#
+# Verified before/after against that exact published image: desktop-niri.sh
+# exits 1 on it as shipped, and exits 0 after 00-copy-files.sh runs.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+OVERLAY="${REPO_ROOT}/Containerfile.overlay"
+
+# The desktop stage body, comment-stripped: from `FROM overlay-base AS desktop`
+# to the next FROM (or EOF). Commenting a RUN out must fail these tests the
+# same as deleting it.
+desktop_stage() {
+  awk 'tolower($0) ~ /^from[ \t]+overlay-base[ \t]+as[ \t]+desktop/ {inside=1; next}
+       inside && tolower($0) ~ /^from[ \t]/ {exit}
+       inside {print}' "$OVERLAY" | grep -v '^[[:space:]]*#' || true
+}
+
+@test "the overlay defines a desktop stage to assert against" {
+  run desktop_stage
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+@test "the overlay desktop stage re-lays system_files" {
+  # Without this the overlay inherits the parent's frozen copy of every
+  # repo-shipped asset — wallpapers, plymouth theme, niri config, the logo.
+  run desktop_stage
+  [[ "$output" == *"00-copy-files.sh"* ]]
+}
+
+@test "the file copy runs before 90-image-info.sh, which reads what it lays down" {
+  # 90-image-info.sh asserts the logo asset the repo ships at
+  # /usr/share/pixmaps/tunaos.svg (system_files). Re-running the branding
+  # script against the parent's stale assets is the ordering bug this pins.
+  local body copy_at info_at
+  body="$(desktop_stage)"
+  copy_at="$(grep -n '00-copy-files.sh' <<<"$body" | head -1 | cut -d: -f1)"
+  info_at="$(grep -n '90-image-info.sh' <<<"$body" | head -1 | cut -d: -f1)"
+  [ -n "$copy_at" ]
+  [ -n "$info_at" ]
+  [ "$copy_at" -lt "$info_at" ]
+}
+
+@test "the overlay context stage actually provides the files that copy reads" {
+  # 00-copy-files.sh copies /run/context/files — which only exists because the
+  # context stage COPYs system_files into /files. A copy step pointed at an
+  # empty directory would pass every test above and change nothing.
+  local ctx
+  ctx="$(awk 'tolower($0) ~ /^from[ \t]+scratch[ \t]+as[ \t]+context/ {inside=1; next}
+              inside && tolower($0) ~ /^from[ \t]/ {exit}
+              inside {print}' "$OVERLAY" | grep -v '^[[:space:]]*#' || true)"
+  [[ "$ctx" == *"COPY system_files /files"* ]]
+  [[ "$ctx" == *"build_scripts"* ]]
+}
+
+@test "the niri live adapter still requires the config it now inherits" {
+  # The fatal branch in desktop-niri.sh (#1056) is what surfaced the staleness.
+  # If it were softened to a warning the overlay could ship a niri ISO whose
+  # installer never autostarts and nothing would fail — so pin it fatal here
+  # too, next to the fix that lets it pass.
+  run grep -A2 'cannot arrange installer autostart' \
+    "${REPO_ROOT}/live-iso/common/src/desktop-niri.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"exit 1"* ]]
+}


### PR DESCRIPTION
## What

The yellowfin `niri-nvidia` and `niri-hwe` LUKS cells ([run 31226672079](https://github.com/tuna-os/tunaOS/actions/runs/31226672079)) died in live customize, before any VM booted:

```
desktop-niri: /usr/share/niri/config.kdl missing; cannot arrange installer autostart
```

Plain `niri` passed in the same run, and that asymmetry is the whole story: a dev/e2e ISO **rebuilds** a stage-2 flavor from the current tree, but an overlay flavor (`-nvidia`/`-hwe`/`-cachyos`/`-asahi`) does **not** rebuild its parent. The Justfile chains it on the published parent tag — the local one when it's in storage, else `<parent>-testing` from ghcr. That fallback is deliberate and stays (it's what unbroke all 24 NVIDIA cells in run 29978067348), but it freezes every file the base stage copies at whatever the published parent carried, while the desktop scripts, live-ISO adapters and contracts reading those files are always current-tree.

Measured on the parent the failing cells actually used — `ghcr.io/tuna-os/yellowfin:niri-testing` (IMAGE_VERSION `niri-3505bf2`):

| path | present |
|---|---|
| `/usr/bin/niri` | yes |
| `/usr/share/niri/` | **absent (no directory at all)** |
| `/usr/share/backgrounds/tunaos/` | **absent** |

Its commit is not a descendant of `453f15b7`, which added both (author dates mislead here — ancestry doesn't). So overlay images were also shipping **unbranded**, silently; niri's fatal check (#1056) is just the first thing that looked.

## Changes

- `Containerfile.overlay`: run `00-copy-files.sh` in the desktop stage — the same regardless-of-base-freshness move `90-image-info.sh` already makes three lines below, and ordered **before** it since that script asserts a logo asset this copy provides.
- `tests/bats/test_overlay_refreshes_system_files.bats`: five comment-stripped pins (copy present, ordered before `90-image-info.sh`, context stage actually supplies `/files`, and the niri adapter's check stays fatal).

## Testing

- **Before/after against that exact published image**, not a stand-in: `desktop-niri.sh` exits 1 on `yellowfin:niri-testing` as shipped; after `00-copy-files.sh` runs it exits 0 with the installer autostart line appended.
- Mutation-verified: commenting the copy out fails two tests; moving it after `90-image-info.sh` fails the ordering test.
- Full suite failure set identical to clean main (24 pre-existing, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->