### PR TITLE
Put Containerfile.gentoo's initramfs on the shared dracut config

### DIFF
--- a/Containerfile.gentoo
+++ b/Containerfile.gentoo
@@ -257,17 +257,12 @@ ENV BASE_IMAGE=${BASE_IMAGE} \
     ENABLE_SSHD=${ENABLE_SSHD} \
     DESKTOP_FLAVOR=${DESKTOP_FLAVOR}
 
+# Stage the kernel image into /usr/lib/modules, and move portage's database out
+# of /var. Both must happen BEFORE the ostree layout below, which deletes /boot
+# outright and wipes /var.
 RUN KVER=$(ls /usr/lib/modules | head -1) && \
     rm -f "/usr/lib/modules/$KVER/vmlinuz" && \
     (cp /boot/vmlinuz-* "/usr/lib/modules/$KVER/vmlinuz" 2>/dev/null || cp /usr/src/linux-*/arch/x86/boot/bzImage "/usr/lib/modules/$KVER/vmlinuz") && \
-    # NOT yet on build_scripts/bootc/dracut-config.sh, unlike every other
-    # composefs variant. That script names the crypt and dm dracut modules,
-    # which require cryptsetup and dmsetup binaries; Gentoo emerges neither, and
-    # dracut treats a requested-but-unsatisfiable module as fatal. So guppy's
-    # initramfs still carries no bootc module and no erofs driver. Packaging
-    # sys-fs/cryptsetup and sys-fs/lvm2 is the prerequisite, not this refactor.
-    dracut --force --no-hostonly --reproducible --zstd --omit "tpm2-tss pcsc" --kver "$KVER" \
-    "/usr/lib/modules/$KVER/initramfs.img" && \
     rm -rf /var/cache && \
     # Keep portage's package database; drop only its caches.
     #
@@ -284,6 +279,7 @@ RUN KVER=$(ls /usr/lib/modules | head -1) && \
     mkdir -p /usr/lib/sysimage && \
     if [ -d /var/db/pkg ]; then rm -rf /usr/lib/sysimage/portage; cp -a /var/db /usr/lib/sysimage/portage; fi && \
     rm -rf /var/db
+
 # Shared bootc/ostree layout (the /var wipe, alias symlinks, tmpfiles.d and
 # prepare-root.conf) — build_scripts/bootc/ostree-layout.sh. What stays here is
 # Gentoo-specific: pruning /dev, and linking portage's relocated database back
@@ -299,6 +295,69 @@ RUN --mount=type=bind,from=context,source=/,target=/run/context \
     printf 'd /var/db 0755 root root -\nL+ /var/db/pkg - - - - ../../usr/lib/sysimage/portage/pkg\n' \
         > /usr/lib/tmpfiles.d/portage-sysimage.conf && \
     mkdir -p /var/db && ln -sfnT ../../usr/lib/sysimage/portage/pkg /var/db/pkg
+
+# Build the initramfs.
+#
+# On build_scripts/bootc/dracut-config.sh, like every other bootc variant, and
+# AFTER ostree-layout.sh above — that script writes prepare-root.conf, which is
+# where dracut-config.sh reads whether this image is composefs and therefore
+# whether the initramfs needs the erofs driver. Reversed, every step still
+# exits 0 and the initramfs silently cannot mount its own root. Same ordering
+# note as Containerfile.debian and Containerfile.arch carry.
+#
+# It was NOT on the shared script, and the comment here said why: it names the
+# crypt and dm dracut modules, "which require cryptsetup and dmsetup binaries;
+# Gentoo emerges neither", so requesting them would be fatal, and packaging
+# sys-fs/cryptsetup and sys-fs/lvm2 was the stated prerequisite. That is no
+# longer true, measured inside the published ghcr.io/tuna-os/guppy:gnome:
+#
+#   /usr/sbin/cryptsetup      present
+#   /usr/sbin/dmsetup         present
+#   dracut modules 51bootc, 70crypt, 70dm   all installed
+#
+# so every module the shared config asks for is satisfiable on this base today.
+#
+# What the gap cost: with no drop-in, dracut never added 51bootc, and `lsinitrd`
+# on that same image's initramfs matched ZERO ostree/bootc files. Nothing then
+# prepared the deployment at boot, so /sysroot stayed the PHYSICAL root and
+# switch-root refused it --
+#
+#   Failed to switch root: Specified switch root path '/sysroot' does not seem
+#   to be an OS tree. os-release file is missing.
+#
+# -- dropping guppy:xfce to an emergency shell with the disk already unlocked
+# and /sysroot already mounted (LUKS run 31232170155). Every other variant was
+# immune because they all run this script.
+#
+# The --omit on the command line stays: it covers this build, while the drop-in
+# written near the top of the file is what reaches tacklebox's ISO-time rebuild
+# and post-install kernel updates.
+RUN --mount=type=bind,from=context,source=/,target=/run/context set -eu; \
+    KVER="$(ls /usr/lib/modules | head -1)"; \
+    IMG="/usr/lib/modules/${KVER}/initramfs.img"; \
+    /run/context/build_scripts/bootc/dracut-config.sh "$KVER"; \
+    dracut --force --no-hostonly --reproducible --zstd --omit "tpm2-tss pcsc" \
+      --kver "$KVER" "$IMG"; \
+    # Assert the module actually landed, the way Containerfile.opensuse does.
+    # A missing 51bootc costs nothing at build time and everything at boot, and
+    # this exact absence shipped undetected through a green image build, a green
+    # ISO build and a successful disk unlock before failing in switch-root.
+    #
+    # Only the two things measured absent are asserted. The crypt/dm payload is
+    # deliberately NOT pinned here: opensuse asserted `sbin/cryptsetup` on the
+    # same reasoning and failed a perfectly good initramfs (run 30735665323),
+    # because a systemd initrd ships systemd-cryptsetup instead. Assert what was
+    # measured, not what seems like it ought to be there.
+    lsinitrd "$IMG" > /tmp/initramfs.list; \
+    if ! grep -qx bootc /tmp/initramfs.list; then \
+      echo "ERROR: initramfs has no 'bootc' dracut module — nothing prepares the composefs deployment, so switch-root gets the physical root and drops to an emergency shell" >&2; \
+      exit 1; \
+    fi; \
+    if ! grep -qEi 'ostree|bootc' /tmp/initramfs.list; then \
+      echo "ERROR: initramfs contains no ostree/bootc files at all" >&2; \
+      exit 1; \
+    fi; \
+    rm -f /tmp/initramfs.list
 
 # Cache-bust so build_scripts edits invalidate the desktop stages' install
 # layers (bind-mounted scripts aren't in the cache key). Inherited by children.
@@ -414,17 +473,12 @@ RUN --mount=type=bind,from=context,source=/,target=/run/context \
     /run/context/build_scripts/desktop/install-desktop.sh ${DESKTOP_FLAVOR}
 
 FROM desktop-build AS desktop
+# Stage the kernel image into /usr/lib/modules, and move portage's database out
+# of /var. Both must happen BEFORE the ostree layout below, which deletes /boot
+# outright and wipes /var.
 RUN KVER=$(ls /usr/lib/modules | head -1) && \
     rm -f "/usr/lib/modules/$KVER/vmlinuz" && \
     (cp /boot/vmlinuz-* "/usr/lib/modules/$KVER/vmlinuz" 2>/dev/null || cp /usr/src/linux-*/arch/x86/boot/bzImage "/usr/lib/modules/$KVER/vmlinuz") && \
-    # NOT yet on build_scripts/bootc/dracut-config.sh, unlike every other
-    # composefs variant. That script names the crypt and dm dracut modules,
-    # which require cryptsetup and dmsetup binaries; Gentoo emerges neither, and
-    # dracut treats a requested-but-unsatisfiable module as fatal. So guppy's
-    # initramfs still carries no bootc module and no erofs driver. Packaging
-    # sys-fs/cryptsetup and sys-fs/lvm2 is the prerequisite, not this refactor.
-    dracut --force --no-hostonly --reproducible --zstd --omit "tpm2-tss pcsc" --kver "$KVER" \
-    "/usr/lib/modules/$KVER/initramfs.img" && \
     rm -rf /var/cache && \
     # Keep portage's package database; drop only its caches.
     #
@@ -441,6 +495,7 @@ RUN KVER=$(ls /usr/lib/modules | head -1) && \
     mkdir -p /usr/lib/sysimage && \
     if [ -d /var/db/pkg ]; then rm -rf /usr/lib/sysimage/portage; cp -a /var/db /usr/lib/sysimage/portage; fi && \
     rm -rf /var/db
+
 # Shared bootc/ostree layout (the /var wipe, alias symlinks, tmpfiles.d and
 # prepare-root.conf) — build_scripts/bootc/ostree-layout.sh. What stays here is
 # Gentoo-specific: pruning /dev, and linking portage's relocated database back
@@ -456,6 +511,69 @@ RUN --mount=type=bind,from=context,source=/,target=/run/context \
     printf 'd /var/db 0755 root root -\nL+ /var/db/pkg - - - - ../../usr/lib/sysimage/portage/pkg\n' \
         > /usr/lib/tmpfiles.d/portage-sysimage.conf && \
     mkdir -p /var/db && ln -sfnT ../../usr/lib/sysimage/portage/pkg /var/db/pkg
+
+# Build the initramfs.
+#
+# On build_scripts/bootc/dracut-config.sh, like every other bootc variant, and
+# AFTER ostree-layout.sh above — that script writes prepare-root.conf, which is
+# where dracut-config.sh reads whether this image is composefs and therefore
+# whether the initramfs needs the erofs driver. Reversed, every step still
+# exits 0 and the initramfs silently cannot mount its own root. Same ordering
+# note as Containerfile.debian and Containerfile.arch carry.
+#
+# It was NOT on the shared script, and the comment here said why: it names the
+# crypt and dm dracut modules, "which require cryptsetup and dmsetup binaries;
+# Gentoo emerges neither", so requesting them would be fatal, and packaging
+# sys-fs/cryptsetup and sys-fs/lvm2 was the stated prerequisite. That is no
+# longer true, measured inside the published ghcr.io/tuna-os/guppy:gnome:
+#
+#   /usr/sbin/cryptsetup      present
+#   /usr/sbin/dmsetup         present
+#   dracut modules 51bootc, 70crypt, 70dm   all installed
+#
+# so every module the shared config asks for is satisfiable on this base today.
+#
+# What the gap cost: with no drop-in, dracut never added 51bootc, and `lsinitrd`
+# on that same image's initramfs matched ZERO ostree/bootc files. Nothing then
+# prepared the deployment at boot, so /sysroot stayed the PHYSICAL root and
+# switch-root refused it --
+#
+#   Failed to switch root: Specified switch root path '/sysroot' does not seem
+#   to be an OS tree. os-release file is missing.
+#
+# -- dropping guppy:xfce to an emergency shell with the disk already unlocked
+# and /sysroot already mounted (LUKS run 31232170155). Every other variant was
+# immune because they all run this script.
+#
+# The --omit on the command line stays: it covers this build, while the drop-in
+# written near the top of the file is what reaches tacklebox's ISO-time rebuild
+# and post-install kernel updates.
+RUN --mount=type=bind,from=context,source=/,target=/run/context set -eu; \
+    KVER="$(ls /usr/lib/modules | head -1)"; \
+    IMG="/usr/lib/modules/${KVER}/initramfs.img"; \
+    /run/context/build_scripts/bootc/dracut-config.sh "$KVER"; \
+    dracut --force --no-hostonly --reproducible --zstd --omit "tpm2-tss pcsc" \
+      --kver "$KVER" "$IMG"; \
+    # Assert the module actually landed, the way Containerfile.opensuse does.
+    # A missing 51bootc costs nothing at build time and everything at boot, and
+    # this exact absence shipped undetected through a green image build, a green
+    # ISO build and a successful disk unlock before failing in switch-root.
+    #
+    # Only the two things measured absent are asserted. The crypt/dm payload is
+    # deliberately NOT pinned here: opensuse asserted `sbin/cryptsetup` on the
+    # same reasoning and failed a perfectly good initramfs (run 30735665323),
+    # because a systemd initrd ships systemd-cryptsetup instead. Assert what was
+    # measured, not what seems like it ought to be there.
+    lsinitrd "$IMG" > /tmp/initramfs.list; \
+    if ! grep -qx bootc /tmp/initramfs.list; then \
+      echo "ERROR: initramfs has no 'bootc' dracut module — nothing prepares the composefs deployment, so switch-root gets the physical root and drops to an emergency shell" >&2; \
+      exit 1; \
+    fi; \
+    if ! grep -qEi 'ostree|bootc' /tmp/initramfs.list; then \
+      echo "ERROR: initramfs contains no ostree/bootc files at all" >&2; \
+      exit 1; \
+    fi; \
+    rm -f /tmp/initramfs.list
 
 LABEL containers.bootc=1 ostree.bootable=1
 COPY --from=context /files /

--- a/tests/bats/test_bootc_ostree_layout.bats
+++ b/tests/bats/test_bootc_ostree_layout.bats
@@ -142,11 +142,16 @@ run_layout() {
   done
 }
 
-@test "arch and debian lay out the filesystem before building the initramfs" {
+@test "every variant lays out the filesystem before building the initramfs" {
   # dracut-config.sh reads prepare-root.conf, which ostree-layout.sh writes.
   # Reversed, the initramfs is built with composefs undetected and no erofs
   # driver — an image that cannot mount its own root, and silent about it.
-  for f in Containerfile.arch Containerfile.debian; do
+  #
+  # Gentoo was excluded here while it built its initramfs first and called no
+  # dracut-config.sh at all. It now does both, in this order, and the per-stage
+  # version of this check lives in test_gentoo_dracut_config.bats — that file
+  # also records what the omission cost (LUKS run 31232170155).
+  for f in Containerfile.arch Containerfile.debian Containerfile.gentoo; do
     local layout dracut
     layout=$(grep -n 'bootc/ostree-layout.sh' "${REPO_ROOT}/$f" | head -1 | cut -d: -f1)
     dracut=$(grep -n 'bootc/dracut-config.sh' "${REPO_ROOT}/$f" | head -1 | cut -d: -f1)

--- a/tests/bats/test_gentoo_dracut_config.bats
+++ b/tests/bats/test_gentoo_dracut_config.bats
@@ -1,0 +1,207 @@
+#!/usr/bin/env bats
+# Containerfile.gentoo's initramfs must be built the way every other bootc
+# variant builds one — through build_scripts/bootc/dracut-config.sh, and only
+# after the ostree layout that script reads from.
+#
+# WHAT WENT WRONG
+#
+# Gentoo was the one bootable variant not calling the shared script. The
+# comment that stood here said why: the script names the crypt and dm dracut
+# modules, "which require cryptsetup and dmsetup binaries; Gentoo emerges
+# neither", and dracut treats a requested-but-unsatisfiable module as fatal.
+#
+# Measured inside the published ghcr.io/tuna-os/guppy:gnome, that is no longer
+# true — /usr/sbin/cryptsetup and /usr/sbin/dmsetup are both present, and dracut
+# modules 51bootc, 70crypt and 70dm are all installed. What the image did NOT
+# have was any of them in its initramfs: `lsinitrd` matched ZERO ostree/bootc
+# files, because with no drop-in nothing ever asked for the bootc module.
+#
+# So nothing prepared the composefs deployment at boot, /sysroot stayed the
+# physical root, and switch-root refused it:
+#
+#   Failed to switch root: Specified switch root path '/sysroot' does not seem
+#   to be an OS tree. os-release file is missing.
+#
+# guppy:xfce reached an emergency shell with the disk already unlocked and
+# /sysroot already mounted (LUKS run 31232170155) — a green image build, a green
+# ISO build and a working LUKS unlock, all the way to the last step.
+#
+# ORDERING IS HALF THE FIX
+#
+# dracut-config.sh decides whether to add the erofs driver by reading
+# /usr/lib/ostree/prepare-root.conf, which ostree-layout.sh writes. Gentoo built
+# its initramfs BEFORE laying out the filesystem, so simply calling the script
+# in place would have read composefs=off and produced an initramfs that still
+# could not mount its own root — with every step exiting 0. And ostree-layout.sh
+# `rm -rf`s /boot, so the kernel image has to be staged into /usr/lib/modules
+# before it runs. Three steps, one order, none of it self-evident from any one
+# line: hence a test.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+GENTOO="${REPO_ROOT}/Containerfile.gentoo"
+
+# The two bootable stages. `desktop` is not a child of `system` (the chain is
+# base -> builder -> desktop-build -> desktop), so each carries its own copy of
+# the whole sequence and each has to be checked on its own.
+BOOTABLE_STAGES=(system desktop)
+
+# Non-comment lines, annotated with the stage they fall in: "<stage>\t<lineno>\t<text>".
+# Comment-stripped so that commenting a step out fails exactly like deleting it.
+stage_lines() {
+  awk '
+    tolower($0) ~ /^from[ \t]/ {
+      stage="?"
+      for (i=1;i<=NF;i++) if (tolower($i)=="as") stage=$(i+1)
+      next
+    }
+    /^[[:space:]]*#/ { next }
+    { print stage "\t" NR "\t" $0 }
+  ' "$GENTOO"
+}
+
+# Line number of the first line in <stage> matching <ERE>, or empty.
+first_in_stage() {
+  stage_lines | awk -F'\t' -v s="$1" -v p="$2" '$1==s && $3 ~ p {print $2; exit}'
+}
+
+# A real dracut run, not the package name in an emerge/pacman/apt list: an
+# invocation is `dracut` followed by a flag.
+DRACUT_RUN='dracut[ \t]+-'
+CONFIG_CALL='bootc/dracut-config\.sh'
+LAYOUT_CALL='bootc/ostree-layout\.sh'
+
+@test "both bootable gentoo stages build an initramfs at all" {
+  local s n
+  for s in "${BOOTABLE_STAGES[@]}"; do
+    n="$(first_in_stage "$s" "$DRACUT_RUN")"
+    [ -n "$n" ] || {
+      echo "FAIL: stage '${s}' runs no dracut — nothing produces its initramfs." >&2
+      return 1
+    }
+  done
+}
+
+@test "every gentoo dracut run is configured by the shared dracut-config.sh" {
+  # The whole bug in one assertion. An unconfigured dracut still exits 0 and
+  # still writes an initramfs; it just writes one with no bootc module.
+  local s cfg dracut
+  for s in "${BOOTABLE_STAGES[@]}"; do
+    cfg="$(first_in_stage "$s" "$CONFIG_CALL")"
+    dracut="$(first_in_stage "$s" "$DRACUT_RUN")"
+    [ -n "$cfg" ] || {
+      echo "FAIL: stage '${s}' runs dracut without calling dracut-config.sh." >&2
+      echo "      Its initramfs gets no bootc module, so switch-root finds the" >&2
+      echo "      physical root instead of the deployment and emergency-shells." >&2
+      return 1
+    }
+    [ "$cfg" -lt "$dracut" ] || {
+      echo "FAIL: stage '${s}' calls dracut-config.sh at line ${cfg}, AFTER the" >&2
+      echo "      dracut run at line ${dracut}. The config lands too late to" >&2
+      echo "      affect the initramfs that was just built." >&2
+      return 1
+    }
+  done
+}
+
+@test "the ostree layout is written before dracut-config.sh reads it" {
+  # dracut-config.sh probes /usr/lib/ostree/prepare-root.conf (written by
+  # ostree-layout.sh) to decide whether this image is composefs and therefore
+  # whether its initramfs needs the erofs driver. Reversed, composefs reads as
+  # off and the driver is silently dropped — the exact bug wiring arch hit, and
+  # the reason Containerfile.debian carries a MUST-precede note.
+  local s layout cfg
+  for s in "${BOOTABLE_STAGES[@]}"; do
+    layout="$(first_in_stage "$s" "$LAYOUT_CALL")"
+    cfg="$(first_in_stage "$s" "$CONFIG_CALL")"
+    [ -n "$layout" ]
+    [ -n "$cfg" ]
+    [ "$layout" -lt "$cfg" ] || {
+      echo "FAIL: stage '${s}' runs ostree-layout.sh at ${layout}, after" >&2
+      echo "      dracut-config.sh at ${cfg} — composefs will read as off and" >&2
+      echo "      the initramfs will ship with no erofs driver." >&2
+      return 1
+    }
+  done
+}
+
+@test "the kernel is staged out of /boot before the layout deletes /boot" {
+  # ostree-layout.sh does `rm -rf /boot`. Gentoo's kernel image only exists
+  # there (or in the kernel source tree), and /usr/lib/modules/<kver>/vmlinuz is
+  # where bootc looks for it. Staging after the wipe leaves an image with no
+  # kernel to boot.
+  local s stage_kernel layout
+  for s in "${BOOTABLE_STAGES[@]}"; do
+    stage_kernel="$(first_in_stage "$s" 'cp /boot/vmlinuz')"
+    layout="$(first_in_stage "$s" "$LAYOUT_CALL")"
+    [ -n "$stage_kernel" ] || {
+      echo "FAIL: stage '${s}' never copies a kernel into /usr/lib/modules." >&2
+      return 1
+    }
+    [ "$stage_kernel" -lt "$layout" ] || {
+      echo "FAIL: stage '${s}' stages the kernel at ${stage_kernel}, after" >&2
+      echo "      ostree-layout.sh removes /boot at ${layout}." >&2
+      return 1
+    }
+  done
+}
+
+@test "the RUN that calls dracut-config.sh mounts the build context" {
+  # The script is reached at /run/context/build_scripts/..., which exists only
+  # inside a RUN carrying the context bind-mount. Without it the path is absent
+  # and the step dies — or, worse, is written with `|| true` somewhere and does
+  # nothing. Caught on the first draft of this very change.
+  local n header
+  while read -r n; do
+    header="$(awk -v n="$n" 'NR<=n && /^RUN/ {h=$0} END {print h}' "$GENTOO")"
+    [[ "$header" == *"from=context"* ]] || {
+      echo "FAIL: the dracut-config.sh call at line ${n} is in a RUN with no" >&2
+      echo "      context bind-mount: ${header}" >&2
+      return 1
+    }
+  done < <(stage_lines | awk -F'\t' -v p="$CONFIG_CALL" '$3 ~ p {print $2}')
+}
+
+@test "each stage verifies the built initramfs actually has the bootc module" {
+  # The failure this whole file is about was invisible at build time. lsinitrd
+  # on the produced image makes it loud, the way Containerfile.opensuse already
+  # does for its own crypt/dm payload.
+  local s code
+  for s in "${BOOTABLE_STAGES[@]}"; do
+    code="$(stage_lines | awk -F'\t' -v st="$s" '$1==st {print $3}')"
+    grep -q 'lsinitrd' <<<"$code" || {
+      echo "FAIL: stage '${s}' never inspects the initramfs it just built." >&2
+      return 1
+    }
+    grep -qE "grep -qx bootc" <<<"$code" || {
+      echo "FAIL: stage '${s}' runs lsinitrd but never asserts the bootc module." >&2
+      return 1
+    }
+  done
+}
+
+@test "the initramfs assertion is fatal, not a warning" {
+  # A check that prints and continues would have let run 31232170155 ship
+  # unchanged. Pin the exit.
+  run grep -A2 "initramfs has no 'bootc' dracut module" "$GENTOO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"exit 1"* ]]
+}
+
+@test "no Containerfile runs dracut before configuring it" {
+  # The cross-variant version of the same property. Scoped to files that have
+  # adopted the shared script — Containerfile.opensuse writes its config inline
+  # and is checked by its own drop-in assertions; Containerfile.ubuntu runs no
+  # dracut at all (tacklebox rebuilds its initramfs at ISO time).
+  local cf name cfg dracut
+  for cf in "${REPO_ROOT}"/Containerfile.*; do
+    name="$(basename "$cf")"
+    cfg=$(grep -nE "$CONFIG_CALL" "$cf" | grep -vE ':[[:space:]]*#' | head -1 | cut -d: -f1)
+    [ -n "$cfg" ] || continue
+    dracut=$(grep -nE "$DRACUT_RUN" "$cf" | grep -vE ':[[:space:]]*#' | head -1 | cut -d: -f1)
+    [ -n "$dracut" ] || continue
+    [ "$cfg" -lt "$dracut" ] || {
+      echo "FAIL: ${name} runs dracut at ${dracut} before dracut-config.sh at ${cfg}." >&2
+      return 1
+    }
+  done
+}


### PR DESCRIPTION
## The failure

`guppy:xfce` unlocked its LUKS root, mounted `/sysroot`, and then dropped to an emergency shell (LUKS run 31232170155):

```
Failed to switch root: Specified switch root path '/sysroot' does not seem to be
an OS tree. os-release file is missing.
```

A green image build, a green ISO build and a working disk unlock — failing at the last step.

## What was measured

Inside the published `ghcr.io/tuna-os/guppy:gnome`:

| probe | result |
|---|---|
| `/usr/sbin/cryptsetup` | present |
| `/usr/sbin/dmsetup` | present |
| `/usr/sbin/ostree`, `/usr/sbin/bootc` | present |
| dracut modules `51bootc`, `70crypt`, `70dm` | all installed |
| `lsinitrd` hits for `ostree\|bootc` in the image's own initramfs | **0** |

Everything needed was in the image. Nothing ever asked dracut for it, so nothing prepared the composefs deployment at boot and `/sysroot` stayed the physical root.

## Why

Gentoo was the only bootable variant not calling `build_scripts/bootc/dracut-config.sh`. The comment standing at both dracut sites said why: that script names the crypt and dm modules, *"which require cryptsetup and dmsetup binaries; Gentoo emerges neither"*, and dracut treats a requested-but-unsatisfiable module as fatal — so packaging `sys-fs/cryptsetup` and `sys-fs/lvm2` was the stated prerequisite. The table above says that is no longer true. The comment is replaced with the measurement and with what its absence cost.

## Ordering was half the fix

Calling the script in place would not have worked:

- `dracut-config.sh` decides whether to add the **erofs** driver by reading `/usr/lib/ostree/prepare-root.conf`, which `ostree-layout.sh` writes — and Gentoo built its initramfs *before* laying out the filesystem. Composefs would have read as off and produced an initramfs that still cannot mount its own root, with every step exiting 0.
- `ostree-layout.sh` also does `rm -rf /boot`, which is where Gentoo's kernel image lives.

So each bootable stage is now three ordered steps instead of two: stage the kernel + relocate portage's database → lay out the filesystem → configure and build the initramfs. `system` and `desktop` each carry their own copy (the chain is `base → builder → desktop-build → desktop`, so `desktop` is a sibling of `system`, not a child).

## The build now checks its own output

Mirroring `Containerfile.opensuse`: `lsinitrd` must show the `bootc` module or the build fails. Only the two things measured absent are asserted — opensuse pinned `sbin/cryptsetup` on the same instinct and failed a perfectly good initramfs (run 30735665323), because a systemd initrd ships `systemd-cryptsetup` instead. Assert what was measured, not what seems like it ought to be there.

## Tests

`tests/bats/test_gentoo_dracut_config.bats` — 8 tests, per stage, comment-stripped so commenting a step out fails like deleting it:

1. both bootable stages build an initramfs at all
2. every dracut run is configured by `dracut-config.sh`, before it runs
3. the layout is written before `dracut-config.sh` reads it
4. the kernel is staged out of `/boot` before the layout deletes `/boot`
5. the RUN calling the script carries the context bind-mount
6. each stage verifies the built initramfs has the `bootc` module
7. that assertion is fatal, not a warning
8. cross-variant: no Containerfile runs dracut before configuring it

All eight mutation-verified, including against the pre-change file (which fails 2, 3, 6 and 7). The now-stale gentoo exclusion in `test_bootc_ostree_layout.bats` is removed — that test now covers arch, debian and gentoo.

Full bats suite failure set is byte-identical to clean `main` (24 pre-existing).

## Follow-up

Proof is LUKS `luks-e2e.yml` on `{"variant":"guppy","flavor":"xfce"}` — the cell that produced the switch-root failure. Dispatching once this lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->