### PR TITLE
fix(verify-asahi): EL10's update-m1n1/asahi-fwupdate live in /usr/sbin (tunaOS#777)

### DIFF
--- a/scripts/verify-asahi-image.sh
+++ b/scripts/verify-asahi-image.sh
@@ -91,12 +91,37 @@ check_any() { # label, candidate paths...
 # Paths differ per packaging family (Fedora lib64, Debian/Ubuntu lib, Arch boot)
 check_any "m1n1 payload" /usr/lib64/m1n1/m1n1.bin /usr/lib/m1n1/m1n1.bin /usr/lib/asahi-boot/m1n1.bin /boot/m1n1.bin
 check_any "Apple U-Boot payload" /usr/share/uboot/apple_m1/u-boot-nodtb.bin /usr/lib/u-boot/apple_m1/u-boot-nodtb.bin /usr/lib/asahi-boot/u-boot.bin
-check_file /usr/bin/update-m1n1
+# CentOS Hyperscale SIG's update-m1n1 RPM (EL10: skipjack/yellowfin/albacore)
+# installs to /usr/sbin, not /usr/bin like Fedora's — verified by downloading
+# update-m1n1-20250426.1-1.hs+asahi.el10.noarch.rpm from the Hyperscale
+# packages-asahi repo and reading its file list directly (tunaOS#777). This
+# was a hard-coded single-path check missing that family split, unlike the
+# two checks above it — every yellowfin/skipjack sweep was scoring a FAIL for
+# a binary that was actually present the whole time.
+check_any "update-m1n1" /usr/bin/update-m1n1 /usr/sbin/update-m1n1
+# Hyperscale's update-m1n1 RPM genuinely does not ship a kernel-install.d (or
+# postinst.d) hook — confirmed the same way, by reading its actual file list;
+# there is no plausible alternate path to add here for this family. This is a
+# real, still-open EL10 packaging gap (tunaOS#777), not a harness bug like the
+# path above. It does not leave EL10 boot-chain updates unmaintained in
+# practice: this repo ships asahi-bootbin-sync.service
+# (build_scripts/asahi/install-bootbin-sync.sh) specifically because bootc
+# deploys never run package scriptlets anyway, on every family, Fedora
+# included — a working kernel-install hook would never fire after a `bootc
+# switch` regardless of which family's kernel it came from. So this FAIL
+# tracks upstream packaging completeness, not "does this image regenerate its
+# boot.bin after an upgrade" — that question is asahi-bootbin-sync.service's,
+# and it does not depend on this hook existing.
 check_any "update-m1n1 kernel hook" /usr/lib/kernel/install.d/15-update-m1n1.install /etc/kernel/postinst.d/update-m1n1 /etc/kernel/postinst.d/zz-update-m1n1
 
 echo "== firmware handling =="
 check_file /usr/bin/asahi-fwextract
-check_file /usr/bin/asahi-fwupdate
+# Same family split as update-m1n1 above, same verification method: Hyperscale
+# SIG's asahi-fwupdate RPM (asahi-fwupdate-20250426.1-1.hs+asahi.el10.noarch)
+# installs to /usr/sbin/asahi-fwupdate. asahi-fwextract, checked just above,
+# really is at /usr/bin in the same RPM family — the split is per-binary, not
+# uniformly bin-vs-sbin, so it is not safe to assume from one to the other.
+check_any "asahi-fwupdate" /usr/bin/asahi-fwupdate /usr/sbin/asahi-fwupdate
 [[ -d "$mnt/usr/lib/dracut/modules.d/99asahi-firmware" ]] && ok "dracut 99asahi-firmware" || bad "dracut module 99asahi-firmware missing"
 [[ -d "$mnt/usr/lib/dracut/modules.d/91kernel-modules-asahi" ]] && ok "dracut 91kernel-modules-asahi" || bad "dracut module 91kernel-modules-asahi missing"
 if grep -qs "asahi-firmware" "$mnt"/usr/lib/dracut/dracut.conf.d/*; then


### PR DESCRIPTION
Addresses tuna-os/tunaOS#777.

## The issue's premise is stale — and what's real underneath it

#777 describes EL10's asahi stack as missing `m1n1`/`u-boot-asahi`/
`asahi-audio`/`speakersafetyd` entirely, needing a brand-new OBS project.
That was true when the issue was filed, but **#783 (merged the same day)
already closed that gap** — the overlay's `centos` branch wires all three
real sources (Hyperscale SIG `packages-asahi`, EPEL10, the `@asahi/u-boot`
COPR), and I confirmed a **fresh yellowfin `:gnome-asahi` build from today**
(run
[31235868152](https://github.com/tuna-os/tunaOS/actions/runs/31235868152),
image `created` `2026-08-08T04:53:15Z`) installs all 17 packages cleanly —
`update-m1n1` and `asahi-fwupdate` both listed under `Installed:` in the raw
`dnf` transaction log.

Yet today's `verify-asahi.yml` sweep still scores yellowfin/skipjack **29
passed, 7 failed** — identical to the 2026-07-30 sweep documented in #776.
So either #783's fix doesn't actually work, or something else is wrong. I
traced it: **two of those seven FAILs are a harness bug, not a packaging
gap.**

## Root cause, verified against the real packages (not guessed)

`scripts/verify-asahi-image.sh` hard-codes `check_file /usr/bin/update-m1n1`
and `check_file /usr/bin/asahi-fwupdate` — the Fedora path. I downloaded the
actual RPMs from the Hyperscale `packages-asahi` mirror
(`mirror.stream.centos.org`) and read their file lists directly:

```
update-m1n1-20250426.1-1.hs+asahi.el10.noarch.rpm   -> /usr/sbin/update-m1n1
asahi-fwupdate-20250426.1-1.hs+asahi.el10.noarch.rpm -> /usr/sbin/asahi-fwupdate
```

Both binaries are genuinely present in the built image — just under
`/usr/sbin`, not `/usr/bin`. The harness has a `check_any` helper for exactly
this kind of family split (already used two lines above, for the m1n1/U-Boot
payload paths across Fedora/Debian/Arch); these two checks just never got the
same treatment. Fixed both to `check_any` with both paths.

One thing I deliberately did **not** do: assume the bin/sbin split is
uniform. `asahi-fwextract`, checked right next to `asahi-fwupdate`, really is
at `/usr/bin` in the exact same package family — I verified that one too
before touching anything, rather than pattern-matching from one binary to
its neighbor.

## What's genuinely still open (not touched here)

- **The "update-m1n1 kernel hook" check** — left as a real FAIL.
  Hyperscale's `update-m1n1` RPM genuinely ships no
  `/usr/lib/kernel/install.d` hook (confirmed the same way — there's no
  alternate path to add). Added a comment explaining why this doesn't
  actually leave EL10 without boot-chain maintenance: this repo's own
  `asahi-bootbin-sync.service` exists *specifically* because `bootc` deploys
  never run package scriptlets on **any** family, Fedora included — a
  working kernel-install hook would never fire after `bootc switch` either
  way. The FAIL correctly tracks upstream packaging completeness; it just
  isn't the same question as "does this image actually stay bootable after
  an upgrade."
- **`tiny-dfr` and `asahi-diagnose`** — confirmed genuinely unpackaged for
  EL10 by the same RPM-inspection method. Matches PR #783's own note that
  tiny-dfr remains unpackaged; `asahi-diagnose` is the same story.
- **`apple-isp.ko` missing from `modules.dep`** — not root-caused. Kernel
  module RPMs store their file list across parallel header tag arrays rather
  than literal path strings, so the "download the RPM and grep it" technique
  that worked for the small script packages above doesn't reliably apply to
  a multi-thousand-file kernel-modules RPM. Left unverified rather than
  guessed at.
- **`bluefin-lts`**, named in the issue title, has no `gnome-asahi` flavor in
  `.github/build-config.yml` and isn't referenced by `asahi.sh` or
  `verify-asahi.yml` at all — it isn't a buildable/testable TunaOS variant
  today, asahi or otherwise.
- **The OBS project itself** — this issue's actual original ask — still
  needs James's `build.opensuse.org` account. Unchanged, out of reach from
  here.

## Verification

Traced the real `yellowfin` build log (run `93058013732`, job
`linux-arm64`) line by line through the `centos` branch's `dnf`
transactions to confirm both binaries land in the image *before* touching
the harness at all. `bash -n scripts/verify-asahi-image.sh` — clean. No
`podman`/`rpm` tooling available in the environment this was written in, so
I couldn't run the harness itself end-to-end — the RPM file-list inspection
above is what stands in for that: downloading the exact packages this
build installs and reading their real payload rather than assuming a path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->