### PR TITLE
fix(luks-e2e): bound the dev-ISO build and make a timeout diagnose itself (#1100)

### DIFF
--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -154,6 +154,39 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # The absolute time by which iso-e2e.sh must have given up, so that the
+      # job ends by failing a step rather than by hitting `timeout-minutes`
+      # above.
+      #
+      # The difference matters. A step that fails leaves `if: always()` steps
+      # to run, so Collect/Upload evidence still happen and the run is
+      # diagnosable. A job-level timeout CANCELS the job, evidence steps
+      # included, which is how #1100's cells burned hours and left nothing to
+      # look at.
+      #
+      # iso-e2e.sh's own backstop could not deliver that on its own: it is a
+      # RELATIVE limit (default 10800s) started when the script starts, and it
+      # was sized against this job's 240 minutes as though nothing ran before
+      # it. Plenty does — guppy:xfce spends ~133 min in Build dev ISO below —
+      # so on the slow cells the 180-minute backstop could never fire inside
+      # the ~105 minutes left and the job timeout won instead. An absolute
+      # deadline is the same guarantee that survives a slow build.
+      #
+      # 10 minutes of reserve: Collect evidence + Upload evidence measure 1-3s
+      # together, and the script's own teardown (stop recorder, ladder QEMU
+      # down, assemble the timelapse) under a minute. The reserve is mostly
+      # slack, deliberately — running the deadline close would trade a
+      # diagnosable failure back for the undiagnosable one.
+      - name: Set the job deadline
+        run: |
+          set -euo pipefail
+          reserve=$((10 * 60))
+          echo "E2E_WALL_CLOCK_DEADLINE=$(($(date +%s) + JOB_TIMEOUT_SECONDS - reserve))" \
+            >> "$GITHUB_ENV"
+        env:
+          # Must track `timeout-minutes: 240` on this job.
+          JOB_TIMEOUT_SECONDS: 14400
+
       # The dev ISO and install disk are large; reclaim ~25 GB first.
       - name: Free up disk space
         run: |
@@ -213,7 +246,14 @@ jobs:
       # this by letting setup-runner install a matched podman stack
       # (update-podman: "true"); this job installs from apt, so the pair has
       # to be pinned together here.
+      #
+      # This step and the next four are bounded because they reach the network. Each limit is an order of
+      # magnitude above the measured cost (apt ~20-40s, yq ~1s, GHCR login
+      # ~1s, clone ~1-6s, the golang build ~15-17s) — they exist to turn a
+      # wedged mirror or registry into a named step failure, not to police
+      # duration.
       - name: Install dependencies
+        timeout-minutes: 15
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
@@ -235,6 +275,7 @@ jobs:
       # falls back to a guessed ref that is wrong for bonito-rawhide and
       # flounder-sid. The matrix job installs yq the same way.
       - name: Install yq
+        timeout-minutes: 5
         run: |
           sudo curl -fsSL -o /usr/local/bin/yq \
             https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
@@ -242,13 +283,35 @@ jobs:
           yq --version
 
       - name: Log in to GHCR
+        timeout-minutes: 5
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \
             podman login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       # Build a dev (SSHD-enabled) live ISO for this cell. dev=1 wires the
       # liveuser SSH login that iso-e2e.sh --luks drives the install over.
+      #
+      # `just iso` was the one genuinely unbounded thing in this job, and it
+      # is also where #1100's "hang" actually was: guppy:xfce spends 2h13m
+      # here (133m30s on run 31232170155, 132m18s on 31242742608 — the two
+      # cells reported as hung, both of which went on to finish the LUKS
+      # phase normally in 14-17 min). It is slow rather than stuck because
+      # TACKLEBOX_FROM_SOURCE=1 on Gentoo compiles bootc from source; the
+      # 9m26s `Finished release profile` line is visible in the run log.
+      #
+      # 170 min is ~1.27x that worst measured build. The rest of the matrix
+      # is nowhere near it — grouper:xfce 10m33s (twice), yellowfin:niri-nvidia
+      # 15m12s — so this only ever bites the Gentoo cells, and only if they
+      # get ~27% slower than they have ever been observed to be. Sized this
+      # loosely on purpose: a bound tight enough to flake is worse than none,
+      # because the gate stops being trusted.
+      #
+      # It still leaves the deadline above with room. Worst case this step
+      # ends at T+170, the two fisherman steps add ~1 min, and iso-e2e.sh
+      # starts around T+174 against a T+230 deadline — 56 min for a phase
+      # whose worst measured run is 17m09s.
       - name: Build dev ISO
+        timeout-minutes: 170
         env:
           VARIANT: ${{ matrix.variant }}
           FLAVOR: ${{ matrix.flavor }}
@@ -268,9 +331,11 @@ jobs:
           echo "ISO_PATH=${ISO}" >> "$GITHUB_ENV"
 
       - name: Clone fisherman (under-test)
+        timeout-minutes: 10
         run: git clone --depth 1 --branch dev https://github.com/tuna-os/fisherman /tmp/fisherman
 
       - name: Build fisherman in a golang container
+        timeout-minutes: 25
         run: |
           # Build inside golang:1.26 so we avoid the runner's root-owned
           # ~/go and ~/.cache (earlier sudo steps) and the apt Go 1.24 vs
@@ -326,7 +391,16 @@ jobs:
           # podman copies into a tmpfs runroot rather than bind-mounting
           # (tunaOS#972 — see customize-live.sh). This headroom is kept for
           # the genuine staging copies, not because that copy still happens.
+          #
+          # E2E_WALL_CLOCK_DEADLINE is named on the `env` line rather than
+          # left to `sudo -E` for the same reason FISHERMAN_OVERRIDE is: -E
+          # is subject to sudoers env_keep/env_reset, and a deadline that
+          # silently fails to arrive would put the harness straight back on
+          # its relative 10800s backstop — the exact thing that could not
+          # fire in time on the slow cells. Passed explicitly, it either
+          # arrives or the script says so.
           sudo -E env FISHERMAN_OVERRIDE="$FISHERMAN_OVERRIDE" \
+            E2E_WALL_CLOCK_DEADLINE="$E2E_WALL_CLOCK_DEADLINE" \
             ./scripts/iso-e2e.sh "${ISO_PATH}" --luks \
             --output luks-out \
             --memory 10240 \

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -100,6 +100,18 @@
 #                         so it is opt-in rather than folded into every
 #                         --luks cell; docs/LUKS-TPM.md calls this "the
 #                         per-variant TPM-enrollment test".
+#   E2E_WALL_CLOCK_LIMIT  Seconds before the whole harness gives up and
+#                         terminates itself with a diagnosis (default 10800,
+#                         0 to disable). Relative to when this script starts.
+#   E2E_WALL_CLOCK_DEADLINE
+#                         Absolute epoch-seconds by which the harness must
+#                         have given up, clamping E2E_WALL_CLOCK_LIMIT down
+#                         when less time than that remains. Set this from a
+#                         CI job's own timeout so the harness fails with
+#                         evidence instead of being cancelled without it —
+#                         a relative limit cannot do that, because it does
+#                         not know how much of the job budget was already
+#                         spent before it was called (#1100).
 #
 # Exit codes:
 #   0  success
@@ -123,6 +135,10 @@
 #      either still showed the cryptsetup passphrase prompt (the first-boot
 #      enrollment oneshot did not seal a working key) or never reached
 #      login within --timeout. See installed-tpm-autounlock-serial.log.
+#   75 the job budget was already exhausted before the harness started
+#      (E2E_WALL_CLOCK_DEADLINE in the past) — nothing was tested, and the
+#      fix is upstream of here: whatever ran first is too slow, or the
+#      caller's timeout is too small.
 #   77 missing dependency (qemu, ovmf, etc.) — distinguishable for CI skip
 
 set -euo pipefail
@@ -447,6 +463,22 @@ LIVE_SERIAL_LOG="${OUTPUT_DIR}/live-serial.log"
 LUKS_EVIDENCE_LOG="${OUTPUT_DIR}/luks-evidence.log"
 INSTALL_DISK="${OUTPUT_DIR}/install-disk.qcow2"
 QEMU_PIDFILE="${OUTPUT_DIR}/qemu.pid"
+
+# What the run is currently waiting on, as a file rather than a variable: the
+# wall-clock watchdog below runs in a background subshell forked before any of
+# this happens, so it has a frozen copy of every variable and can only learn
+# the current phase by reading it back off disk. Without that, a watchdog
+# firing can say "it hung" but not "it hung waiting for X", which is most of
+# the value (#1100).
+PHASE_FILE="${OUTPUT_DIR}/current-phase.txt"
+: >"$PHASE_FILE"
+
+# Announce a phase AND record it for the watchdog. Same output as the plain
+# `echo "==> ..."` it replaces, so nothing that greps this log changes.
+e2e_phase() {
+	printf '%s | %s\n' "$(date -u +%H:%M:%SZ)" "$*" >"$PHASE_FILE"
+	echo "==> $*"
+}
 
 # A dedicated swap disk for the live guest, attached only to the install boot.
 #
@@ -788,17 +820,86 @@ trap 'exit 143' TERM
 # diagnosis at all — the log had to be recovered by cancelling them by hand,
 # because GitHub returns BlobNotFound for a running job.
 #
-# Deliberately generous, and well under luks-e2e.yml's `timeout-minutes: 240`:
-# firing must leave time for the Collect/Upload evidence steps, because a
-# backstop that trips without preserving evidence just reproduces the failure
-# it exists to prevent. Set E2E_WALL_CLOCK_LIMIT=0 to disable.
+# Deliberately generous. 10800 is not arbitrary: it is what this script's own
+# per-call guards can legitimately add up to on the slowest path (1800 pull +
+# 1800 podman run + 1800 scp + 1800 podman load + 3600 fisherman install), so
+# anything shorter as a fixed value could cut off a working-but-slow run.
+# Set E2E_WALL_CLOCK_LIMIT=0 to disable.
 E2E_WALL_CLOCK_LIMIT="${E2E_WALL_CLOCK_LIMIT:-10800}"
+
+# ...but "generous" is only safe if the job actually has that much time left,
+# and the old comment here reasoned that 10800s sits "well under
+# timeout-minutes: 240" — comparing the script's budget against the WHOLE
+# job's budget while ignoring everything the job does before calling us.
+# luks-e2e.yml spends a dev-ISO build first, and that is not small: guppy:xfce
+# takes ~133 min there (runs 31232170155 and 31242742608, 133m30s and
+# 132m18s), leaving ~105 min of the 240. A 180-minute relative backstop cannot
+# fire inside 105 minutes, so on those cells this watchdog was dead code and
+# the job-level timeout won instead — which cancels the job and takes the
+# `if: always()` Collect/Upload evidence steps with it. That is precisely the
+# outcome this backstop exists to prevent (#1100).
+#
+# So take an ABSOLUTE deadline from the caller and clamp to whichever comes
+# first. This can only ever shorten the budget to something the job was never
+# going to grant anyway — the job would have been killed at that point
+# regardless, just without a diagnosis — so it introduces no risk of failing a
+# run that would otherwise have passed.
+if [[ -n "${E2E_WALL_CLOCK_DEADLINE:-}" ]]; then
+	_remaining=$((E2E_WALL_CLOCK_DEADLINE - $(date +%s)))
+	if ((_remaining <= 0)); then
+		echo "ERROR: no time left in the job budget before iso-e2e.sh even started" >&2
+		echo "       (E2E_WALL_CLOCK_DEADLINE=${E2E_WALL_CLOCK_DEADLINE} is already past)." >&2
+		echo "       Everything before this step consumed the job's timeout-minutes." >&2
+		exit 75
+	fi
+	# A deadline arms the watchdog even when the relative limit was disabled:
+	# E2E_WALL_CLOCK_LIMIT=0 says "I don't want an arbitrary cap", not "let
+	# the job get killed undiagnosed".
+	if [[ "$E2E_WALL_CLOCK_LIMIT" -eq 0 ]]; then
+		echo "==> Wall-clock backstop armed at ${_remaining}s by the job deadline (relative limit disabled)"
+		E2E_WALL_CLOCK_LIMIT="$_remaining"
+	elif ((_remaining < E2E_WALL_CLOCK_LIMIT)); then
+		echo "==> Wall-clock backstop clamped to ${_remaining}s by the job deadline (was ${E2E_WALL_CLOCK_LIMIT}s)"
+		E2E_WALL_CLOCK_LIMIT="$_remaining"
+	fi
+fi
+
+# What the watchdog prints when it fires. Defined HERE, above the fork, because
+# the subshell only has the functions and variables that existed when it was
+# forked. "It hung" is not a diagnosis; the phase it hung in and the tail of
+# the console it went quiet on are.
+dump_hang_diagnosis() {
+	local phase="(never recorded)" log
+	[[ -s "$PHASE_FILE" ]] && phase="$(cat "$PHASE_FILE")"
+	echo "===== iso-e2e.sh hang diagnosis ====================================="
+	echo "waiting on : ${phase}"
+	echo "mode       : ${MODE}  luks=${LUKS}  variant=${VARIANT:-?}:${FLAVOR:-?}"
+	if [[ -f "$QEMU_PIDFILE" ]] && kill -0 "$(cat "$QEMU_PIDFILE" 2>/dev/null)" 2>/dev/null; then
+		echo "qemu       : alive (pid $(cat "$QEMU_PIDFILE")) — the guest stopped talking, not QEMU"
+	else
+		echo "qemu       : not running — the guest died or was never started"
+	fi
+	for log in "$SERIAL_LOG" "$LIVE_SERIAL_LOG" \
+		"${OUTPUT_DIR}/installed-serial.log" \
+		"${OUTPUT_DIR}/installed-tpm-autounlock-serial.log"; do
+		[[ -s "$log" ]] || continue
+		echo "----- last 40 lines of ${log##*/} ($(wc -c <"$log") bytes) -----"
+		tail -n 40 "$log" | tr -d '\r'
+	done
+	echo "====================================================================="
+}
+
 WATCHDOG_PID=""
 if [[ "$E2E_WALL_CLOCK_LIMIT" -gt 0 ]]; then
 	(
 		sleep "$E2E_WALL_CLOCK_LIMIT"
 		echo "ERROR: iso-e2e.sh exceeded its ${E2E_WALL_CLOCK_LIMIT}s wall-clock limit — terminating" >&2
-		echo "       The last '==>' line above is where it hung. See tunaOS#939." >&2
+		# Both destinations on purpose: stderr reaches the job log, and the
+		# evidence log reaches the uploaded artifact. The job log is the one
+		# that is NOT retrievable while a run is still going (GitHub answers
+		# BlobNotFound), which is how the 07-31 hangs left nothing behind.
+		dump_hang_diagnosis 2>&1 | tee -a "$LUKS_EVIDENCE_LOG" >&2
+		echo "       See tunaOS#939 and tunaOS#1100." >&2
 		kill -TERM "$$" 2>/dev/null || true
 	) &
 	WATCHDOG_PID=$!
@@ -857,7 +958,7 @@ boot_live_iso() {
 	# we instead rely on the ISO's default cmdline already enabling
 	# console=ttyS0 (livesys-config does this in upstream).
 
-	echo "==> Booting ISO: ${ISO_PATH}"
+	e2e_phase "Booting ISO: ${ISO_PATH}"
 	echo "==> Accel: ${ACCEL}, CPU: ${CPU_ARG}, MEM: ${MEMORY}M, CPUS: ${CPUS}"
 
 	# shellcheck disable=SC2086  # TPM_ARGS is intentionally word-split (empty unless --luks)
@@ -1144,7 +1245,7 @@ screenshot_sane() {
 wait_for_ready() {
 	local deadline=$(($(date +%s) + TIMEOUT))
 	local last_size=0
-	echo "==> Waiting up to ${TIMEOUT}s for readiness marker (${LIVE_MARKER})..."
+	e2e_phase "Waiting up to ${TIMEOUT}s for readiness marker (${LIVE_MARKER})..."
 	while (($(date +%s) < deadline)); do
 		if [[ -f "$SERIAL_LOG" ]] && grep -qE -- "$LIVE_MARKER" "$SERIAL_LOG" 2>/dev/null; then
 			echo "==> Readiness marker found"
@@ -1471,7 +1572,7 @@ poweroff_and_wait_vm() {
 	[[ -n "$pid" ]] || return 0
 	kill -0 "$pid" 2>/dev/null || return 0
 
-	echo "==> Waiting for VM to shut down..."
+	e2e_phase "Waiting for VM to shut down..."
 	wait_pid_gone "$pid" "$POWEROFF_WAIT_SECS" && return 0
 
 	# The install is finished by here — fisherman/bootc have unmounted, frozen
@@ -1595,7 +1696,7 @@ run_install_generic() {
 
 	start_guest_heartbeat
 
-	echo "==> Pulling ${imgref} in the guest (bounded 1800s)..."
+	e2e_phase "Pulling ${imgref} in the guest (bounded 1800s)..."
 	if ! timeout 1800 "${ssh_cmd[@]}" "sudo podman pull ${imgref} 2>&1" 2>&1 | tee -a "${SERIAL_LOG}"; then
 		echo "ERROR: podman pull failed or timed out" >&2
 		return 3
@@ -1681,7 +1782,7 @@ run_install_generic() {
 			start_swtpm keep || return 77
 		fi
 	fi
-	echo "==> Booting installed disk (TPM auto-unlock), expecting a login prompt..."
+	e2e_phase "Booting installed disk (TPM auto-unlock), expecting a login prompt..."
 	# shellcheck disable=SC2086  # TPM_ARGS is intentionally word-split (empty unless --luks)
 	reset_qemu_sockets
 	"$QEMU" -name "tunaos-iso-e2e-installed" -machine pc -cpu "$CPU_ARG" \
@@ -2175,7 +2276,7 @@ run_install() {
 			# The workflow's --timeout does not cover this; that is a PER-PHASE
 			# timeout (see the usage text above) consulted only by the
 			# readiness wait and the installed-boot wait.
-			echo "==> Transferring image to guest (this may take a few minutes)..."
+			e2e_phase "Transferring image to guest (this may take a few minutes)..."
 			if ! timeout 1800 "${scp_cmd[@]}" "$host_tar" \
 				"${GUEST_SCP_DEST}:${GUEST_HOME}/"; then
 				echo "ERROR: image transfer to guest timed out or failed" >&2
@@ -2245,7 +2346,7 @@ EOF
 
 	start_guest_heartbeat
 
-	echo "==> Running fisherman ${GUEST_HOME}/e2e-recipe.json..."
+	e2e_phase "Running fisherman ${GUEST_HOME}/e2e-recipe.json..."
 	# Bound with `timeout` as a safety net; the image is already local at
 	# this point so this should only cover the actual install steps, not a
 	# network pull.
@@ -2351,7 +2452,7 @@ EOF
 	# the opt-in that does gate it). Boot with a serial socket and inject the
 	# passphrase at the cryptsetup prompt; reaching login proves the unlock.
 	if [[ "$LUKS" -eq 1 ]]; then
-		echo "==> LUKS passphrase gate: booting installed disk, injecting passphrase, expecting login..."
+		e2e_phase "LUKS passphrase gate: booting installed disk, injecting passphrase, expecting login..."
 		local FB_SERIAL="${OUTPUT_DIR}/installed-serial.sock"
 		rm -f "$FB_SERIAL"
 		# A TPM IS needed on THIS boot (tunaOS#680): fisherman#48 stages a
@@ -2579,7 +2680,7 @@ EOF
 		# workflow_dispatch boolean, or its own scheduled job over a smaller
 		# variant set) once satisfied with the added runtime.
 		if [[ "${TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK:-0}" == "1" ]]; then
-			echo "==> TPM auto-unlock verification: rebooting the installed disk with no passphrase..."
+			e2e_phase "TPM auto-unlock verification: rebooting the installed disk with no passphrase..."
 			local tpid2
 			tpid2=$(cat "$TPM_PIDFILE" 2>/dev/null || true)
 			if [[ -z "$tpid2" ]] || ! kill -0 "$tpid2" 2>/dev/null; then
@@ -2650,7 +2751,7 @@ EOF
 		return 0
 	fi
 
-	echo "==> Booting installed system..."
+	e2e_phase "Booting installed system..."
 	# Boot from the install disk (remove cdrom). bootindex=0 overrides the
 	# BootOrder the live-ISO boot left in the shared OVMF_VARS; see the
 	# LUKS passphrase gate above for why the shell wins without it.
@@ -2718,7 +2819,7 @@ EOF
 boot_disk_image() {
 	local fmt="qcow2"
 	[[ "$ISO_PATH" == *.raw || "$ISO_PATH" == *.img ]] && fmt="raw"
-	echo "==> Booting disk image: ${ISO_PATH} (${fmt})"
+	e2e_phase "Booting disk image: ${ISO_PATH} (${fmt})"
 	echo "==> Accel: ${ACCEL}, CPU: ${CPU_ARG}, MEM: ${MEMORY}M, CPUS: ${CPUS}"
 
 	reset_qemu_sockets
@@ -2757,7 +2858,7 @@ boot_disk_image() {
 case "$MODE" in
 disk)
 	boot_disk_image || exit 1
-	echo "==> Waiting up to ${TIMEOUT}s for a graphical session..."
+	e2e_phase "Waiting up to ${TIMEOUT}s for a graphical session..."
 	deadline=$(($(date +%s) + TIMEOUT))
 	rc=2
 	while (($(date +%s) < deadline)); do

--- a/tests/bats/test_iso_e2e_poweroff.bats
+++ b/tests/bats/test_iso_e2e_poweroff.bats
@@ -28,14 +28,23 @@ setup() {
 	BIN="$BATS_TEST_TMPDIR/bin"
 	mkdir -p "$BIN"
 
-	# The driver evaluates the shipped function and its helper, then runs it
+	PHASE_FILE="$BATS_TEST_TMPDIR/current-phase.txt"
+
+	# The driver evaluates the shipped function and its helpers, then runs it
 	# against whatever the test has staged. `sleep` becomes a token delay so a
 	# 180-iteration poll finishes in milliseconds without turning the polls
 	# into a busy race.
+	#
+	# e2e_phase comes along because the function announces its wait through it
+	# (#1100): it prints the same `==> ...` line the plain echo did and also
+	# records the phase for the wall-clock watchdog, so the driver has to give
+	# it a $PHASE_FILE to write to the way the real script does.
 	cat >"$BATS_TEST_TMPDIR/drive.sh" <<-'EOF'
 		set -Eeuo pipefail
 		SCRIPT="$1"
+		: >"$PHASE_FILE"
 		eval "$(grep '^POWEROFF_WAIT_SECS=' "$SCRIPT")"
+		eval "$(sed -n '/^e2e_phase()/,/^}/p' "$SCRIPT")"
 		eval "$(sed -n '/^wait_pid_gone()/,/^}/p' "$SCRIPT")"
 		eval "$(sed -n '/^poweroff_and_wait_vm()/,/^}/p' "$SCRIPT")"
 		GUEST_SSH=("$SSH_STUB")
@@ -92,6 +101,7 @@ drive() {
 	run env \
 		SSH_STUB="$1" \
 		QEMU_PIDFILE="$PIDFILE" \
+		PHASE_FILE="$PHASE_FILE" \
 		MONITOR_SOCK="${MONITOR_SOCK_OVERRIDE:-$MONSOCK}" \
 		PATH="$BIN:$PATH" \
 		bash "$BATS_TEST_TMPDIR/drive.sh" "$SCRIPT"


### PR DESCRIPTION
Fixes #1100.

## Where the time actually went

The issue reports `LUKS yellowfin:niri-nvidia` hung on run 31232833237. That job **finished green in 28m05s** — the report was a stale poll of a job that was still running. The recurrence in the issue comment is real, though, and the time is not in the QEMU/LUKS phase anyone was looking at. It is in `Build dev ISO`:

| cell | run | `Build dev ISO` | LUKS phase |
|---|---|---|---|
| `guppy:xfce` | 31232170155 | **133m30s** | 14m20s |
| `guppy:xfce` | 31242742608 | **132m18s** | 17m09s |
| `grouper:xfce` | 31236474250 | 10m33s | 5m47s |
| `grouper:xfce` | 31181743606 | 10m33s | 10m35s |
| `yellowfin:niri-nvidia` | 31232833237 | 15m12s | 11m42s |

guppy is Gentoo, so `TACKLEBOX_FROM_SOURCE=1` compiles bootc from source — `Finished \`release\` profile [optimized + debuginfo] target(s) in 9m 26s` is right there in the run log, and the rest is image build, squashfs and offline-store staging. It is **slow, not stuck**, and reproducibly so within 72 seconds across two runs.

**Not niri-nvidia-specific.** The recurrence was `guppy:xfce`; the two slow cells share a variant, not a flavor. That cell just got unlucky with a poll.

## The part that is a real bug

`just iso` had no bound at all, and `iso-e2e.sh`'s wall-clock backstop could not cover it.

The backstop is a **relative** limit (10800s) started when the script starts, and its own comment sized it as *"well under `luks-e2e.yml`'s `timeout-minutes: 240`"* — comparing the script's budget against the **whole job's** budget while ignoring everything the job does first. On a guppy cell ~133 min are already gone, leaving ~105 min of the 240, so a 180-minute backstop **can never fire** and the job-level timeout wins instead.

That distinction is the whole problem. A **step** timeout fails the step and lets `if: always()` steps run, so Collect/Upload evidence still happen. A **job** timeout *cancels* the job and takes the evidence steps with it — precisely the undiagnosable outcome the backstop was written to prevent, and why the earlier hangs "left no diagnosis at all".

So the harness could hang-then-die-silently by construction, just not in the place the issue guessed.

## Changes

- **Bound `Build dev ISO` at 170 min.** ~1.27x the worst measured build, >10x every non-Gentoo cell.
- **Absolute deadline.** `iso-e2e.sh` gains `E2E_WALL_CLOCK_DEADLINE` and clamps its relative limit to whichever comes first; the workflow computes it once as job-start + 230 min, holding 10 min back for evidence collection. A relative limit cannot know how much of the job budget was spent before it was called; an absolute one can.
- **Bound the network-touching steps** (apt, yq, GHCR login, clone, go build), each an order of magnitude over measured cost.
- **A timeout now diagnoses itself.** The current phase is recorded to a file the watchdog subshell can read back (it forks before any of it happens, so a variable would be frozen). On firing it dumps the phase, whether QEMU is still alive, and the last 40 lines of every serial log — to stderr *and* `luks-evidence.log`, because the job log is not retrievable while a run is still in progress (GitHub answers `BlobNotFound`).

The 10800s default is **kept**, with its provenance written down: it is the sum of this script's own per-call guards on the slowest path (1800 pull + 1800 podman run + 1800 scp + 1800 podman load + 3600 fisherman install), so shortening it as a fixed value could cut off a working-but-slow run.

## On timeout values / flake risk

The deadline clamp **cannot fail a run that passes today**: it only ever shortens the budget to something the job was never going to grant anyway — the job would have been killed at that moment regardless, just without evidence. It converts an undiagnosable cancellation into a diagnosable failure.

The one number carrying genuine (small) risk is the 170-min build bound. Worst measured is 133m30s, and the two guppy builds are 72 seconds apart, so the distribution is tight; 170 needs a ~27% regression to bite. Sized loosely on purpose — a bound tight enough to flake is worse than no bound, because the gate stops being trusted.

Nothing is skipped or downgraded. If a boot genuinely fails, the job still goes red, now with the serial tail attached.

## Verification

Extracted the changed blocks verbatim from the script and ran them:

| case | result |
|---|---|
| deadline already past | exits **75** with "no time left in the job budget" |
| deadline 3s out | clamps, fires, names the phase, dumps serial tail to both destinations, exits **143** |
| deadline 4h out | stays 10800 |
| no deadline | stays 10800 |
| `E2E_WALL_CLOCK_LIMIT=0` + deadline | armed at the deadline |
| `E2E_WALL_CLOCK_LIMIT=0`, no deadline | stays disabled, no watchdog |
| guppy-shaped (134 min already spent of 230) | armed at **96 min** instead of never |

Also exercised both branches of the QEMU alive/dead check and the multi-log tail, and dry-ran the workflow's deadline arithmetic (lands at exactly 230.0 min).

**Not verified:** QEMU with a real ISO cannot run in this environment, so the boot paths themselves are unexercised — the phase-instrumentation call sites are mechanical `echo "==> X"` → `e2e_phase "X"` swaps that emit byte-identical output, but no real boot has run through them.

## Lint

`actionlint`, `yamllint -c ./.yamllint.yml`, `shellcheck --severity=error --exclude=SC1091,SC2114`, `jq .` and `just --unstable --fmt --check` all run and diffed against `origin/main`: **no new findings**. The only actionlint hit is the known pre-existing `SC2153` in `reusable-build-image.yml`, present identically on the baseline. `shfmt -d` is clean on the changed script.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->