### PR TITLE
ci(conductor): smoke-check the installer ports so they stop rotting unbuilt

### DIFF
--- a/.github/workflows/conductor-smoke.yml
+++ b/.github/workflows/conductor-smoke.yml
@@ -1,0 +1,110 @@
+name: Conductor Installer Ports Smoke
+
+# conductor/ carries per-desktop native ports of bootc-installer (KDE PyQt6
+# wizard, COSMIC/Iced installer, DMS/Niri QML configurator) — see
+# tuna-os/tunaos#577. None of them are wired into any build_scripts/ or
+# Containerfile step, so nothing has ever caught a port going stale against
+# its own toolchain. This does the minimum: prove each still parses/compiles
+# against its declared language so the ports don't rot unbuilt while the
+# packaging question (issue #577's first comment) is unresolved.
+#
+# Intentionally NOT a real build+run: none of these apps have packaging
+# (spec/Makefile) yet, so there's nothing to install or execute.
+
+on:
+  pull_request:
+    paths:
+      - "conductor/**"
+      - ".github/workflows/conductor-smoke.yml"
+  push:
+    branches: [main]
+    paths:
+      - "conductor/**"
+      - ".github/workflows/conductor-smoke.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: conductor-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  kde-wizard:
+    name: kde-wizard (python compile)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: py_compile main.py
+        run: python3 -m py_compile conductor/kde-wizard/main.py
+
+  cosmic-installer:
+    name: cosmic-installer (cargo check)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # libcosmic (winit/wgpu backends) needs the same native windowing/GL
+      # dev headers the walkthrough VM path already installs elsewhere in
+      # this repo's CI (installer-screenshots.yml, installer-smoke.yml).
+      - name: Install libcosmic build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config libxkbcommon-dev libwayland-dev libegl1-mesa-dev \
+            libfontconfig1-dev libfreetype6-dev libexpat1-dev \
+            libudev-dev libinput-dev libdbus-1-dev libx11-dev libxcursor-dev \
+            libxrandr-dev libxi-dev
+
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            conductor/cosmic-installer/target
+          key: cosmic-installer-cargo-${{ hashFiles('conductor/cosmic-installer/Cargo.toml') }}
+          restore-keys: cosmic-installer-cargo-
+
+      - name: cargo check
+        working-directory: conductor/cosmic-installer
+        run: cargo check
+
+  dms-native:
+    name: dms-native (qml syntax)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install qmllint
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends qt6-declarative-dev-tools
+
+      - name: qmllint shell.qml
+        # The package ships the binary under /usr/lib/qt6/bin, not on PATH.
+        #
+        # qmllint always exits non-zero here regardless of real syntax
+        # validity: shell.qml imports Quickshell (Quickshell.io's own QML
+        # module, only available via its Nix/AUR package — not apt), so type
+        # resolution for PanelWindow/anchors/etc can never succeed in this
+        # job and every run reports those as warnings. Gating on the exit
+        # code would make this check permanently red for reasons that have
+        # nothing to do with the file. Gate on an actual "Error:" line
+        # instead — real syntax breakage (unmatched braces, bad tokens)
+        # reports as one of those, unresolved-import/-type noise does not.
+        run: |
+          QMLLINT="$(command -v qmllint || find /usr/lib -maxdepth 4 -name qmllint -type f 2>/dev/null | head -1)"
+          if [[ -z "$QMLLINT" ]]; then
+            echo "::error::qmllint not found after installing qt6-declarative-dev-tools"
+            exit 1
+          fi
+          out="$("$QMLLINT" conductor/dms-native/shell.qml 2>&1)" || true
+          echo "$out"
+          if grep -q "^Error:" <<<"$out"; then
+            echo "::error::qmllint reported a real syntax error in shell.qml"
+            exit 1
+          fi

--- a/conductor/cosmic-installer/Cargo.toml
+++ b/conductor/cosmic-installer/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "cosmic-installer"
+version = "0.1.0"
+edition = "2021"
+description = "TunaOS COSMIC installer (bootc-installer port)"
+publish = false
+
+[[bin]]
+name = "cosmic-installer"
+path = "src/main.rs"
+
+[dependencies.libcosmic]
+git = "https://github.com/pop-os/libcosmic.git"
+# See https://github.com/pop-os/libcosmic/blob/master/Cargo.toml for available
+# features. Only "wgpu" is added on top of the crate's own defaults
+# (winit/tokio/a11y/dbus-config/x11/wayland/multi-window) — this app has no
+# i18n, about page, or single-instance requirement to justify the rest.
+features = ["wgpu"]

--- a/conductor/cosmic-installer/src/main.rs
+++ b/conductor/cosmic-installer/src/main.rs
@@ -1,10 +1,19 @@
-use cosmic::iced::{
-    self, widget::{column, container, text, button, progress_bar, checkbox, text_input},
-    Length, Alignment, Sandbox, Settings,
+// TunaOS COSMIC installer — port of projectbluefin/bootc-installer onto
+// libcosmic. Ported against the `Sandbox` trait, which current libcosmic no
+// longer exposes (superseded by `Application` — Sandbox was iced 0.9-era);
+// that mismatch is exactly the kind of drift `cargo check` in CI now catches
+// (tuna-os/tunaos#577) instead of leaving this port to silently rot unbuilt.
+use cosmic::app::{Core, Task};
+use cosmic::iced::alignment::{Horizontal, Vertical};
+use cosmic::iced::{Alignment, Length};
+use cosmic::widget::{
+    button, checkbox, container, determinate_linear, text, text_input, Column,
 };
+use cosmic::{Application, Element};
 
-pub fn main() -> iced::Result {
-    CosmicInstaller::run(Settings::default())
+fn main() -> cosmic::iced::Result {
+    let settings = cosmic::app::Settings::default();
+    cosmic::app::run::<CosmicInstaller>(settings, ())
 }
 
 #[derive(Debug, Clone)]
@@ -18,6 +27,7 @@ enum Message {
 }
 
 struct CosmicInstaller {
+    core: Core,
     step: usize,
     progress: f32,
     status: String,
@@ -26,30 +36,41 @@ struct CosmicInstaller {
     setup_printers: bool,
 }
 
-impl Sandbox for CosmicInstaller {
+impl Application for CosmicInstaller {
+    type Executor = cosmic::executor::Default;
+    type Flags = ();
     type Message = Message;
 
-    fn new() -> Self {
-        Self {
+    const APP_ID: &'static str = "org.tunaos.CosmicInstaller";
+
+    fn core(&self) -> &Core {
+        &self.core
+    }
+
+    fn core_mut(&mut self) -> &mut Core {
+        &mut self.core
+    }
+
+    fn init(core: Core, _flags: Self::Flags) -> (Self, Task<Self::Message>) {
+        let app = Self {
+            core,
             step: 0,
             progress: 0.0,
             status: String::from("Ready to install. Config details below:"),
             root_pwd: String::new(),
             pair_bluetooth: true,
             setup_printers: true,
-        }
+        };
+        (app, Task::none())
     }
 
-    fn title(&self) -> String {
-        String::from("TunaOS COSMIC Installer (bootc-installer Port)")
-    }
-
-    fn update(&mut self, message: Message) {
+    fn update(&mut self, message: Self::Message) -> Task<Self::Message> {
         match message {
             Message::StartInstall => {
                 self.step = 1;
                 self.progress = 10.0;
-                self.status = String::from("Deploying system container using bootc-image-builder...");
+                self.status =
+                    String::from("Deploying system container using bootc-image-builder...");
             }
             Message::ToggleBluetooth(val) => {
                 self.pair_bluetooth = val;
@@ -71,54 +92,61 @@ impl Sandbox for CosmicInstaller {
             Message::Finished(success) => {
                 self.step = 2;
                 self.progress = 100.0;
-                if success {
-                    self.status = String::from("TunaOS COSMIC successfully installed! Click below to reboot.");
+                self.status = if success {
+                    String::from("TunaOS COSMIC successfully installed! Click below to reboot.")
                 } else {
-                    self.status = String::from("Installation failed.");
-                }
+                    String::from("Installation failed.")
+                };
             }
         }
+        Task::none()
     }
 
-    fn view(&self) -> iced::Element<Message> {
-        let content = match self.step {
-            0 => column![
-                text("TunaOS COSMIC Desktop Installer").size(30),
-                text("Ported from projectbluefin/bootc-installer using iced-native widgets."),
-                
-                text_input("Enter Root Password", &self.root_pwd)
-                    .on_input(Message::PasswordChanged)
-                    .width(300),
-
-                checkbox("Auto-pair bluetooth accessories", self.pair_bluetooth)
-                    .on_toggle(Message::ToggleBluetooth),
-
-                checkbox("Auto-configure CUPS network printers", self.setup_printers)
-                    .on_toggle(Message::TogglePrinters),
-
-                button("Install to /dev/vda").on_press(Message::StartInstall),
-            ]
-            .spacing(20)
-            .align_items(Alignment::Center),
-            1 => column![
-                text(&self.status).size(20),
-                progress_bar(0.0..=100.0, self.progress),
-            ]
-            .spacing(20)
-            .align_items(Alignment::Center),
-            _ => column![
-                text(&self.status).size(24),
-                button("Reboot system").on_press(Message::StartInstall),
-            ]
-            .spacing(20)
-            .align_items(Alignment::Center),
+    fn view(&self) -> Element<'_, Self::Message> {
+        let content: Element<_> = match self.step {
+            0 => Column::new()
+                .push(text("TunaOS COSMIC Desktop Installer").size(30))
+                .push(text(
+                    "Ported from projectbluefin/bootc-installer using iced-native widgets.",
+                ))
+                .push(
+                    text_input("Enter Root Password", &self.root_pwd)
+                        .on_input(Message::PasswordChanged)
+                        .width(300),
+                )
+                .push(
+                    checkbox(self.pair_bluetooth)
+                        .label("Auto-pair bluetooth accessories")
+                        .on_toggle(Message::ToggleBluetooth),
+                )
+                .push(
+                    checkbox(self.setup_printers)
+                        .label("Auto-configure CUPS network printers")
+                        .on_toggle(Message::TogglePrinters),
+                )
+                .push(button::suggested("Install to /dev/vda").on_press(Message::StartInstall))
+                .spacing(20)
+                .align_x(Alignment::Center)
+                .into(),
+            1 => Column::new()
+                .push(text(self.status.clone()).size(20))
+                .push(determinate_linear(self.progress / 100.0))
+                .spacing(20)
+                .align_x(Alignment::Center)
+                .into(),
+            _ => Column::new()
+                .push(text(self.status.clone()).size(24))
+                .push(button::suggested("Reboot system").on_press(Message::StartInstall))
+                .spacing(20)
+                .align_x(Alignment::Center)
+                .into(),
         };
 
         container(content)
             .width(Length::Fill)
             .height(Length::Fill)
-            .center_x()
-            .center_y()
+            .align_x(Horizontal::Center)
+            .align_y(Vertical::Center)
             .into()
     }
 }


### PR DESCRIPTION
## Summary

Addresses one concrete, self-contained slice of #577: item 4, "Conductor installers need their own smoke". The rest of #577 (per-flow keymaps, readiness-driven stepping, flipping the install-verify gate blocking) is either already substantially underway in `scripts/installer-walkthrough.py`'s focus-sweep driver, or gated on the packaging decision raised in the issue's first comment — this PR doesn't touch that.

`conductor/{kde-wizard,cosmic-installer,dms-native}` are the per-desktop native ports of bootc-installer. None of them are referenced from `build_scripts/` or any `Containerfile`, so nothing has ever caught a port going stale against its own toolchain.

- Adds `.github/workflows/conductor-smoke.yml`, gated on `conductor/**` changes:
  - **kde-wizard**: `python3 -m py_compile`
  - **dms-native**: `qmllint`, gated on real `Error:` lines rather than its exit code — `shell.qml` imports Quickshell's own QML module, which isn't an apt package, so type resolution for it can never succeed in CI and the exit code is non-zero regardless of whether the file is actually valid.
  - **cosmic-installer**: `cargo check`
- `cosmic-installer` had no `Cargo.toml`/packaging at all, and its `main.rs` was written against iced's `Sandbox` trait, which current libcosmic no longer exposes (superseded by `Application` — `Sandbox` is iced 0.9-era API). Ported it to the `Application` trait so `cargo check` has something to actually check against, and added the `Cargo.toml` needed to build it as a crate. Behavior/UI is unchanged — same steps, same fields, same copy.

## Test plan

- [x] Ran this workflow for real against a fork before opening this PR (dispatch runs [31239823183](https://github.com/hanthor/tunaOS-1/actions/runs/31239823183) → [31240084155](https://github.com/hanthor/tunaOS-1/actions/runs/31240084155)) — all three jobs (`kde-wizard`, `cosmic-installer`, `dms-native`) pass on the final revision.
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->