### PR TITLE
docs(guppy): record the GURU-overlay ebuild check for niri/cosmic (tunaOS#923)

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -821,7 +821,11 @@ variants:
       #   niri    — no ebuild in the Gentoo main tree at all. A search returns
       #             only dev-ruby/niceogiri. Declaring it would publish an
       #             installable image with no compositor, exactly as
-      #             flounder:niri did (tunaOS#915).
+      #             flounder:niri did (tunaOS#915). It IS packaged in the
+      #             community GURU overlay (gui-wm/niri, ~amd64) — see
+      #             manifests/desktops/niri.yaml for the full finding. Not
+      #             enabled here: an untested source build, and ~amd64
+      #             keywording that can shift under guppy without warning.
       #   cosmic  — same: no cosmic-comp or cosmic-session ebuild in the tree,
       #             and cosmic.yaml has no emerge section.
       # Both measured and tracked in tunaOS#923.

--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -223,6 +223,21 @@ packages:
     - Mesa-dri
     - Mesa-libEGL1
 
+  # ── Emerge (Gentoo) ────────────────────────────────────────────────
+  # DELIBERATELY ABSENT — no emerge section at all, same treatment as
+  # apt's flounder/flounder-sid non-declaration above. Checked
+  # (packages.gentoo.org/packages/<cat>/<pkg>.json, 200 = present) for
+  # cosmic-comp and cosmic-session under both gui-wm/ and gui-apps/: all
+  # four return 404, and no other category has a match either.
+  #
+  # Also checked the community GURU overlay (github.com/gentoo/guru,
+  # enabled via `eselect repository` — not a bespoke third-party repo):
+  # zero cosmic-* ebuilds there either, unlike niri (see niri.yaml), which
+  # GURU does carry. guppy does not declare a cosmic flavor in
+  # build-config.yml, so this never fails out loud; recorded here so a
+  # future manifest edit doesn't add one on the strength of "there might
+  # be an emerge section for this". tunaOS#923.
+
 post_install_inline:
   - "glib-compile-schemas /usr/share/glib-2.0/schemas || true"
   - "if [ -f /etc/pam.d/greetd ]; then sed --sandbox -i -e '/gnome_keyring.so/ s/-auth/auth/ ; /gnome_keyring.so/ s/-session/session/' /etc/pam.d/greetd; fi"

--- a/manifests/desktops/niri.yaml
+++ b/manifests/desktops/niri.yaml
@@ -238,6 +238,21 @@ packages:
   # What IS in the tree, for whoever packages niri later: gui-libs/greetd,
   # gui-apps/gtkgreet. Missing alongside niri: cage.
   #
+  # Update (tunaOS#923, 2026-08-08): niri IS packaged, just not in ::gentoo.
+  # The community GURU overlay (github.com/gentoo/guru — the one enabled via
+  # `eselect repository`/app-eselect/eselect-repository, not a bespoke
+  # third-party repo) carries gui-wm/niri (niri-26.04.ebuild and a -9999 live
+  # ebuild), KEYWORDS="~amd64" (testing, not stable), cargo-based with real
+  # deps (libinput, wayland, mesa, seatd, libxkbcommon; pipewire optional for
+  # screencast). cage and gtkgreet are still not there, so the greeter story
+  # is unchanged either way. Not wired into Containerfile.gentoo/guppy here:
+  # it is an untested source build against this pipeline's time budget, and
+  # ~amd64 keywording means the rest of the overlay's dependency graph can
+  # shift under guppy with no warning. Enabling the overlay is the "bigger
+  # decision" tunaOS#923 already flagged — this just removes the "does an
+  # ebuild exist anywhere" unknown for whoever makes that call. cosmic-comp
+  # and cosmic-session were checked the same way and are 404 in GURU too.
+  #
   # Do not add an emerge list here until niri has an ebuild. Tracked in
   # tunaOS#923. Leaving the key absent is intentional: the installer's emerge
   # path now fails loudly on an empty list rather than shipping a desktop-less


### PR DESCRIPTION
## What

tunaOS#923's actual mitigation (build `xfce` for guppy with corrected atoms, exclude `niri`/`cosmic` from `build-config.yml`, make the emerge install path fail loudly on an empty package list) is already on `main` — it shipped as a rider commit (`628bfe3e`, *"feat(guppy): build XFCE; niri and cosmic have no ebuilds"*) inside PR #921. That PR never referenced #923, so the issue was left open even though its described work is done. Verified all four pieces are present on current `main` before touching anything.

## What this PR actually adds

The issue's own follow-up comment says closing it for real needs "either ebuilds upstream/in an overlay the image enables, or a Gentoo target added to the [package] factory" — bigger than #923 itself, so nothing was decided either way.

I checked the community **GURU** overlay (`github.com/gentoo/guru`, enabled via Gentoo's own `eselect repository` — not a bespoke third-party repo) against both `niri` and `cosmic`:

| package | Gentoo main tree | GURU overlay |
|---|---|---|
| `niri` | 404 | **present** — `gui-wm/niri` (`niri-26.04.ebuild`, `KEYWORDS="~amd64"`, cargo-based; deps: libinput, wayland, mesa, seatd, libxkbcommon; pipewire optional) |
| `cosmic-comp` / `cosmic-session` | 404 | 404 (both `gui-wm/` and `gui-apps/` categories checked, plus a full-repo search) |

`cage`/`gtkgreet` (niri's greeter stack) are still absent from GURU either way, so this doesn't change what niri needs to actually boot — it only answers "does an ebuild exist anywhere" for whoever picks up the bigger decision later.

This is a **comment-only** change: no `packages.emerge` keys added, no flavors declared in `build-config.yml`, no build behavior changes. I deliberately did not wire the overlay into `Containerfile.gentoo`/guppy — it's an untested cargo/rust source build against this pipeline's time budget, and `~amd64` keywording means the rest of the overlay's dependency graph can shift under guppy with no warning. That integration call is exactly the "bigger decision" the issue already flagged as out of scope for it.

- `manifests/desktops/niri.yaml` — appended the GURU finding to the existing "deliberately absent" comment block.
- `manifests/desktops/cosmic.yaml` — added a matching Gentoo comment block (it previously had **no** mention of Gentoo at all, unlike niri.yaml/xfce.yaml).
- `.github/build-config.yml` — one-line pointer from guppy's niri exclusion comment to the new finding.

## Verification

- `git diff --stat`: 3 files, comments only (+35/-1).
- No tabs, no structural YAML changes — `packages.emerge` stays absent on both `niri.yaml` and `cosmic.yaml`, so `install-desktop.sh`'s "fail loudly on empty emerge list" behavior (lines 163–178) and the manifest cross-check bats tests are unaffected.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `f5c5e36a`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->