### PR TITLE
feat(luks-e2e): verify TPM2 auto-unlock actually works after fisherman's first-boot enrollment (tunaOS#680)

### DIFF
--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -7,9 +7,20 @@ name: LUKS E2E
 # env needs SSH to drive the install), then scripts/iso-e2e.sh --luks:
 #   1. boots the live ISO under QEMU with an emulated TPM 2.0 (swtpm),
 #   2. installs via fisherman (the same backend every TunaOS installer
-#      frontend uses) with a recipe.json requesting encryption.type=tpm2-luks,
-#   3. reboots the installed disk with the *same* TPM and confirms the
-#      encrypted root auto-unlocks (reaching the login target proves it).
+#      frontend uses) with a recipe.json requesting
+#      encryption.type=tpm2-luks-passphrase,
+#   3. reboots the installed disk and confirms the passphrase unlocks it and
+#      login is reached (proving fisherman's install-time encryption works).
+#
+# TPM2 auto-unlock is enrolled by a fisherman#48 first-boot oneshot against
+# the INSTALLED system's own PCR 7 — not at install time, which used to seal
+# against the live ISO's boot chain instead and never unseal afterward
+# (tunaOS#679/#680) — so step 3 above does NOT prove it; that would need a
+# fourth boot with no passphrase. scripts/iso-e2e.sh's
+# TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK=1 does that boot when set, but this
+# workflow does not set it: docs/LUKS-TPM.md tracks that as "the per-variant
+# TPM-enrollment test", a smaller-scope check, since a fourth boot on every
+# cell here would materially raise this workflow's already-expensive cost.
 #
 # This is expensive (a dev ISO build + two QEMU boots per cell), so it only
 # runs on demand or monthly — never per push. Modelled on iso-e2e.yml and
@@ -321,8 +332,10 @@ jobs:
             --memory 10240 \
             --timeout 1200
           # Gate = encrypted install + passphrase unlock to login. TPM2
-          # auto-unlock is a POST-INSTALL step (ujust enable-luks-tpm2), tested
-          # separately per docs/LUKS-TPM.md — not asserted at install.
+          # auto-unlock is enrolled automatically by a first-boot oneshot
+          # (fisherman#48) rather than a manual `ujust enable-luks-tpm2` step,
+          # but it is still not asserted here — see docs/LUKS-TPM.md and the
+          # header comment above for why (tested separately, per-variant).
           grep -qx 'TUNAOS_LUKS_E2E_INSTALL_STARTED luks=1' luks-out/luks-evidence.log
           grep -qx 'TUNAOS_LUKS_E2E_ENCRYPTED_DISK_CONFIRMED' luks-out/luks-evidence.log
           grep -qx 'TUNAOS_LUKS_E2E_PASS encrypted=1 passphrase_unlock=1 installed_boot=1' luks-out/luks-evidence.log

--- a/docs/LUKS-TPM.md
+++ b/docs/LUKS-TPM.md
@@ -1,38 +1,49 @@
 # Disk encryption & TPM2 auto-unlock
 
 TunaOS installs (via fisherman) can encrypt the root filesystem with LUKS2.
-You choose a **passphrase** during install. Optionally, after the system is up,
-you can enroll this machine's **TPM2** chip so the disk unlocks automatically at
-boot — no passphrase prompt.
+You choose a **passphrase** during install, and TPM2 auto-unlock — no
+passphrase prompt at boot — is enrolled automatically shortly after.
 
-## Why TPM enrollment is a post-install step (not the installer)
+## Why TPM enrollment happens on first boot (not during the install)
 
 TPM2 auto-unlock works by *sealing* the unlock key to the machine's measured
-boot state (PCRs **7** = Secure Boot state, **14** = MokList/shim). Those
-measurements only exist once the **real installed system** boots — an installer
-running from the live ISO measures *different* PCRs, so enrolling at install time
-seals against the wrong state and the disk won't unlock. This is the same model
+boot state (PCR **7** = Secure Boot state). That measurement only exists once
+the **real installed system** boots — an installer running from the live ISO
+measures a *different* PCR 7, so enrolling at install time seals against the
+wrong state and the disk never unlocks afterward. This is the same model
 Universal Blue (`ublue-os-luks`), Bazzite, and Fedora Silverblue use, and why
 `bootc install` doesn't do it either ([bootc#421](https://github.com/bootc-dev/bootc/issues/421)).
 
-So: **the installer sets a passphrase; you opt into TPM auto-unlock afterward.**
+So: **the installer sets a passphrase and stages a one-time enrollment for the
+next boot; the first boot of your installed system enrolls the TPM against its
+own real PCR 7 and removes the staged key** — no action needed from you. This
+is a `ConditionFirstBoot` oneshot ([fisherman#48](https://github.com/tuna-os/fisherman/pull/48)),
+fixing an earlier version that enrolled at install time and never actually
+unsealed on the installed system (tunaOS#679, tunaOS#680).
 
-## Enabling TPM2 auto-unlock
+**First boot after install still shows the passphrase prompt once** — TPM2
+isn't enrolled yet at that point, so the passphrase is still required. Every
+boot after that should be prompt-free.
 
-After installing and booting, run once:
+## Re-enrolling manually
+
+Enrollment can also be triggered by hand — useful if you disabled it, or need
+to re-seal after a firmware/Secure Boot change invalidates the old seal:
 
 ```sh
 ujust enable-luks-tpm2          # TPM only
 ujust enable-luks-tpm2 --pin    # TPM + a PIN you set
 ```
 
-(or `sudo tunaos-luks-tpm2-enroll`). It seals to PCRs 7+14, wires up
-`/etc/crypttab`, and the next boot unlocks with no prompt. To revert:
-`ujust disable-luks-tpm2`.
+(or `sudo tunaos-luks-tpm2-enroll`). This path seals to PCRs **7+14** (Secure
+Boot state + MokList/shim — a stricter set than the automatic first-boot
+enrollment's PCR 7 alone) and prompts interactively for your current
+passphrase. To revert either kind of enrollment: `ujust disable-luks-tpm2`.
 
-> **Keep your passphrase.** Updating firmware, toggling Secure Boot, or
-> re-enrolling MOK keys changes PCR 7/14 — the TPM then refuses to unseal and you
-> fall back to the passphrase. That's the security trade-off, by design.
+> **Keep your passphrase regardless.** Updating firmware, toggling Secure
+> Boot, or re-enrolling MOK keys changes PCR 7/14 — the TPM then refuses to
+> unseal and you fall back to the passphrase. That's the security trade-off,
+> by design.
 
 ## Variant support matrix
 
@@ -51,5 +62,11 @@ TPM2 auto-unlock needs the systemd TPM2 modules in the initramfs and a working
 | marlin | Arch | ✅ | _pending E2E_ | |
 | guppy | Gentoo | ✅ | _pending E2E_ | |
 
-Filled in by the per-variant TPM-enrollment test (install → passphrase boot →
-`enable-luks-tpm2` → reboot → confirm auto-unlock). See the LUKS-TPM tracking issue.
+Filled in by the per-variant TPM-enrollment test: install → first installed
+boot (passphrase, first-boot oneshot enrolls TPM2 in the background) → reboot
+with no passphrase → confirm auto-unlock. `scripts/iso-e2e.sh --luks` with
+`TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK=1` runs exactly this sequence and records
+`TUNAOS_LUKS_E2E_TPM_AUTOUNLOCK_CONFIRMED` / `_FAILED` in the LUKS evidence
+log — not yet wired into a scheduled workflow (see the header comment in
+`.github/workflows/luks-e2e.yml`). See the LUKS-TPM tracking issue
+(tunaOS#680).

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -37,11 +37,18 @@
 #   scripts/iso-e2e.sh <iso_path> --luks
 #       Full LUKS e2e: boot the live ISO (needs ENABLE_SSHD=1), install via
 #       fisherman (the same backend every TunaOS installer frontend uses)
-#       with encryption.type=tpm2-luks against an emulated TPM 2.0 (swtpm),
-#       then reboot the installed disk with the same TPM and confirm the
-#       encrypted root auto-unlocks (reaching the login target proves it — a
-#       missing/wrong TPM would hang in the initramfs). Requires the swtpm
+#       with encryption.type=tpm2-luks-passphrase against an emulated TPM
+#       2.0 (swtpm), then reboot the installed disk and confirm the
+#       passphrase unlocks it and login is reached. Requires the swtpm
 #       package.
+#
+#       TPM2 auto-unlock is enrolled by a fisherman#48 first-boot oneshot
+#       against the INSTALLED system's own PCR 7 (not at install time — an
+#       install-time seal measures the live ISO's boot chain instead, and
+#       never unseals afterward; tunaOS#679/#680), so it is not proven by
+#       the passphrase gate above. Set TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK=1
+#       to additionally reboot a third time with no passphrase and confirm
+#       the TPM unlocks it unattended — see Environment below.
 #
 # Options:
 #   --timeout SEC         Per-phase timeout (default: 300)
@@ -81,6 +88,18 @@
 #                         with `bootc install to-disk` (tpm2-luks under
 #                         --luks; the reboot gate then proves TPM auto-unlock
 #                         instead of passphrase injection).
+#   TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK=1
+#                         --luks only. After the passphrase gate passes,
+#                         reboot the fisherman-installed disk a third time
+#                         with the same swtpm and NO passphrase injected,
+#                         and require it to reach login unattended (proving
+#                         the fisherman#48 first-boot enrollment oneshot
+#                         actually sealed a working key against the
+#                         installed system's real PCR 7). Default: 0 (off) —
+#                         this is real added runtime + a new failure mode,
+#                         so it is opt-in rather than folded into every
+#                         --luks cell; docs/LUKS-TPM.md calls this "the
+#                         per-variant TPM-enrollment test".
 #
 # Exit codes:
 #   0  success
@@ -99,6 +118,11 @@
 #      working desktop, and the two catch different holes (a greeter that
 #      draws satisfies 6 and still fails 7). TUNAOS_DESKTOP_CONTRACT=0
 #      downgrades to advisory.
+#   8  TPM auto-unlock verification failed (only reachable with
+#      TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK=1) — the third, no-passphrase boot
+#      either still showed the cryptsetup passphrase prompt (the first-boot
+#      enrollment oneshot did not seal a working key) or never reached
+#      login within --timeout. See installed-tpm-autounlock-serial.log.
 #   77 missing dependency (qemu, ovmf, etc.) — distinguishable for CI skip
 
 set -euo pipefail
@@ -618,10 +642,15 @@ record_luks_evidence() {
 }
 
 # ── Emulated TPM 2.0 (swtpm) — LUKS mode only ───────────────────────────────
-# The install-time enrollment (systemd-cryptenroll --tpm2-device=auto) and the
-# reboot-time unlock must see the SAME TPM state, so a single swtpm instance is
-# started once and its socket attached to every QEMU launch below. TPM_ARGS is
-# empty unless --luks is set, so non-LUKS modes are byte-for-byte unchanged.
+# Every boot that needs the TPM — the generic (--block-setup tpm2-luks)
+# path's install-time enrollment, fisherman's first-boot enrollment oneshot
+# (tunaOS#680), and any later unlock/verification boot — must see the SAME
+# swtpm STATE, so TPM_DIR is created once and reused (start_swtpm keep)
+# across boots. The swtpm PROCESS itself does not survive a boot on its own,
+# though: it exits when the QEMU it is attached to disconnects, so each
+# caller that needs it on a later boot restarts it against the preserved
+# state dir rather than assuming it is still running. TPM_ARGS is empty
+# unless --luks is set, so non-LUKS modes are byte-for-byte unchanged.
 TPM_DIR="${OUTPUT_DIR}/swtpm"
 TPM_SOCK="${TPM_DIR}/swtpm-sock"
 TPM_PIDFILE="${TPM_DIR}/swtpm.pid"
@@ -2282,15 +2311,33 @@ EOF
 	# reaches userspace. That is fisherman's job and works on every variant.
 	# TPM2 auto-unlock is a SEPARATE, post-install, per-variant test (it seals
 	# to PCRs that only exist on the installed system — see docs/LUKS-TPM.md),
-	# so it is NOT required here. Boot with a serial socket and inject the
+	# so it is NOT gated here (see TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK below for
+	# the opt-in that does gate it). Boot with a serial socket and inject the
 	# passphrase at the cryptsetup prompt; reaching login proves the unlock.
 	if [[ "$LUKS" -eq 1 ]]; then
 		echo "==> LUKS passphrase gate: booting installed disk, injecting passphrase, expecting login..."
 		local FB_SERIAL="${OUTPUT_DIR}/installed-serial.sock"
 		rm -f "$FB_SERIAL"
-		# No TPM here: the passphrase gate doesn't need one, and the
-		# install-phase swtpm has already exited (its socket is gone). TPM
-		# auto-unlock is the separate post-install test.
+		# A TPM IS needed on THIS boot (tunaOS#680): fisherman#48 stages a
+		# ConditionFirstBoot oneshot that enrolls systemd-cryptenroll
+		# --tpm2-device=auto against the REAL installed system's PCR 7 —
+		# measured during exactly this boot, which is the whole point (the
+		# old install-time enrollment sealed against the live ISO's PCR 7
+		# instead, and never unsealed on the installed system — tunaOS#679/
+		# #680). Without a TPM attached here, that oneshot has nothing to
+		# enroll against and TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK's later boot
+		# would only ever see the passphrase prompt.
+		#
+		# The install-phase swtpm has already exited — it dies when its own
+		# QEMU (fisherman's install VM, just powered off above) disconnects
+		# — so it must be restarted against the SAME state dir, exactly like
+		# run_install_generic's TPM auto-unlock gate does.
+		local tpid
+		tpid=$(cat "$TPM_PIDFILE" 2>/dev/null || true)
+		if [[ -z "$tpid" ]] || ! kill -0 "$tpid" 2>/dev/null; then
+			echo "==> Restarting swtpm with preserved state for the first installed boot..."
+			start_swtpm keep || return 77
+		fi
 		#
 		# bootindex=0 on the disk (see also boot_installed) is what makes
 		# "boot the thing we just installed" deterministic. Both boots share
@@ -2306,8 +2353,10 @@ EOF
 		# QEMU fw_cfg boot order that OVMF applies over the stale NVRAM,
 		# putting this disk first and leaving the shell as the last resort.
 		reset_qemu_sockets
+		# shellcheck disable=SC2086  # TPM_ARGS is intentionally word-split (empty unless --luks)
 		"$QEMU" -name "tunaos-iso-e2e-installed" -machine pc -cpu "$CPU_ARG" \
 			-accel "$ACCEL" -m "$MEMORY" -smp "$CPUS" \
+			${TPM_ARGS} \
 			-drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
 			-drive "if=pflash,format=raw,file=${OVMF_VARS}" \
 			-drive "if=none,id=disk,file=${INSTALL_DISK},format=qcow2" \
@@ -2471,6 +2520,97 @@ EOF
 		fi
 
 		echo "==> LUKS passphrase gate PASSED for ${VARIANT:-}:${FLAVOR:-}"
+
+		# ── Opt-in: TPM2 auto-unlock verification (tunaOS#680) ──────────
+		# The passphrase gate above proves fisherman's install-time
+		# encryption works; it does NOT prove the first-boot enrollment
+		# oneshot (fisherman#48) actually seals a working key, because it
+		# never boots the disk a second time. luks-first-boot.py's own
+		# docstring says as much: "The SECOND boot (driven by iso-e2e.sh)
+		# then proves TPM auto-unlock: no passphrase prompt" — that second
+		# boot did not exist until this block. docs/LUKS-TPM.md's variant
+		# table has read "_pending E2E_" for TPM2 auto-unlock on every
+		# variant because of exactly this gap.
+		#
+		# Opt-in (default off) rather than folded into the gate above: the
+		# passphrase gate alone already runs on every {variant, flavor} cell
+		# with build_image=true (luks-e2e.yml's monthly sweep), and a third
+		# boot per cell is real added cost + a new failure mode across ~50
+		# cells at once. docs/LUKS-TPM.md already describes this as "the
+		# per-variant TPM-enrollment test", run separately — this flag is
+		# that test, callable from the same harness instead of a
+		# reimplementation. A maintainer can wire it into luks-e2e.yml (a
+		# workflow_dispatch boolean, or its own scheduled job over a smaller
+		# variant set) once satisfied with the added runtime.
+		if [[ "${TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK:-0}" == "1" ]]; then
+			echo "==> TPM auto-unlock verification: rebooting the installed disk with no passphrase..."
+			local tpid2
+			tpid2=$(cat "$TPM_PIDFILE" 2>/dev/null || true)
+			if [[ -z "$tpid2" ]] || ! kill -0 "$tpid2" 2>/dev/null; then
+				echo "==> Restarting swtpm with preserved state for the TPM auto-unlock boot..."
+				start_swtpm keep || return 77
+			fi
+			# $SERIAL_LOG was truncated before the passphrase-gate boot
+			# above and never reopened (that boot used its own FB_SERIAL
+			# socket instead), so it is still empty here — safe to reuse
+			# via the same file-chardev E2E_SERIAL_ARGS the generic path's
+			# TPM auto-unlock gate uses.
+			reset_qemu_sockets
+			# shellcheck disable=SC2086  # TPM_ARGS is intentionally word-split (empty unless --luks)
+			"$QEMU" -name "tunaos-iso-e2e-installed" -machine pc -cpu "$CPU_ARG" \
+				-accel "$ACCEL" -m "$MEMORY" -smp "$CPUS" \
+				${TPM_ARGS} \
+				-drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
+				-drive "if=pflash,format=raw,file=${OVMF_VARS}" \
+				-drive "if=none,id=disk,file=${INSTALL_DISK},format=qcow2" \
+				-device virtio-blk-pci,drive=disk,bootindex=0 \
+				-netdev "user,id=net0" -device virtio-net-pci,netdev=net0 \
+				-monitor "unix:${MONITOR_SOCK},server,nowait" \
+				"${E2E_SERIAL_ARGS[@]}" \
+				"${QEMU_GPU_ARGS[@]}" -pidfile "$QEMU_PIDFILE" -daemonize || {
+				echo "ERROR: QEMU would not start for the TPM auto-unlock verification boot" >&2
+				record_luks_evidence "TUNAOS_LUKS_E2E_TPM_AUTOUNLOCK_FAILED reason=qemu-launch"
+				return 5
+			}
+			local tpm_deadline=$(($(date +%s) + TIMEOUT))
+			local tpm_ok=0 tpm_saw_prompt=0
+			while (($(date +%s) < tpm_deadline)); do
+				if grep -qaE "login:|Reached target.*(Graphical|Multi-User)" "$SERIAL_LOG" 2>/dev/null; then
+					tpm_ok=1
+					break
+				fi
+				# A passphrase prompt here means the disk is STILL sealed to
+				# a passphrase, not the TPM — the oneshot did not enroll (or
+				# enrolled against the wrong PCR state). That is a distinct,
+				# more actionable failure than a bare timeout, so name it
+				# rather than waiting out the full deadline for a boot that
+				# is truthfully just stuck at a prompt no one will answer.
+				if [[ "$tpm_saw_prompt" -eq 0 ]] && grep -qai "passphrase for disk root" "$SERIAL_LOG" 2>/dev/null; then
+					tpm_saw_prompt=1
+					echo "==> (still shows a passphrase prompt — TPM enrollment did not take; waiting out the deadline for a clean report)"
+				fi
+				if [[ -f "$QEMU_PIDFILE" ]] && ! kill -0 "$(cat "$QEMU_PIDFILE")" 2>/dev/null; then
+					echo "ERROR: TPM auto-unlock verification VM exited during boot" >&2
+					break
+				fi
+				sleep 5
+			done
+			screenshot "installed-tpm-autounlock" || true
+			[[ -s "$QEMU_PIDFILE" ]] && kill "$(cat "$QEMU_PIDFILE")" 2>/dev/null || true
+			mv -f "$SERIAL_LOG" "${OUTPUT_DIR}/installed-tpm-autounlock-serial.log" 2>/dev/null || true
+			: >"$SERIAL_LOG"
+			if [[ "$tpm_ok" -eq 1 ]]; then
+				echo "==> TPM auto-unlock verification PASSED — no passphrase prompt, login reached"
+				record_luks_evidence "TUNAOS_LUKS_E2E_TPM_AUTOUNLOCK_CONFIRMED"
+			else
+				local reason="timeout"
+				[[ "$tpm_saw_prompt" -eq 1 ]] && reason="passphrase-still-required"
+				echo "ERROR: TPM auto-unlock verification FAILED (${reason}) — see installed-tpm-autounlock-serial.log" >&2
+				record_luks_evidence "TUNAOS_LUKS_E2E_TPM_AUTOUNLOCK_FAILED reason=${reason}"
+				return 8
+			fi
+		fi
+
 		return 0
 	fi
 

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -993,3 +993,61 @@ setup_runtime_check_stubs() {
   grep -qF 'cat /run/initramfs/rdsosreport.txt 2>/dev/null' "$harness"
   grep -qF 'journalctl -b --no-pager -n 120' "$harness"
 }
+
+# ── TPM2 auto-unlock verification opt-in (tunaOS#680) ──────────────────────
+#
+# fisherman#48 moved TPM2 enrollment from install time (sealed against the
+# wrong PCR 7 — the live ISO's, not the installed system's; tunaOS#679/#680)
+# to a first-boot oneshot on the installed system. The LUKS passphrase gate
+# above proves the passphrase-encrypted install works; it never reboots a
+# second time with no passphrase, so it cannot prove the oneshot actually
+# enrolled a working key. These tests pin the opt-in that closes that gap.
+
+@test "TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK is off by default" {
+  grep -qF '${TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK:-0}' "$SCRIPT"
+}
+
+@test "TPM auto-unlock verification restarts swtpm for the first installed boot" {
+  # fisherman's first-boot oneshot needs /dev/tpmrm0 present on THIS boot to
+  # enroll against — without it there is nothing for the later verification
+  # boot to ever unlock with. Scoped to the LUKS passphrase gate block (the
+  # first `start_swtpm keep` call after the fisherman install, ahead of the
+  # TPM auto-unlock verification block below it).
+  awk '/LUKS passphrase gate ─/,/TPM auto-unlock verification/' "$SCRIPT" |
+    grep -q 'start_swtpm keep'
+}
+
+@test "the LUKS passphrase gate boot attaches TPM_ARGS" {
+  awk '/LUKS passphrase gate: booting installed disk, injecting passphrase/,/-pidfile "\$QEMU_PIDFILE" -daemonize \|\| \{/' "$SCRIPT" |
+    grep -qF '${TPM_ARGS}'
+}
+
+@test "TPM auto-unlock verification reboots with no passphrase and requires login" {
+  awk '/TPM auto-unlock verification: rebooting/,/^\t\tfi$/' "$SCRIPT" > "${BATS_TEST_TMPDIR}/block.txt"
+  grep -q 'start_swtpm keep' "${BATS_TEST_TMPDIR}/block.txt"
+  grep -qF '${TPM_ARGS}' "${BATS_TEST_TMPDIR}/block.txt"
+  grep -q 'login:|Reached target.*(Graphical|Multi-User)' "${BATS_TEST_TMPDIR}/block.txt"
+  # And it must NOT inject anything at a passphrase prompt — the whole point
+  # is proving the TPM unlocks it unattended.
+  ! grep -q 'sendall(passphrase' "${BATS_TEST_TMPDIR}/block.txt"
+}
+
+@test "TPM auto-unlock verification distinguishes a still-passphrase-locked disk from a bare timeout" {
+  grep -qF 'passphrase for disk root' "$SCRIPT"
+  grep -qF 'reason="passphrase-still-required"' "$SCRIPT"
+  grep -qF 'reason="timeout"' "$SCRIPT"
+}
+
+@test "TPM auto-unlock verification records confirm/fail evidence markers" {
+  grep -qF 'TUNAOS_LUKS_E2E_TPM_AUTOUNLOCK_CONFIRMED' "$SCRIPT"
+  grep -qF 'TUNAOS_LUKS_E2E_TPM_AUTOUNLOCK_FAILED' "$SCRIPT"
+}
+
+@test "TPM auto-unlock verification failure returns a distinct, documented exit code" {
+  awk '/TPM auto-unlock verification FAILED/,/return 8/' "$SCRIPT" | grep -q 'return 8'
+  grep -qF '#   8  TPM auto-unlock verification failed' "$SCRIPT"
+}
+
+@test "TPM auto-unlock verification preserves its own serial log rather than clobbering others" {
+  grep -qF 'installed-tpm-autounlock-serial.log' "$SCRIPT"
+}

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -715,8 +715,9 @@ setup_runtime_check_stubs() {
   # on the shared append-mode chardev.
   grep -q 'append=on' "$SCRIPT"
   ! grep -q -- '-serial "file:${SERIAL_LOG}"' "$SCRIPT"
-  # live boot, fisherman installed boot, generic installed boot, --disk boot
-  [ "$(grep -c '"${E2E_SERIAL_ARGS\[@\]}"' "$SCRIPT")" -eq 4 ]
+  # live boot, fisherman installed boot, TPM auto-unlock verify boot,
+  # generic installed boot, --disk boot
+  [ "$(grep -c '"${E2E_SERIAL_ARGS\[@\]}"' "$SCRIPT")" -eq 5 ]
 }
 
 @test "install: a console heartbeat outlives the ssh channel" {
@@ -759,8 +760,9 @@ setup_runtime_check_stubs() {
   # bootindex publishes a QEMU fw_cfg boot order OVMF applies over the stale
   # NVRAM. Both post-install boots need it; the live boot must NOT have it
   # (the ISO has to win there).
-  # fisherman passphrase gate, fisherman installed boot, generic TPM gate
-  [ "$(grep -c 'device virtio-blk-pci,drive=disk,bootindex=0' "$SCRIPT")" -eq 3 ]
+  # fisherman passphrase gate, TPM auto-unlock verify boot, fisherman
+  # installed boot, generic TPM gate
+  [ "$(grep -c 'device virtio-blk-pci,drive=disk,bootindex=0' "$SCRIPT")" -eq 4 ]
   grep -q -- '-device virtio-blk-pci,drive=disk \\' "$SCRIPT"
 }
 


### PR DESCRIPTION
## What

Adds the second-reboot TPM2 auto-unlock verification this issue's own design calls for, as an opt-in capability in `scripts/iso-e2e.sh --luks`.

## Where this picks up

fisherman#48 (referenced in the first comment on this issue) fixed the actual root cause: TPM2 enrollment moved from install time (sealed against the live ISO's PCR 7) to a `ConditionFirstBoot` oneshot on the installed system itself (sealed against its own real PCR 7). That's fisherman-repo work, already landed, not something I touched here.

What's still missing on the tunaOS side is proof it actually works end-to-end. `scripts/iso-e2e.sh`'s LUKS gate already:
- installs via fisherman with `encryption.type=tpm2-luks-passphrase` and a known test passphrase,
- boots the installed disk once, injects that passphrase at the cryptsetup prompt, and confirms login is reached.

...but it **stops there**. `scripts/luks-first-boot.py`'s own docstring says exactly what should happen next:

> "The SECOND boot (driven by iso-e2e.sh) then proves TPM auto-unlock: no passphrase prompt."

That second boot didn't exist — which is exactly why `docs/LUKS-TPM.md`'s variant support table reads `_pending E2E_` for TPM2 auto-unlock on **every single variant**.

I also found a real bug feeding into this gap: the first installed boot (the passphrase-gate boot) had **no TPM attached at all** ("No TPM here: the passphrase gate doesn't need one" — a leftover comment from the pre-fisherman#48 design). Without a TPM present on that boot, fisherman's first-boot oneshot has nothing to enroll against, so even a perfectly-working oneshot could never succeed there.

## Changes

- **`scripts/iso-e2e.sh`**:
  - Attach the emulated TPM (swtpm, restarted with its preserved state — mirroring the exact pattern `run_install_generic`'s own TPM-unlock gate already uses) to the passphrase-gate boot, so the first-boot oneshot has something to enroll against.
  - New opt-in `TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK=1` (default **off**): after the passphrase gate passes, reboot a third time with the same TPM state and **no** passphrase injected, and require login to be reached unattended. If a passphrase prompt is still shown, that's reported as a distinct, more actionable failure (`reason=passphrase-still-required`) than a bare timeout. Records `TUNAOS_LUKS_E2E_TPM_AUTOUNLOCK_CONFIRMED` / `_FAILED` and a new documented exit code `8`.
  - Fixed several comments (header usage text, the `--luks` description, the swtpm section banner) that still described the old install-time-enrollment design.
- **`.github/workflows/luks-e2e.yml`**: fixed the same class of stale comments (`encryption.type=tpm2-luks` → `tpm2-luks-passphrase`, "confirms auto-unlock" → accurately describes the passphrase gate, and the `ujust enable-luks-tpm2` reference which is no longer the primary path).
- **`docs/LUKS-TPM.md`**: documents the actual current behavior — TPM2 is enrolled automatically on first boot, no user action needed — while keeping the manual `ujust enable-luks-tpm2` / `tunaos-luks-tpm2-enroll` path documented for re-enrollment (it still exists, still works, and seals to a stricter PCR 7+14 vs the automatic path's PCR 7 alone — a real difference worth calling out, not one I papered over).
- **`tests/bats/test_iso_e2e.bats`**: new tests pinning the opt-in default, the TPM attach on both boots, the no-injection assertion on the verify boot, the prompt-vs-timeout distinction, the evidence markers, and the exit code.

## Why opt-in rather than folded into the default `--luks` gate

`luks-e2e.yml` already sweeps every `{variant, flavor}` cell with `build_image=true` (~50 cells) monthly. A third boot per cell is real added runtime and a new failure mode across all of them at once. `docs/LUKS-TPM.md` already described this as a separate "per-variant TPM-enrollment test" rather than part of the main gate — this PR builds that test as an opt-in capability of the existing harness rather than a second implementation, and leaves wiring it into a workflow trigger (a `workflow_dispatch` boolean, or its own smaller scheduled sweep) for a maintainer to decide, since that's a real runtime-cost tradeoff I can't make on their behalf.

## Testing

- `bash -n scripts/iso-e2e.sh` — clean.
- `actionlint .github/workflows/luks-e2e.yml` — clean.
- Every new bats `grep`/`awk` assertion hand-verified against the modified script (bats itself isn't installed in this sandbox).
- **Could not run this against real QEMU/swtpm/fisherman** — no KVM available here. Would appreciate a maintainer dispatching `luks-e2e.yml` (or running `scripts/iso-e2e.sh <dev-iso> --luks` locally) with `TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK=1` for one cell — yellowfin:kde matches the original #679 pilot — to confirm the second reboot actually reaches login unattended.

Refs: #679, #673, fisherman#48

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->