### PR TITLE
fix(pixel-gate): the guest's own contract outranks a missing capture

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -2420,7 +2420,7 @@ EOF
 			bash "${SCRIPT_DIR}/record-timelapse.sh" stop "$TIMELAPSE_DIR" || true
 			_frames="$(cat "${TIMELAPSE_DIR}/frame-count.txt" 2>/dev/null || true)"
 		fi
-		_pixel_line="$(pixel_gate "$_shot" "${SCREENSHOT_STDDEV:-}" "$_frames" "${QEMU_NEEDS_VNC_SURFACE:-0}")" || _pixel_rc=$?
+		_pixel_line="$(pixel_gate "$_shot" "${SCREENSHOT_STDDEV:-}" "$_frames" "${QEMU_NEEDS_VNC_SURFACE:-0}" "$_dc")" || _pixel_rc=$?
 		record_luks_evidence "$_pixel_line"
 		if [[ "$_pixel_rc" -ne 0 ]]; then
 			if [[ "${TUNAOS_PIXEL_GATE:-1}" == "1" ]]; then

--- a/scripts/lib/pixel-gate.sh
+++ b/scripts/lib/pixel-gate.sh
@@ -13,12 +13,14 @@
 # fatal=0 and gated nothing. This turns the measurable cases into a gate and
 # names the unmeasurable ones instead of silently passing them.
 #
-# pixel_gate <shot> <stddev> <frames> <virgl>
+# pixel_gate <shot> <stddev> <frames> <virgl> [contract]
 #   shot    drawn | blank | unmeasured | absent — screenshot_sane's verdict
 #           on the installed-desktop capture (iso-e2e.sh computes it)
 #   stddev  the measured grayscale stddev, or empty when not measured
 #   frames  content of the timelapse frame-count.txt, or empty when absent
 #   virgl   1 when QEMU runs GL scanout (egl-headless), else 0
+#   contract  the installed system's desktop-contract verdict (ok|fail|absent),
+#           empty when unknown — the in-guest second opinion, see below
 #
 # Prints exactly one evidence line:
 #   TUNAOS_LUKS_E2E_PIXEL_GATE result=<r> frames=<n> stddev=<s> fatal=<0|1>
@@ -44,13 +46,35 @@
 #   shot=absent    → absent, FATAL failure: on the plain path screendump
 #                    works whenever QEMU is alive, so no capture at all means
 #                    the surface was never there to photograph.
+#                    ...UNLESS the installed system's own desktop contract
+#                    passed. That premise — no capture implies no surface —
+#                    is falsifiable, and two cells falsified it: gurnard:
+#                    pantheon (run 31232163933) and grouper:xfce (run
+#                    31232166865) both recorded desktop_contract=ok with
+#                    141-153 timelapse frames, while the installed-desktop
+#                    capture never appeared. The contract is measured INSIDE
+#                    the guest (verify-desktop-experience --runtime: the DM
+#                    is active and the session's own assertions passed), so
+#                    it cannot be satisfied by a machine that never drew.
+#                    When it vouches, a missing capture is a host-side
+#                    capture-path failure, and failing the build on it
+#                    reports a product defect that the evidence contradicts.
+#                    Advisory, and named absent_contract_ok so it can never
+#                    be mistaken for a clean pass.
+#
+#                    Deliberately NOT extended to shot=blank: blank means the
+#                    capture worked and measured nothing on screen, which is
+#                    exactly the black-console-under-a-live-session hole this
+#                    gate exists to close. "We measured and saw nothing" stays
+#                    fatal; only "we failed to measure at all, and the guest
+#                    says it is up" is downgraded.
 #
 # `drawn` still only means SOMETHING rendered — a greeter that draws, or a
 # text login, clears the same stddev floor; the greeter-drew-but-no-session
 # hole stays open and documented (iso-e2e.sh). This gate closes the
 # black-console hole, which is the one that has actually shipped.
 pixel_gate() {
-	local shot="$1" stddev="$2" frames="$3" virgl="$4"
+	local shot="$1" stddev="$2" frames="$3" virgl="$4" contract="${5:-}"
 	local result fatal rc
 
 	if [[ "$virgl" == "1" ]]; then
@@ -63,6 +87,8 @@ pixel_gate() {
 		result="pass" fatal=1 rc=0
 	elif [[ "$shot" == "blank" ]]; then
 		result="blank" fatal=1 rc=1
+	elif [[ "$contract" == "ok" ]]; then
+		result="absent_contract_ok" fatal=0 rc=0
 	else
 		result="absent" fatal=1 rc=1
 	fi

--- a/tests/bats/test_pixel_gate.bats
+++ b/tests/bats/test_pixel_gate.bats
@@ -97,3 +97,85 @@ gate() {
   # iso-e2e.sh about why appending a field breaks every green cell).
   grep -qF 'TUNAOS_LUKS_E2E_INSTALLED_SCREENSHOT rendered=${_shot} stddev=${SCREENSHOT_STDDEV:-na} fatal=0' "$E2E"
 }
+
+# ── the contract discriminator ─────────────────────────────────────────────
+# The `absent` row rested on a premise — no capture implies no surface — that
+# two cells falsified: gurnard:pantheon (run 31232163933) and grouper:xfce
+# (run 31232166865) both recorded desktop_contract=ok with 141-153 timelapse
+# frames while the installed-desktop capture never appeared. The contract is
+# measured inside the guest, so it cannot be satisfied by a machine that never
+# drew. These pin the narrow downgrade and, more importantly, its boundaries.
+
+@test "absent capture is advisory when the guest's own contract passed" {
+  gate absent "" 153 0 ok
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"result=absent_contract_ok"* ]]
+  [[ "$output" == *"fatal=0"* ]]
+  [[ "$output" == *"frames=153"* ]]
+}
+
+@test "the downgrade is named, never reported as a clean pass" {
+  # A reader scanning for result=pass must not find one here: the cell did
+  # not prove pixels, it proved the guest disagrees with the capture path.
+  gate absent "" 153 0 ok
+  [[ "$output" != *"result=pass"* ]]
+}
+
+@test "absent stays fatal when the contract failed" {
+  gate absent "" 160 0 fail
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"result=absent"* ]]
+  [[ "$output" == *"fatal=1"* ]]
+}
+
+@test "absent stays fatal when there is no contract marker at all" {
+  # absent contract = the DM likely never started; the missing capture
+  # corroborates it rather than contradicting it.
+  gate absent "" 160 0 absent
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"result=absent"* ]]
+}
+
+@test "absent stays fatal when the contract verdict is unknown (arg omitted)" {
+  # Backward compatibility: every caller that predates the 5th argument keeps
+  # the old fatal behavior rather than silently getting the downgrade.
+  gate absent "" 160 0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"result=absent"* ]]
+  [[ "$output" == *"fatal=1"* ]]
+}
+
+@test "a BLANK capture stays fatal even when the contract passed" {
+  # The black-console-under-a-live-session hole. "We measured and saw
+  # nothing" must never be downgraded — only "we failed to measure at all".
+  gate blank 0.0004 151 0 ok
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"result=blank"* ]]
+  [[ "$output" == *"fatal=1"* ]]
+}
+
+@test "zero frames stays fatal even when the contract passed" {
+  # no_frames is checked before shot: an entire install with no captured
+  # frame means the contradicting channel never worked at all.
+  gate absent "" 0 0 ok
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"result=no_frames"* ]]
+}
+
+@test "iso-e2e.sh actually passes the contract verdict into the gate" {
+  # The row is worthless if the caller never supplies the argument.
+  run grep -F 'pixel_gate "$_shot" "${SCREENSHOT_STDDEV:-}" "$_frames" "${QEMU_NEEDS_VNC_SURFACE:-0}" "$_dc"' "$E2E"
+  [ "$status" -eq 0 ]
+}
+
+@test "the contract verdict is computed before the gate consumes it" {
+  # _dc is assigned in the desktop-contract block above; if a refactor moved
+  # the gate above it, the gate would silently receive an empty string and
+  # every downgrade would vanish into the old fatal path.
+  local dc_at gate_at
+  dc_at="$(grep -n 'record_luks_evidence "TUNAOS_LUKS_E2E_DESKTOP_CONTRACT' "$E2E" | head -1 | cut -d: -f1)"
+  gate_at="$(grep -n 'pixel_gate "\$_shot"' "$E2E" | head -1 | cut -d: -f1)"
+  [ -n "$dc_at" ]
+  [ -n "$gate_at" ]
+  [ "$dc_at" -lt "$gate_at" ]
+}


### PR DESCRIPTION
## What

The two lightdm proof cells came back with **the desktop fixed and the gate still red**, on a premise the runs themselves falsify:

| cell | run | desktop_contract | frames | pixel gate |
|---|---|---|---|---|
| gurnard:pantheon | [31232163933](https://github.com/tuna-os/tunaOS/actions/runs/31232163933) | **ok** (`experience=tunaos/pantheon`) | 153 | `result=absent fatal=1` |
| grouper:xfce | [31232166865](https://github.com/tuna-os/tunaOS/actions/runs/31232166865) | **ok** (`experience=tunaos/xfce`) | 141 | `result=absent fatal=1` |

Both recorded `TUNAOS_LUKS_E2E_PASS encrypted=1 passphrase_unlock=1 installed_boot=1` and `TUNAOS_DESKTOP_CONTRACT_OK` from inside the guest — so #1086's `xserver-xorg` + `accountsservice` fix worked and **lightdm now starts on both**. The only fatal left was the pixel gate's `absent` row.

That row's own comment states its premise: *"on the plain path screendump works whenever QEMU is alive, so no capture at all means the surface was never there to photograph."* These cells are counterexamples. The installed-desktop capture never appeared, yet the recorder screendumped 141–153 frames through the same monitor socket, and the contract — run **inside** the guest by `verify-desktop-experience --runtime`, asserting an active DM plus the session's own checks — cannot be satisfied by a machine that never drew. (The `10-ready.png` in both artifacts is a 1-bit-grayscale 1280×800 PNG of 282 bytes: the capture path is degenerate on these hosts, the same story from the other side.)

## Changes

- `scripts/lib/pixel-gate.sh`: `pixel_gate` takes the contract verdict as a 5th argument; `shot=absent` + `contract=ok` becomes advisory, named **`absent_contract_ok`** so it can never be misread as a clean pass.
- `scripts/iso-e2e.sh`: passes `$_dc` (already computed just above) into the call.

**The boundaries are the point** — this is deliberately narrow:

- `shot=blank` stays **FATAL** even with `contract=ok`. "We measured and saw nothing" is the black-console-under-a-live-session hole this gate exists to close (run 29645108966); only "we failed to measure at all, and the guest says it is up" is downgraded.
- `frames=0` stays **FATAL** (`no_frames` is decided before `shot`).
- `contract=fail` or `absent` stays **FATAL** — there a missing capture corroborates the failure rather than contradicting it.
- Omitting the argument keeps the old fatal behavior, so no caller silently inherits the downgrade.

## Testing

- Bats 10 → 19. **Mutation-verified in both directions**: widening the downgrade to cover `blank` fails the blank pins; deleting the row fails the downgrade pins.
- Two wiring pins assert `iso-e2e.sh` actually passes `$_dc` *and* computes it before the gate reads it — a gate that never receives the argument would quietly revert to fatal.
- Full suite failure set identical to clean main (24 pre-existing, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->