### PR TITLE
fix(nvidia): count kernel module trees, not every /usr/lib/modules entry

### DIFF
--- a/build_scripts/checks/verify-nvidia.sh
+++ b/build_scripts/checks/verify-nvidia.sh
@@ -186,7 +186,7 @@ else
 fi
 
 echo "== exactly one kernel tree =="
-# The kernel swap must leave exactly ONE /usr/lib/modules entry. rpm --erase
+# The kernel swap must leave exactly ONE kernel module tree. rpm --erase
 # keeps a directory alive when it holds generated (unowned) files, and a
 # stale half-alive tree is a landmine for every consumer that scans
 # /usr/lib/modules: the yellowfin:kde-nvidia live ISO resolved its kernel
@@ -195,19 +195,49 @@ echo "== exactly one kernel tree =="
 # drivers, and hung in dracut with no sr0 ever appearing (run 31208526159)
 # — while the swapped kernel's own initramfs, one directory over, carried
 # every driver the boot needed.
-_tree_count=0
-_tree_name=""
+#
+# WHAT COUNTS AS A KERNEL TREE. Not every /usr/lib/modules entry is one, and
+# counting them all is how this check failed six correct images (#1118, run
+# 31235806989: "6 kernel module trees ... expected exactly
+# 6.12.0-254.el10.x86_64", while every other assertion in the same log
+# passed — kmod built for 6.12.0-254, module version matched, initramfs
+# carried all eight boot drivers). Measured cause: the driver transaction
+# pulls kernel-abi-stablelists from baseos, whose entire payload under
+# /lib/modules is
+#     kabi-current -> kabi-rhel103   (symlink to a directory)
+#     kabi-rhel100 kabi-rhel101 kabi-rhel102 kabi-rhel103
+# (rpm header of kernel-abi-stablelists-6.12.0-254.el10.noarch — 5 entries,
+# holding kabi_stablelist_<arch> text files only). One real tree plus those
+# five is the 6. A kabi directory has no vmlinuz, no modules.dep and no
+# kernel-release name, so nothing that resolves a kernel version out of
+# /usr/lib/modules can select one — they are reported, never counted.
+#
+# A kernel module tree is an entry named for a kernel release (uname -r,
+# always <maj>.<min>.<patch>…) — which is exactly the shape of the husk this
+# check exists to catch (6.12.0-250.el10.x86_64), so the failure mode is
+# still fatal here.
+_kernel_trees=()
+_other_entries=()
 for _tree in "${NV_ROOT}"/usr/lib/modules/*/; do
 	[[ -d "$_tree" ]] || continue
-	_tree_count=$((_tree_count + 1))
 	_tree_name="$(basename "$_tree")"
+	if [[ "$_tree_name" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+		_kernel_trees+=("$_tree_name")
+	else
+		_other_entries+=("$_tree_name")
+	fi
 done
-if [[ "$_tree_count" -eq 1 && "$_tree_name" == "$KERNEL_VRA" ]]; then
-	pass "single kernel module tree (${_tree_name})"
-elif [[ "$_tree_count" -eq 1 ]]; then
-	fail "single module tree ${_tree_name} does not match the installed kernel ${KERNEL_VRA}"
+# Evidence with the verdict: name the entries, so the next mismatch does not
+# cost a diagnosis round the way #1118 did (its log printed only the count).
+if [[ "${#_other_entries[@]}" -gt 0 ]]; then
+	echo "  info: non-kernel /usr/lib/modules entries (not kernel trees): ${_other_entries[*]}"
+fi
+if [[ "${#_kernel_trees[@]}" -ne 1 ]]; then
+	fail "${#_kernel_trees[@]} kernel module trees under /usr/lib/modules (${_kernel_trees[*]:-none}) — a stale tree breaks kernel/initrd selection downstream (expected exactly ${KERNEL_VRA})"
+elif [[ "${_kernel_trees[0]}" == "$KERNEL_VRA" ]]; then
+	pass "single kernel module tree (${_kernel_trees[0]})"
 else
-	fail "${_tree_count} kernel module trees under /usr/lib/modules — a stale tree breaks kernel/initrd selection downstream (expected exactly ${KERNEL_VRA})"
+	fail "single module tree ${_kernel_trees[0]} does not match the installed kernel ${KERNEL_VRA}"
 fi
 
 echo "== initramfs boot-driver parity =="

--- a/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
+++ b/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
@@ -113,9 +113,19 @@ else
 	# 6.12.0-250 husk (no vmlinuz, no initramfs, empty modules.dep) sitting
 	# beside it. verify-nvidia.sh now fails the build if more than one
 	# module tree survives to the end.
+	#
+	# Only kernel-release-named entries (uname -r: <maj>.<min>.<patch>…) are
+	# kernel trees. /usr/lib/modules also holds kernel-abi-stablelists'
+	# rpm-owned kabi-current symlink and kabi-rhel10* directories (#1118);
+	# rm -rf'ing those deletes files an installed package still owns and
+	# removes nothing a kernel selector could ever pick.
 	for _mod_dir in "${MODULES_ROOT}"/*/; do
 		[[ -d "$_mod_dir" ]] || continue
 		_mod_ver="$(basename "$_mod_dir")"
+		if [[ ! "$_mod_ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+			echo "==> keeping non-kernel /usr/lib/modules entry ${_mod_ver}"
+			continue
+		fi
 		if [[ "$_mod_ver" != "$CACHED_VERSION" ]]; then
 			echo "==> removing stale kernel module tree ${_mod_dir}"
 			rm -rf "$_mod_dir"

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -455,6 +455,67 @@ print('ok')
   [[ "$output" == *"kernel module trees under /usr/lib/modules"* ]]
 }
 
+# ── kabi entries are not kernel trees (#1118, run 31235806989) ─────────────
+#
+# The driver transaction pulls kernel-abi-stablelists from baseos. Its whole
+# payload under /lib/modules is the five entries reproduced below (read out
+# of the rpm header of kernel-abi-stablelists-6.12.0-254.el10.noarch):
+# kabi-current, a symlink to the kabi-rhel103 DIRECTORY, plus kabi-rhel100
+# through kabi-rhel103. Counting every /usr/lib/modules entry read that as
+# "6 kernel module trees" and failed six *-nvidia amd64 variants whose other
+# assertions all passed. They hold kabi_stablelist_<arch> text files: no
+# vmlinuz, no modules.dep, no kernel-release name.
+
+make_kabi_entries() {
+  local r="$1"
+  mkdir -p "$r/usr/lib/modules/kabi-rhel10"{0,1,2,3}
+  for n in 0 1 2 3; do
+    touch "$r/usr/lib/modules/kabi-rhel10${n}/kabi_stablelist_x86_64"
+  done
+  ln -sfn kabi-rhel103 "$r/usr/lib/modules/kabi-current"
+}
+
+@test "verify-nvidia passes with kernel-abi-stablelists' kabi entries present" {
+  make_stub_tools
+  root="$(make_good_root)"
+  make_kabi_entries "$root"
+  run_verify "$root"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"single kernel module tree (${KVER})"* ]]
+  # Reported as evidence, not counted — a silent skip would hide a real
+  # surprise entry the next time one appears.
+  [[ "$output" == *"non-kernel /usr/lib/modules entries"* ]]
+  [[ "$output" == *"kabi-current"* ]]
+}
+
+@test "verify-nvidia still fails on a stale kernel tree beside the kabi entries" {
+  make_stub_tools
+  root="$(make_good_root)"
+  make_kabi_entries "$root"
+  mkdir -p "$root/usr/lib/modules/6.12.0-250.el10.x86_64"
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"2 kernel module trees under /usr/lib/modules"* ]]
+  # The names, so the next failure diagnoses itself.
+  [[ "$output" == *"6.12.0-250.el10.x86_64"* ]]
+}
+
+@test "kernel-swap does not delete the rpm-owned kabi entries" {
+  make_swap_stubs "6.12.0-250.el10.x86_64"
+  make_swap_fixture
+  mkdir -p "${BATS_TEST_TMPDIR}/modules/6.12.0-250.el10.x86_64"
+  mkdir -p "${BATS_TEST_TMPDIR}/modules/${AKMODS_KVER}"
+  mkdir -p "${BATS_TEST_TMPDIR}/modules/kabi-rhel103"
+  touch "${BATS_TEST_TMPDIR}/modules/kabi-rhel103/kabi_stablelist_x86_64"
+  ln -sfn kabi-rhel103 "${BATS_TEST_TMPDIR}/modules/kabi-current"
+  run_swap
+  [ "$status" -eq 0 ]
+  [ ! -d "${BATS_TEST_TMPDIR}/modules/6.12.0-250.el10.x86_64" ]
+  [ -f "${BATS_TEST_TMPDIR}/modules/kabi-rhel103/kabi_stablelist_x86_64" ]
+  [ -L "${BATS_TEST_TMPDIR}/modules/kabi-current" ]
+  [[ "$output" == *"keeping non-kernel /usr/lib/modules entry kabi-rhel103"* ]]
+}
+
 @test "verify-nvidia fails when the initramfs lacks a boot-critical driver" {
   make_stub_tools
   root="$(make_good_root)"


### PR DESCRIPTION
Fixes #1118.

## What the contract asserts, and what actually happened

`build_scripts/checks/verify-nvidia.sh`, section `== exactly one kernel tree ==`, counted **every directory** under `/usr/lib/modules` and failed unless the count was exactly 1. It exists to catch the stale-husk failure from run 31208526159, where a leftover `6.12.0-250.el10.x86_64` tree (no vmlinuz, no initramfs, empty `modules.dep`) made the `yellowfin:kde-nvidia` live ISO resolve its kernel against the husk and hang in dracut with no `sr0`. That protection is real and stays.

But not every `/usr/lib/modules` entry is a kernel module tree, and counting them all failed six `*-nvidia` amd64 variants on 2026-08-08 against images that were provably fine. From the same failing job (run 31235806989, job 93049781905, `skipjack:base-nvidia/linux-amd64`):

```
  ok: kmod-nvidia ships a module for 6.12.0-254.el10.x86_64 (.../nvidia-drm.ko.xz)
  ok: kmod-nvidia and nvidia-driver agree (610.43.03)
  ok: module file version matches kmod rpm (610.43.03)
  ok: dracut force_drivers set for nvidia
  FAIL: 6 kernel module trees under /usr/lib/modules ... (expected exactly 6.12.0-254.el10.x86_64)
  ok: initramfs carries sr_mod / cdrom / isofs / squashfs / virtio_scsi / virtio_blk / overlay / loop
```

Every other assertion — including the eight-driver initramfs parity floor on `/usr/lib/modules/6.12.0-254.el10.x86_64/initramfs.img` — passed. Only the count failed.

## What the six trees are

One real kernel tree plus the five entries that `kernel-abi-stablelists` owns. Read directly out of the rpm header of `kernel-abi-stablelists-6.12.0-254.el10.noarch` (fetched from the CentOS Stream 10 BaseOS mirror), its **entire** payload under `/lib/modules` is:

| entry | type |
|---|---|
| `kabi-current` | symlink → `kabi-rhel103` (a directory, so `*/` + `[[ -d ]]` both match) |
| `kabi-rhel100` … `kabi-rhel103` | directories, holding `kabi_stablelist_<arch>` text files |

`1 + 5 = 6`. The derivation closes exactly, with nothing left over.

**Where it comes from.** The log shows `/usr/lib/modules` holding exactly one entry when `10-kernel-swap.sh` finished (its cleanup loop iterated once, over `6.12.0-254.el10.x86_64`). The five kabi entries arrive in the next step: `20-nvidia.sh`'s first `dnf install` resolved `kmod-nvidia` → `akmod-nvidia` → `akmods` → `kernel-devel` → `kernel-abi-stablelists` (log line 1803, `baseos`).

**Why it's intermittent.** Compare the passing `albacore:base-nvidia/linux-amd64` in run 31235777772 five minutes earlier: there dnf resolved `nvidia-kmod-common` to the matching `610.43.03` and installed 5 packages, never touching `akmod-nvidia`. In skipjack it picked `610.57.04`, dragged in `akmod-nvidia` plus a 108-package build toolchain (`kernel-devel`, `rpm-build`, perl, `gdb-minimal`, 274 MB installed), and downgraded back to `610.43.03` later in the script. Same repo state, different solver outcome — which is exactly the flakiness reported in the issue comments.

## Decision: fix the measurement, in both places

Not "relax the contract to get green", and not "delete the extra trees":

- They are **not kernel module trees**. No vmlinuz, no `modules.dep`, no kernel-release name — nothing that resolves a kernel version out of `/usr/lib/modules` can select one.
- They are **not debris**. They belong to an installed rpm; deleting them corrupts `kernel-abi-stablelists` while removing nothing that could ever affect boot.

So a kernel module tree is now identified by having a kernel-release name (`uname -r`, always `<maj>.<min>.<patch>…`) — which is precisely the shape of the husk this check exists to catch (`6.12.0-250.el10.x86_64`). **That failure mode stays fatal**; the new test `verify-nvidia still fails on a stale kernel tree beside the kabi entries` pins it. Non-kernel entries are printed as `info:` rather than silently skipped, and both verdicts now name the trees they found — #1118's log printed only a count, which cost a diagnosis round.

`10-kernel-swap.sh` gets the same rule for the same reason. Its cleanup loop `rm -rf`s every `/usr/lib/modules` entry that is not the akmods kernel, so on any base image that already carries `kernel-abi-stablelists` it silently deletes rpm-owned files. That is not what broke #1118 (the kabi entries land after the swap), but it is the same mis-identification and the same `rm -rf`.

## Verification

- `tests/bats/test_nvidia_overlay.bats`: 31/31 pass with this change. The three new tests all fail on `origin/main` — including `kernel-swap does not delete the rpm-owned kabi entries`, which reproduces the latent deletion above.
- Lint gates, run as `lint.yml` runs them: `shellcheck --severity=error --exclude=SC1091,SC2114` over all 109 `.sh` files — clean (also clean at default severity on both changed scripts); `yamllint -c ./.yamllint.yml` — warnings only, all pre-existing, no YAML touched; `jq .` over all JSON — clean; `just --unstable --fmt --check` on `Justfile` and every `.just` — clean; `actionlint` 1.7.7 with the workflow's ignore list — one finding, the known pre-existing `SC2153` in `reusable-build-image.yml:733`, untouched here (and `continue-on-error` in CI). Nothing new.

**Not verified here:** an EL10 NVIDIA image cannot be built in this environment. The kabi payload is measured from the real rpm and the failure is measured from the real job logs, but the end-to-end proof is the next `*-nvidia/linux-amd64` build.

## Follow-up worth filing separately (not changed here)

The `akmod-nvidia` pull-in above is a genuine second problem: it non-deterministically ships ~274 MB of build toolchain (gcc plugins, perl, `rpm-build`, `kernel-devel`, `gdb-minimal`) plus `akmods` into published desktop images. It is inherited from upstream (`_upstream-snapshots/bluefin-lts/.../gdx/20-nvidia.sh` has the same loose install), it is not boot-breaking, and pinning the first transaction — e.g. to the bundle's own `nvidia-kmod-common-610.43.03-1.el10.noarch.rpm`, which is already mounted at `/tmp/akmods-nvidia-open-rpms/nvidia/` — is a dnf-resolution change that should not be made blind without a real build to test it against.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->