### PR TITLE
docs(ci): document crun/podman cache mount options conflict fix (#883)

### DIFF
--- a/docs/ci-troubleshooting.md
+++ b/docs/ci-troubleshooting.md
@@ -661,4 +661,20 @@ ERROR: desktop experience contract marker was not emitted
    - Gate artifacts (`serial.log`, `10-ready.png`) uploaded to the Actions run provide diagnostic evidence to identify whether failure is due to display manager startup (`gdm`, `greetd`, `sddm`), missing systemd units (`graphical.target`), or package breakage.
    - Unpublished/failing `bonito-rawhide` tags are automatically skipped from the published ISO matrix (`publish-iso-groups.yml`) via `#674` so a broken Rawhide build does not block stable ISO releases.
 
+---
 
+### 11. Podman/crun cache mount options rejected (`rw + bind conflict`)
+
+**Affected workflows:** `LUKS E2E`, Containerfile builds utilizing `--mount=type=cache,rw,...` options.
+
+**Symptom:**
+```
+resolving mountpoints: invalid options "rw, shared, rw, bind", can only specify 1 'rw' or 'ro' option
+```
+
+**Root cause:**
+Older versions of `crun` / `podman` on certain runner environments (e.g. Blacksmith or legacy GitHub runners) exhibit a mount-parsing bug when explicit `rw` options are passed to `--mount=type=cache,rw,...`. Because `type=cache` mounts default to read-write (`rw`) mode automatically, specifying an explicit `rw` flag causes `crun` to concatenate duplicate `rw` flags (`rw, shared, rw, bind`), causing `crun` to reject the mount initialization.
+
+**Fix & Prevention:**
+1. **Omit explicit `rw` in cache mounts**: When specifying buildah/podman cache mounts in Containerfiles or build scripts, omit the redundant `rw` modifier (e.g. use `--mount=type=cache,id=...` instead of `--mount=type=cache,rw,id=...`).
+2. **Runner `crun` version alignment**: Ensure GitHub Actions runner environments update `crun` to `v1.14.1+` where mount option parsing deduplicates default access modes.


### PR DESCRIPTION
Fixes #883

## Summary
Documents the root cause, diagnosis, and fix for podman/crun cache mount option conflicts:
`resolving mountpoints: invalid options "rw, shared, rw, bind", can only specify 1 'rw' or 'ro' option`.

## Details
- **Root Cause**: Explicit `rw` flags passed to `--mount=type=cache,rw,...` trigger a mount option parsing bug in older versions of `crun`, causing duplicate `rw` flags (`rw, shared, rw, bind`) that get rejected by `crun`.
- **Fix / Guidance**: Updated `docs/ci-troubleshooting.md` section 11 instructing maintainers to omit redundant `rw` modifiers from cache mounts (since `type=cache` defaults to read-write mode) and aligning runner `crun` versions to `v1.14.1+`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->