### PR TITLE
ci(live-iso): don't 403 the boot verification on fork PRs

### DIFF
--- a/.github/workflows/live-iso-bootc.yml
+++ b/.github/workflows/live-iso-bootc.yml
@@ -188,8 +188,15 @@ jobs:
           path: screenshot.png
           if-no-files-found: warn
 
+      # Only same-repo PRs can comment. On a fork `pull_request` run GITHUB_TOKEN
+      # is read-only no matter what the `permissions:` block above asks for, so
+      # `issues.createComment` 403s — which used to fail this job *after* the ISO
+      # had already built and booted, throwing away a successful verification.
+      # Forks get the same text in the run summary instead (see next step).
       - name: Post boot screenshot to PR
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           VARIANT: ${{ env.VARIANT }}
@@ -222,3 +229,30 @@ jobs:
               issue_number: context.issue.number,
               body,
             });
+
+      # Fork PRs cannot be commented on, but the verification still ran and its
+      # result still matters — put it where a fork contributor can actually see
+      # it rather than dropping it on the floor.
+      - name: Report boot verification in run summary (fork PR)
+        if: >-
+          github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          VARIANT: ${{ env.VARIANT }}
+          FLAVOR: ${{ env.FLAVOR }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "## Live ISO Boot Verification"
+            echo ""
+            echo "The live ISO built and booted successfully to the GNOME desktop."
+            echo ""
+            echo "**Variant:** \`${VARIANT}\` | **Flavor:** \`${FLAVOR}\` | **Commit:** \`${HEAD_SHA:0:7}\`"
+            echo ""
+            echo "📸 [Download desktop screenshot](${RUN_URL}) — expand **Artifacts**"
+            echo "and download \`desktop-screenshot\`."
+            echo ""
+            echo "> Posted here rather than as a PR comment: this run is from a fork,"
+            echo "> so \`GITHUB_TOKEN\` is read-only and cannot comment."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## The problem

The `build` job asks for `pull-requests: write`:

```yaml
    permissions:
      contents: read
      packages: read
      pull-requests: write
```

But on a fork `pull_request` run, GitHub makes `GITHUB_TOKEN` read-only **regardless of what the `permissions:` block requests**. `Post boot screenshot to PR` was guarded only by `github.event_name == 'pull_request'` — no fork check, no `continue-on-error` — so `issues.createComment` returns 403 and fails the job.

## Why this is worse than a red check

That step runs **last**. By the time it fires, the job has already built the live ISO, booted it in QEMU, taken the desktop screenshot and uploaded the artifact. A fork PR did all of that work *successfully* and then discarded the result on the comment call — and no fork contributor could do anything about it.

## The change

- Guard the comment on the PR being same-repo (`head.repo.full_name == github.repository`).
- Add a fork-only step that writes the same content to `$GITHUB_STEP_SUMMARY`, so the verification lands somewhere a fork contributor can actually read it, with a line explaining why it isn't a comment.

Skipping loudly rather than silently: the summary states the result *and* the reason it isn't a PR comment.

## Relationship to the R2 fix

This is a **different mechanism** from #1139. That one was about repository *secrets* arriving empty on fork runs; this is about *token scope*. Neither fix helps the other case, which is why this is a separate change rather than an extension of that one.

## Verification

- **`actionlint` 1.7.7** — findings are byte-identical to `origin/main`'s copy of this file, so the new `if:` expressions introduce none. Both exit 1 on a pre-existing `SC2034` at line 110, in a step this PR doesn't touch:
  ```
  baseline exit=1
  mine     exit=1
  IDENTICAL findings -> my change adds none
  ```
- **`yamllint -c ./.yamllint.yml`** — only the pre-existing 155-char warning at line 54, present identically on main. Longest line added here is 102 chars.
- **`shellcheck --severity=error --exclude=SC1091,SC2114`** on the new `run:` block — clean.
- **Executed the block** with the step's env set; renders the expected Markdown, and `${HEAD_SHA:0:7}` yields the same 7 characters as the JS `.slice(0, 7)` it mirrors:
  ```
  **Variant:** `skipjack` | **Flavor:** `gnome` | **Commit:** `abcdef1`
  ```

**Not verified:** no fork PR touching `live-iso/**` has exercised this. The `pull_request` trigger is `paths`-filtered to `live-iso/**`, `scripts/build-iso-tacklebox.sh` and this workflow, so it only fires for those changes — the real confirmation needs such a PR from a fork.

## Also noticed, deliberately not changed

This workflow declares a `RCLONE_CONFIG_R2_*` / `UPLOAD_R2` env block that **nothing downstream reads** — `scripts/build-iso-tacklebox.sh` has no rclone/R2 references and `UPLOAD_R2` has no consumer in the repo. It's harmless but misleading, and belongs in its own tidy-up rather than bundled here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->