### PR TITLE
fix(debian): restore dpkg db symlink + /var/log/apt after 99-cleanup's /var wipe (tunaOS#880)

### DIFF
--- a/build_scripts/99-cleanup.sh
+++ b/build_scripts/99-cleanup.sh
@@ -28,6 +28,35 @@ fi
 find /var -mindepth 1 -maxdepth 1 ! -path '/var/cache' -delete 2>/dev/null || true
 find /var/cache -mindepth 1 -delete 2>/dev/null || true
 
+# Restore the dpkg database path and apt's log directory, for apt-based
+# variants, immediately after the wipe above — for the exact reason
+# Containerfile.debian's own comment on the FIRST /var wipe gives ("apt/dpkg
+# run in later layers ... before tmpfiles has ever executed"), which applies
+# here too, one wipe later.
+#
+# ostree-layout.sh (source: Containerfile.debian's dpkg relocation step)
+# already relocates /var/lib/dpkg to /usr/lib/sysimage/dpkg and symlinks it
+# back, and creates /var/log/apt, specifically so apt/dpkg keep working
+# through their default paths at BUILD time — not just after boot, when
+# systemd-tmpfiles would apply the tmpfiles.d entry it also writes. But this
+# script runs in base-no-de AFTER that, does its own `find /var ... -delete`
+# above, and base-no-de is the base every desktop flavor (gnome/kde/xfce/
+# cosmic/niri) is built FROM — each running its own `apt-get install` via
+# install-desktop.sh in a LATER layer, still at build time, with no boot
+# (and so no systemd-tmpfiles) in between. Without this, that install runs
+# against a /var with no dpkg database at the path apt/dpkg actually look at,
+# and no /var/log/apt for them to write to (tunaOS#880 — flounder-sid's
+# python3 postinst failed running fwupd's rtupdate hook with exit status 4;
+# that hook's only command without a `|| true` is `py3clean -p fwupd
+# /usr/share/fwupd`, and py3clean resolves a package's files via `dpkg -L`).
+#
+# Guard on the symlink's REAL target rather than PKG_MGR: cheap, and correct
+# even if this script is ever reordered relative to ostree-layout.sh.
+if [[ -d /usr/lib/sysimage/dpkg ]]; then
+	mkdir -p /var/lib /var/log/apt
+	ln -sfnT ../../usr/lib/sysimage/dpkg /var/lib/dpkg
+fi
+
 # Declare /var/cache/dnf and /var/lib/dnf in tmpfiles.d so they're recreated on first boot (bootc lint: var-tmpfiles)
 # (dnf-only — apt uses /var/lib/apt/lists which is handled by its own tmpfiles.d)
 if [[ "$PKG_MGR" == "dnf" ]]; then


### PR DESCRIPTION
## What

flounder-sid (Debian) ISO builds fail during desktop package install with:

```
error running python rtupdate hook fwupd
dpkg: error processing package python3 (--configure):
 old python3 package postinst maintainer script subprocess failed with exit status 4
```

## Root cause

Traced python3's actual postinst script (this sandbox runs Debian 12 and has the real package installed, so I read it directly rather than guessing):

```sh
for hook in /usr/share/python3/runtime.d/*.rtupdate; do
    [ -x $hook ] || continue
    if ! $hook rtupdate python$oldv python3.11; then
        ...
        errors=yes
    fi
done
[ -z "$errors" ] || exit 4
```

`exit 4` matches the issue exactly. I downloaded the real `fwupd_2.1.7-2_amd64.deb` from `deb.debian.org` and extracted it with `dpkg-deb` — its rtupdate hook is:

```sh
if [ "$1" = rtupdate ]; then
	py3clean -p fwupd /usr/share/fwupd
	py3compile -p fwupd  /usr/share/fwupd || true
fi
```

`py3clean` is the only command here without `|| true`. Its real source (`/usr/share/python3/debpython/files.py`) resolves a package's files by shelling out to `dpkg -L <package>`.

`Containerfile.debian` already relocates `/var/lib/dpkg` to `/usr/lib/sysimage/dpkg` (so the database survives ostree's `/var` wipe) and symlinks it back, plus creates `/var/log/apt` — but only once, in the same `RUN` step as that first wipe (`ostree-layout.sh`). `build_scripts/99-cleanup.sh` runs later, still inside `base-no-de`, and does its own `find /var -mindepth 1 -maxdepth 1 -delete`. This is the exact same line `build_scripts/40-services.sh` already has a comment about, describing it deleting `/var/home/liveuser` — so it's documented elsewhere in this codebase as genuinely wiping content, not just top-level directories that happen to be empty. It takes the dpkg symlink and `/var/log/apt` right back out.

Every desktop flavor (`gnome`/`kde`/`xfce`/`cosmic`/`niri`) is `FROM base-no-de` and runs its own `apt-get install` via `install-desktop.sh`, in a *later* layer, still at build time — no boot happens in between, so the `tmpfiles.d` entry that would normally recreate the symlink at boot never fires. That desktop-stage install is where `dpkg -L fwupd` (and `/var/log/apt`) actually gets exercised, against a `/var` that `99-cleanup.sh` just wiped a second time.

## Fix

Recreate both the dpkg symlink and `/var/log/apt` in `99-cleanup.sh`, right after its own wipe — mirroring exactly what `Containerfile.debian` already does after `ostree-layout.sh`'s wipe, for the same reason. Guarded on `/usr/lib/sysimage/dpkg` existing (the Debian-specific relocation target) rather than `PKG_MGR`, so it's a no-op for every other family, including Ubuntu (which doesn't relocate its dpkg database this way).

## On the issue's "still failing" note

The issue's own "fix applied" section says `mkdir -p /var/log/apt` was already added to `Containerfile.debian` (confirmed present on `main`), but "the dpkg error persists." That's explained by this: that mkdir runs before `99-cleanup.sh`'s *second* wipe, not after it, so it never survives to the point where the desktop-stage install actually needs it.

## Testing

- `bash -n build_scripts/99-cleanup.sh` — syntax OK
- `shellcheck` (freshly built in-sandbox, no cached binary was available) — zero new findings; the one pre-existing finding in this file (`SC1091`, about not following a bind-mount-relative source path) is unrelated and unchanged
- Downloaded and inspected the real `fwupd_2.1.7-2_amd64.deb` and this box's own installed `python3-minimal`/`python3` maintainer scripts to confirm the failure mechanism against real package content
- Could **not** run an actual `buildah`/`podman` image build in this sandbox (no container-build tooling available here), so this hasn't been exercised end-to-end against a real Debian build. The fix is intentionally minimal and mirrors an existing, working pattern in the same file family (`ostree-layout.sh`) rather than introducing a new mechanism.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `d4e977c9`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->