### PR TITLE
fix(asahi): stop promoting flounder/marlin gnome-asahi as unbootable; fix a real portability bug (tunaOS#911)

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -1100,14 +1100,26 @@ variants:
         platforms: ["linux/amd64", "linux/arm64"]
         build_image: true
         build_iso: true
-      # Apple Silicon (M1/M2, Asahi Linux) — overlay/asahi.sh, Asahi-ALARM
-      # repos. aarch64 only; no ISO (asahi-installer path).
-      - id: gnome-asahi
-        stage: 3
-        platforms: ["linux/arm64"]
-        build_image: true
-        build_iso: false
-        build_qcow2: false
+      # gnome-asahi: NOT declared, and not an oversight.
+      #
+      # The Asahi-ALARM repo's linux-asahi package is real (verified by
+      # downloading it directly: asahi-alarm/asahi-alarm release "aarch64",
+      # linux-asahi-7.1.5.asahi2-1-aarch64.pkg.tar.xz), but it ships only 5
+      # T8103 (M1) device trees — nowhere near the ~50 the asahi-verify
+      # harness requires for real hardware coverage — and is missing several
+      # Apple SoC kernel modules the harness checks for, most importantly
+      # asahi.ko itself (the GPU driver; appledrm.ko, the older
+      # display-only driver, IS present). The published
+      # ghcr.io/tuna-os/marlin:gnome-asahi tag scored 23/36 on the harness
+      # (run 31243787771, 2026-08-08) — an ordinary arm64 image with a
+      # differently-named kernel, not a bootable Apple Silicon image.
+      #
+      # tunaOS#911: "until fixed, [this] should stop being promoted rather
+      # than shipping as unbootable" — a user selecting it in the installer
+      # catalog gets a Mac that does not boot. Re-add once asahi-alarm's
+      # linux-asahi actually ships the missing modules and device trees, or
+      # once TunaOS has its own source of a complete Apple Silicon kernel
+      # for Arch. Same pattern as guppy's absent niri/cosmic flavors above.
       - id: kde
         stage: 2
         build_image: true
@@ -1161,14 +1173,33 @@ variants:
         platforms: ["linux/amd64", "linux/arm64"]
         build_image: true
         build_iso: true
-      # Apple Silicon (M1/M2, Asahi Linux) — overlay/asahi.sh, Debian
-      # Bananas archive. aarch64 only; no ISO (asahi-installer path).
-      - id: gnome-asahi
-        stage: 3
-        platforms: ["linux/arm64"]
-        build_image: true
-        build_iso: false
-        build_qcow2: false
+      # gnome-asahi: NOT declared, and not an oversight.
+      #
+      # build_scripts/overlay/asahi.sh's debian branch resolves a real
+      # linux-image-*-asahi package from the Bananas team's archive, but the
+      # published ghcr.io/tuna-os/flounder:gnome-asahi tag currently ships
+      # stock 6.12.100+deb13-arm64 — the purge-then-install of the asahi
+      # kernel never runs, because it is not even reached: this flavor's
+      # arm64 build fails outright at Containerfile.overlay's `pacman`
+      # detection step. That step uses bash-only `command -v pacman
+      # &>/dev/null` in a RUN instruction with no `bash -c` wrapper, so it
+      # runs under the image's default shell — dash on this (Debian) base,
+      # which does not understand `&>` and mis-parses it as `command -v
+      # pacman &` (backgrounded) `>/dev/null` (redirecting nothing), always
+      # entering the `then` branch and invoking a `pacman` that does not
+      # exist on Debian (build 93057902527, 2026-08-08: "pacman: not
+      # found", exit 127). Fixed in this same change (Containerfile.overlay
+      # now uses portable redirection), but with that fixed the harness
+      # still needs to confirm the Bananas kernel actually boots and covers
+      # real Apple Silicon hardware before this is safe to publish again —
+      # unverified as of this writing.
+      #
+      # tunaOS#911: "until fixed, [this] should stop being promoted rather
+      # than shipping as unbootable" — a user selecting it in the installer
+      # catalog gets a Mac that does not boot. Re-add once a build with the
+      # portability fix has actually produced and verified an asahi kernel
+      # here. Same pattern as guppy's absent niri/cosmic flavors elsewhere
+      # in this file.
       - id: kde
         stage: 2
         build_image: true

--- a/Containerfile.overlay
+++ b/Containerfile.overlay
@@ -103,7 +103,19 @@ ENV DESKTOP_FLAVOR=${DESKTOP_FLAVOR}
 # fuse-overlayfs is the live ISO storage.conf's hardcoded mount_program
 # (customize-live.sh) — without it podman fails with "can't stat program
 # /usr/bin/fuse-overlayfs".
-RUN if command -v pacman &>/dev/null; then \
+#
+# `&>/dev/null` is bash-only redirection syntax. This RUN has no `bash -c`
+# wrapper (unlike the OVERLAY_TYPE dispatch above), so it runs under the
+# image's default shell — dash on a Debian base, which does not understand
+# `&>` and mis-parses it as `command -v pacman &` (backgrounded, exits 0
+# immediately) followed by a separate, argument-less `>/dev/null`
+# redirection. The `if` then sees that trivial success and ALWAYS enters the
+# `then` branch, regardless of whether pacman actually exists — invoking a
+# `pacman` that is not installed on non-Arch bases and killing the whole
+# build with "pacman: not found" (exit 127). Measured on flounder:gnome-asahi
+# linux-arm64, build 93057902527, 2026-08-08. `>/dev/null 2>&1` is the
+# POSIX-portable equivalent and needs no shell-specific wrapper.
+RUN if command -v pacman >/dev/null 2>&1; then \
         pacman -S --needed --noconfirm sudo fuse-overlayfs; \
     fi
 

--- a/scripts/verify-asahi-image.sh
+++ b/scripts/verify-asahi-image.sh
@@ -90,7 +90,12 @@ check_any() { # label, candidate paths...
 }
 # Paths differ per packaging family (Fedora lib64, Debian/Ubuntu lib, Arch boot)
 check_any "m1n1 payload" /usr/lib64/m1n1/m1n1.bin /usr/lib/m1n1/m1n1.bin /usr/lib/asahi-boot/m1n1.bin /boot/m1n1.bin
-check_any "Apple U-Boot payload" /usr/share/uboot/apple_m1/u-boot-nodtb.bin /usr/lib/u-boot/apple_m1/u-boot-nodtb.bin /usr/lib/asahi-boot/u-boot.bin
+# /usr/lib/asahi-boot/u-boot.bin was a guess at Arch's filename under that
+# directory; the real uboot-asahi package (asahi-alarm/asahi-alarm, verified
+# by downloading uboot-asahi-2026.04.asahi2-1-aarch64.pkg.tar.xz and listing
+# its contents directly) ships u-boot-nodtb.bin there instead, matching the
+# other two families' filename — only the directory differs by family.
+check_any "Apple U-Boot payload" /usr/share/uboot/apple_m1/u-boot-nodtb.bin /usr/lib/u-boot/apple_m1/u-boot-nodtb.bin /usr/lib/asahi-boot/u-boot-nodtb.bin
 # CentOS Hyperscale SIG's update-m1n1 RPM (EL10: skipjack/yellowfin/albacore)
 # installs to /usr/sbin, not /usr/bin like Fedora's — verified by downloading
 # update-m1n1-20250426.1-1.hs+asahi.el10.noarch.rpm from the Hyperscale


### PR DESCRIPTION
## What

`flounder:gnome-asahi` and `marlin:gnome-asahi` are published tags that are not real Apple Silicon images. Confirmed with today's evidence (2026-08-08), not just the issue's original (2026-07-30) numbers:

- **marlin**: `verify-asahi` harness run [31243787771](https://github.com/tuna-os/tunaOS/actions/runs/31243787771) scores 23/36 against the published tag. I downloaded asahi-alarm's actual `linux-asahi` package (`linux-asahi-7.1.5.asahi2-1-aarch64.pkg.tar.xz`) and listed its contents directly: it ships only 5 T8103 (M1) device trees, nowhere near the ~50 the harness requires, and is missing several Apple SoC kernel modules the harness checks for — most importantly `asahi.ko`, the actual GPU driver (`appledrm.ko`, the older display-only driver, IS present, which is what let this look partially plausible). This is a real gap in the third-party asahi-alarm repo, not something TunaOS's own scripts can fix.
- **flounder**: the published tag ships stock `6.12.100+deb13-arm64` — `build_scripts/overlay/asahi.sh`'s debian branch never even gets to install the Bananas archive's asahi kernel. Root cause (build `93057902527`, 2026-08-08): `Containerfile.overlay`'s pacman-detection `RUN` uses bash-only `command -v pacman &>/dev/null` with no `bash -c` wrapper, so it runs under the image's default shell — dash on this Debian base. dash does not understand `&>` and mis-parses it as `command -v pacman &` (backgrounded, trivially exits 0) followed by an empty `>/dev/null` redirection, so the `if` always takes the then-branch and invokes a `pacman` that does not exist on Debian: "pacman: not found", exit 127, killing the whole overlay build before `asahi.sh` ever runs. I verified the exact misparse locally with dash directly.

## Changes

1. **`Containerfile.overlay`**: fix the redirect to the POSIX-portable `>/dev/null 2>&1`, which needs no shell-specific wrapper. This is a real, independent bug in a script shared by every overlay (hwe/nvidia/cachyos/asahi) on every variant, not asahi- or flounder-specific — worth fixing regardless of what happens to the asahi flavor below.
2. **`.github/build-config.yml`**: remove the `gnome-asahi` flavor from marlin and flounder, following the exact precedent already in this file for guppy's absent niri/cosmic flavors ("NOT declared, and not an oversight", with the reasoning and a tracking issue inline). This is the issue's own explicit ask: *"until fixed, both tags should stop being promoted rather than shipping as unbootable — a user selecting either in the installer catalog gets a Mac that does not boot."* Both comments record exactly what would need to change before either flavor comes back.
3. **`scripts/verify-asahi-image.sh`**: also fixed while gathering evidence — the Apple U-Boot payload check listed `/usr/lib/asahi-boot/u-boot.bin` as the Arch-family candidate, which was a guess. I downloaded the real `uboot-asahi` package (`uboot-asahi-2026.04.asahi2-1-aarch64.pkg.tar.xz`) and confirmed it actually ships `u-boot-nodtb.bin` there, matching the other two families' filename (only the directory differs by family). This alone would not have flipped marlin to passing (the DTB count and missing kernel modules are the real blockers), but it was a genuine inaccuracy worth correcting, same class as #777.

## Not touched (flagged for follow-up)

The deeper structural gap that let this ship in the first place: the Gate/Promote workflow treats a skipped boot gate (asahi flavors are arm64-only, so the x86 QEMU Gate always skips) as equivalent to a passing one, and the separate 35-point asahi harness that actually verifies these images runs *after* publish and is never wired back into the promotion decision (`reusable-build-image.yml`, `tag-image` job, and the comment on `verify_boot` explaining why the gate is skipped). Reworking that is a bigger, riskier change that would affect bonito/grouper's currently-working asahi pipeline too, and is out of scope for this fix.

## Testing

- `bash -n` + a freshly built `shellcheck` (zero new findings) on the shell script change
- The dash misparse reproduced directly, and the fix confirmed to correctly skip pacman-detection under dash in this sandbox
- A freshly downloaded `yq` confirming `build-config.yml` still parses and that `gnome-asahi` is cleanly gone from exactly marlin's and flounder's flavor lists, with every sibling flavor untouched
- Downloaded and inspected the real `linux-asahi` and `uboot-asahi` packages directly rather than guessing at their contents
- Could **not** run an actual `buildah`/`podman` image build in this sandbox (no container-build tooling available here)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `564bfdb5`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->