### PR TITLE
docs(asahi): document Apple Silicon tracking initiative (#781)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,6 +89,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | Outreach sequencing | strategist | #563 | ✅ Done (gate lifted) |
 | Populate Q3 milestone | strategist | #562 | ✅ Done (2026-08-08, 9 issues) |
 | **User-proven ISO installs roadmap** | ci-maintainer | #763 | 🟡 In progress (Phase 1 baseline dispatched #761; GUI gate #577) |
+| **Apple Silicon (Asahi Linux) support** | architect / ci-maintainer | #781 | 🟡 In progress (Bonito & Grouper 36/36 verified #776; D0–D4 installer track active) |
 
 ---
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -185,3 +185,19 @@ Canonical rollout plan for verifying end-to-end user ISO installation experience
 3. **Phase 3 — One Known-Good End-to-End GUI Pilot**: Yellowfin GNOME frontend installation gate through visible GUI to installed contract.
 4. **Phase 4 — Frontend Expansion**: Progressive extension across GNOME, KDE, COSMIC, Niri, and XFCE frontends.
 5. **Phase 5 — ISO Builder Parity**: Unified verification contract for both CI-built and browser-built (ISO Builder #673) media via required experience manifests.
+
+---
+
+## Apple Silicon (Asahi Linux) Support (#781)
+
+Umbrella initiative for making TunaOS bootable on M1/M2 Apple Silicon Macs via the Asahi stack:
+
+- **Naming Convention**: `asahi` is a **tag suffix** (`bonito:gnome-asahi`), never a separate variant/image name.
+- **Verification Harness (#776 / #910)**: Daily 35-point golden-manifest boot-chain sweep. Bonito (Fedora) and Grouper (Ubuntu) are verified 36/36 green. Remaining variants are undergoing kernel and boot-chain alignment (#777, #911, #912, #914).
+- **Installer Track (`bootc-installer-asahi`)**:
+  - D0: Real-image payload packaging & validation.
+  - D1: Fisherman first-boot agent integration.
+  - D2: `asahi-installer` JSON mode interface.
+  - D3: macOS SwiftUI frontend application.
+  - D4: recoveryOS UX, LUKS, and Wi-Fi configuration.
+- **Constraints**: M1/M2 hardware targets only; no live-ISO path on Apple Silicon; no Apple firmware redistribution; GitHub arm64 runners use TCG emulation.


### PR DESCRIPTION
Fixes #781

## Summary
Documents the Apple Silicon (Asahi Linux) support initiative (#781) across project references:
- `ROADMAP.md`: Added "Apple Silicon (Asahi Linux) support" item to active Q3 goals.
- `docs/AGENT_GUIDE.md`: Documented naming conventions (`asahi` tag suffix, e.g. `bonito:gnome-asahi`), harness verification results (Bonito & Grouper 36/36 green #776), `bootc-installer-asahi` milestone track (D0–D4), and hardware/CI constraints.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->