### PR TITLE
fix(setup): ublue-system-setup.service crashes on every boot — unbound $VEN_ID (tunaOS#576)

### DIFF
--- a/system_files/usr/share/ublue-os/system-setup.hooks.d/10-framework.sh
+++ b/system_files/usr/share/ublue-os/system-setup.hooks.d/10-framework.sh
@@ -6,6 +6,17 @@ version-script framework-lts system 1 || exit 0
 
 set -euo pipefail
 
+# VEN_ID and CPU_VENDOR were referenced below without ever being assigned —
+# under `set -u` that is an immediate "unbound variable" crash on the very
+# first `[[ ... =~ ... ]]` check, on EVERY machine (not just Framework
+# hardware, since the crash happens before the vendor check can even
+# short-circuit). This is why ublue-system-setup.service showed as failed
+# on a plain yellowfin:gnome VM boot with no Framework chassis at all
+# (tunaOS#576). user-setup.hooks.d/10-theming.sh already reads VEN_ID
+# correctly; CPU_VENDOR mirrors bluefin's equivalent hook.
+VEN_ID="$(cat /sys/devices/virtual/dmi/id/chassis_vendor)"
+CPU_VENDOR="$(grep "vendor_id" /proc/cpuinfo | uniq | awk -F": " '{ print $2 }')"
+
 # GLOBAL
 KARGS=$(rpm-ostree kargs)
 NEEDED_KARGS=()
@@ -25,11 +36,18 @@ if [[ ":Framework:" =~ :$VEN_ID: ]]; then
 	fi
 fi
 
-#shellcheck disable=SC2128
-if [[ -n "$NEEDED_KARGS" ]]; then
+# Bare `$NEEDED_KARGS` (SC2128, previously suppressed) only ever expands
+# element 0 — with zero elements that is itself an unbound-variable crash
+# under `set -u` (the common case: no karg changes needed at all). Test the
+# array's length instead, which is well-defined for zero, one, or many
+# elements. Passing `"${NEEDED_KARGS[*]}"` as a single rpm-ostree argument
+# was also wrong once there could be more than one entry — each
+# --delete-if-present=/--append-if-missing= flag must be its own argv
+# entry, not one space-joined string. tunaOS#576.
+if [[ "${#NEEDED_KARGS[@]}" -gt 0 ]]; then
 	echo "Found needed karg changes, applying the following: ${NEEDED_KARGS[*]}"
 	plymouth display-message --text="Updating kargs - Please wait, this may take a while" || true
-	rpm-ostree kargs "${NEEDED_KARGS[*]}" --reboot || exit 1
+	rpm-ostree kargs "${NEEDED_KARGS[@]}" --reboot || exit 1
 else
 	echo "No karg changes needed"
 fi


### PR DESCRIPTION
## What

`#576`'s first manual functional-test run flagged `ublue-system-setup.service` as failed on a plain `yellowfin:gnome` VM boot with **no Framework hardware involved at all** ("ours — needs a look").

Root cause: `system_files/usr/share/ublue-os/system-setup.hooks.d/10-framework.sh` references `$VEN_ID` and `$CPU_VENDOR` in its very first `[[ ... =~ ... ]]` check without ever assigning them. Under this script's own `set -euo pipefail`, that's an immediate "unbound variable" crash — reproduced directly:

```
$ bash -c 'set -euo pipefail; [[ ":Framework:" =~ :$VEN_ID: ]]'
bash: line 1: VEN_ID: unbound variable
```

Since the crash happens **before** the vendor comparison can even run, this fires on every machine, not just Framework hardware — exactly matching the reported symptom on a bare VM. `ublue-system-setup` dispatches every `system-setup.hooks.d/*` script via a bare `bash $script` loop (no `set -e` on the dispatcher itself), and the **service's** own exit status is whatever the last hook returns — so this one script crashing marks the whole unit failed on literally every fresh boot of every tunaOS image.

## Fix

- Assign `VEN_ID` from `chassis_vendor` and `CPU_VENDOR` from `/proc/cpuinfo` before they're used, matching the pattern already used correctly in the sibling `user-setup.hooks.d/10-theming.sh` and bluefin's equivalent hook.
- Second bug in the same script, exposed once the first crash was fixed and the script could run past it: the empty-array check `[[ -n "$NEEDED_KARGS" ]]` (shellcheck `SC2128`, suppressed) expands only element 0 — itself an unbound-variable crash under `set -u` when the array has zero elements, the common case (no karg changes needed). Replaced with a length check (`${#NEEDED_KARGS[@]}`).
- Also fixed `"${NEEDED_KARGS[*]}"` (space-joins multiple kargs into one `rpm-ostree` argument) to `"${NEEDED_KARGS[@]}"` (each karg its own argv entry) — latent but real, once a Framework laptop could ever need more than one karg change applied in the same run.

## Verification

No podman/rpm-ostree available in this sandbox, so verified with `bash -n` plus a full functional simulation (faked `/sys/devices/virtual/dmi/id/*`, `/proc/cpuinfo`, and `rpm-ostree`) covering all three reachable paths:
- **Non-Framework VM** (previously crashed at `VEN_ID`): now exits 0 with "No karg changes needed".
- **Framework + Intel with a needed karg**: now correctly reaches `rpm-ostree` with each flag as a separate argument.
- Plain syntax check (`bash -n`) passes.

## Scope note

This fixes one of the two concrete findings from `#576`'s own first-run comment (`ublue-system-setup.service`). The other finding (Flathub remote not visible via `flatpak remotes` as root) and the full functional test-suite framework that issue proposes are unrelated, much larger pieces of work, deliberately left out of this change.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `591ae7dd`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->