### PR TITLE
feat(redfin): ship local image-factory units for auto-update (#609)

### DIFF
--- a/docs/rhel-setup.md
+++ b/docs/rhel-setup.md
@@ -140,21 +140,51 @@ corral delete redfin-gnome --force
 
 ## Auto-Update (Local Image Factory)
 
-For ongoing updates without internet access to GHCR (since images can't be published), set up a local auto-rebuild:
+For ongoing updates without internet access to GHCR (since images can't be published), the image ships a ready-made auto-rebuild unit pair, adapted from the [renner0e/server](https://github.com/renner0e/server) pattern:
+
+- `bootc-image-factory-build.service` — one-shot: rebuilds the configured Redfin flavors with `just build redfin <flavor>` from a local repo checkout, then `bootc switch`s this system to the freshly built image, runs `bootc update`, and prunes superseded bootc images.
+- `bootc-image-factory-build.timer` — triggers the service daily at 04:00 (`Persistent=true`, 15-minute randomized delay).
+
+### One-time setup on a Redfin system
 
 ```bash
-# 1. Build updated image periodically (cron or systemd timer)
-just build redfin gnome
+# 1. Put a repo checkout where the service expects it (any checkout works; it
+#    git-pulls itself before each build)
+sudo mkdir -p /etc/bootc-image-factory
+sudo git clone https://github.com/tuna-os/tunaOS /etc/bootc-image-factory/tunaos
 
-# 2. Push to local registry (optional — for multi-machine deployments)
+# 2. RHSM credentials + flavor selection (chmod 600 — secrets)
+sudo tee /etc/default/redfin-image-factory >/dev/null <<'EOF'
+REDFIN_FLAVORS="gnome kde"
+RHSM_USER="your-rh-username"
+RHSM_PASSWORD="your-rh-password"
+# or, with an activation key:
+# RHSM_ORG="your-org-id"
+# RHSM_ACTIVATION_KEY="your-key"
+EOF
+sudo chmod 600 /etc/default/redfin-image-factory
+
+# 3. Enable the timer
+sudo systemctl enable --now bootc-image-factory-build.timer
+
+# Inspect / debug
+systemctl list-timers bootc-image-factory-build.timer
+sudo systemctl start bootc-image-factory-build.service   # run once now
+journalctl -u bootc-image-factory-build.service -e
+```
+
+### Multi-machine deployments
+
+Builds happen on one machine; the rest pull from a private registry:
+
+```bash
+# On the factory machine, after a build
 podman push localhost/redfin:gnome registry.internal.example.com/redfin:gnome
 
-# 3. Running systems pull updates
+# On each other system
 sudo bootc switch registry.internal.example.com/redfin:gnome
 # After first switch, updates happen automatically via uupd timer
 ```
-
-See [renner0e/server](https://github.com/renner0e/server) for a systemd timer pattern that automates this.
 
 Each deployed system must be covered by a RHEL subscription (the same free Developer Subscription works).
 

--- a/system_files/etc/systemd/system/bootc-image-factory-build.service
+++ b/system_files/etc/systemd/system/bootc-image-factory-build.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Rebuild local Redfin images and apply them (bootc image factory)
+Documentation=https://github.com/tuna-os/tunaOS/blob/main/docs/rhel-setup.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# RHSM credentials / flavor selection live here (see docs/rhel-setup.md):
+EnvironmentFile=-/etc/default/redfin-image-factory
+ExecStart=/usr/local/bin/redfin-image-factory-build.sh
+# A full image build takes far longer than the default 90s start timeout.
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/etc/systemd/system/bootc-image-factory-build.timer
+++ b/system_files/etc/systemd/system/bootc-image-factory-build.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Daily Redfin image factory rebuild
+
+[Timer]
+# Daily at 04:00, matching the renner0e/server pattern (tuna-os/tunaos#609).
+OnCalendar=*-*-* 04:00:00
+# Fire immediately after boot if the last run was missed (machine off at 04:00).
+Persistent=true
+# Avoid thundering-herd load spikes on RHSM/CDN at the top of the hour.
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=timers.target

--- a/system_files/usr/local/bin/redfin-image-factory-build.sh
+++ b/system_files/usr/local/bin/redfin-image-factory-build.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# system_files/usr/local/bin/redfin-image-factory-build.sh — rebuild local
+# Redfin images and apply them to this system, on a schedule
+# (tuna-os/tunaos#609).
+#
+# Adaptation of renner0e/server's bootc-image-factory for TunaOS Redfin
+# (RHEL 10, local-build only — the EULA forbids publishing images). Runs the
+# TunaOS build for the configured flavors from a local repo checkout, then
+# switches the running system to the freshly built image, applies any pending
+# updates, and prunes superseded bootc images.
+#
+# Configure via environment (systemd: /etc/default/redfin-image-factory):
+#   TUNAOS_REPO      repo checkout to build from (default: /etc/bootc-image-factory/tunaos)
+#   REDFIN_FLAVORS   space-separated flavors to rebuild (default: "gnome kde")
+#   RHSM_USER / RHSM_PASSWORD, or RHSM_ORG / RHSM_ACTIVATION_KEY
+#                    (passed through to `just build`, see docs/rhel-setup.md)
+#
+# The unit files bootc-image-factory-build.{service,timer} ship in the image;
+# enable the timer only on Redfin systems:
+#   sudo systemctl enable --now bootc-image-factory-build.timer
+set -euo pipefail
+
+REPO="${TUNAOS_REPO:-/etc/bootc-image-factory/tunaos}"
+FLAVORS="${REDFIN_FLAVORS:-gnome kde}"
+
+if [[ ! -d "${REPO}" ]]; then
+    echo "redfin-image-factory: repo missing at ${REPO} — clone tunaos/tunaos there first" >&2
+    exit 1
+fi
+if ! command -v just >/dev/null 2>&1; then
+    echo "redfin-image-factory: 'just' not found (dnf install just)" >&2
+    exit 1
+fi
+
+echo "==> redfin image factory: rebuilding [${FLAVORS}] from ${REPO}"
+cd "${REPO}"
+git pull --ff-only || true
+
+for flavor in ${FLAVORS}; do
+    echo "==> just build redfin ${flavor}"
+    just build redfin "${flavor}"
+done
+
+# Switch to the first flavor's fresh build, then update + prune. The remaining
+# flavors stay available in containers-storage for a later `bootc switch`.
+first_flavor="${FLAVORS%% *}"
+echo "==> bootc switch --transport=containers-storage localhost/redfin:${first_flavor}"
+bootc switch --quiet --transport=containers-storage "localhost/redfin:${first_flavor}"
+bootc update --quiet
+podman image prune --force --filter=label=containers.bootc=1 --filter "until=168h" 2>/dev/null || true
+
+echo "==> redfin image factory: done"


### PR DESCRIPTION
## Summary

Progress on tuna-os/tunaos#609 step 3: the auto-update mechanism. The docs already covered ISO generation, local builds, and corral testing (steps 1/2/4 via #610/#612/#617), but the auto-update section only pointed at the external renner0e/server pattern — the concrete units were never adapted.

This PR ships the adaptation in the image:

- **`system_files/usr/local/bin/redfin-image-factory-build.sh`** — rebuilds the configured Redfin flavors with `just build redfin <flavor>` from a local repo checkout (`/etc/bootc-image-factory/tunaos`, git-pulls itself before building), then `bootc switch --transport=containers-storage`es the running system to the fresh build, runs `bootc update`, and prunes superseded bootc images. RHSM credentials / flavor selection come from `/etc/default/redfin-image-factory` (EnvironmentFile, secrets file). Shellcheck-clean (v0.10.0).
- **`bootc-image-factory-build.service`** — one-shot wrapper; `TimeoutStartSec=0` because a full image build outlives systemd's default 90s start timeout.
- **`bootc-image-factory-build.timer`** — daily 04:00, `Persistent=true`, `RandomizedDelaySec=15m` (thundering-herd avoidance), mirroring the renner0e/server pattern.
- **`docs/rhel-setup.md`** — replaced the external reference with the full one-time setup: repo checkout, secrets file, `systemctl enable --now bootc-image-factory-build.timer`, manual-run + `journalctl` debugging, and the multi-machine private-registry push path.

The units ship in every image but are inert unless the timer is explicitly enabled; the docs scope them to Redfin systems (bootc switch only fires when the service runs).

## Verification

- `bash -n` + `shellcheck v0.10.0` on the script — clean.
- Unit files structurally validated ([Unit]/[Service]/[Timer] sections, key=value pairs, no empty values).
- Docs-only + inert-by-default unit files; no gate or build path affected.

- [x] I am using an agent and I take responsibility for this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->