### PR TITLE
docs(matrix-status): document Asahi hardware support state (tunaOS#776)

### DIFF
--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -207,7 +207,51 @@ answer different questions and should not be compared directly.
 
 ---
 
-## 4. Regenerating this document
+## 4. Apple Silicon (Asahi) hardware support
+
+None of the axes above say anything about this — they run in QEMU/KVM on x86,
+and Apple Silicon needs its own kernel, DTBs, and boot chain
+(`build_scripts/overlay/asahi.sh`) that no x86 guest ever exercises. That gap is
+exactly how six of the eight promoted `:gnome-asahi` tags turned out to be
+unbootable on real hardware despite every other axis being green
+([tunaOS#776](https://github.com/tuna-os/tunaOS/issues/776)) — a tag existing in
+`ghcr` only means some build promoted it once, never that the image boots on a
+Mac.
+
+`scripts/verify-asahi-image.sh` is the check that actually looks: it unpacks
+the image and inspects it for the asahi kernel, the 12 hardware-critical
+modules, Apple DTBs, the m1n1/U-Boot payloads, and the audio stack, graded
+against a known-working Fedora Asahi Remix image. `.github/workflows/
+verify-asahi.yml` runs it in **sweep** mode daily at 05:40 UTC against every
+promoted `:gnome-asahi` tag (`workflow_dispatch` for one flavor at a time), so
+— same principle as the rest of this document — a result decays on its own if
+nobody re-runs it; [the workflow's run history](https://github.com/tuna-os/tunaOS/actions/workflows/verify-asahi.yml)
+is the live, current answer. This document does not attempt to mirror it into
+a generated table: unlike the three axes above, only two flavors are wired up
+at all, and per-check state on this axis is why the numbers below have
+individual tracking issues rather than a matrix cell each.
+
+As of the last full sweep:
+
+| Variant | Harness | Status |
+|---|:--:|---|
+| **bonito** | 36 / 0 | ✅ verified |
+| **grouper** | 36 / 0 | ✅ verified |
+| yellowfin, skipjack | 29 / 7 | ❌ no `update-m1n1` — [tunaOS#777](https://github.com/tuna-os/tunaOS/issues/777) |
+| sailfin | 27 / 9 | ❌ no Apple DTBs, no U-Boot payload — [tunaOS#914](https://github.com/tuna-os/tunaOS/issues/914) |
+| marlin, flounder | 23 / 13, 21 / 15 | ❌ overlay never applied — stock kernel — [tunaOS#911](https://github.com/tuna-os/tunaOS/issues/911) |
+| albacore | 11 / 25 | ❌ stock kernel not removed — [tunaOS#912](https://github.com/tuna-os/tunaOS/issues/912) |
+| guppy | — | not offered — overlay is stubbed, not broken, and deliberately excluded from the sweep matrix |
+
+Only `bonito` and `grouper` are safe to hand to a user today. The installer
+catalog agrees — `bootc-installer-asahi`'s `catalog.json` ships with exactly
+one hand-written entry (`bonito`) rather than enumerating every `*-asahi` tag,
+and its README documents the same six-of-eight gap
+([tuna-os/bootc-installer-asahi#42](https://github.com/tuna-os/bootc-installer-asahi/pull/42)).
+
+---
+
+## 5. Regenerating this document
 
 The tables between the `GENERATED` markers are rewritten by
 `scripts/gen-matrix-status.py`; everything else is hand-written and the


### PR DESCRIPTION
Closes tuna-os/tunaOS#776.

## What #776 asked for, and what's actually done

- ✅ Watch the dispatched Build Bonito run, verify against
  `bonito:gnome-asahi-testing` — done, 36/0.
- ✅ Triage build-log warnings from `build_scripts/overlay/asahi.sh`
  (package-name/path unknowns in the UbuntuAsahi PPA / Hyperscale SIG
  paths) — done, across #794, #795, #796, #798, #800, #801, #802, #804,
  #806.
- ✅ Repeat for grouper gnome-asahi — done, 36/0.
- ✅ Fix package names/paths until the harness passes — done for both.

And re-confirmed durable, not a one-off pass: today's scheduled
`verify-asahi.yml` sweep (run
[31243787771](https://github.com/tuna-os/tunaOS/actions/runs/31243787771),
2026-08-08) — nine days after the last status comment on #776 — still
shows both green:

```
sweep (bonito)  / verify: success
sweep (grouper) / verify: success
sweep (marlin)    / verify: failure
sweep (skipjack)  / verify: failure
sweep (albacore)  / verify: failure
sweep (yellowfin) / verify: failure
sweep (flounder)  / verify: failure
sweep (sailfin)   / verify: failure
```

The other six were already root-caused and triaged into their own issues
by the same comment thread — #777 (EL10 boot-chain userspace), #911
(overlay never applied on Debian/Arch), #912 (albacore's stock kernel not
removed), #914 (sailfin has no DTBs/U-Boot). Those are genuinely separate
defects with their own fixes to make, not "overlay fallout" left over
from #776's own scope.

## What this PR actually changes

The three axes `docs/MATRIX-STATUS.md` already tracks (LUKS E2E,
Installer smoke, Live overlay) all run in QEMU/KVM on x86 and say nothing
about Apple Silicon — which is exactly how six of eight promoted
`:gnome-asahi` tags turned out unbootable on real hardware despite being
green everywhere else the repo already checks. Until now the only record
of the sweep results was an issue comment thread — the same "no data
anywhere durable" gap this document exists to close for its other three
axes.

Adds a new hand-written **"Apple Silicon (Asahi) hardware support"**
section (outside `scripts/gen-matrix-status.py`'s generated block —
verified structurally unaffected, see below) stating current per-flavor
state with each failure linked to its tracking issue, and pointing at the
live [`verify-asahi.yml` run
history](https://github.com/tuna-os/tunaOS/actions/workflows/verify-asahi.yml)
rather than trying to mirror it into a generated table — only two of
eight flavors are an image anyone should actually be handed, unlike the
matrix axes above.

Cross-references the installer side too:
`bootc-installer-asahi`'s `catalog.json` already ships with exactly one
hand-written entry (`bonito`) rather than enumerating every `*-asahi` tag,
documented in [tuna-os/bootc-installer-asahi#42](https://github.com/tuna-os/bootc-installer-asahi/pull/42)
(already merged) — this PR is the tunaOS-side half of the same record.

## Verification

`python3 -m unittest tests.test_matrix_status` — 20/21 pass; the one
failure is a pre-existing `ModuleNotFoundError: yaml` from this sandbox
lacking PyYAML (no `pip` available to install it here), unrelated to this
change. The new section sits entirely outside the `BEGIN GENERATED`/`END
GENERATED` markers that test file and the generator script both operate
on, so it cannot affect either.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->