### PR TITLE
ci(iso-e2e): skip loudly instead of failing when R2 secrets are absent

### DIFF
--- a/.github/workflows/iso-e2e.yml
+++ b/.github/workflows/iso-e2e.yml
@@ -77,24 +77,90 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # When workflow_dispatch is used, the user picks a single
-      # variant/flavor — but the matrix still spawns every cell. Skip
-      # the cells that don't match the dispatch inputs so we don't end
-      # up running both yellowfin and albacore jobs both downloading
-      # the dispatched variant's ISO.
-      - name: Matrix-vs-dispatch filter
+      # Two preflight gates, both meaning "this cell must not go on", and
+      # both of which have to be evaluated in a step rather than a
+      # job-level `if:`.
+      #
+      # 1. When workflow_dispatch is used, the user picks a single
+      #    variant/flavor — but the matrix still spawns every cell. Skip
+      #    the cells that don't match the dispatch inputs so we don't end
+      #    up running both yellowfin and albacore jobs both downloading
+      #    the dispatched variant's ISO.
+      #
+      # 2. The R2 credentials are repository secrets, and GitHub does not
+      #    expose repository secrets to `pull_request` runs whose head
+      #    branch lives in a fork. Empty, they make rclone fall back to the
+      #    AWS endpoint template and resolve `s3.auto.amazonaws.com` (from
+      #    REGION=auto), which doesn't exist: three retries, ~3.5 wasted
+      #    minutes, and a red check on every fork PR forever (#1129). Since
+      #    `secrets` cannot be referenced from a job-level `if:`, the
+      #    availability check happens here and is exported as an output the
+      #    later steps already gate on. When the secrets ARE present this
+      #    changes nothing and the job stays fully gating.
+      - name: Preflight (dispatch filter, R2 credentials)
         id: filter
         env:
           DISPATCH_VARIANT: ${{ inputs.variant }}
           DISPATCH_FLAVOR: ${{ inputs.flavor }}
+          # Read only to test for emptiness — never printed.
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          # Mirrors the `if:` on the download step below: source=artifact
+          # never touches R2, so it must not be blocked on R2 secrets.
+          NEEDS_R2: ${{ github.event_name != 'workflow_dispatch' || inputs.source == 'r2-latest' }}
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             if [[ "${DISPATCH_VARIANT}" != "${{ matrix.variant }}" ]] \
                || [[ "${DISPATCH_FLAVOR}" != "${{ matrix.flavor }}" ]]; then
               echo "skip=true" >> "$GITHUB_OUTPUT"
               echo "Skipping ${{ matrix.variant }}:${{ matrix.flavor }} — dispatch chose ${DISPATCH_VARIANT}:${DISPATCH_FLAVOR}"
+              exit 0
             fi
           fi
+
+          if [[ "${NEEDS_R2}" == "true" ]]; then
+            missing=()
+            for name in R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_ENDPOINT R2_BUCKET; do
+              [[ -n "${!name}" ]] || missing+=("${name}")
+            done
+            if [[ ${#missing[@]} -gt 0 ]]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "no_r2_credentials=true" >> "$GITHUB_OUTPUT"
+              echo "missing_secrets=${missing[*]}" >> "$GITHUB_OUTPUT"
+              echo "R2 credentials unavailable (missing: ${missing[*]}) — see the next step."
+            fi
+          fi
+
+      # A gating job that quietly turns green having verified nothing is
+      # worse than one that turns red, so say so three ways: in the log, as
+      # an annotation on the run, and in the run summary.
+      - name: Report skipped ISO E2E (no R2 credentials)
+        if: steps.filter.outputs.no_r2_credentials == 'true'
+        env:
+          CELL: ${{ matrix.variant }}:${{ matrix.flavor }}
+          MISSING: ${{ steps.filter.outputs.missing_secrets }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "::warning title=ISO E2E SKIPPED — no R2 credentials::${CELL} was NOT tested." \
+            "Empty repository secrets: ${MISSING}. GitHub withholds repository secrets from" \
+            "pull_request runs raised from a fork, so the published ISO cannot be downloaded." \
+            "This job verified NOTHING about this change."
+          {
+            echo "## :warning: ISO E2E ${CELL} — SKIPPED, nothing was verified"
+            echo ""
+            echo "The published ISO could not be downloaded: these repository secrets were empty in this run."
+            echo ""
+            echo "\`${MISSING}\`"
+            echo ""
+            echo "GitHub does not expose repository secrets to \`pull_request\` runs whose head branch"
+            echo "lives in a fork, so this job can never fetch the ISO on a fork PR."
+            echo ""
+            echo "**A green check here is not evidence that this change boots.** To actually exercise"
+            echo "the ISO E2E gate, re-run this workflow from a branch in \`${REPO}\`, or dispatch it"
+            echo "manually, where the secrets are available."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # GitHub-hosted ubuntu-24.04 runners expose /dev/kvm but with mode 0660
       # owned by root:kvm. The runner user is not in the kvm group, so the


### PR DESCRIPTION
## What

The "E2E yellowfin:gnome" / "E2E albacore:gnome" jobs in `iso-e2e.yml` fail on **every** pull request opened from a fork, and can never be made to pass from there. This makes them skip loudly instead, while leaving them fully gating wherever the credentials actually exist.

## Root cause

GitHub does not expose repository secrets to `pull_request` runs whose head branch lives in a fork, so `secrets.R2_*` arrive empty. Confirmed on PR #1129 (head `hanthor/tunaOS-1`), run [31246918355](https://github.com/tuna-os/tunaOS/actions/runs/31246918355), job `93076942597`, step **Download latest ISO from R2**:

```
env:
  RCLONE_CONFIG_R2_ACCESS_KEY_ID:            (empty)
  RCLONE_CONFIG_R2_SECRET_ACCESS_KEY:        (empty)
  RCLONE_CONFIG_R2_REGION: auto
  RCLONE_CONFIG_R2_ENDPOINT:                 (empty)
==> Fetching yellowfin-gnome-latest.iso from R2...
ERROR : ... Get "https://s3.auto.amazonaws.com/live-isos?...":
        dial tcp: lookup s3.auto.amazonaws.com on 127.0.0.53:53: no such host
```

With `RCLONE_CONFIG_R2_ENDPOINT` empty, rclone falls back to the AWS endpoint template and resolves `s3.auto.amazonaws.com` (from `REGION: auto`), which does not exist. Three retries, ~3m11s burned, job red.

`secrets.R2_BUCKET` was empty too — visible in the same log as the source path collapsing to `R2:/live-isos/yellowfin-gnome-latest.iso`, i.e. bucket `live-isos`. So the check covers all four secrets, not just the endpoint.

The result was a permanently red, permanently unactionable check on fork PRs.

## Changes

Single file, `.github/workflows/iso-e2e.yml`:

- **Credential preflight.** `secrets` cannot be referenced from a job-level `if:`, so the availability check runs as a step and exports its verdict as a step output. It is folded into the existing preflight step (renamed `Matrix-vs-dispatch filter` → `Preflight (dispatch filter, R2 credentials)`), which already owns the job's `skip` output — so **no downstream `if:` condition had to change**.
- **Loud skip notice.** A new step fires only when credentials were missing, emitting a `::warning::` annotation on the run *and* a `$GITHUB_STEP_SUMMARY` block that names the empty secrets and states plainly that the job verified nothing and that a green check here is not evidence the change boots.

## Why it does not weaken gating

- The gate is conditioned on **the secrets genuinely being empty**, not on `github.event.pull_request.head.repo.fork`, and not unconditionally.
- Pushes to `main`, the weekly `schedule` run, `workflow_dispatch`, and **same-repo pull requests** all still take the original path and still fail on a real e2e failure.
- If a secret is ever accidentally unset or rotated away on the main repo, the job skips *loudly* rather than silently — the annotation and summary make that visible.
- Scoped to runs that actually need R2: `NEEDS_R2` mirrors the existing `if:` on the download step, so a `source=artifact` dispatch is not blocked on R2 secrets.

Behaviour matrix, verified by running the extracted preflight script under `bash -e`:

| Scenario | Outputs | Result |
|---|---|---|
| Fork PR, all four secrets empty | `skip=true`, `no_r2_credentials=true`, `missing_secrets=…` | skips loudly |
| Same-repo PR, all secrets present | *(none)* | runs, fully gating |
| Schedule, one secret missing | `skip=true`, `no_r2_credentials=true`, `missing_secrets=R2_ENDPOINT` | skips loudly |
| Dispatch, non-matching matrix cell | `skip=true` | skips quietly (pre-existing behaviour) |
| Dispatch `source=artifact`, secrets empty | *(none)* | runs, unaffected |

## Scope check — other workflows

Enumerated every `pull_request`-triggered workflow and the secrets it references:

- **`iso-e2e.yml`** — the bug. Fixed here.
- **`live-iso-bootc.yml`** — declares the same `RCLONE_CONFIG_R2_*` / `UPLOAD_R2` env block, but **nothing downstream reads it**: `scripts/build-iso-tacklebox.sh` contains zero `rclone`/`R2` references, and `UPLOAD_R2` has no consumer anywhere in the repo. It builds from source and never touches R2, so it does not hit this failure. Left untouched (the dead env block is a separate tidy-up, out of scope here).
- **`matrix-status.yml`** — uses only `GITHUB_TOKEN`, which *is* provided on fork PRs, and its `pull_request` path is drift-check-only (`--check-structure`). Not affected.
- **`just-fix.yml`, `lint.yml`, `test.yml`, `validate-renovate.yaml`** — reference no secrets.

The remaining R2 consumers (`publish-iso-groups.yml`, `reusable-build-artifacts.yml`, `installer-smoke.yml`, `installer-screenshots.yml`, `weekly-desktop-screenshots.yml`, `weekly-qcow2-screenshots.yml`) are `schedule` / `workflow_dispatch` / `workflow_call` only, so they never run in a fork-PR context. Several already carry an equivalent empty-credential guard.

Also confirmed `iso-e2e.yml` is hand-maintained, not generated: `scripts/generate-workflows.py` only emits `build-{variant}.yml` files, which are schedule/dispatch-only.

## Testing

All five CI lint gates run locally, real output.

`actionlint` over all workflows, using the exact `-ignore` flags from `lint.yml`:

```
.github/workflows/reusable-build-image.yml:733:9: shellcheck reported issue in this script:
  SC2153:info:5:35: Possible misspelling: PLATFORMS may not be assigned.
exit=1
```

That finding is **pre-existing and in a file this PR does not touch** — reproduced against `origin/main`'s copy of `reusable-build-image.yml` in isolation (same finding, exit 1). `actionlint` on `iso-e2e.yml` alone is **exit 0**. (CI's actionlint step is `continue-on-error: true` regardless.)

The other four, each using CI's exact `find` invocation:

```
yamllint -c ./.yamllint.yml ...          -> exit 0  (warnings only, none in iso-e2e.yml)
shellcheck --severity=error --exclude=SC1091,SC2114 ...  -> exit 0
jq . on every *.json                     -> exit 0
just --unstable --fmt --check -f Justfile   -> exit 0
just --unstable --fmt --check on every *.just -> exit 0
```

Additionally:
- Extracted the preflight `run:` script and executed it under `/usr/bin/bash -e` (the shell GitHub uses) across the five scenarios in the table above; all produced the expected `$GITHUB_OUTPUT`.
- Verified the `::warning::` annotation renders as a **single line** (backslash-continued `echo` arguments join with spaces), which is required for annotations to be picked up.
- `git diff origin/main` reviewed hunk by hunk: one file, 72 insertions / 6 deletions, no unrelated lines touched.

**Not verified:** the change has not been exercised in a real GitHub Actions run. `actionlint` validates the expression syntax and the shell, and the logic was tested locally, but confirmation that a fork PR now goes green-with-warning needs an actual fork PR after this merges.