### PR TITLE
fix(luks-e2e): fail fast when the scp image-transfer fallback can't fit in guest RAM (tunaOS#882)

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -2132,6 +2132,42 @@ run_install() {
 		if podman image exists "$host_img" 2>/dev/null; then
 			echo "==> Saving $host_img on host..."
 			podman save "$host_img" -o "$host_tar"
+
+			# Pre-flight: refuse a transfer the comment above already proves is
+			# doomed, instead of discovering it the same way #941 did — a
+			# silent multi-hour hang ending in the kernel OOM-killing the
+			# guest. The scp destination is GUEST_HOME (/home/liveuser), which
+			# is the live overlay's upperdir: a RAM-backed tmpfs, not disk.
+			# `df` on the guest reports 8G free there because that is the
+			# tmpfs's ADVERTISED size, not real backing store — every byte
+			# written to it is guest RAM. Compare the tar we are about to ship
+			# against the guest's live MemAvailable (not MemTotal: some RAM is
+			# already spoken for by the live session before we start copying)
+			# and fail fast with an actionable message if it cannot possibly
+			# fit, rather than burning the rest of the job's timeout budget on
+			# a transfer that ends in `scp: write remote ...: Failure`.
+			#
+			# 70% headroom, not 100%: podman load on the guest side still has
+			# to hold the tar AND unpack layers concurrently, plus whatever
+			# the live session itself needs to keep running. The one measured
+			# data point (#941) was a ~4.9G image against ~2.9G available —
+			# 169% of available, nowhere near this line — so 70% is a
+			# deliberately conservative guess, not a proven boundary.
+			local host_tar_bytes guest_mem_avail_kb
+			host_tar_bytes="$(stat -c%s "$host_tar" 2>/dev/null || echo 0)"
+			guest_mem_avail_kb="$("${ssh_cmd[@]}" "awk '/^MemAvailable:/{print \$2}' /proc/meminfo" 2>/dev/null || echo 0)"
+			if [[ "$host_tar_bytes" -gt 0 && "$guest_mem_avail_kb" -gt 0 ]]; then
+				local guest_mem_avail_bytes=$((guest_mem_avail_kb * 1024))
+				local safe_limit_bytes=$((guest_mem_avail_bytes * 70 / 100))
+				if [[ "$host_tar_bytes" -ge "$safe_limit_bytes" ]]; then
+					echo "ERROR: image tar (${host_tar_bytes} bytes / $((host_tar_bytes / 1024 / 1024))M) is too large for the guest's available RAM ($((guest_mem_avail_bytes / 1024 / 1024))M) to receive safely." >&2
+					echo "The SSH-transfer fallback writes into a RAM-backed tmpfs (${GUEST_HOME}) and will OOM-kill the guest partway through — this is a measured failure mode, not a guess (see #941)." >&2
+					echo "This path should not have been taken at all: make the offline store resolve so Fisherman can install directly from containers-storage (#941), or re-run with --memory well above the image size." >&2
+					rm -f "$host_tar" || true
+					return 3
+				fi
+			fi
+
 			# Bounded, like the fisherman call below. This is a multi-GB copy
 			# over a QEMU SLIRP hostfwd, so it is legitimately slow — but the
 			# failure mode it had was not slowness, it was silence: no output


### PR DESCRIPTION
## What

Adds a pre-flight size check to the LUKS E2E SSH-transfer fallback in `run_install()` (`scripts/iso-e2e.sh`), which ships a saved OCI image tar to the guest via `scp` when the offline store doesn't resolve.

## Why

The scp destination, `${GUEST_HOME}` (`/home/liveuser`), is the live overlay's upperdir — a RAM-backed tmpfs, not disk. `df` reports 8G free there because that's the tmpfs's *advertised* size, not real backing store; every byte written to it is guest RAM. The code already carries an extensive comment block documenting that an image tar close to or larger than the guest's available RAM cannot be delivered this way, citing #941 as the measured case: a ~4.9G image against ~2.9G available RAM OOM-killed the guest every time, and the job burned ~2.5 hours in silence before failing.

That comment explicitly says: *"Do not 'fix' this with a longer timeout, MTU clamping ... or retries. Any image larger than guest RAM cannot be delivered this way. Make the offline store resolve, or raise --memory above the image size."* This PR doesn't try to make oversized transfers succeed (nothing short of more guest RAM or fixing #941's offline-store resolution can). It converts the *failure mode* from a multi-hour silent hang into an immediate, explained failure — right after `podman save`, before the doomed `scp`/`podman load` is even attempted.

The check compares the saved tar's actual byte size against the guest's live `MemAvailable` (read via the same `ssh_cmd` already used elsewhere in this function) and refuses with a clear error if the tar is within 70% of available memory. 70%, not 100%: `podman load` on the guest side still has to hold the tar *and* unpack layers concurrently, on top of whatever the live session itself needs — the one measured data point (#941) was 169% of available, nowhere near this line, so 70% is a deliberately conservative guess rather than a proven boundary. If either measurement is unavailable for any reason, the check is skipped and behavior is unchanged (old behavior, not a new failure mode).

## On issue #882's body

`tunaOS#882` is titled *"LUKS E2E: scp image transfer to guest /tmp fails (tmpfs too small)"*, but its body text is Sailfin/zypper SSL content that doesn't match the title at all (looks like a copy-paste mixup during batch issue creation). I confirmed the title's actual topic is real and current by cross-referencing:
- `scripts/iso-e2e.sh`'s own comments, which independently and extensively document this exact tmpfs-too-small failure mode
- `#941` ("LUKS E2E: guest podman cannot see the offline store..."), which is the deep-dive this fix's comments point back to
- `#1100`, which references *"#879–#883 (podman cache mount options, scp tmpfs too small, dpkg/var-log-apt, missing SSH on dev ISOs)"* — explicitly naming #882 as the "scp tmpfs too small" issue

So this PR addresses the title's stated problem, not the mismatched body.

## Testing

- `bash -n scripts/iso-e2e.sh` — syntax OK
- `shellcheck scripts/iso-e2e.sh` — zero new findings from this change (all existing findings are pre-existing, at unrelated line numbers, and info-level)
- Manually verified the byte-math against both the #941 scenario (4.9G tar / 2.9G available → correctly blocks) and a small-image scenario (500M tar / 2.9G available → correctly allows)
- Could not run the actual QEMU LUKS E2E harness in this sandbox (no KVM/nested virtualization available), so this hasn't been exercised against a real guest. The check is intentionally conservative and fails open (skips the check, falls back to prior behavior) if it can't get both measurements, to minimize risk of a false-positive block on a real run.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `d7972053`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->