### PR TITLE
fix(cosmic): mask cosmic-greeter.service so it stops racing our greetd on the live ISO (tunaOS#678)

### DIFF
--- a/live-iso/common/src/desktop-cosmic.sh
+++ b/live-iso/common/src/desktop-cosmic.sh
@@ -3,7 +3,8 @@
 # Sourced by live-iso/common/src/build.sh for cosmic* desktop flavors.
 #
 # Configures:
-#   - greetd + cosmic-greeter autologin
+#   - greetd + cosmic-session autologin (masking the packaged
+#     cosmic-greeter.service, which otherwise races it for vt1)
 #   - Disable screen lock + power suspend
 #   - Mask suspend targets
 
@@ -35,6 +36,44 @@ systemctl enable greetd.service 2>/dev/null || true
 ln -sf /usr/lib/systemd/system/greetd.service /etc/systemd/system/display-manager.service 2>/dev/null || true
 systemctl set-default graphical.target 2>/dev/null ||
 	ln -sf /usr/lib/systemd/system/graphical.target /etc/systemd/system/default.target 2>/dev/null || true
+
+# Mask the packaged cosmic-greeter.service (tunaOS#678). On EL10 (yellowfin)
+# it ships with `[Install] WantedBy=graphical.target` and NO
+# `Alias=display-manager.service` — unlike Debian/Ubuntu's cosmic-greeter
+# deb, which claims the alias and would at least get overridden by the
+# `ln -sf` above. Without an alias to override, re-pointing
+# display-manager.service does nothing to it: it is independently pulled in
+# by graphical.target and starts anyway, alongside our greetd.service,
+# racing it for vt1.
+#
+# CONFIRMED via installer-smoke run 31229915708 (yellowfin:cosmic): both
+# units start in the same second —
+#
+#   Started cosmic-greeter.service - COSMIC Greeter.
+#   Started greetd.service - Greeter daemon.
+#   greetd[1235]: pam_unix(greetd-greeter:session): session opened for user
+#     cosmic-greeter(uid=974) ...
+#   greetd[1207]: error: check_children: greeter exited without creating a
+#     session
+#   cosmic-greeter.service: Scheduled restart job, restart counter is at 1.
+#   ...
+#   greetd[2680]: pam_unix(cosmic-greeter:auth): authentication failure;
+#     ... user=liveuser
+#
+# — and cosmic-greeter.service wins vt1: every captured screenshot across
+# a full 9-step walkthrough showed its GUI login prompt for liveuser (never
+# the desktop), crash-looping and re-showing the password field each
+# restart. That is also why prior "compositor is running" checks passed —
+# `pgrep -x cosmic-comp` matches cosmic-greeter's OWN compositor, which it
+# uses to render its greeter UI, indistinguishably from a real session's.
+#
+# `mask` (not `disable`): disable only removes the WantedBy symlink and
+# still lets something else start it by name; mask hard-links it to
+# /dev/null so nothing — not graphical.target, not a dependency, not a
+# manual `systemctl start` from another script run later in this same
+# pipeline — can bring it up again.
+systemctl mask cosmic-greeter.service 2>/dev/null ||
+	ln -sf /dev/null /etc/systemd/system/cosmic-greeter.service 2>/dev/null || true
 
 # Disable idle screen-off / lock / suspend for the live session.
 #

--- a/tests/bats/test_cosmic_live_greeter_mask.bats
+++ b/tests/bats/test_cosmic_live_greeter_mask.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# BATS tests for the live-ISO cosmic-greeter mask (tunaOS#678).
+#
+# live-iso/common/src/desktop-cosmic.sh unconditionally repoints
+# display-manager.service at greetd.service so the LIVE session autologins
+# straight into COSMIC via our own /etc/greetd/config.toml. That is
+# necessary but not sufficient on EL10 (yellowfin, skipjack, bonito, ...):
+# their cosmic-greeter package ships cosmic-greeter.service with
+# `[Install] WantedBy=graphical.target` and no `Alias=display-manager.service`
+# (see build_scripts/desktop/configure-desktop-runtime.sh's cosmic case for
+# the full story of why Debian/Ubuntu and EL10 differ here). With no alias to
+# override, re-pointing display-manager.service does nothing to it: it is
+# independently pulled in by graphical.target and starts anyway, alongside
+# our greetd.service, racing it for vt1.
+#
+# CONFIRMED at runtime by installer-smoke run 31229915708 (yellowfin:cosmic):
+# both units started in the same second, cosmic-greeter.service won vt1, and
+# every screenshot across a full 9-step installer walkthrough showed its
+# login prompt for liveuser — crash-looping (check_children: greeter exited
+# without creating a session) and re-showing the password field on every
+# restart — never the desktop, never the installer. The "compositor is
+# running" check upstream of the walkthrough still passed throughout, because
+# cosmic-greeter renders its own login UI via cosmic-comp too, so `pgrep -x
+# cosmic-comp` cannot tell the greeter and a real session apart.
+#
+# This is the LIVE-ISO half of the problem; it is deliberately a different
+# script and a different mechanism from tests/bats/test_cosmic_display_manager.bats
+# (which covers the INSTALLED system's DM choice at image-build time, made by
+# build_scripts/desktop/configure-desktop-runtime.sh and
+# build_scripts/desktop/install-desktop.sh). The live ISO always wants direct
+# autologin, on every base — masking cosmic-greeter.service here is correct
+# regardless of which DM that installed-system logic chose, because
+# desktop-cosmic.sh already overrides the DM choice unconditionally for the
+# live session.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/live-iso/common/src/desktop-cosmic.sh"
+
+@test "desktop-cosmic.sh: exists" {
+  run test -f "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "desktop-cosmic.sh: has valid bash syntax" {
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "desktop-cosmic.sh: masks cosmic-greeter.service" {
+  run grep -q 'systemctl mask cosmic-greeter.service' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "desktop-cosmic.sh: masks, not merely disables, cosmic-greeter.service" {
+  # disable only removes the WantedBy symlink and still lets something else
+  # start the unit by name later in the same pipeline (e.g. a subsequent
+  # systemctl enable/start elsewhere); mask hard-links it to /dev/null so
+  # nothing can bring it back up. A regression to 'disable' would reopen the
+  # exact race this test suite exists to catch.
+  run grep -qE 'systemctl (disable|stop) cosmic-greeter' "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "desktop-cosmic.sh: has an offline symlink fallback if systemctl mask is unavailable" {
+  # mkdir -p /etc/systemd/system already exists via other systemctl calls in
+  # this same live_customize container; the manual fallback must target the
+  # same well-known mask idiom (symlink to /dev/null) systemctl itself uses.
+  run grep -qE "ln -sf /dev/null /etc/systemd/system/cosmic-greeter\.service" "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "desktop-cosmic.sh: still enables our own greetd.service (the mask is additive)" {
+  # A future edit that swaps the fix in the wrong direction — masking
+  # cosmic-greeter without keeping greetd enabled — would leave the live ISO
+  # with no display manager running at all.
+  run grep -q 'systemctl enable greetd.service' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "desktop-cosmic.sh: passes shellcheck" {
+  if ! command -v shellcheck >/dev/null 2>&1; then
+    skip "shellcheck not installed"
+  fi
+  run shellcheck --exclude=SC1091 "$SCRIPT"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## What

Fixes the COSMIC live-ISO greeter race that's currently the top blocker for #678's Phase 1 (installer presence/autostart evidence): `live-iso/common/src/desktop-cosmic.sh` now masks the packaged `cosmic-greeter.service` in addition to enabling our own `greetd.service`.

## Root cause (evidence from a run *this morning*)

`installer-smoke.yml` run [31229915708](https://github.com/tuna-os/tunaOS/actions/runs/31229915708) (yellowfin:cosmic) — I downloaded the walkthrough screenshots and they show the **cosmic-greeter login prompt for `liveuser`** on all 9 captured frames, stuck on `Authenticating…` on the last one. Never the desktop, never the installer.

The greetd journal captured by that same run's diagnostics explains it exactly:

```
Started cosmic-greeter.service - COSMIC Greeter.
Started greetd.service - Greeter daemon.
greetd[1235]: pam_unix(greetd-greeter:session): session opened for user cosmic-greeter(uid=974) by (uid=0)
greetd[1207]: error: check_children: greeter exited without creating a session
cosmic-greeter.service: Deactivated successfully.
cosmic-greeter.service: Scheduled restart job, restart counter is at 1.
Started cosmic-greeter.service - COSMIC Greeter.
greetd[2680]: pam_unix(cosmic-greeter:auth): authentication failure; ... user=liveuser
```

Both units start in the *same second* and race for vt1. `desktop-cosmic.sh` already writes its own `/etc/greetd/config.toml` (`initial_session` straight into `cosmic-session`, no prompt) and repoints `display-manager.service` at `greetd.service` — but on EL10 bases (yellowfin, skipjack, bonito, ...) `cosmic-greeter.service` ships with `[Install] WantedBy=graphical.target` and **no** `Alias=display-manager.service` (this asymmetry with the Debian/Ubuntu package is already documented in `build_scripts/desktop/configure-desktop-runtime.sh`'s cosmic case, including the "ships both units, which is worse than failing" line). With no alias to override, re-pointing `display-manager.service` does nothing to `cosmic-greeter.service` — `graphical.target` pulls it in independently, it wins the vt1 race, and it crash-loops on its own login screen forever.

This also explains why the workflow's "compositor is running" gate (`pgrep -x cosmic-comp`) kept passing while the screenshots showed a stuck greeter: `cosmic-greeter` renders its own login UI *through* `cosmic-comp` too, so the process-name check can't tell a greeter from a real session. (Not something I've changed here — flagging it as a real gap for a follow-up, since it's exactly the "harden the assertion" ask from an earlier comment on this issue.)

## Fix

Mask `cosmic-greeter.service` in the same `live_customize` step that enables `greetd.service`, using the file's existing `systemctl`-then-manual-symlink fallback idiom. `mask`, not `disable`: disable only drops the `WantedBy` symlink and still lets something later in the pipeline start it by name; mask hard-links it to `/dev/null`.

This is scoped to the **live ISO only** (`live-iso/common/src/desktop-cosmic.sh`, tacklebox's `live_customize` layer) and does not touch the *installed* system's display-manager choice — `configure-desktop-runtime.sh` / `install-desktop.sh` already resolve that correctly (deferring to whichever DM claimed the alias at image-build time) and have their own coverage in `tests/bats/test_cosmic_display_manager.bats`. I checked: neither that file nor any other existing bats test references `desktop-cosmic.sh`, so there was no existing regression guard for this script at all.

## Testing

- Added `tests/bats/test_cosmic_live_greeter_mask.bats` (bats not available in this sandbox, so I hand-verified every `grep` assertion in it against the modified file — all pass).
- `bash -n live-iso/common/src/desktop-cosmic.sh` — clean.
- Could not re-run `installer-smoke.yml` myself (no GHCR/Actions write access from a fork for a workflow that needs `packages: read` + the runner minutes), so this is unverified against a real boot. Would appreciate a maintainer re-dispatching `installer-smoke.yml` (flavor=cosmic) after merge to confirm the walkthrough now reaches the desktop/installer instead of the greeter.

## Other findings from the same investigation (not fixed here, flagging for follow-up)

While diagnosing cosmic I pulled the artifacts for all five flavors from the same run:

- **niri**: still lands on what looks like a plain TTY/login-shell banner (`/etc/profile.d/zmotd.sh: line 3: /usr/bin/zmotd: No such file or directory`) even though `pgrep -x niri` succeeds and the greetd journal shows a *clean* session open (no crash, no restart loop) — a different and, from the evidence I have, less understood failure than cosmic's. This is new information versus the original issue comment's "niri-session never starts" hypothesis: niri clearly does start here. Needs a live debugging session I can't do from this sandbox.
- **gnome**: genuinely healthy (autologin lands the real desktop, installer autostarts, "Welcome to Yellowfin" screen renders correctly) — but the walkthrough's synthetic Tab/Enter/Space navigation never manages to activate the "Install Bluefin" row, so it never reaches the required `disk` screen and the job fails on that, not on rendering.
- **kde**: compositor (`kwin_wayland`) and the installer flatpak are both confirmed running, but every screendump frame is solid black (282 bytes, `stddev` 0 across all 9). I haven't root-caused this one — possibly related to `installer-walkthrough.py`'s documented `screendump`-under-virgl gap, though this run used plain `-vga virtio` mode per the boot log, so that's not a full explanation.

I didn't attempt fixes for these in this PR — cosmic's root cause was the one I could pin down with confidence from CI evidence alone, and I'd rather ship that than guess at the other three. Left this section here so whoever picks up niri/gnome/kde next has a running start.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->