### PR TITLE
fix(installer): derive the recipe's disk layout from the image, not a hardcode

### DIFF
--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -595,6 +595,67 @@ cat >/etc/tuna-installer/offline-stores <<'STORESEOF'
 /var/lib/superiso-store
 STORESEOF
 
+# ── 5b. Installer recipe: backend keys, from the image rather than a guess ───
+#
+# /etc/bootc-installer/recipe.json is what the GUI frontends install FROM. It
+# ships three keys that describe the target's on-disk layout —
+#
+#     "bootloader": "systemd", "composeFsBackend": true, "filesystem": "xfs"
+#
+# — and until now nothing ever set them per variant. build_scripts/90-image-info.sh
+# is the only thing that rewrites that file and it touches branding only
+# (distro_name, welcome_title, distro_logo, tour), so every one of the 13
+# variants shipped that same hardcoded triple.
+#
+# It is wrong for the EL10 variants. yellowfin, albacore and skipjack are
+# traditional ostree + bootupd + GRUB with composefs explicitly disabled
+# (Containerfile.el10 pins `[composefs] enabled = no`), so the GUI was telling
+# fisherman to do a composefs/systemd-boot install on three images that cannot
+# take one. The headless path never hit this because scripts/iso-e2e.sh probes
+# the image and builds its own recipe — which is exactly why LUKS E2E can be
+# green on a cell whose GUI install has never once been proven.
+#
+# WHY HERE and not in 90-image-info.sh, which already owns this file: on EL10
+# the prepare-root.conf pin is written AFTER 90-image-info.sh runs
+# (Containerfile.el10 — 90-image-info at line 134, the pin at line 156), so a
+# probe there reads whatever the upstream base happens to ship. That default
+# has already drifted once (tuna-os/wootc#28). By live-ISO customize time the
+# payload image is final, which makes this the first point where the answer is
+# trustworthy.
+#
+# Same probe as scripts/lib/common.sh TUNAOS_BACKEND_PROBE_SH, and the order is
+# load-bearing for the same reason documented there: bootupd payload first, so
+# a SEALED image that still ships bootupd stays on the ostree path.
+RECIPE_FILE="/etc/bootc-installer/recipe.json"
+if [[ -f "$RECIPE_FILE" ]]; then
+	# Fatal on failure, deliberately. An image we cannot classify must not get
+	# a guessed recipe: 10 seconds of ISO build is a better place to learn this
+	# than hour three of a matrix cell, the same rule the sudo and podman
+	# assertions above follow.
+	_backend_kv="$("${SCRIPT_DIR}/installer-recipe-backend.sh")"
+	_bootloader="$(sed -n 's/^bootloader=//p' <<<"$_backend_kv")"
+	_composefs_backend="$(sed -n 's/^composeFsBackend=//p' <<<"$_backend_kv")"
+	_filesystem="$(sed -n 's/^filesystem=//p' <<<"$_backend_kv")"
+
+	python3 - "$RECIPE_FILE" "$_bootloader" "$_composefs_backend" "$_filesystem" <<'PYEOF'
+import json
+import sys
+
+path, bootloader, composefs, filesystem = sys.argv[1:5]
+with open(path) as f:
+    recipe = json.load(f)
+recipe["bootloader"] = bootloader
+recipe["composeFsBackend"] = composefs == "true"
+recipe["filesystem"] = filesystem
+with open(path, "w") as f:
+    json.dump(recipe, f, indent=2)
+    f.write("\n")
+PYEOF
+
+	echo "customize-live: installer recipe bootloader=${_bootloader}" \
+		"composefs=${_composefs_backend} filesystem=${_filesystem}"
+fi
+
 # ── /var/tmp headroom ─────────────────────────────────────────────────────────
 # The live overlay puts /var on a small RAM overlay; bootc needs real space
 # in /var/tmp when staging an install (dakota-iso pattern).

--- a/live-iso/common/src/installer-recipe-backend.sh
+++ b/live-iso/common/src/installer-recipe-backend.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Decide the three on-disk-layout keys the installer recipe has to carry, by
+# PROBING THE IMAGE rather than guessing from its name.
+#
+#   bootloader        grub2 | systemd
+#   composeFsBackend  false | true
+#   filesystem        xfs   | ext4
+#
+# Echoes three `KEY=value` lines and exits non-zero if the image cannot be
+# classified. Extracted from customize-live.sh so the decision is unit-testable
+# against fixture trees (tests/bats/test_installer_recipe_backend.bats) — the
+# branches below are the difference between a bootable disk and a dracut
+# emergency shell, and they were previously not exercised by anything.
+#
+# Usage: installer-recipe-backend.sh [sysroot]   (default "", i.e. the live root)
+#
+# This is a faithful port of TUNAOS_BACKEND_PROBE_SH in scripts/lib/common.sh.
+# THE ORDER IS LOAD-BEARING and is documented at length there; the short form:
+# bootupd payload is checked FIRST so that a composefs-SEALED image which still
+# ships bootupd stays on the ostree path.
+
+set -euo pipefail
+
+SYSROOT="${1:-}"
+
+# Sealing is read once and used twice — it selects the filesystem on its own,
+# and it is branch 2 of the backend decision. They are genuinely separate
+# questions: `ostree` + sealed is a real combination (see common.sh), and
+# keying the filesystem off the backend would get exactly those images wrong.
+composefs_enabled=0
+if grep -A8 '^\[composefs\]' "${SYSROOT}/usr/lib/ostree/prepare-root.conf" 2>/dev/null |
+	grep -qiE 'enabled[[:space:]]*=[[:space:]]*(yes|true|1|signed)'; then
+	composefs_enabled=1
+fi
+
+# bootupd 0.2.x kept binaries under updates/EFI/<vendor>; current Fedora keeps
+# versioned binaries under /usr/lib/efi with only EFI.json under bootupd/
+# updates — hence the two-form test.
+if ls "${SYSROOT}"/usr/lib/bootupd/updates/EFI/*/grubx64.efi >/dev/null 2>&1 ||
+	{ [[ -f "${SYSROOT}/usr/lib/bootupd/updates/EFI.json" ]] &&
+		find "${SYSROOT}/usr/lib/efi/grub2" -type f -name grubx64.efi -print -quit 2>/dev/null | grep -q . &&
+		find "${SYSROOT}/usr/lib/efi/shim" -type f -name shimx64.efi -print -quit 2>/dev/null | grep -q .; }; then
+	backend="ostree"
+elif [[ "$composefs_enabled" == "1" ]]; then
+	# Reaching here means there is NO bootupd payload, so an ostree install is
+	# impossible: bootc aborts with
+	#   error: Installing to disk: bootupd is required for ostree-based installs
+	backend="composefs-native"
+elif [[ -f "${SYSROOT}/usr/lib/systemd/boot/efi/systemd-bootx64.efi" ]]; then
+	backend="composefs-native"
+else
+	# Never guessed. A wrong guess in either direction is an unbootable disk,
+	# and the failure surfaces minutes later with nothing in the log that
+	# points back here.
+	echo "ERROR: cannot determine the bootc backend of this image." >&2
+	echo "       No bootupd payload, no composefs pin in prepare-root.conf," >&2
+	echo "       and no systemd-boot EFI binary." >&2
+	exit 1
+fi
+
+# A composefs-sealed rootfs is verified with fs-verity. XFS has no fs-verity,
+# so a sealed image installed onto XFS fails initrd-switch-root and drops to a
+# dracut emergency shell — see the warning in
+# system_files/usr/lib/bootc/install/00-tunaos.toml. ext4 is the proven sealed
+# filesystem; btrfs has fs-verity but its ostree deployment fails to mount
+# (wootc#35). scripts/build-qcow2.sh has always done this for the Gate's disk
+# image; the ISO install path and the GUI recipe did not, which is the
+# disagreement this file exists to end.
+if [[ "$composefs_enabled" == "1" ]]; then
+	filesystem="ext4"
+else
+	filesystem="xfs"
+fi
+
+if [[ "$backend" == "composefs-native" ]]; then
+	echo "bootloader=systemd"
+	echo "composeFsBackend=true"
+else
+	echo "bootloader=grub2"
+	echo "composeFsBackend=false"
+fi
+echo "filesystem=${filesystem}"

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -1932,7 +1932,7 @@ run_install() {
 	local local_ref="localhost/${VARIANT:-}:${FLAVOR:-}" # dev=1 ISO
 	local prod_ref="$published_ref"                      # production ISO
 	local recipe_image=""                                # set below after probing the VM
-	local composefs_backend="false" bootloader="grub2"
+	local composefs_backend="false" bootloader="grub2" root_filesystem="xfs"
 	# Probed from IMAGE CONTENT, never from the variant name. This used to be
 	# `[[ "$VARIANT" == "grouper" ]]`, so sailfin, marlin, flounder,
 	# flounder-sid, guppy and gurnard — every other composefs variant — were
@@ -1952,6 +1952,33 @@ run_install() {
 			composefs_backend="true"
 			bootloader="systemd"
 		fi
+		# SEALED decides the ROOT FILESYSTEM, and it is a separate question
+		# from the backend — which is why it gets its own branch rather than
+		# riding along inside the one above.
+		#
+		# A composefs-sealed rootfs is verified with fs-verity. XFS has no
+		# fs-verity, so a sealed image installed onto XFS fails
+		# initrd-switch-root and lands in a dracut emergency shell — see the
+		# warning in system_files/usr/lib/bootc/install/00-tunaos.toml and
+		# tuna-os/wootc payload/deployer/deploy.sh. ext4 is the proven sealed
+		# filesystem (btrfs has fs-verity but its ostree deployment fails to
+		# mount, wootc#35).
+		#
+		# Sealing does NOT imply composefs-native: branch 1 of the probe
+		# deliberately keeps sealed images that ship a bootupd payload on the
+		# ostree path, so `BACKEND=ostree SEALED=1` is a real combination and
+		# it still needs ext4. Keying the filesystem off the backend would get
+		# exactly those images wrong.
+		#
+		# scripts/build-qcow2.sh:126-129 has always done this for the Gate's
+		# disk image. This recipe hardcoded "xfs" regardless, so the ISO
+		# install path and the qcow2 install path disagreed about the same
+		# image — the ISO path being the one a user actually takes.
+		if grep -q '^SEALED=1$' <<<"$_probe"; then
+			root_filesystem="ext4"
+		fi
+		echo "==> install target: filesystem=${root_filesystem}" \
+			"bootloader=${bootloader} composefs=${composefs_backend}"
 	else
 		echo "ERROR: could not probe ${_probe_ref} for its bootc backend" >&2
 		return 3
@@ -2215,7 +2242,7 @@ run_install() {
 	cat >"$RECIPE_LOCAL" <<EOF
 {
   "disk": "/dev/vda",
-  "filesystem": "xfs",
+  "filesystem": "${root_filesystem}",
   "image": "${recipe_image}",
   "targetImgref": "${target_imgref}",
   "composeFsBackend": ${composefs_backend},

--- a/tests/bats/test_installer_recipe_backend.bats
+++ b/tests/bats/test_installer_recipe_backend.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+# live-iso/common/src/installer-recipe-backend.sh — the three on-disk-layout
+# keys the GUI installer recipe carries.
+#
+# WHY THIS FILE EXISTS. Until this script, nothing set those keys per variant:
+# system_files/etc/bootc-installer/recipe.json shipped a hardcoded
+# `bootloader: systemd, composeFsBackend: true, filesystem: xfs` to all 13
+# variants, and build_scripts/90-image-info.sh — the only thing that rewrites
+# that file — touches branding only. That triple is wrong for the three EL10
+# variants, which are traditional ostree + bootupd + GRUB with composefs
+# explicitly disabled.
+#
+# The headless path never caught it because scripts/iso-e2e.sh probes the image
+# and builds its own recipe. That is exactly how a cell can be green on LUKS
+# E2E while its GUI install has never been proven — the two paths disagreed
+# about the same image.
+#
+# Each branch below is the difference between a bootable disk and a dracut
+# emergency shell, so they are checked against fixture trees in seconds rather
+# than by a matrix cell that only notices when something fails to boot.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/live-iso/common/src/installer-recipe-backend.sh"
+
+setup() {
+  FIXTURE="${BATS_TEST_TMPDIR}/root"
+  mkdir -p "$FIXTURE/usr/lib/ostree"
+}
+
+# A composefs pin in prepare-root.conf. `signed` counts as enabled, the same as
+# yes/true/1 — that is what the probe in scripts/lib/common.sh accepts.
+set_composefs() {
+  printf '[composefs]\nenabled = %s\n\n[sysroot]\nreadonly = true\n' "$1" \
+    >"$FIXTURE/usr/lib/ostree/prepare-root.conf"
+}
+
+# bootupd 0.2.x shape: binaries under updates/EFI/<vendor>.
+add_bootupd_legacy() {
+  mkdir -p "$FIXTURE/usr/lib/bootupd/updates/EFI/almalinux"
+  touch "$FIXTURE/usr/lib/bootupd/updates/EFI/almalinux/grubx64.efi"
+}
+
+# Current Fedora shape: only EFI.json under bootupd/updates, versioned binaries
+# under /usr/lib/efi. The probe requires ALL THREE, which is what stops a bare
+# EFI.json from being read as a payload.
+add_bootupd_modern() {
+  mkdir -p "$FIXTURE/usr/lib/bootupd/updates" \
+    "$FIXTURE/usr/lib/efi/grub2/x64" "$FIXTURE/usr/lib/efi/shim/x64"
+  touch "$FIXTURE/usr/lib/bootupd/updates/EFI.json"
+  touch "$FIXTURE/usr/lib/efi/grub2/x64/grubx64.efi"
+  touch "$FIXTURE/usr/lib/efi/shim/x64/shimx64.efi"
+}
+
+add_systemd_boot() {
+  mkdir -p "$FIXTURE/usr/lib/systemd/boot/efi"
+  touch "$FIXTURE/usr/lib/systemd/boot/efi/systemd-bootx64.efi"
+}
+
+probe() {
+  run bash "$SCRIPT" "$FIXTURE"
+}
+
+# ── EL10: the case that was actually broken ──────────────────────────────────
+
+@test "el10 (bootupd payload, composefs off) installs ostree/grub2 on xfs" {
+  add_bootupd_legacy
+  set_composefs no
+  probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bootloader=grub2"* ]]
+  [[ "$output" == *"composeFsBackend=false"* ]]
+  [[ "$output" == *"filesystem=xfs"* ]]
+}
+
+@test "el10 with no prepare-root.conf at all is still ostree/grub2/xfs" {
+  # The EL10 pin is written late in Containerfile.el10; an image that never
+  # got one must not fall through to the composefs branch.
+  add_bootupd_legacy
+  probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bootloader=grub2"* ]]
+  [[ "$output" == *"filesystem=xfs"* ]]
+}
+
+# ── Ordering: bootupd wins over a composefs pin ──────────────────────────────
+
+@test "sealed image that still ships bootupd stays on the ostree path" {
+  # THE ORDER IS LOAD-BEARING (scripts/lib/common.sh). bootupd is checked
+  # first so this image keeps grub2 — but it is sealed, so it must still get
+  # ext4. Backend and filesystem are separate questions and this is the case
+  # that proves it: keying the filesystem off the backend would hand a sealed
+  # rootfs to XFS, which has no fs-verity, and the install would boot into a
+  # dracut emergency shell.
+  add_bootupd_legacy
+  set_composefs yes
+  probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bootloader=grub2"* ]]
+  [[ "$output" == *"composeFsBackend=false"* ]]
+  [[ "$output" == *"filesystem=ext4"* ]]
+}
+
+@test "the modern three-part bootupd payload is recognised" {
+  add_bootupd_modern
+  set_composefs no
+  probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bootloader=grub2"* ]]
+}
+
+@test "a bare EFI.json with no efi binaries is not a bootupd payload" {
+  # Guards the two-form test: EFI.json alone must not claim the ostree path,
+  # because an ostree install without a real payload aborts with
+  # "bootupd is required for ostree-based installs".
+  mkdir -p "$FIXTURE/usr/lib/bootupd/updates"
+  touch "$FIXTURE/usr/lib/bootupd/updates/EFI.json"
+  set_composefs yes
+  probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bootloader=systemd"* ]]
+  [[ "$output" == *"composeFsBackend=true"* ]]
+}
+
+# ── composefs-native bases ───────────────────────────────────────────────────
+
+@test "composefs pin with no bootupd installs systemd-boot on ext4" {
+  set_composefs yes
+  probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bootloader=systemd"* ]]
+  [[ "$output" == *"composeFsBackend=true"* ]]
+  [[ "$output" == *"filesystem=ext4"* ]]
+}
+
+@test "enabled = signed counts as sealed" {
+  set_composefs signed
+  probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"filesystem=ext4"* ]]
+}
+
+@test "systemd-boot alone (the dakota shape) is composefs-native on xfs" {
+  # No composefs pin, so nothing is sealed and xfs is correct here.
+  add_systemd_boot
+  probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bootloader=systemd"* ]]
+  [[ "$output" == *"composeFsBackend=true"* ]]
+  [[ "$output" == *"filesystem=xfs"* ]]
+}
+
+# ── Never guess ──────────────────────────────────────────────────────────────
+
+@test "an unclassifiable image fails instead of guessing" {
+  # No payload, no pin, no systemd-boot. A guess in either direction produces
+  # an unbootable disk whose failure surfaces minutes later with nothing
+  # pointing back here, so this must be fatal at ISO-build time.
+  probe
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot determine the bootc backend"* ]]
+}


### PR DESCRIPTION
## The bug

The GUI installer recipe told fisherman to do a **composefs/systemd-boot install on every variant**, including the three EL10 ones that cannot take one.

`system_files/etc/bootc-installer/recipe.json` ships:

```json
"bootloader": "systemd", "composeFsBackend": true, "filesystem": "xfs"
```

and nothing ever set those per variant. `build_scripts/90-image-info.sh` is the only thing that rewrites that file and it touches branding only (`distro_name`, `welcome_title`, `distro_logo`, `tour`) — so all 13 variants shipped the same triple. But `yellowfin`, `albacore` and `skipjack` are traditional ostree + bootupd + GRUB with composefs explicitly disabled (`Containerfile.el10` pins `[composefs] enabled = no`).

**Why nothing caught it:** `scripts/iso-e2e.sh` probes the image and builds its own recipe, so the headless path never reads the shipped one. That is how a cell can be green on LUKS E2E while its GUI install has never been proven — the two paths disagreed about the same image, and only one of them is the path a user takes. `docs/MATRIX-STATUS.md` already says this out loud: *"A variant can be green on LUKS E2E and still ship an ISO nobody can use, because LUKS E2E never looks at the screen."*

`scripts/iso-e2e.sh` had a narrower version of the same bug: it derived `composeFsBackend` and `bootloader` from the probe but hardcoded `"filesystem": "xfs"` and never read `SEALED` — so the ISO install path and the qcow2 Gate path (`scripts/build-qcow2.sh:126-129`, which has always passed `--filesystem ext4` for sealed images) disagreed too. A composefs-sealed rootfs is verified with fs-verity, which XFS does not have, so that install fails `initrd-switch-root` into a dracut emergency shell — the warning is already written in `system_files/usr/lib/bootc/install/00-tunaos.toml`.

## The change

New `live-iso/common/src/installer-recipe-backend.sh` makes the decision once, by probing the image, and both callers use it. It is a faithful port of `TUNAOS_BACKEND_PROBE_SH` in `scripts/lib/common.sh`, including the load-bearing ordering.

**Why the live-ISO layer** and not `90-image-info.sh`, which already owns the recipe: on EL10 the `prepare-root.conf` pin is written *after* `90-image-info.sh` runs (`Containerfile.el10` — 90-image-info at line 134, the pin at line 156), so a probe there reads whatever the upstream base happens to ship. That default has already drifted once (tuna-os/wootc#28). By live-ISO customize time the payload image is final, which makes it the first point where the answer is trustworthy.

**Backend and filesystem stay separate questions.** `ostree` + sealed is a real combination — branch 1 of the probe deliberately keeps sealed images that ship a bootupd payload on the ostree path — and it still needs ext4. Keying the filesystem off the backend would get exactly those images wrong.

**An unclassifiable image is now fatal at ISO-build time** rather than guessed, matching the existing `sudo`/`podman` assertions in `customize-live.sh`. A wrong guess in either direction is an unbootable disk whose failure surfaces minutes later with nothing pointing back at the cause.

## Verification

`tests/bats/test_installer_recipe_backend.bats` — 9 branches against fixture trees, all passing:

- EL10 (bootupd payload, composefs off) → `grub2` / `false` / `xfs`
- EL10 with no `prepare-root.conf` at all → still ostree/grub2/xfs
- **sealed image that still ships bootupd** → stays `grub2`, but gets `ext4` (the ordering case)
- the modern three-part bootupd payload is recognised
- a bare `EFI.json` with no EFI binaries is **not** a bootupd payload
- composefs pin, no bootupd → `systemd` / `true` / `ext4`
- `enabled = signed` counts as sealed
- systemd-boot alone (the dakota shape) → composefs-native on `xfs`
- an unclassifiable image fails instead of guessing

Full suite: **1078 bats tests pass, 0 failures.** `bash -n` clean on both modified shell scripts.

## Scope

This is the first change from a broader piece of work on making the live-ISO install experience provable from CI. The remaining axes (headless per-frontend flow contract, a compositor-independent window-mapped assertion for `installer-smoke`, driving the walkthrough through to a completed install, and the per-base sweep) are separate and land independently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPQRhh1y5yEgXzXVgRfBkt)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->