### PR TITLE
gate(luks): the installed desktop contract is now fatal

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -93,6 +93,12 @@
 #      provably rendered (blank/absent capture, or zero timelapse frames on
 #      a host where capture works). TUNAOS_PIXEL_GATE=0 downgrades to
 #      advisory. See scripts/lib/pixel-gate.sh for the decision table.
+#   7  desktop contract failed on the installed system — the DM/session
+#      assertions run INSIDE the guest did not pass. Distinct from 6 on
+#      purpose: 6 says nothing drew, 7 says the guest itself reports no
+#      working desktop, and the two catch different holes (a greeter that
+#      draws satisfies 6 and still fails 7). TUNAOS_DESKTOP_CONTRACT=0
+#      downgrades to advisory.
 #   77 missing dependency (qemu, ovmf, etc.) — distinguishable for CI skip
 
 set -euo pipefail
@@ -2381,17 +2387,26 @@ EOF
 		# on a string mismatch, across every variant and several sessions'
 		# work.
 		#
-		# Deliberately NOT fatal in this commit. This is the first time the
-		# assertion has ever run post-install on any edition, so a red result
-		# would be ambiguous between "the desktop does not come up" and "the
-		# harvest is wrong". Get one named run first, then gate on it.
+		# FATAL as of this commit. The rule the earlier revision set for
+		# itself was "get one named run first, then gate on it", because a
+		# red result would otherwise be ambiguous between "the desktop does
+		# not come up" and "the harvest is wrong". That run now exists twice,
+		# on two different families and package managers:
+		#
+		#   gurnard:pantheon (31232163933)  desktop_contract=ok  apt/lightdm
+		#   grouper:xfce     (31232166865)  desktop_contract=ok  apt/lightdm
+		#
+		# and the harvest was proven in the same arc by its failures: it
+		# reported dm_inactive with the DM's own journal tail while lightdm
+		# was genuinely crash-looping (#1073), and flipped to ok once the
+		# missing X server was installed (#1086). It measures what it claims.
 		local _dc="absent"
 		if grep -q "LUKS_FIRST_BOOT_DESKTOP_CONTRACT=ok" "${OUTPUT_DIR}/installed-serial.log" 2>/dev/null; then
 			_dc="ok"
 		elif grep -q "LUKS_FIRST_BOOT_DESKTOP_CONTRACT=fail" "${OUTPUT_DIR}/installed-serial.log" 2>/dev/null; then
 			_dc="fail"
 		fi
-		record_luks_evidence "TUNAOS_LUKS_E2E_DESKTOP_CONTRACT desktop_contract=${_dc} fatal=0"
+		record_luks_evidence "TUNAOS_LUKS_E2E_DESKTOP_CONTRACT desktop_contract=${_dc} fatal=1"
 		case "$_dc" in
 		ok) echo "==> Desktop contract PASSED on the installed encrypted system" ;;
 		fail)
@@ -2431,6 +2446,28 @@ EOF
 				return 6
 			fi
 			echo "::warning::pixel gate failed but TUNAOS_PIXEL_GATE=0 — advisory only (${_pixel_line})"
+		fi
+
+		# ── Desktop contract verdict ──────────────────────────────────
+		# Checked HERE, after the pixel gate, for two reasons. Both evidence
+		# lines land on every run regardless of outcome — returning earlier
+		# would drop TUNAOS_LUKS_E2E_PIXEL_GATE from exactly the artifacts
+		# someone debugging a contract failure needs. And this is the
+		# placement that closes the hole the pixel gate cannot see: a greeter
+		# that draws clears the stddev floor and passes the pixel gate, while
+		# the in-guest contract still reports no session (the
+		# greeter-drew-but-no-session case named in the screenshot comment
+		# above). That case reaches this line with _pixel_rc=0.
+		if [[ "$_dc" != "ok" ]]; then
+			if [[ "${TUNAOS_DESKTOP_CONTRACT:-1}" == "1" ]]; then
+				echo "ERROR: desktop contract FAILED on the installed system" >&2
+				echo "       (desktop_contract=${_dc}) — the encrypted install booted, but the" >&2
+				echo "       guest's own DM/session assertions did not pass. installed-serial.log" >&2
+				echo "       carries the dm_diag detail; TUNAOS_DESKTOP_CONTRACT=0 downgrades" >&2
+				echo "       this to advisory." >&2
+				return 7
+			fi
+			echo "::warning::desktop contract ${_dc} but TUNAOS_DESKTOP_CONTRACT=0 — advisory only"
 		fi
 
 		echo "==> LUKS passphrase gate PASSED for ${VARIANT:-}:${FLAVOR:-}"

--- a/tests/bats/test_desktop_contract_fatal.bats
+++ b/tests/bats/test_desktop_contract_fatal.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# The installed-boot desktop contract is a GATE, not a note.
+#
+# It shipped recording `fatal=0` with an explicit rule for its own promotion:
+# "This is the first time the assertion has ever run post-install on any
+# edition, so a red result would be ambiguous between 'the desktop does not
+# come up' and 'the harvest is wrong'. Get one named run first, then gate on
+# it." That run now exists twice — gurnard:pantheon (31232163933) and
+# grouper:xfce (31232166865), both desktop_contract=ok — and the harvest was
+# proven by its failures in the same arc: it reported dm_inactive with the
+# DM's own journal tail while lightdm was genuinely crash-looping (#1073),
+# then flipped to ok once the missing X server landed (#1086).
+#
+# These pin the promotion, its exit code, its escape hatch, and — the part
+# that matters most — that it is checked where it can still catch what the
+# pixel gate cannot.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+E2E="${REPO_ROOT}/scripts/iso-e2e.sh"
+
+@test "the contract evidence line is recorded fatal=1" {
+  run grep -F 'TUNAOS_LUKS_E2E_DESKTOP_CONTRACT desktop_contract=${_dc} fatal=1' "$E2E"
+  [ "$status" -eq 0 ]
+}
+
+@test "no fatal=0 desktop-contract evidence line survives" {
+  run grep -F 'TUNAOS_LUKS_E2E_DESKTOP_CONTRACT desktop_contract=${_dc} fatal=0' "$E2E"
+  [ "$status" -ne 0 ]
+}
+
+@test "a non-ok contract returns 7" {
+  run bash -c "grep -A10 'if \[\[ \"\\\$_dc\" != \"ok\" \]\]' '$E2E'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"return 7"* ]]
+}
+
+@test "exit code 7 is documented and distinguished from 6" {
+  grep -qE '^#   7  desktop contract failed' "$E2E"
+  # The table must say why it is not simply folded into 6.
+  run grep -A6 '^#   7  desktop contract failed' "$E2E"
+  [[ "$output" == *"greeter"* ]]
+}
+
+@test "the gate has an escape hatch, like the pixel gate" {
+  grep -qF 'TUNAOS_DESKTOP_CONTRACT:-1' "$E2E"
+  grep -qF 'TUNAOS_DESKTOP_CONTRACT=0' "$E2E"
+}
+
+@test "the contract is checked AFTER the pixel gate, not before" {
+  # Two reasons, both load-bearing: every run keeps both evidence lines, and
+  # a greeter that draws passes the pixel gate while failing the contract —
+  # that case only reaches the contract check if it sits downstream.
+  local pixel_at contract_at
+  pixel_at="$(grep -n 'pixel_gate "\$_shot"' "$E2E" | head -1 | cut -d: -f1)"
+  contract_at="$(grep -n 'if \[\[ "\$_dc" != "ok" \]\]' "$E2E" | head -1 | cut -d: -f1)"
+  [ -n "$pixel_at" ]
+  [ -n "$contract_at" ]
+  [ "$pixel_at" -lt "$contract_at" ]
+}
+
+@test "the contract verdict is still computed before both consumers" {
+  local dc_at pixel_at
+  dc_at="$(grep -n 'record_luks_evidence "TUNAOS_LUKS_E2E_DESKTOP_CONTRACT' "$E2E" | head -1 | cut -d: -f1)"
+  pixel_at="$(grep -n 'pixel_gate "\$_shot"' "$E2E" | head -1 | cut -d: -f1)"
+  [ "$dc_at" -lt "$pixel_at" ]
+}
+
+@test "the workflow's exact-match PASS line is untouched" {
+  # The LUKS workflow greps `grep -qx 'TUNAOS_LUKS_E2E_PASS encrypted=1
+  # passphrase_unlock=1 installed_boot=1'` -- anchored and exact. Appending a
+  # field to THAT line would turn every currently-green passphrase cell red
+  # on a string mismatch, which is precisely why the contract got its own
+  # evidence line instead. (The TPM-path PASS lines legitimately carry
+  # tpm_unlock/desktop_contract fields; they are gated differently and are
+  # not what this pins.)
+  run grep -c 'TUNAOS_LUKS_E2E_PASS encrypted=1 passphrase_unlock=1 installed_boot=1"' "$E2E"
+  [ "$output" -ge 1 ]
+  # Nothing may follow installed_boot=1 on a passphrase PASS line.
+  run grep 'TUNAOS_LUKS_E2E_PASS encrypted=1 passphrase_unlock=1' "$E2E"
+  [[ "$output" != *'installed_boot=1 '* ]]
+}
+
+@test "a passing contract still reaches the success path" {
+  # The flip must not make ok fall through to a failure return.
+  run bash -c "awk '/if \[\[ \"\\\$_dc\" != \"ok\" \]\]/,/^\t\tfi\$/' '$E2E' | tail -3"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"return 0"* ]]
+  run grep -F 'echo "==> LUKS passphrase gate PASSED' "$E2E"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## What

The block recording `TUNAOS_LUKS_E2E_DESKTOP_CONTRACT` set the rule for its own promotion and then waited for it:

> Deliberately NOT fatal in this commit. This is the first time the assertion has ever run post-install on any edition, so a red result would be ambiguous between "the desktop does not come up" and "the harvest is wrong". **Get one named run first, then gate on it.**

That run now exists twice, on two flavors sharing a display manager but not a desktop:

| cell | run | verdict |
|---|---|---|
| gurnard:pantheon | [31232163933](https://github.com/tuna-os/tunaOS/actions/runs/31232163933) | `desktop_contract=ok`, `experience=tunaos/pantheon` |
| grouper:xfce | [31232166865](https://github.com/tuna-os/tunaOS/actions/runs/31232166865) | `desktop_contract=ok`, `experience=tunaos/xfce` |

And the ambiguity the comment worried about is gone, because **the harvest was proven by its failures in between**: it reported `reason=dm_inactive` and shipped the DM's own journal tail to the serial while lightdm was genuinely crash-looping (#1073's `Wants=` change is what delivered that evidence), stayed red through the tmpfiles fix, and flipped to `ok` only once the missing X server landed (#1086). A harvest that tracks the defect appearing *and* disappearing measures what it claims.

## Changes

- `scripts/iso-e2e.sh`: evidence line → `fatal=1`; a non-`ok` verdict returns **7**. `TUNAOS_DESKTOP_CONTRACT=0` downgrades to advisory, mirroring `TUNAOS_PIXEL_GATE=0`. Exit-code table documents 7 and why it isn't folded into 6.
- `tests/bats/test_desktop_contract_fatal.bats`: 9 pins.

**Placed after the pixel gate, deliberately**, for two reasons:
1. Both evidence lines land on every run — returning earlier would drop `TUNAOS_LUKS_E2E_PIXEL_GATE` from exactly the artifacts someone debugging a contract failure needs.
2. It's the placement that closes the hole the pixel gate *cannot* see: a greeter that draws clears the stddev floor and **passes** the pixel gate while the in-guest contract still reports no session — the greeter-drew-but-no-session case named in the screenshot comment. That case reaches the new check with `_pixel_rc=0`.

**Exit 7, not 6**: 6 means nothing drew; 7 means the guest itself reports no working desktop.

**Untouched on purpose** — the workflow's gate greps `grep -qx 'TUNAOS_LUKS_E2E_PASS encrypted=1 passphrase_unlock=1 installed_boot=1'`, anchored and exact. That's why the contract has its own evidence line, and a test pins that nothing was appended to it.

## Testing

- 9 new bats, **mutation-verified three ways**: reverting `fatal=1` fails two pins; deleting the return fails the exit-code pin; moving the check above the pixel gate fails the ordering pin.
- Full suite failure set identical to clean main (24 pre-existing, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->