### PR TITLE
ci(frontend-parity): land the import through the merge queue, not a push to main

### DIFF
--- a/.github/workflows/frontend-parity.yml
+++ b/.github/workflows/frontend-parity.yml
@@ -17,6 +17,12 @@ on:
 permissions:
   contents: write
   actions: read
+  # Needed to open the import PR; `main` only accepts merge-queue changes.
+  pull-requests: write
+
+concurrency:
+  group: frontend-parity
+  cancel-in-progress: false
 
 jobs:
   import:
@@ -31,15 +37,54 @@ jobs:
           GH_TOKEN: ${{ secrets.FRONTEND_READ_TOKEN || github.token }}
         run: python3 scripts/import-frontend-parity.py
 
-      - name: commit
+      # `main` carries a "changes must be made through the merge queue" rule,
+      # so the `git push` straight to main this step used to do was rejected
+      # every time an import produced anything:
+      #
+      #   remote: error: GH013: Repository rule violations found for refs/heads/main
+      #   remote: - Changes must be made through the merge queue
+      #   ! [remote rejected] main -> main
+      #
+      # The import itself had already succeeded, so the red job hid the real
+      # symptom: the matrix has never received a single imported cell, and the
+      # generated block still reads "not yet imported" — the exact "no data
+      # looks like fine" failure the document exists to prevent. matrix-status
+      # hit this identically (see its comment); do what it does and open a PR.
+      - name: Open a PR with the imported parity reports
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: automation/frontend-parity
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/INSTALLER-FRONTENDS.md
-          if git diff --cached --quiet; then
+          set -euo pipefail
+          # Pushed only when a cell actually moves, same rule as matrix-status.
+          if git diff --quiet -- docs/INSTALLER-FRONTENDS.md; then
             echo "no parity changes"
             exit 0
           fi
-          # Pushed only when a cell actually moves, same rule as matrix-status.
-          git commit -m "docs: import installer frontend parity reports [skip ci]"
-          git push
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          # One long-lived branch, force-pushed: the block is fully generated,
+          # so each import supersedes the last. It also keeps this to a single
+          # open PR — the block embeds each frontend's newest capture run URL,
+          # which moves whenever that repo pushes to main (KDE alone ran nine
+          # times on 2026-08-07), so a fresh PR per night would be daily noise.
+          git checkout -b "$BRANCH"
+          git add docs/INSTALLER-FRONTENDS.md
+          # No `[skip ci]`: that marker existed to stop a direct-to-main push
+          # from re-triggering CI. On a PR head commit it suppresses the PR's
+          # own checks instead, and a check that never reports cannot clear the
+          # merge queue — the change would sit unmergeable rather than land.
+          git commit -m "docs: import installer frontend parity reports ($(date -u +%Y-%m-%d))"
+          git push --force origin "$BRANCH"
+
+          if [[ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]]; then
+            gh pr create --base main --head "$BRANCH" \
+              --title "docs: import installer frontend parity reports" \
+              --body "$(printf '%s\n\n%s\n\n%s\n' \
+                'Imported by `scripts/import-frontend-parity.py` from the GPU-less captures in each frontend repo.' \
+                'Screen columns only — launch, render and advance stay with the VM walkthrough.' \
+                'Force-updated in place by the `frontend parity` workflow, so this branch always holds the newest import.')"
+          else
+            echo "PR already open for $BRANCH — force-push refreshed it."
+          fi


### PR DESCRIPTION
## What

`frontend-parity.yml` ended its `commit` step in a bare `git push` to `main`. `main`'s ruleset rejects that:

```
remote: error: GH013: Repository rule violations found for refs/heads/main
remote: - Changes must be made through the merge queue
 ! [remote rejected] main -> main (push declined due to repository rule violations)
```

This replaces the direct push with a long-lived `automation/frontend-parity` branch and a single PR, which the merge queue accepts — the same shape `matrix-status.yml` already uses for the same reason.

## Why

The import ahead of the push works. Run [31246363328](https://github.com/tuna-os/tunaOS/actions/runs/31246363328) fetched every frontend's capture, rewrote the generated block correctly, and then threw the result away on the push.

That is worse than an ordinary red job. The workflow has never landed output once — the generated block in `docs/INSTALLER-FRONTENDS.md` still reads `_Not yet imported — run scripts/import-frontend-parity.py._` while the job reports failure, so the visible symptom points at a broken importer rather than at a protected branch. "No data" and "fine" looking identical is the precise failure that document exists to prevent.

The alternative fix — an admin adding a ruleset bypass actor for `github-actions[bot]` — was rejected. It needs an action no contributor can take, and it weakens a deliberate protection on `main` so that a generated doc can skip the review path everything else goes through. Nothing in this job needs that.

## Details

- **One long-lived branch, force-updated**, so there is a single open PR rather than one per night. The existing "only push when a cell moves" guard would not have contained the churn on its own: the block embeds each frontend's newest capture run URL, and those move constantly — `tuna-installer-kde` ran its screenshots workflow nine times on `main` on 2026-08-07 alone, so a fresh run URL is essentially guaranteed daily.
- **`[skip ci]` dropped.** It was there to keep a direct-to-main push from re-triggering CI. On a PR head commit it does something different and unwanted: it suppresses the PR's own checks, and a required check that never reports cannot clear the merge queue, so the change would sit unmergeable instead of landing.
- **`pull-requests: write` added.** `contents: write` alone pushes the branch and then fails at `gh pr create`.
- **`concurrency: frontend-parity`** so a manual `workflow_dispatch` cannot race the nightly run onto the same force-pushed branch.

## Testing

Lint gates, run locally with the repo's own commands from `.github/workflows/lint.yml`:

| gate | result |
|---|---|
| `actionlint` (with CI's `-ignore` flags) | exit 0, no output |
| `yamllint -c ./.yamllint.yml` | exit 0; the edited file emits no warnings |
| `shellcheck --severity=error --exclude=SC1091,SC2114` | exit 0 |
| json-validate (`jq .`) | exit 0 |
| `just --unstable --fmt --check` (Justfile + `*.just`) | exit 0 |

`actionlint` was also diffed against `origin/main`: the baseline emits the same 60 lines of `SC2086`/`SC2129` findings (all in CI's ignore list), and this change adds only two `SC2016` notes for the intentional single-quoted backticks in the PR body — also in CI's ignore list.

The new step's shell was extracted from the YAML and exercised against a local bare repo with a stubbed `gh`, covering all three paths: doc changed with no PR open (branch created, pushed, `gh pr create` invoked with a well-formed body), doc unchanged (`no parity changes`, exit 0), and doc changed from a `--depth 1` clone with the branch already on the remote and a PR open (forced update, `PR already open`).

**Not verified:** the scheduled run itself cannot be triggered from here, so the live `gh pr create` against this repo and the resulting PR's behaviour in the merge queue are unconfirmed. The strongest available evidence is that the identical pattern in `matrix-status.yml` has produced PRs that merged through the queue on six consecutive days (#961, #977, #987, #994, #1041, #1120).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->