### PR TITLE
feat(asahi): hardware CI tiers — safe SSH-driven switch/reboot + nightly wiring (tunaOS#780)

### DIFF
--- a/.github/workflows/asahi-hw-nightly-one.yml
+++ b/.github/workflows/asahi-hw-nightly-one.yml
@@ -1,0 +1,71 @@
+name: Asahi hardware smoke (one)
+
+# Reusable single-image leg of the Tier 2 hardware smoke (tunaOS#780). Called
+# by asahi-hw-nightly.yml, once per flavor in sweep mode and once for an
+# explicit ref in dispatch mode. Not meant to be dispatched directly.
+#
+# Runs on an ordinary GitHub-hosted runner and drives the rental entirely
+# over SSH via scripts/asahi-remote-switch.sh — see that script's header and
+# docs/ASAHI-HARDWARE-TIERS.md for why the rental itself is never registered
+# as a self-hosted runner. The caller is responsible for checking
+# ASAHI_HW_TIER2_HOST is actually set before invoking this at all.
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: "Asahi image ref to boot-test"
+        required: true
+        type: string
+    secrets:
+      ASAHI_HW_TIER2_HOST:
+        required: true
+      ASAHI_HW_TIER2_SSH_KEY:
+        required: true
+      ASAHI_HW_TIER2_USER:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    # bootc switch + reboot + Apple Silicon's boot chain + polling for SSH to
+    # come back is generously covered by asahi-remote-switch.sh's own
+    # ASAHI_HW_REBOOT_TIMEOUT (420s default); this bounds the whole job
+    # against a rental that's gone unresponsive for a reason the script's own
+    # timeout won't catch (e.g. the SSH agent step itself hanging).
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Start an SSH agent with the rental's key
+        run: |
+          eval "$(ssh-agent -s)"
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
+          echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
+          ssh-add - <<< "${{ secrets.ASAHI_HW_TIER2_SSH_KEY }}"
+
+      - name: Switch the rental and confirm it survives reboot
+        id: switch
+        env:
+          ASAHI_HW_HOST: ${{ secrets.ASAHI_HW_TIER2_HOST }}
+          ASAHI_HW_USER: ${{ secrets.ASAHI_HW_TIER2_USER || 'root' }}
+        run: |
+          set -o pipefail
+          scripts/asahi-remote-switch.sh "${{ inputs.image }}" 2>&1 | tee /tmp/switch.log
+
+      - name: Summarize
+        # Always runs, so a rollback or a timeout reports clearly in the run
+        # summary — this step must not mask the switch step's own exit code.
+        if: always()
+        run: |
+          {
+            echo "### \`${{ inputs.image }}\`"
+            echo
+            echo '```'
+            tail -20 /tmp/switch.log 2>/dev/null || echo "(no log captured)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/asahi-hw-nightly.yml
+++ b/.github/workflows/asahi-hw-nightly.yml
@@ -1,0 +1,90 @@
+name: Asahi hardware smoke (Tier 2 rental)
+
+# Real-hardware boot smoke for the two flavors verify-asahi.yml has actually
+# proven correct at the image level (bonito, grouper — see MATRIX-STATUS.md
+# §4 and tunaOS#776). verify-asahi.yml only inspects the image; it never
+# boots it, and GitHub-hosted arm64 runners have no /dev/kvm and no Apple SoC
+# emulation exists anywhere. This is Tier 2 of tunaOS#780 — a rented Scaleway
+# Mac mini M2 Pro — driven entirely over SSH from an ordinary GitHub-hosted
+# runner via scripts/asahi-remote-switch.sh (asahi-hw-nightly-one.yml). See
+# docs/ASAHI-HARDWARE-TIERS.md for why: the rental is never registered as a
+# self-hosted runner at all, so it never holds a standing credential of its
+# own — only an SSH server this workflow connects out to.
+#
+# Same sweep/single split as verify-asahi.yml, on purpose: schedule or an
+# empty `image` input tests every flavor this tier actually trusts with real
+# rental time; an explicit `image` input tests exactly that one ref.
+#
+# Safe to merge with no rental configured: the `configured` job is the only
+# thing that runs until ASAHI_HW_TIER2_HOST is set, and it does nothing but
+# report that clearly — visible in the Actions tab as "waiting to be wired
+# up" rather than invisible, without ever failing the run.
+
+on:
+  schedule:
+    # Same slot as verify-asahi.yml's sweep (05:40 UTC) plus a 20-minute
+    # offset, so a fresh promoted tag from the nightly builds and a fresh
+    # image-level sweep both land before this tries to boot one of them.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Single image ref to boot-test (leave empty to test both bonito and grouper)"
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  configured:
+    runs-on: ubuntu-latest
+    outputs:
+      ready: ${{ steps.check.outputs.ready }}
+    steps:
+      - name: Check whether a Tier 2 rental is configured
+        id: check
+        run: |
+          if [ -n "${{ secrets.ASAHI_HW_TIER2_HOST }}" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+            echo "ASAHI_HW_TIER2_HOST is set — running the real boot smoke."
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### No Tier 2 rental configured"
+              echo
+              echo "\`ASAHI_HW_TIER2_HOST\` is not set, so there is nothing to boot-test yet."
+              echo "See \`docs/ASAHI-HARDWARE-TIERS.md\` — this is expected until someone"
+              echo "with a funded Scaleway account provisions the rental and sets"
+              echo "\`ASAHI_HW_TIER2_HOST\` / \`ASAHI_HW_TIER2_SSH_KEY\` as repository secrets."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  # Sweep mode: every flavor this tier trusts with real rental time.
+  sweep:
+    needs: configured
+    if: needs.configured.outputs.ready == 'true' && (github.event_name == 'schedule' || inputs.image == '')
+    strategy:
+      fail-fast: false
+      matrix:
+        # Only bonito and grouper — the two flavors verify-asahi.yml's sweep
+        # has actually proven bootable at the image level (tunaOS#776). The
+        # other six have known, tracked defects (#777, #911, #912, #914);
+        # spending rental minutes to re-discover them on real hardware would
+        # tell us nothing verify-asahi.yml hasn't already. Add a flavor here
+        # once its own verify-asahi.yml leg goes green.
+        flavor: [bonito, grouper]
+    uses: ./.github/workflows/asahi-hw-nightly-one.yml
+    with:
+      image: ghcr.io/tuna-os/${{ matrix.flavor }}:gnome-asahi
+    secrets: inherit
+
+  # Dispatch mode: one explicit ref, for iterating on a single build (e.g. a
+  # -testing tag) before it's promoted.
+  single:
+    needs: configured
+    if: needs.configured.outputs.ready == 'true' && github.event_name == 'workflow_dispatch' && inputs.image != ''
+    uses: ./.github/workflows/asahi-hw-nightly-one.yml
+    with:
+      image: ${{ inputs.image }}
+    secrets: inherit

--- a/docs/ASAHI-HARDWARE-TIERS.md
+++ b/docs/ASAHI-HARDWARE-TIERS.md
@@ -1,0 +1,162 @@
+# Asahi hardware CI tiers (tunaOS#780)
+
+`verify-asahi.yml` (see [MATRIX-STATUS.md §4](MATRIX-STATUS.md)) proves an
+image *contains* what Apple Silicon boot needs — the kernel, DTBs, m1n1/U-Boot
+payloads, modules. It never boots the image. GitHub-hosted arm64 runners have
+no `/dev/kvm` and there is no Apple SoC emulation anywhere, so CI caps out at
+"looks right" and cannot answer "boots on a Mac" — which is exactly the gap
+that let six of eight promoted `:gnome-asahi` tags ship unbootable
+(tunaOS#776).
+
+Two hardware tiers close that gap. Neither can be provisioned or enrolled by
+a sandboxed contributor: Tier 2 needs a funded Scaleway account (real EUR/hour
+billing), and Tier 3 needs physical hands on a specific person's laptop. What
+this document and the accompanying script (`scripts/asahi-remote-switch.sh`)
+give whoever *does* have that access is the safety-checked automation to run
+against either host once it exists, and CI wiring that activates the moment
+its target host is configured — no code change required at that point.
+
+## The one rule that matters more than either tier
+
+**Never let anything write `<ESP>/m1n1/boot.bin` on a hardware-tier host
+outside of a deliberate, watched, one-off action.**
+
+This is not a generic caution — it is a landmine already sitting in this
+repo. `build_scripts/asahi/install-bootbin-sync.sh` ships
+`asahi-bootbin-sync.service`, a oneshot that runs on **every boot** and
+regenerates `boot.bin` whenever its content stamp is stale, specifically
+*because* `bootc` deploys never run package scriptlets, so `update-m1n1`
+would otherwise never re-run after `bootc switch`/`bootc upgrade`. That is
+the correct behaviour on a machine with a keyboard next to it and a person
+who can hold the recovery key combo if a bad payload leaves it unbootable.
+
+Neither hardware tier has that. A Scaleway rental has no console access
+beyond SSH and a "brick risk, no physical access" clause in the issue that
+created this tier; James's M1 Air only has whoever is at James's desk. On
+both, an automatic `boot.bin` rewrite triggered by switching to a
+**deliberately experimental or known-broken test image** — which is the
+entire point of iterating against this tier — turns a bad OS image into a
+bricked machine, with no path back.
+
+So: `asahi-bootbin-sync.service` gets masked on both tiers before any
+iteration begins, and stays masked. `scripts/asahi-remote-switch.sh` does
+this itself on every run (idempotent, safe to repeat) rather than relying on
+a one-time setup step nobody re-checks. It also hard-refuses to run any
+command matching `update-m1n1`, `asahi-fwupdate`, `m1n1-installer`, or a raw
+write to `/boot/efi` — see `DANGEROUS_PATTERNS` in the script — so a copy-paste
+mistake in a future caller cannot reach the firmware path even if the mask
+above were somehow bypassed. Defense in depth on a mistake with no undo.
+
+## Tier 2 — Scaleway Mac mini M2 Pro rental
+
+Scaleway rents Mac mini M2 Pro bare metal with Asahi Linux preinstalled
+(`~EUR 0.21/h`, 24h minimum billing increment, provisionable via their API).
+Ephemeral by design: rent it, run the nightly/release smoke pass, tear it
+down. This is the tier that can exercise real m1n1 boot and the mesa
+`deqp-asahi-agx2` GPU acceptance suites (in-tree in mesa's `src/asahi/ci/`) —
+neither is reachable any other way.
+
+**What is out of scope for a code contribution:** the actual account,
+billing authority, and API token. This repo does not — and should not —
+carry a Scaleway credential, and the rental is deliberately never registered
+as a GitHub Actions self-hosted runner at all: `asahi-remote-switch.sh` (see
+its header for why) always drives its target over SSH from somewhere else,
+so the rental only ever needs an SSH server and never gets a standing
+credential of its own to keep secure or to worry about a workflow
+compromising. `.github/workflows/asahi-hw-nightly.yml` (added alongside this
+doc) runs on an ordinary GitHub-hosted `ubuntu-latest` runner and simply
+skips its one real step whenever the `ASAHI_HW_TIER2_HOST` repository
+variable/secret isn't set — which is its default state until someone with
+Scaleway access starts filling it in, so merging the workflow now is safe
+and does nothing until then.
+
+**Sequence once a rental exists:**
+
+1. Rent the instance (Scaleway console or API — see their Apple silicon
+   bare-metal docs; out of scope here) and note its address (Tailscale, if
+   joined to the same tailnet as the CI runner can reach; otherwise its
+   public IP with SSH locked down to GitHub's runner IP ranges).
+2. SSH in once by hand, confirm it boots to the preinstalled Asahi Linux,
+   and set `ASAHI_HW_TIER2_HOST` (and `ASAHI_HW_TIER2_USER` if not `root`)
+   as repository secrets/variables.
+3. `asahi-hw-nightly.yml` picks it up on the next scheduled run (nightly,
+   05:40 UTC — same slot as `verify-asahi.yml`'s sweep, so a fresh promoted
+   tag and a fresh hardware pass land close together) or `workflow_dispatch`.
+4. The workflow runs `scripts/asahi-remote-switch.sh` against that host to
+   switch it to the promoted image under test, confirm the switch survived a
+   reboot without bootc falling back to the previous deployment, then runs
+   whatever live-hardware checks are wired in (today: a `bootc status`
+   confirmation over the same SSH connection; mesa `deqp-asahi-agx2` and a
+   live-system rerun of `verify-asahi-image.sh`'s checks against the
+   *running* filesystem rather than a container mount are follow-up work —
+   the image-inspection version already exists, the boot-hardware version
+   does not yet).
+5. Tear the instance down (manual, or a provisioning script someone with a
+   live account writes and tests — not included here, see below). Scaleway
+   bills in 24h increments regardless of how long the job actually took, so
+   batching multiple flavors into one rental window is worth doing once this
+   is real rather than renting per flavor per night.
+
+## Tier 3 — James's M1 Air (`jamess-macbook-air` on tailnet)
+
+A standing, non-ephemeral personal machine reachable over Tailscale. One-time
+physical setup, then indefinite remote iteration:
+
+**One-time, physical, by James:**
+
+1. Install [Fedora Asahi Remix](https://asahilinux.org/fedora/) (the
+   "Minimal" spin — no desktop needed on the host itself, TunaOS images
+   bring their own) using the official `asahi-installer` from macOS Recovery.
+2. Boot it, `dnf install tailscale openssh-server`, `systemctl enable --now
+   tailscaled sshd`, `tailscale up`, note the tailnet hostname
+   (`jamess-macbook-air`, per the issue).
+3. Confirm SSH from a machine already on the tailnet:
+   `ssh james@jamess-macbook-air.<tailnet>.ts.net true`.
+4. `systemctl mask asahi-bootbin-sync.service` if a TunaOS bootc image is
+   ever switched to on this host (see the rule above) — the stock Fedora
+   Asahi Remix install won't have this unit at all until the first `bootc
+   switch` to a TunaOS image installs it, so this step is really "remember
+   to do it as part of every first switch," which is why the remote-switch
+   script does it unconditionally on every run instead of trusting a human
+   to remember once.
+
+None of the above can be done from this sandbox — it requires a keyboard in
+front of James's laptop. What follows can run from anywhere with tailnet
+reach and does not need repeating per-machine.
+
+**Ongoing, remote, by anyone (agent or human) on the tailnet:**
+
+```sh
+ASAHI_HW_HOST=jamess-macbook-air.<tailnet>.ts.net \
+ASAHI_HW_USER=james \
+  scripts/asahi-remote-switch.sh ghcr.io/tuna-os/bonito:gnome-asahi
+```
+
+masks `asahi-bootbin-sync.service`, records the currently-booted deployment,
+runs `bootc switch` to the given image, reboots, waits for the host to come
+back, and reports one of three outcomes: switched cleanly to the new image,
+rolled back on its own (bootc's own boot-counting mechanism selected the
+previous deployment because the new one never confirmed — the "greenboot"
+the issue refers to; TunaOS does not ship literal `greenboot`, `bootc`'s
+built-in staged-deployment/boot-counting rollback is the actual mechanism and
+this script only *observes* it, it implements none of the recovery logic
+itself), or never came back within the timeout (the one outcome that needs a
+human at the keyboard — bootc's rollback covers "new deployment doesn't
+confirm," not "new deployment hangs the whole boot before bootc's own health
+check can run").
+
+## What is deliberately not in this PR
+
+- A Scaleway provisioning/teardown script. Writing one against an API this
+  repo has never called, that cannot be tested without spending real money,
+  is exactly the kind of "confident but unverified" contribution that is
+  worse than not shipping it — see `iso-e2e-gpu.sh`'s precedent of shipping
+  the host-side script and documenting the host requirements, and leaving
+  actual host acquisition to whoever controls it.
+- Live-hardware GPU/`deqp-asahi-agx2` harness integration. `mesa`'s in-tree
+  suite is a real, separate piece of tooling with its own invocation and
+  result format; wiring it in blind, with no hardware to run it against, has
+  the same problem as the point above.
+- Renting any actual instance, setting any actual repository secret, or
+  touching James's actual laptop. All three require access this environment
+  does not have.

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -207,7 +207,51 @@ answer different questions and should not be compared directly.
 
 ---
 
-## 4. Regenerating this document
+## 4. Apple Silicon (Asahi) hardware support
+
+None of the axes above say anything about this — they run in QEMU/KVM on x86,
+and Apple Silicon needs its own kernel, DTBs, and boot chain
+(`build_scripts/overlay/asahi.sh`) that no x86 guest ever exercises. That gap is
+exactly how six of the eight promoted `:gnome-asahi` tags turned out to be
+unbootable on real hardware despite every other axis being green
+([tunaOS#776](https://github.com/tuna-os/tunaOS/issues/776)) — a tag existing in
+`ghcr` only means some build promoted it once, never that the image boots on a
+Mac.
+
+`scripts/verify-asahi-image.sh` is the check that actually looks: it unpacks
+the image and inspects it for the asahi kernel, the 12 hardware-critical
+modules, Apple DTBs, the m1n1/U-Boot payloads, and the audio stack, graded
+against a known-working Fedora Asahi Remix image. `.github/workflows/
+verify-asahi.yml` runs it in **sweep** mode daily at 05:40 UTC against every
+promoted `:gnome-asahi` tag (`workflow_dispatch` for one flavor at a time), so
+— same principle as the rest of this document — a result decays on its own if
+nobody re-runs it; [the workflow's run history](https://github.com/tuna-os/tunaOS/actions/workflows/verify-asahi.yml)
+is the live, current answer. This document does not attempt to mirror it into
+a generated table: unlike the three axes above, only two flavors are wired up
+at all, and per-check state on this axis is why the numbers below have
+individual tracking issues rather than a matrix cell each.
+
+As of the last full sweep:
+
+| Variant | Harness | Status |
+|---|:--:|---|
+| **bonito** | 36 / 0 | ✅ verified |
+| **grouper** | 36 / 0 | ✅ verified |
+| yellowfin, skipjack | 29 / 7 | ❌ no `update-m1n1` — [tunaOS#777](https://github.com/tuna-os/tunaOS/issues/777) |
+| sailfin | 27 / 9 | ❌ no Apple DTBs, no U-Boot payload — [tunaOS#914](https://github.com/tuna-os/tunaOS/issues/914) |
+| marlin, flounder | 23 / 13, 21 / 15 | ❌ overlay never applied — stock kernel — [tunaOS#911](https://github.com/tuna-os/tunaOS/issues/911) |
+| albacore | 11 / 25 | ❌ stock kernel not removed — [tunaOS#912](https://github.com/tuna-os/tunaOS/issues/912) |
+| guppy | — | not offered — overlay is stubbed, not broken, and deliberately excluded from the sweep matrix |
+
+Only `bonito` and `grouper` are safe to hand to a user today. The installer
+catalog agrees — `bootc-installer-asahi`'s `catalog.json` ships with exactly
+one hand-written entry (`bonito`) rather than enumerating every `*-asahi` tag,
+and its README documents the same six-of-eight gap
+([tuna-os/bootc-installer-asahi#42](https://github.com/tuna-os/bootc-installer-asahi/pull/42)).
+
+---
+
+## 5. Regenerating this document
 
 The tables between the `GENERATED` markers are rewritten by
 `scripts/gen-matrix-status.py`; everything else is hand-written and the

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ user-facing site:
 | [CI_SPEC.md](CI_SPEC.md) | CI behavior specification |
 | [TESTING.md](TESTING.md) | ISO end-to-end test harness |
 | [MATRIX-STATUS.md](MATRIX-STATUS.md) | Which variant×desktop combinations are actually verified — and which have never been tested |
+| [ASAHI-HARDWARE-TIERS.md](ASAHI-HARDWARE-TIERS.md) | Real Apple Silicon hardware CI: rented Scaleway rental + personal-machine tiers, and the m1n1/boot.bin safety rule both must follow |
 | [rhel-setup.md](rhel-setup.md) | RHEL 10 (Redfin) local-build instructions |
 | [ROLL_YOUR_OWN.md](ROLL_YOUR_OWN.md) | Guide to building custom TunaOS variants for your own use |
 | [IMPROVEMENT_PLAN.md](IMPROVEMENT_PLAN.md) | Historical record of the May 2026 sprint + remaining roadmap items |

--- a/scripts/asahi-remote-switch.sh
+++ b/scripts/asahi-remote-switch.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# scripts/asahi-remote-switch.sh — switch a live Asahi/bootc host to a new
+# image over SSH, reboot it, and report whether the switch stuck.
+#
+# WHY THIS EXISTS (tunaOS#780)
+#
+# The only two ways to exercise a real m1n1/Apple-Silicon boot chain are a
+# rented Scaleway Mac mini M2 Pro (Tier 2 — ephemeral, real per-hour billing)
+# or a standing personal machine reachable over Tailscale (Tier 3 — James's
+# M1 Air, "jamess-macbook-air"). Neither can be provisioned or enrolled from
+# here: Tier 2 needs a funded Scaleway account, Tier 3 needs physical hands
+# on a specific laptop. See docs/ASAHI-HARDWARE-TIERS.md for the full
+# picture; this script is the one piece both tiers need in common — safely
+# iterating `bootc switch` against whichever host is already up.
+#
+# ALWAYS DRIVEN FROM OUTSIDE THE TARGET, OVER SSH — NEVER LOCALLY
+#
+# This script reboots its target. A process cannot survive the reboot of the
+# machine it is running on — a "run this locally on the box under test" mode
+# would die the instant `systemctl reboot` fires, before it ever reached the
+# post-reboot verification it exists to do. So there is deliberately no local
+# mode: this always runs from a second machine (a GitHub-hosted runner, or
+# any other host with SSH reach) against ASAHI_HW_HOST over the network. For
+# Tier 2 that also means the Scaleway rental never needs to be registered as
+# a GitHub Actions self-hosted runner at all — a scoped SSH connection out to
+# it is a smaller blast radius than letting arbitrary workflow code execute
+# on it, and it is the rental's whole reason to exist for this one job, not a
+# standing credential.
+#
+# THE RULE THIS SCRIPT EXISTS TO ENFORCE
+#
+# Neither hardware tier has a keyboard next to it during a test run. A Mac
+# whose bootloader payload (<ESP>/m1n1/boot.bin) gets rewritten with garbage
+# has no recovery path without physical access — "brick risk, no physical
+# access" is the exact phrase from the issue that created this tier. This
+# repo already ships a systemd oneshot, asahi-bootbin-sync.service
+# (build_scripts/asahi/install-bootbin-sync.sh), that rewrites boot.bin on
+# EVERY boot when it detects the running kernel/DTB/m1n1 content changed —
+# correct behaviour on a machine someone can walk over to, actively
+# dangerous on one nobody can. So, before ever touching bootc:
+#
+#   1. asahi-bootbin-sync.service is masked, unconditionally, every run.
+#      Masking a unit that does not exist yet (a fresh Fedora Asahi Remix
+#      install, before its first TunaOS `bootc switch`) is a harmless no-op —
+#      systemd creates the mask symlink regardless, so there is nothing to
+#      special-case for "first switch on this host" vs. "hundredth".
+#   2. Every command this script is about to run remotely is checked against
+#      DANGEROUS_PATTERNS before it is sent — belt-and-suspenders against a
+#      future edit accidentally reintroducing a firmware-writing call even
+#      if the mask above were somehow bypassed.
+#
+# WHAT "SUCCESS" ACTUALLY MEANS HERE
+#
+# `bootc switch`/`bootc upgrade` stage a new deployment; they do not prove it
+# boots. bootc's own boot-counting mechanism is what decides that — if the
+# staged deployment never reaches its "boot complete" confirmation within the
+# configured number of tries, the bootloader falls back to the previous
+# deployment on its own. (The issue calls this "greenboot auto-rollback";
+# TunaOS does not ship the literal greenboot package, bootc's own mechanism
+# is what is actually doing the work, and the fallback is a real distinction
+# worth keeping — see the exit codes below.) This script does not implement
+# any recovery logic itself — it only switches, reboots, waits, and reports
+# which of bootc's own outcomes happened.
+#
+# USAGE
+#
+#   scripts/asahi-remote-switch.sh <image-ref>
+#
+#   # Tier 3 — over Tailscale to a standing machine:
+#   ASAHI_HW_HOST=jamess-macbook-air.example.ts.net ASAHI_HW_USER=james \
+#     scripts/asahi-remote-switch.sh ghcr.io/tuna-os/bonito:gnome-asahi
+#
+#   # Tier 2 — from a GitHub-hosted runner, over the rental's Tailscale/public
+#   # address (set as a repo/environment secret once the rental exists):
+#   ASAHI_HW_HOST="$ASAHI_HW_TIER2_HOST" ASAHI_HW_USER=root \
+#     scripts/asahi-remote-switch.sh ghcr.io/tuna-os/bonito:gnome-asahi
+#
+# ENVIRONMENT
+#
+#   ASAHI_HW_HOST            Target hostname (Tailscale MagicDNS name, public
+#                            IP, or any resolvable host). Required.
+#   ASAHI_HW_USER             SSH user (default: root — bootc switch/reboot
+#                            both need root either way; sudo prompting over a
+#                            one-shot non-interactive SSH command is exactly
+#                            the kind of thing that hangs silently in CI, so
+#                            this script assumes the SSH user can run these
+#                            commands directly rather than shelling out to
+#                            sudo itself).
+#   ASAHI_HW_SSH_PORT        default 22
+#   ASAHI_HW_REBOOT_TIMEOUT  Seconds to wait for the host to come back after
+#                            reboot before giving up (default 420 — Apple
+#                            Silicon's boot chain through m1n1/U-Boot is not
+#                            instant, and this has to cover a POST-to-SSH
+#                            round trip, not just an OS boot).
+#
+# EXIT CODES
+#
+#   0  switched cleanly — the host rebooted into the requested image
+#   1  generic failure (see stderr)
+#   2  usage/precondition error (bad args, ssh not found)
+#   3  confirmed rollback — bootc's own boot-counting reverted to the
+#      previous deployment. The HOST SURVIVED; the candidate image is bad.
+#      This is a genuinely useful, non-broken result, not a script failure.
+#   4  host did not come back within ASAHI_HW_REBOOT_TIMEOUT — the one
+#      outcome that needs a human (or the Tier 2 provisioning flow) to check
+#      on the machine directly. bootc's rollback covers "new deployment
+#      didn't confirm"; it does not cover "new deployment hung the boot
+#      before bootc's own health check could even run".
+#   5  could not reach the host before attempting anything (initial SSH
+#      connectivity check failed) — nothing was touched.
+#   77 missing local dependency (ssh)
+
+set -euo pipefail
+
+IMAGE="${1:?usage: asahi-remote-switch.sh <image-ref>}"
+
+HOST="${ASAHI_HW_HOST:?set ASAHI_HW_HOST=<tailnet-or-resolvable-hostname> — see the script header for why there is no local mode}"
+USER_NAME="${ASAHI_HW_USER:-root}"
+SSH_PORT="${ASAHI_HW_SSH_PORT:-22}"
+REBOOT_TIMEOUT="${ASAHI_HW_REBOOT_TIMEOUT:-420}"
+
+if ! command -v ssh >/dev/null 2>&1; then
+	echo "ERROR: ssh not found on PATH." >&2
+	exit 77
+fi
+
+# accept-new (not StrictHostKeyChecking=no): unlike iso-e2e.sh's throwaway
+# QEMU guests, these are real, persistent, repeatedly-reconnected-to hosts —
+# trust-on-first-use and then actually verify on every later connection is
+# the right tradeoff here, not "never verify".
+SSH_OPTS=(
+	-o StrictHostKeyChecking=accept-new
+	-o ConnectTimeout=10
+	-o BatchMode=yes
+	-p "$SSH_PORT"
+)
+
+# Patterns that must never appear in a command this script sends, on this
+# host or any future copy-paste of it. update-m1n1 and asahi-fwupdate are the
+# real m1n1/firmware-payload writers on Asahi userspace; m1n1-installer is the
+# lower-level tool they wrap; a raw write under /boot/efi (where the ESP is
+# mounted) is the generic catch-all for "something is about to dd/cp onto the
+# boot partition directly, bypassing all of the above." See the module-level
+# comment for why this class of command is unrecoverable on either hardware
+# tier.
+DANGEROUS_PATTERNS='update-m1n1|asahi-fwupdate|m1n1-installer|/boot/efi'
+
+assert_safe_command() {
+	local cmd="$1"
+	if grep -qE "$DANGEROUS_PATTERNS" <<<"$cmd"; then
+		echo "ERROR: refusing to run a command that touches m1n1/firmware on a hardware-tier host: $cmd" >&2
+		echo "       This class of command is unrecoverable without physical access — see" >&2
+		echo "       docs/ASAHI-HARDWARE-TIERS.md. If this really is intentional, it does not" >&2
+		echo "       belong in this script; run it by hand, deliberately, watching the console." >&2
+		exit 1
+	fi
+}
+
+# run <cmd-string>: execute one command on the target over SSH, after the
+# safety check above. Always a single quoted string (not "$@") so the safety
+# check sees exactly what will run, including any shell operators.
+run() {
+	local cmd="$1"
+	assert_safe_command "$cmd"
+	ssh "${SSH_OPTS[@]}" "${USER_NAME}@${HOST}" -- "$cmd"
+}
+
+# Same as run(), but never fails the script — for steps that are fine to no-op
+# (masking a unit that may not exist yet on a fresh, pre-first-switch host).
+run_best_effort() {
+	run "$1" || true
+}
+
+ssh_reachable() {
+	ssh "${SSH_OPTS[@]}" -o ConnectTimeout=5 "${USER_NAME}@${HOST}" -- true 2>/dev/null
+}
+
+echo "==> Target: ${USER_NAME}@${HOST}:${SSH_PORT}"
+
+if ! ssh_reachable; then
+	echo "ERROR: could not reach the host before attempting anything. Nothing was touched." >&2
+	exit 5
+fi
+
+echo "==> Masking asahi-bootbin-sync.service (idempotent — safe if the unit does not exist yet)"
+run_best_effort "systemctl mask asahi-bootbin-sync.service"
+
+echo "==> Recording the currently-booted deployment"
+PRE_STATUS="$(run "bootc status" 2>/dev/null || true)"
+PRE_BOOTED="$(grep -A1 '^Booted image' <<<"$PRE_STATUS" | grep -oE 'Image:.*|image:.*' | head -1 || true)"
+echo "    pre-switch booted: ${PRE_BOOTED:-<could not determine>}"
+
+echo "==> Switching to ${IMAGE}"
+run "bootc switch --retain ${IMAGE@Q}"
+
+STAGED_STATUS="$(run "bootc status" 2>/dev/null || true)"
+echo "$STAGED_STATUS" | sed 's/^/    /'
+
+echo "==> Rebooting"
+# systemctl reboot drops the SSH connection by design — a nonzero exit from
+# run() here is expected, not a failure.
+run "systemctl reboot" || true
+
+echo "==> Waiting up to ${REBOOT_TIMEOUT}s for the host to come back"
+deadline=$(($(date +%s) + REBOOT_TIMEOUT))
+# Give the host a moment to actually go down before polling for it to come
+# back — otherwise the first few checks can hit the still-shutting-down old
+# boot and report "reachable" before the reboot has even started.
+sleep 10
+came_back=0
+while (($(date +%s) < deadline)); do
+	if ssh_reachable; then
+		came_back=1
+		break
+	fi
+	sleep 5
+done
+
+if [[ "$came_back" -ne 1 ]]; then
+	echo "ERROR: host did not come back within ${REBOOT_TIMEOUT}s." >&2
+	echo "       This needs a human (or the Tier 2 provisioning flow) to check on the machine" >&2
+	echo "       directly — bootc's boot-counting rollback covers a deployment that fails to" >&2
+	echo "       confirm, not one that hangs the boot before that check can run." >&2
+	exit 4
+fi
+
+echo "==> Host is back. Confirming what actually booted."
+# Re-mask on every run, not just before the switch: if the reboot landed on
+# a TunaOS image for the first time, THIS is the first boot where the unit
+# exists at all, and it runs before this script gets another chance to.
+run_best_effort "systemctl mask asahi-bootbin-sync.service"
+
+POST_STATUS="$(run "bootc status" 2>/dev/null || true)"
+echo "$POST_STATUS" | sed 's/^/    /'
+POST_BOOTED="$(grep -A1 '^Booted image' <<<"$POST_STATUS" | grep -oE 'Image:.*|image:.*' | head -1 || true)"
+
+if grep -qF "$IMAGE" <<<"$POST_BOOTED"; then
+	echo "==> SUCCESS: booted ${IMAGE}"
+	exit 0
+elif [[ -n "$PRE_BOOTED" && "$POST_BOOTED" == "$PRE_BOOTED" ]]; then
+	echo "==> ROLLED BACK: bootc reverted to the pre-switch deployment on its own." >&2
+	echo "    The host survived. ${IMAGE} did not confirm and is the thing to fix, not this run." >&2
+	exit 3
+else
+	echo "==> UNEXPECTED: booted image does not match the target or the pre-switch state." >&2
+	echo "    pre-switch:  ${PRE_BOOTED:-<unknown>}" >&2
+	echo "    post-reboot: ${POST_BOOTED:-<unknown>}" >&2
+	exit 1
+fi


### PR DESCRIPTION
Addresses tuna-os/tunaOS#780.

## What's blocked, and what isn't

CI caps out at proving an image *contains* what Apple Silicon boot needs
(`verify-asahi.yml`) — GitHub-hosted arm64 runners have no `/dev/kvm` and
there is no Apple SoC emulation anywhere, so nothing in CI today can prove
an image actually *boots* on a Mac. That gap is exactly how six of eight
promoted `:gnome-asahi` tags shipped unbootable despite being green
everywhere else the repo already checks (#776). #780 asks for two
real-hardware tiers to close it — a rented Scaleway Mac mini M2 Pro, and
James's M1 Air over Tailscale.

**Neither tier can actually be provisioned or enrolled from here.** Tier 2
needs a funded Scaleway account with real per-hour billing; Tier 3 needs
physical hands on a specific person's laptop. Pretending otherwise would be
the same "confident but unverified" mistake this repo's own culture
explicitly guards against elsewhere (see `iso-e2e-gpu.sh`'s precedent:
ship the host-side script and document the host requirements, leave actual
acquisition to whoever controls it).

What this PR adds is the piece that doesn't need either: the safety-checked
automation both tiers need in common, and CI wiring that activates the
moment its target host is configured — no further code change required at
that point.

## The safety rule, enforced, not just documented

This repo already ships `asahi-bootbin-sync.service`
(`build_scripts/asahi/install-bootbin-sync.sh`) — a oneshot that rewrites
`<ESP>/m1n1/boot.bin` on **every boot** when its content stamp is stale,
because `bootc` deploys never run package scriptlets. Correct behaviour on a
machine someone can walk over to; actively dangerous on hardware with no
physical recovery path, which is exactly what both hardware tiers are — the
issue's own words are "brick risk, no physical access."

`scripts/asahi-remote-switch.sh`:
- Masks that unit **unconditionally on every run**, not as a one-time setup
  step nobody re-checks.
- Hard-refuses to run any command matching `update-m1n1`, `asahi-fwupdate`,
  `m1n1-installer`, or a raw write to `/boot/efi` **before it ever sends
  one** (`assert_safe_command`, checked inside the single `run()` chokepoint
  every remote command goes through) — defense in depth on a mistake with no
  undo.

## `scripts/asahi-remote-switch.sh`

Always driven from **outside** the target over SSH, deliberately with **no
local mode**. A process cannot survive the reboot of the machine it's
running on — a "run this on the box under test" design would die at
`systemctl reboot`, before it ever reached the verification it exists to
do (I designed it that way first, caught the bug reviewing my own work, and
rewrote it — see the script's own header for the fuller explanation). This
also means the Scaleway rental never needs to be registered as a GitHub
Actions self-hosted runner at all: a scoped SSH connection out to it is a
smaller blast radius than letting arbitrary workflow code execute on it,
and it never holds a standing credential of its own.

Sequence: mask the sync unit → record the pre-switch deployment → `bootc
switch` → reboot → poll for the host to come back (same
`deadline=$(($(date +%s) + TIMEOUT))` idiom `scripts/iso-e2e.sh` already
uses) → report one of three outcomes:

- **switched cleanly** to the requested image
- **rolled back on its own** — `bootc`'s own boot-counting mechanism (the
  "greenboot" the issue refers to; TunaOS does not ship literal `greenboot`,
  `bootc`'s built-in staged-deployment rollback is the actual mechanism, and
  this script only *observes* it — it implements no recovery logic itself)
- **never came back** within the timeout — the one outcome that genuinely
  needs a human (or the Tier 2 provisioning flow) to check the machine
  directly; `bootc`'s rollback covers a deployment that fails to confirm,
  not one that hangs the boot before that check can even run

## CI wiring

`.github/workflows/asahi-hw-nightly.yml` + `asahi-hw-nightly-one.yml`, same
sweep/single reusable-workflow split `verify-asahi.yml`/
`verify-asahi-one.yml` already use. Safe to merge with no rental configured:
a `configured` job checks for the `ASAHI_HW_TIER2_HOST` secret and reports
clearly in the run summary when it's absent (its default state until
someone with Scaleway access sets it) — visible as "waiting to be wired up"
rather than invisible, without ever failing the run. Sweep mode only spends
rental time on **bonito and grouper** — the two flavors `verify-asahi.yml`
has actually proven bootable at the image level; the other six have their
own tracked, root-caused defects (#777, #911, #912, #914) that real
hardware time would only rediscover, not tell us anything new.

## `docs/ASAHI-HARDWARE-TIERS.md`

Full runbook: the safety rule and why it matters, Tier 2's sequence once a
rental exists, Tier 3's one-time physical setup (by James) followed by
indefinite remote iteration (by anyone with tailnet reach — agent or
human), and an explicit "what this PR deliberately does not attempt"
section.

## Verification

No real Scaleway account or Tailscale host exists to test the actual
SSH/reboot flow against — which is exactly why the riskiest, most
untestable piece (a Scaleway provisioning/teardown script) was deliberately
left out rather than shipped unverified. What I could check:

- `bash -n scripts/asahi-remote-switch.sh` — clean.
- `actionlint` (built from source for this session — `go install
  github.com/rhysd/actionlint/cmd/actionlint@latest`, not a repo
  dependency) against both new workflow files: **zero findings**. A full
  repo-wide run shows the only findings are 12 pre-existing ones in
  `.github/workflows/archive/build.yml`, unrelated to this change.
- Checked the exact `bootc status` output shape and `systemctl mask`
  idempotency-on-a-missing-unit behaviour against what's already documented
  elsewhere in this repo before relying on either in the script.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->