### PR TITLE
ci(bench): GDM first-paint benchmark for the QEMU boot gate (#581)

### DIFF
--- a/.github/workflows/gdm-paint-benchmark.yml
+++ b/.github/workflows/gdm-paint-benchmark.yml
@@ -1,0 +1,135 @@
+name: GDM Paint Benchmark
+
+# Manual investigation tool for tuna-os/tunaos#581: characterize how long
+# GDM takes to actually paint under plain QEMU/virtio-vga (the llvmpipe
+# software-render path hosted runners are stuck on — see the GPU-selection
+# comment in scripts/iso-e2e.sh for why gnome is the one desktop still
+# expected to render there at all) across machine type, vga device, and
+# vCPU count, so #581 item 1 has real numbers instead of "it's slow" to pick
+# defaults/timeouts from.
+#
+# Not wired into any gate — this only ever runs on request. scripts/bench-
+# gdm-paint.sh does the actual boot+poll and is safe to run locally too.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Image to build the base qcow2 from"
+        required: false
+        default: "ghcr.io/tuna-os/yellowfin:gnome"
+      timeout:
+        description: "Per-config timeout in seconds"
+        required: false
+        default: "300"
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build-base:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6 # main as of 2026-02-11
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends just qemu-utils podman
+
+      - name: Log in to GHCR
+        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build base qcow2
+        env:
+          IMAGE: ${{ inputs.image || 'ghcr.io/tuna-os/yellowfin:gnome' }}
+        run: |
+          just qcow2 "${IMAGE}" ghcr
+          QCOW2=$(find . -maxdepth 1 -name "*.qcow2" | head -1)
+          [[ -n "$QCOW2" ]] || { echo "::error::no qcow2 produced"; exit 1; }
+          mv "$QCOW2" base.qcow2
+          sudo chown "$USER:$(id -gn)" base.qcow2
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gdm-bench-base-qcow2
+          path: base.qcow2
+          retention-days: 1
+
+  benchmark:
+    needs: build-base
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Current default (scripts/iso-e2e.sh boot_disk_image / installed-system paths).
+          - label: pc-virtio-4cpu
+            machine: pc
+            vga: virtio
+            cpus: 4
+          - label: q35-virtio-4cpu
+            machine: q35
+            vga: virtio
+            cpus: 4
+          - label: pc-virtio-2cpu
+            machine: pc
+            vga: virtio
+            cpus: 2
+          - label: pc-std-4cpu
+            machine: pc
+            vga: std
+            cpus: 4
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Enable KVM group permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | \
+            sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm || true
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends qemu-system-x86 qemu-utils ovmf socat imagemagick
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: gdm-bench-base-qcow2
+
+      - name: Run benchmark (${{ matrix.label }})
+        id: bench
+        run: |
+          RESULT=$(sudo ./scripts/bench-gdm-paint.sh base.qcow2 \
+            --label "${{ matrix.label }}" \
+            --machine "${{ matrix.machine }}" \
+            --vga "${{ matrix.vga }}" \
+            --cpus "${{ matrix.cpus }}" \
+            --timeout "${{ inputs.timeout || '300' }}" \
+            --output-dir bench-out)
+          sudo chown -R "$USER:$(id -gn)" bench-out || true
+          echo "$RESULT" | tee "bench-out/${{ matrix.label }}.json"
+
+          {
+            echo "### ${{ matrix.label }}"
+            echo '```json'
+            echo "$RESULT"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: gdm-bench-result-${{ matrix.label }}
+          path: |
+            bench-out/*.json
+            bench-out/*.serial.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/scripts/bench-gdm-paint.sh
+++ b/scripts/bench-gdm-paint.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# scripts/bench-gdm-paint.sh — measure GDM first-paint latency under a given
+# QEMU config, for tuna-os/tunaos#581 (GDM slow/black under plain
+# QEMU/virtio-vga on hosted-runner llvmpipe).
+#
+# Boots a pre-built qcow2 (e.g. `just qcow2 ghcr.io/tuna-os/yellowfin:gnome
+# ghcr`) with -snapshot (so the base disk is never mutated — the same qcow2
+# can be reused across every config in the matrix) and polls until either the
+# framebuffer stops being blank (screendump stddev, same 0.02 floor iso-e2e.sh
+# uses) or the serial console reaches graphical.target, recording whichever
+# comes first plus the other for comparison. Prints one JSON object to stdout.
+#
+# Usage:
+#   bench-gdm-paint.sh <qcow2> [--label NAME] [--machine pc|q35]
+#                       [--vga virtio|std|cirrus] [--cpus N] [--memory MB]
+#                       [--timeout SEC] [--output-dir DIR]
+set -euo pipefail
+
+QCOW2="${1:?usage: $0 <qcow2> [--label NAME] [--machine pc|q35] [--vga virtio|std|cirrus] [--cpus N] [--memory MB] [--timeout SEC] [--output-dir DIR]}"
+shift
+
+LABEL="bench"
+MACHINE="pc"
+VGA="virtio"
+CPUS=4
+MEMORY=4096
+TIMEOUT=300
+OUTPUT_DIR="./bench-out"
+POLL_INTERVAL=3
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--label) LABEL="$2"; shift 2 ;;
+	--machine) MACHINE="$2"; shift 2 ;;
+	--vga) VGA="$2"; shift 2 ;;
+	--cpus) CPUS="$2"; shift 2 ;;
+	--memory) MEMORY="$2"; shift 2 ;;
+	--timeout) TIMEOUT="$2"; shift 2 ;;
+	--output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+	*) echo "unknown arg: $1" >&2; exit 2 ;;
+	esac
+done
+
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(realpath "$OUTPUT_DIR")"
+QCOW2="$(realpath "$QCOW2")"
+
+MONITOR_SOCK="${OUTPUT_DIR}/${LABEL}.monitor.sock"
+SERIAL_LOG="${OUTPUT_DIR}/${LABEL}.serial.log"
+QEMU_PIDFILE="${OUTPUT_DIR}/${LABEL}.qemu.pid"
+OVMF_VARS="${OUTPUT_DIR}/${LABEL}.OVMF_VARS.fd"
+rm -f "$MONITOR_SOCK" "$SERIAL_LOG" "$QEMU_PIDFILE" "$OVMF_VARS"
+
+QEMU=""
+for candidate in /usr/libexec/qemu-kvm /usr/bin/qemu-kvm /usr/bin/qemu-system-x86_64; do
+	[[ -x "$candidate" ]] && { QEMU="$candidate"; break; }
+done
+[[ -z "$QEMU" ]] && { echo "ERROR: QEMU not found" >&2; exit 77; }
+
+OVMF_CODE=""
+for f in /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/OVMF/OVMF_CODE.fd /usr/share/edk2/ovmf/OVMF_CODE.fd /usr/share/edk2-ovmf/x64/OVMF_CODE.fd; do
+	[[ -f "$f" ]] && { OVMF_CODE="$f"; break; }
+done
+OVMF_VARS_SRC=""
+for f in /usr/share/OVMF/OVMF_VARS_4M.fd /usr/share/OVMF/OVMF_VARS.fd /usr/share/edk2/ovmf/OVMF_VARS.fd /usr/share/edk2-ovmf/x64/OVMF_VARS.fd; do
+	[[ -f "$f" ]] && { OVMF_VARS_SRC="$f"; break; }
+done
+[[ -z "$OVMF_CODE" ]] && { echo "ERROR: OVMF not found" >&2; exit 77; }
+if [[ -n "$OVMF_VARS_SRC" ]]; then cp -f "$OVMF_VARS_SRC" "$OVMF_VARS"; else truncate -s 4M "$OVMF_VARS"; fi
+
+ACCEL="tcg"
+[[ -r /dev/kvm && -w /dev/kvm ]] && ACCEL="kvm"
+CPU_ARG="qemu64"
+[[ "$ACCEL" == "kvm" ]] && CPU_ARG="host"
+
+case "$VGA" in
+virtio) VGA_ARGS=(-vga virtio -display none) ;;
+std) VGA_ARGS=(-vga std -display none) ;;
+cirrus) VGA_ARGS=(-vga cirrus -display none) ;;
+*) echo "unknown --vga: $VGA (want virtio|std|cirrus)" >&2; exit 2 ;;
+esac
+
+QEMU_PID=""
+cleanup() {
+	if [[ -n "$QEMU_PID" ]]; then
+		kill -TERM "$QEMU_PID" 2>/dev/null || true
+		sleep 1
+		kill -KILL "$QEMU_PID" 2>/dev/null || true
+	fi
+}
+trap cleanup EXIT
+
+echo "==> [$LABEL] machine=$MACHINE vga=$VGA cpus=$CPUS accel=$ACCEL timeout=${TIMEOUT}s" >&2
+BOOT_START=$(date +%s)
+"$QEMU" \
+	-name "gdm-bench-${LABEL}" \
+	-machine "$MACHINE" \
+	-cpu "$CPU_ARG" \
+	-accel "$ACCEL" \
+	-m "$MEMORY" \
+	-smp "$CPUS" \
+	-drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
+	-drive "if=pflash,format=raw,file=${OVMF_VARS}" \
+	-drive "if=none,id=disk,file=${QCOW2},format=qcow2,snapshot=on" \
+	-device virtio-blk-pci,drive=disk \
+	-monitor "unix:${MONITOR_SOCK},server,nowait" \
+	-serial "file:${SERIAL_LOG}" \
+	"${VGA_ARGS[@]}" \
+	-pidfile "$QEMU_PIDFILE" \
+	-daemonize
+
+sleep 2
+QEMU_PID="$(cat "$QEMU_PIDFILE" 2>/dev/null || true)"
+if [[ -z "$QEMU_PID" ]] || ! kill -0 "$QEMU_PID" 2>/dev/null; then
+	echo "ERROR: [$LABEL] QEMU failed to start" >&2
+	printf '{"label":%s,"machine":%s,"vga":%s,"cpus":%s,"accel":%s,"error":"qemu_failed_to_start"}\n' \
+		"\"$LABEL\"" "\"$MACHINE\"" "\"$VGA\"" "$CPUS" "\"$ACCEL\""
+	exit 1
+fi
+
+paint_s=""
+graphical_s=""
+elapsed=0
+while [[ "$elapsed" -lt "$TIMEOUT" ]]; do
+	if [[ -z "$graphical_s" ]] && grep -qE "Reached target.*Graphical" "$SERIAL_LOG" 2>/dev/null; then
+		graphical_s=$elapsed
+		echo "==> [$LABEL] graphical.target reached at ${elapsed}s" >&2
+	fi
+
+	if [[ -z "$paint_s" ]]; then
+		ppm="${OUTPUT_DIR}/${LABEL}-${elapsed}.ppm"
+		echo "screendump ${ppm}" | socat - "UNIX-CONNECT:${MONITOR_SOCK}" >/dev/null 2>&1 || true
+		if [[ -f "$ppm" ]]; then
+			stddev=$(convert "$ppm" -colorspace Gray -format "%[fx:standard_deviation]" info: 2>/dev/null || echo 0)
+			rm -f "$ppm"
+			if awk -v s="$stddev" 'BEGIN{exit !(s > 0.02)}'; then
+				paint_s=$elapsed
+				echo "==> [$LABEL] screen painted (stddev=${stddev}) at ${elapsed}s" >&2
+			fi
+		fi
+	fi
+
+	[[ -n "$paint_s" && -n "$graphical_s" ]] && break
+
+	sleep "$POLL_INTERVAL"
+	elapsed=$(($(date +%s) - BOOT_START))
+done
+
+timed_out=false
+[[ -z "$paint_s" && -z "$graphical_s" ]] && timed_out=true
+
+printf '{"label":%s,"machine":%s,"vga":%s,"cpus":%s,"accel":%s,"paint_s":%s,"graphical_target_s":%s,"timed_out":%s}\n' \
+	"\"$LABEL\"" "\"$MACHINE\"" "\"$VGA\"" "$CPUS" "\"$ACCEL\"" \
+	"${paint_s:-null}" "${graphical_s:-null}" "$timed_out"


### PR DESCRIPTION
## Summary

Progress on tuna-os/tunaos#581 item 1 ("Characterize GDM first-paint time under QEMU/llvmpipe — pick settings + timeout that reliably paint").

The gate already keys off the serial `TUNAOS_DESKTOP_CONTRACT_*` marker (the #575 mitigation), but screenshots remain second-class in exactly the environments this issue describes — GDM is slow or never paints under plain `-vga virtio` on hosted-runner llvmpipe, so pixel-based evidence misreads "slow GDM" as "blank/failed". Before changing the gate defaults, we need numbers.

This PR adds the characterization tooling (manual dispatch only — deliberately not wired into any gate):

- **`scripts/bench-gdm-paint.sh`** — boots a pre-built qcow2 with `-snapshot` (one base disk reused across every config), then polls both signals until timeout: screendump standard deviation (>0.02, the same floor `iso-e2e.sh` uses) for first paint, and the serial log for `Reached target.*Graphical`. Records whichever fires first plus the other, prints one JSON row per config, and is safe to run locally.
- **`.github/workflows/gdm-paint-benchmark.yml`** — 4-config matrix: the current gate default (`pc/virtio/4cpu`) plus `q35`, `2cpu`, and `std` vga, with per-config artifacts (JSON + serial log) and a step summary.

Once run on real hosted runners, the results pick the machine/vga/cpu settings and timeout that reliably paint; those then land in `scripts/iso-e2e.sh`'s QEMU invocation as the fix for #581 item 1. Items 2 (service masking + autologin for capture VMs) and 3 (VT3-black) remain follow-ups.

## Verification

- `bash -n scripts/bench-gdm-paint.sh` — passes.
- Workflow YAML parses; matrix resolves to the 4 intended labels.
- Benchmark pattern mirrors the proven `iso-e2e.sh` QEMU/OVMF/serial/screendump machinery.
- The workflow itself is dispatch-only, so it cannot affect any gate or CI status.

- [x] I am using an agent and I take responsibility for this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->