### PR TITLE
ci(installer-smoke): require proof a window reached the screen

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -228,7 +228,7 @@ jobs:
           # both rather than assuming which one this ISO produced.
           echo "expecting readiness stamp from: ${APP}"
           STAMP=""
-          for i in $(seq 1 18); do
+          for _ in $(seq 1 18); do
             STAMP=$($SSH "cat /run/user/*/app/${APP}/tuna-installer-ready /run/user/*/tuna-installer-ready 2>/dev/null | head -20" 2>/dev/null || true)
             [ -n "$STAMP" ] && break
             sleep 10
@@ -245,7 +245,9 @@ jobs:
             exit 1
           fi
 
-          echo "readiness stamp:"; echo "$STAMP" | sed 's/^/  /'
+          # awk rather than `sed 's/^/  /'`: shellcheck's SC2001 fires on
+          # echo-into-sed, and this file is actionlint-clean.
+          echo "readiness stamp:"; echo "$STAMP" | awk '{print "  " $0}'
 
           # The stamp must come from the frontend we asked for. A stale stamp
           # from a previous boot cannot survive ($XDG_RUNTIME_DIR is tmpfs),

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -203,6 +203,92 @@ jobs:
             exit 1
           fi
 
+          # ── 2b. The frontend must have PUT A WINDOW ON THE SCREEN ──────────
+          #
+          # Check 2 above answers "is the process alive". That is not the same
+          # question as "did the user get a window", and the two have already
+          # diverged HERE: the cosmic leg ran the installer process with no
+          # window ever appearing, and check 2 stayed green. The only thing
+          # that noticed was a human looking at a screenshot.
+          #
+          # Checks 3-5 (the walkthrough) would notice, but they need a
+          # compositor that renders — and cosmic, niri, xfwl4 and kwin_wayland
+          # all require a DRM render node that GitHub-hosted runners do not
+          # have. So on exactly the runners where this matters most, the
+          # rendering checks are the ones that cannot run.
+          #
+          # The frontends therefore say it themselves: each writes
+          # $XDG_RUNTIME_DIR/tuna-installer-ready when its window comes up. No
+          # GPU, no OCR, just a file read over SSH. Contract and field list:
+          # docs/INSTALLER-FRONTENDS.md.
+          #
+          # Inside the Flatpak sandbox $XDG_RUNTIME_DIR is the app's own
+          # runtime dir, which the host sees at /run/user/<uid>/app/<app-id>/;
+          # an unsandboxed run writes to /run/user/<uid>/ directly. Look in
+          # both rather than assuming which one this ISO produced.
+          echo "expecting readiness stamp from: ${APP}"
+          STAMP=""
+          for i in $(seq 1 18); do
+            STAMP=$($SSH "cat /run/user/*/app/${APP}/tuna-installer-ready /run/user/*/tuna-installer-ready 2>/dev/null | head -20" 2>/dev/null || true)
+            [ -n "$STAMP" ] && break
+            sleep 10
+          done
+
+          if [ -z "$STAMP" ]; then
+            echo "::error::${FLAVOR}: ${APP} is running but never reported a window"
+            echo "  The process is alive (check 2 passed) and no readiness stamp"
+            echo "  was written, which is the cosmic failure shape: a frontend"
+            echo "  that starts, stays up, and puts nothing on the screen."
+            echo "  If this frontend's stamp is new, confirm the ISO's flatpak"
+            echo "  postdates it before treating this as a UI regression."
+            echo "--- runtime dirs:"; $SSH 'ls -la /run/user/*/ /run/user/*/app/*/ 2>/dev/null | head -40' 2>/dev/null || true
+            exit 1
+          fi
+
+          echo "readiness stamp:"; echo "$STAMP" | sed 's/^/  /'
+
+          # The stamp must come from the frontend we asked for. A stale stamp
+          # from a previous boot cannot survive ($XDG_RUNTIME_DIR is tmpfs),
+          # but the WRONG frontend autostarting is a real and silent failure —
+          # every desktop's autostart entry is written by a different
+          # desktop-*.sh adapter.
+          STAMP_APP=$(echo "$STAMP" | sed -n 's/^app_id=//p' | head -1)
+          if [ "$STAMP_APP" != "${APP}" ]; then
+            echo "::error::${FLAVOR}: expected a stamp from ${APP}, got '${STAMP_APP:-<none>}'"
+            exit 1
+          fi
+
+          # `signal` records HOW each frontend earned its stamp, because the
+          # five toolkits cannot all make the same claim:
+          #
+          #   frame-swapped  a frame actually reached the compositor
+          #                  (kde, niri — Qt's QQuickWindow::frameSwapped)
+          #   gtk-map        the widget was mapped
+          #                  (gnome/bootc-installer, xfce)
+          #   first-frame    the toolkit asked for a frame. Proves the event
+          #                  loop runs; does NOT prove a surface was presented
+          #                  (cosmic — libcosmic is iced-on-wgpu, no map hook)
+          #
+          # first-frame is deliberately NOT failed here: it is the strongest
+          # claim libcosmic can make, and rejecting it would fail the one
+          # frontend this check exists for. It is reported instead, so a
+          # reader weighs cosmic's evidence for what it is rather than
+          # assuming a mapped window. An UNKNOWN value does fail — that means
+          # a frontend invented a claim this workflow has not reasoned about.
+          STAMP_SIGNAL=$(echo "$STAMP" | sed -n 's/^signal=//p' | head -1)
+          case "${STAMP_SIGNAL}" in
+            frame-swapped|gtk-map)
+              echo "${FLAVOR}: window confirmed on screen (${STAMP_SIGNAL})" ;;
+            first-frame)
+              echo "::notice::${FLAVOR}: stamp is 'first-frame' — the app is"\
+                   "producing frames, which does not prove a surface was"\
+                   "presented. Strongest claim libcosmic offers." ;;
+            *)
+              echo "::error::${FLAVOR}: unrecognised readiness signal '${STAMP_SIGNAL:-<none>}'."
+              echo "  Add it to this case with a note on what it proves, or fix the frontend."
+              exit 1 ;;
+          esac
+
       # Capturing frames proves nothing on its own, so this also asserts the
       # installer RENDERS (non-blank), ADVANCES (frames differ), and WHICH
       # spec'd screens it reached (OCR vs tests/installer-screens.yaml) — the

--- a/docs/INSTALLER-FRONTENDS.md
+++ b/docs/INSTALLER-FRONTENDS.md
@@ -23,6 +23,7 @@ Nothing about "it built" or "it launched" catches that — this page does.
 |---|-------|-----|---------|
 | 1 | **Desktop is up** | `pgrep -x` the exact compositor binary | greeter loops, TTY fallback |
 | 2 | **Frontend launched** | `flatpak ps` matches the desktop's app id | wrong/missing frontend, autostart broken |
+| 2b | **A window reached the screen** | readiness stamp in `$XDG_RUNTIME_DIR` | **a frontend that runs and shows nothing** |
 | 3 | **Screen is not blank** | grayscale stddev of each frame > 0.02 | black screen, no GL, dead compositor |
 | 4 | **It advances** | consecutive frames differ > 500px | stuck on one screen, modal error |
 | 5 | **Which screens** | OCR each frame vs `tests/installer-screens.yaml` | **feature drift between forks** |
@@ -35,6 +36,59 @@ screendumps each screen, and emits TAP plus `walkthrough-<flavor>.json`.
 > `bash -c` — the pattern matched its own command line, so it passed
 > unconditionally and never verified anything. Assertions that can match
 > themselves are worse than no assertion: they read as green forever.
+
+### The readiness stamp (check 2b)
+
+Check 2 answers *"is the process alive"*. That is not *"did the user get a
+window"*, and the two have already diverged: the cosmic leg ran the installer
+with no window ever appearing and check 2 stayed green. A human looking at a
+screenshot was the only thing that caught it.
+
+Checks 3–5 would have caught it too — but they need a compositor that renders,
+and cosmic, niri, xfwl4 and kwin_wayland all require a DRM render node that
+GitHub-hosted runners do not have. On exactly the runners where this matters
+most, the rendering checks are the ones that cannot run.
+
+So each frontend says it itself, in
+`$XDG_RUNTIME_DIR/tuna-installer-ready` — readable over SSH with no GPU and no
+OCR. Inside the Flatpak sandbox the host sees it at
+`/run/user/<uid>/app/<app-id>/`.
+
+```
+app_id=org.tunaos.InstallerKde
+window=ApplicationWindow
+signal=frame-swapped
+mapped_at=1786215232.825
+page=welcome
+```
+
+| Field | Meaning |
+|-------|---------|
+| `app_id` | Must match the desktop's expected frontend. The wrong frontend autostarting is silent otherwise — each desktop's entry comes from a different `desktop-*.sh` adapter. |
+| `window` | The class that mapped. Not decoration: `bootc-installer` can present `BootcRamWindow`/`BootcCpuWindow`/`BootcUnsupportedWindow` instead of the wizard, and `flatpak ps` reports all of them as a healthy install. |
+| `signal` | **How the stamp was earned** — see below. |
+| `mapped_at` | Unix seconds, 3dp. |
+| `page` | Wizard page showing at map time. `unknown` if unavailable — never a bare `page=`, which would parse as a page named `""`. |
+
+#### `signal` — the five toolkits cannot make the same claim
+
+| Value | Proves | Frontends |
+|-------|--------|-----------|
+| `frame-swapped` | A frame actually reached the compositor (`QQuickWindow::frameSwapped`). Strongest. | kde, niri |
+| `gtk-map` | The widget was mapped (GTK `map`). | gnome/bootc-installer, xfce |
+| `first-frame` | The toolkit asked for a frame. Proves the event loop runs; **not** that a surface was presented. | cosmic |
+
+cosmic is weaker because libcosmic is iced-on-wgpu and offers no `map`
+equivalent — `first-frame` is the strongest claim it can honestly make. The
+smoke test reports it rather than failing it: rejecting it would fail the one
+frontend this check exists for. An **unrecognised** value does fail, because
+that means a frontend invented a claim the workflow has not reasoned about.
+
+Flattening these into one boolean would let the check believe a frame callback
+proves a mapped window — on the very frontend whose window never appeared.
+
+The stamp is best-effort in every frontend: one that cannot write it must still
+install. Observability must not be able to take down the installer.
 
 ### Rendering caveat (why strictness differs per desktop)
 


### PR DESCRIPTION
This is the step that turns the readiness stamp from a description into a detection.

## The gap

Check 2 answers *"is the process alive"*. That is not *"did the user get a window"* — and the two have already diverged **in this workflow**: the cosmic leg ran the installer process with no window ever appearing, and check 2 stayed green. A human looking at a screenshot was the only thing that caught it.

Checks 3–5 would have caught it too, but they need a compositor that renders — and cosmic, niri, xfwl4 and kwin_wayland all require a DRM render node that GitHub-hosted runners don't have. **On exactly the runners where this matters most, the rendering checks are the ones that cannot run.**

So each frontend now says it itself, in `$XDG_RUNTIME_DIR/tuna-installer-ready`. Readable over SSH with no GPU and no OCR.

All five frontends ship the stamp as of tuna-os/bootc-installer#7 / #8, tuna-os/tuna-installer-xfce#11 / #12, tuna-os/tuna-installer-cosmic#24, tuna-os/tuna-installer-niri#13 and tuna-os/tuna-installer-kde#16 — all merged.

## What's asserted

1. **The stamp exists** — the cosmic failure shape.
2. **`app_id` matches the desktop's expected frontend.** The *wrong* frontend autostarting is otherwise silent, and every desktop's autostart entry comes from a different `desktop-*.sh` adapter.
3. **`signal` is a value this workflow has reasoned about.**

## On `signal`, and why `first-frame` doesn't fail

The five toolkits cannot make the same claim:

| Value | Proves | Frontends |
|---|---|---|
| `frame-swapped` | A frame actually reached the compositor | kde, niri |
| `gtk-map` | The widget was mapped | gnome, xfce |
| `first-frame` | The toolkit asked for a frame — **not** that a surface was presented | cosmic |

`first-frame` is the strongest claim libcosmic can make (iced-on-wgpu, no `map` hook). Rejecting it would fail **the one frontend this check exists for**, so it's reported via `::notice::` instead — a reader weighs cosmic's evidence for what it is rather than assuming a mapped window.

An **unrecognised** value *does* fail. That means a frontend invented a claim nothing here has reasoned about, and silently accepting it is how this check would rot — the same way the old `pgrep -af` check read as green forever while verifying nothing.

## Rollout note for reviewers

This check depends on the ISO's frontend flatpaks postdating the stamp commits. If a leg goes red immediately after merge, confirm the flatpak was rebuilt before reading it as a UI regression — the error message says so explicitly and dumps the runtime dirs.

## Verification

YAML parses; the three jobs are unchanged in shape. The assertion logic itself is shell inside a workflow step, so **its first real execution is the workflow run** — I can't drive a live ISO here. The stamp *formats* it parses were verified against all five implementations (2 Rust tests, 5 Go tests, executed output from both Python frontends, and a numeric check that the two `frame-swapped` frontends emit byte-identical `mapped_at`).

`docs/INSTALLER-FRONTENDS.md` gains the field list as check 2b, so a sixth frontend has something to be written against.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPQRhh1y5yEgXzXVgRfBkt)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->