### PR TITLE
feat(nvidia): add *-nvidia flavors for marlin, flounder, flounder-sid

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -1154,6 +1154,47 @@ variants:
       - id: xfce-cachyos
         stage: 3
         build_image: true
+      # NVIDIA overlay on the Arch base (tunaOS#624): nvidia-open-dkms via
+      # pacman + dkms, not akmods — Arch has no RPM/akmods concept at all.
+      # See build_scripts/overlay/overrides/nvidia-arch/20-nvidia.sh. No
+      # *-nvidia-hwe: marlin has no HWE kernel layer to begin with (Arch
+      # ships the latest kernel natively), so there is nothing to stack an
+      # nvidia overlay on top of beyond plain *-nvidia.
+      #
+      # platforms is pinned to linux/amd64 explicitly (not inherited from
+      # the variant default) on every *-nvidia flavor in this file — a
+      # test (tests/bats/test_nvidia_overlay.bats) asserts that directly,
+      # and nvidia-open-dkms/nvidia-utils only publish x86_64 builds.
+      - id: gnome-nvidia
+        platforms: ["linux/amd64"]
+        stage: 3
+        build_image: true
+        build_iso: true
+        build_qcow2: false
+      - id: kde-nvidia
+        platforms: ["linux/amd64"]
+        stage: 3
+        build_image: true
+        build_iso: true
+        build_qcow2: false
+      - id: cosmic-nvidia
+        platforms: ["linux/amd64"]
+        stage: 3
+        build_image: true
+        build_iso: false
+        build_qcow2: false
+      - id: niri-nvidia
+        platforms: ["linux/amd64"]
+        stage: 3
+        build_image: true
+        build_iso: false
+        build_qcow2: false
+      - id: xfce-nvidia
+        platforms: ["linux/amd64"]
+        stage: 3
+        build_image: true
+        build_iso: false
+        build_qcow2: false
 
   # ── Debian ─────────────────────────────────────────────────────────────────
   # Flounder: Debian Trixie (13) stable. Uses Containerfile.debian.
@@ -1232,6 +1273,35 @@ variants:
       - id: xfce
         stage: 2
         build_image: true
+      # NVIDIA overlay on the Debian base (tunaOS#624): nvidia-driver via
+      # apt (official Debian non-free component, not a third-party repo) +
+      # dkms. See build_scripts/overlay/overrides/nvidia-debian/20-nvidia.sh.
+      # No *-nvidia-hwe: flounder has no HWE kernel layer (Debian ships one
+      # kernel per suite), so there is nothing to stack an nvidia overlay on
+      # top of beyond plain *-nvidia.
+      #
+      # platforms is pinned to linux/amd64 explicitly on every *-nvidia
+      # flavor in this file — asserted by
+      # tests/bats/test_nvidia_overlay.bats — matching nvidia-driver's own
+      # Debian archive coverage focus and this variant's amd64-only DE set.
+      - id: gnome-nvidia
+        platforms: ["linux/amd64"]
+        stage: 3
+        build_image: true
+        build_iso: true
+        build_qcow2: false
+      - id: kde-nvidia
+        platforms: ["linux/amd64"]
+        stage: 3
+        build_image: true
+        build_iso: true
+        build_qcow2: false
+      - id: xfce-nvidia
+        platforms: ["linux/amd64"]
+        stage: 3
+        build_image: true
+        build_iso: false
+        build_qcow2: false
 
   # Flounder-sid: Debian Sid (unstable/rolling).
   - id: flounder-sid
@@ -1260,3 +1330,30 @@ variants:
       - id: xfce
         stage: 2
         build_image: true
+      # NVIDIA overlay on the Debian sid base (tunaOS#624) — same mechanism
+      # as flounder above (apt non-free + dkms). No *-nvidia-hwe: sid has
+      # no HWE kernel layer, same reasoning as flounder. No ISOs: this
+      # variant does not build any today (rolling/unstable), so none of its
+      # base DE flavors set build_iso either — nvidia flavors match that.
+      #
+      # platforms is pinned to linux/amd64 explicitly on every *-nvidia
+      # flavor in this file — asserted by
+      # tests/bats/test_nvidia_overlay.bats.
+      - id: gnome-nvidia
+        platforms: ["linux/amd64"]
+        stage: 3
+        build_image: true
+        build_iso: false
+        build_qcow2: false
+      - id: kde-nvidia
+        platforms: ["linux/amd64"]
+        stage: 3
+        build_image: true
+        build_iso: false
+        build_qcow2: false
+      - id: xfce-nvidia
+        platforms: ["linux/amd64"]
+        stage: 3
+        build_image: true
+        build_iso: false
+        build_qcow2: false

--- a/build_scripts/checks/verify-nvidia-arch.sh
+++ b/build_scripts/checks/verify-nvidia-arch.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# verify-nvidia-arch.sh — fatal build-time contract for marlin (Arch)
+# *-nvidia overlay images. Sibling of verify-nvidia.sh (the dnf/rpm family
+# contract) — see that file's header for why this class of check exists at
+# all (tunaOS was shipping driverless "nvidia" images for months because
+# nothing asserted a single nvidia file). Kept as a separate script rather
+# than teaching verify-nvidia.sh a second package family: that script's own
+# header commits to exiting loudly rather than pretending to verify a
+# family it does not know, and the two families' assertions (rpm -q vs
+# pacman -Q, dracut 99-nvidia.conf contents, module search paths) share no
+# code worth factoring — see nvidia.sh for the dispatch between them.
+#
+# Assertion sources — measured, not guessed:
+#   /usr/lib/libEGL_nvidia.so.0, libGLX_nvidia.so.0,
+#   /usr/lib/gbm/nvidia-drm_gbm.so,
+#   /usr/share/glvnd/egl_vendor.d/10_nvidia.json,
+#   /usr/share/vulkan/icd.d/nvidia_icd.json
+# read out of the Arch package file list for nvidia-utils 610.57.04-1
+# (archlinux.org/packages/extra/x86_64/nvidia-utils/files/, 2026-08-08).
+# Arch's /usr/lib has no lib64 or multiarch-triplet split (single x86_64
+# tree), unlike the RPM (/usr/lib64) and Debian
+# (/usr/lib/x86_64-linux-gnu) families — do not port those paths here.
+#
+# The dkms-built module's exact registered name is NOT asserted (see
+# overrides/nvidia-arch/20-nvidia.sh's header on why) — this script finds
+# the built .ko by glob under the kernel's module tree instead, matching
+# how the install script itself proves success.
+#
+# Test hooks (same pattern as TUNAOS_NVIDIA_VERIFY_ROOT in verify-nvidia.sh):
+#   TUNAOS_NVIDIA_VERIFY_ROOT  prefix for every filesystem path, so bats can
+#                              run the real logic against a fixture tree.
+#   pacman/modinfo/dracut are resolved via PATH, so tests stub them.
+
+set -euo pipefail
+
+NV_ROOT="${TUNAOS_NVIDIA_VERIFY_ROOT:-}"
+
+fails=0
+fail() {
+	echo "  FAIL: $*" >&2
+	fails=$((fails + 1))
+}
+pass() { echo "  ok: $*"; }
+
+if ! command -v pacman >/dev/null 2>&1; then
+	echo "ERROR: verify-nvidia-arch.sh only knows the pacman family, and this image has" >&2
+	echo "       no pacman. This check is dispatched from nvidia.sh based on IS_ARCH; if" >&2
+	echo "       that dispatch is wrong, fix nvidia.sh rather than this script." >&2
+	exit 1
+fi
+
+echo "== packages =="
+for pkg in nvidia-open-dkms nvidia-utils nvidia-settings dkms egl-wayland; do
+	if v=$(pacman -Q --info "$pkg" 2>/dev/null | awk -F': ' '/^Version/{print $2; exit}'); then
+		pass "${pkg}=${v}"
+	else
+		fail "${pkg} is not installed"
+	fi
+done
+
+echo "== kernel/module coherence =="
+# The dkms-built module must exist for the kernel this image actually ships.
+# Found by glob rather than asserting a registered dkms module name — see
+# header — the same reasoning that made verify-nvidia.sh stop name-globbing
+# on the RPM side (the wmi-ec-backlight false match, run 31196251408).
+KERNEL_TREES=()
+for _tree in "${NV_ROOT}"/usr/lib/modules/*/; do
+	[[ -d "$_tree" ]] || continue
+	_name="$(basename "$_tree")"
+	[[ "$_name" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] && KERNEL_TREES+=("$_name")
+done
+if [[ "${#KERNEL_TREES[@]}" -ne 1 ]]; then
+	fail "${#KERNEL_TREES[@]} kernel module trees under /usr/lib/modules (${KERNEL_TREES[*]:-none}) — expected exactly 1"
+	KVER=""
+else
+	KVER="${KERNEL_TREES[0]}"
+	pass "single kernel module tree (${KVER})"
+fi
+
+MODULE_FILE=""
+if [[ -n "$KVER" ]]; then
+	MODULE_FILE="$(find "${NV_ROOT}/usr/lib/modules/${KVER}" -name 'nvidia.ko*' -print -quit 2>/dev/null || true)"
+	if [[ -n "$MODULE_FILE" ]]; then
+		pass "dkms built a module for ${KVER} (${MODULE_FILE#"${NV_ROOT}"})"
+	else
+		fail "no nvidia.ko under /usr/lib/modules/${KVER} — dkms did not build for this kernel"
+	fi
+fi
+
+if [[ -n "$MODULE_FILE" ]] && command -v modinfo >/dev/null 2>&1; then
+	MODINFO_VERSION="$(modinfo -F version "$MODULE_FILE" 2>/dev/null | head -1 || true)"
+	NVUTILS_VERSION="$(pacman -Q --info nvidia-utils 2>/dev/null | awk -F': ' '/^Version/{print $2; exit}' | cut -d- -f1 || true)"
+	if [[ -z "$MODINFO_VERSION" ]]; then
+		fail "modinfo could not read a version from ${MODULE_FILE#"${NV_ROOT}"}"
+	elif [[ -n "$NVUTILS_VERSION" && "$MODINFO_VERSION" != "$NVUTILS_VERSION" ]]; then
+		fail "kmod version (${MODINFO_VERSION}) does not match nvidia-utils (${NVUTILS_VERSION})"
+	else
+		pass "module version matches nvidia-utils (${MODINFO_VERSION})"
+	fi
+fi
+
+echo "== nouveau is out of the way =="
+if grep -rqs 'blacklist nouveau' "${NV_ROOT}/usr/lib/modprobe.d" "${NV_ROOT}/etc/modprobe.d" 2>/dev/null; then
+	pass "nouveau blacklisted in modprobe.d"
+else
+	fail "no 'blacklist nouveau' under /usr/lib/modprobe.d or /etc/modprobe.d"
+fi
+if grep -rqs 'nvidia-drm.modeset=1' "${NV_ROOT}/usr/lib/bootc/kargs.d" 2>/dev/null; then
+	pass "nvidia-drm.modeset=1 karg declared in /usr/lib/bootc/kargs.d"
+else
+	fail "nvidia-drm.modeset=1 missing from /usr/lib/bootc/kargs.d — Wayland/KMS will not engage"
+fi
+
+echo "== GL/Vulkan/Wayland plumbing =="
+# Arch's /usr/lib is a single unified tree — no lib64, no multiarch triplet.
+if compgen -G "${NV_ROOT}/usr/share/glvnd/egl_vendor.d/10_nvidia.json" >/dev/null; then
+	pass "glvnd EGL vendor JSON present"
+else
+	fail "missing /usr/share/glvnd/egl_vendor.d/10_nvidia.json"
+fi
+if compgen -G "${NV_ROOT}/usr/lib/libEGL_nvidia.so.0" >/dev/null; then
+	pass "libEGL_nvidia.so.0 present"
+else
+	fail "missing /usr/lib/libEGL_nvidia.so.0"
+fi
+if compgen -G "${NV_ROOT}/usr/share/vulkan/icd.d/nvidia_icd.json" >/dev/null; then
+	pass "Vulkan ICD JSON present"
+else
+	fail "missing /usr/share/vulkan/icd.d/nvidia_icd.json"
+fi
+if compgen -G "${NV_ROOT}/usr/lib/libGLX_nvidia.so.0" >/dev/null; then
+	pass "libGLX_nvidia.so.0 present"
+else
+	fail "missing /usr/lib/libGLX_nvidia.so.0"
+fi
+if compgen -G "${NV_ROOT}/usr/lib/gbm/nvidia-drm_gbm.so" >/dev/null; then
+	pass "GBM backend nvidia-drm_gbm.so present"
+else
+	fail "missing /usr/lib/gbm/nvidia-drm_gbm.so — Wayland compositors cannot use the driver"
+fi
+
+echo "== initramfs policy =="
+DRACUT_CONF="${NV_ROOT}/usr/lib/dracut/dracut.conf.d/99-nvidia.conf"
+if [[ ! -f "$DRACUT_CONF" ]]; then
+	fail "missing /usr/lib/dracut/dracut.conf.d/99-nvidia.conf"
+elif grep -q 'force_drivers' "$DRACUT_CONF"; then
+	pass "dracut force_drivers set for nvidia"
+else
+	fail "99-nvidia.conf does not force_drivers — black screen at boot on nvidia desktops"
+fi
+
+echo "== initramfs present for the shipped kernel =="
+if [[ -n "$KVER" ]]; then
+	INITRAMFS="${NV_ROOT}/usr/lib/modules/${KVER}/initramfs.img"
+	if [[ -s "$INITRAMFS" ]]; then
+		pass "initramfs present for ${KVER}"
+	else
+		fail "missing or empty initramfs for the installed kernel: /usr/lib/modules/${KVER}/initramfs.img"
+	fi
+fi
+
+echo
+if [[ "$fails" -gt 0 ]]; then
+	echo "TUNAOS_NVIDIA_ARCH_CONTRACT_FAIL failures=${fails}"
+	exit 1
+fi
+echo "TUNAOS_NVIDIA_ARCH_CONTRACT_OK"

--- a/build_scripts/checks/verify-nvidia-debian.sh
+++ b/build_scripts/checks/verify-nvidia-debian.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# verify-nvidia-debian.sh — fatal build-time contract for flounder /
+# flounder-sid (Debian) *-nvidia overlay images. Sibling of verify-nvidia.sh
+# (dnf/rpm) and verify-nvidia-arch.sh (pacman) — see verify-nvidia.sh's
+# header for why this class of check exists at all (tunaOS was shipping
+# driverless "nvidia" images for months because nothing asserted a single
+# nvidia file).
+#
+# Assertion sources — measured, not guessed:
+#   /usr/lib/x86_64-linux-gnu/nvidia/current/libEGL_nvidia.so.0,
+#   libGLX_nvidia.so.0, nvidia-drm_gbm.so,
+#   /usr/share/glvnd/egl_vendor.d/10_nvidia.json,
+#   /usr/share/vulkan/icd.d/nvidia_icd.json
+# read out of the trixie non-free Contents-amd64 index
+# (ftp.debian.org/debian/dists/trixie/non-free/Contents-amd64.gz,
+# 2026-08-08) for nvidia-driver 550.163.01. Debian's driver libraries live
+# under the "current" alternatives-managed symlink at
+# /usr/lib/x86_64-linux-gnu/nvidia/current/ — a multiarch-triplet path,
+# unlike Arch's flat /usr/lib and RPM's /usr/lib64. The Vulkan ICD JSON is
+# a single fixed filename here (nvidia_icd.json), not the per-arch-suffixed
+# glob (nvidia_icd.*.json) the RPM contract uses.
+#
+# The dkms-built module's exact registered name is NOT asserted (see
+# overrides/nvidia-debian/20-nvidia.sh's header on why) — this script finds
+# the built .ko by glob under the kernel's module tree instead, matching
+# how the install script itself proves success.
+#
+# Test hooks (same pattern as TUNAOS_NVIDIA_VERIFY_ROOT in verify-nvidia.sh):
+#   TUNAOS_NVIDIA_VERIFY_ROOT  prefix for every filesystem path, so bats can
+#                              run the real logic against a fixture tree.
+#   dpkg/modinfo/dracut are resolved via PATH, so tests stub them.
+
+set -euo pipefail
+
+NV_ROOT="${TUNAOS_NVIDIA_VERIFY_ROOT:-}"
+
+fails=0
+fail() {
+	echo "  FAIL: $*" >&2
+	fails=$((fails + 1))
+}
+pass() { echo "  ok: $*"; }
+
+if ! command -v dpkg >/dev/null 2>&1; then
+	echo "ERROR: verify-nvidia-debian.sh only knows the dpkg family, and this image has" >&2
+	echo "       no dpkg. This check is dispatched from nvidia.sh based on IS_DEBIAN; if" >&2
+	echo "       that dispatch is wrong, fix nvidia.sh rather than this script." >&2
+	exit 1
+fi
+
+echo "== packages =="
+for pkg in nvidia-kernel-dkms nvidia-driver-libs nvidia-vulkan-icd nvidia-settings dkms; do
+	if v=$(dpkg-query -W -f='${Version}' "$pkg" 2>/dev/null); then
+		pass "${pkg}=${v}"
+	else
+		fail "${pkg} is not installed"
+	fi
+done
+
+echo "== kernel/module coherence =="
+# The dkms-built module must exist for the kernel this image actually ships.
+# Found by glob rather than asserting a registered dkms module name — see
+# header — the same reasoning that made verify-nvidia.sh stop name-globbing
+# on the RPM side (the wmi-ec-backlight false match, run 31196251408).
+KERNEL_TREES=()
+for _tree in "${NV_ROOT}"/usr/lib/modules/*/; do
+	[[ -d "$_tree" ]] || continue
+	_name="$(basename "$_tree")"
+	[[ "$_name" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] && KERNEL_TREES+=("$_name")
+done
+if [[ "${#KERNEL_TREES[@]}" -ne 1 ]]; then
+	fail "${#KERNEL_TREES[@]} kernel module trees under /usr/lib/modules (${KERNEL_TREES[*]:-none}) — expected exactly 1"
+	KVER=""
+else
+	KVER="${KERNEL_TREES[0]}"
+	pass "single kernel module tree (${KVER})"
+fi
+
+MODULE_FILE=""
+if [[ -n "$KVER" ]]; then
+	MODULE_FILE="$(find "${NV_ROOT}/usr/lib/modules/${KVER}" -name 'nvidia.ko*' -print -quit 2>/dev/null || true)"
+	if [[ -n "$MODULE_FILE" ]]; then
+		pass "dkms built a module for ${KVER} (${MODULE_FILE#"${NV_ROOT}"})"
+	else
+		fail "no nvidia.ko under /usr/lib/modules/${KVER} — dkms did not build for this kernel"
+	fi
+fi
+
+if [[ -n "$MODULE_FILE" ]] && command -v modinfo >/dev/null 2>&1; then
+	MODINFO_VERSION="$(modinfo -F version "$MODULE_FILE" 2>/dev/null | head -1 || true)"
+	DRIVER_VERSION="$(dpkg-query -W -f='${Version}' nvidia-driver-libs 2>/dev/null || true)"
+	if [[ -z "$MODINFO_VERSION" ]]; then
+		fail "modinfo could not read a version from ${MODULE_FILE#"${NV_ROOT}"}"
+	elif [[ -n "$DRIVER_VERSION" && "$MODINFO_VERSION" != "${DRIVER_VERSION%%-*}" ]]; then
+		fail "kmod version (${MODINFO_VERSION}) does not match nvidia-driver-libs (${DRIVER_VERSION})"
+	else
+		pass "module version matches nvidia-driver-libs (${MODINFO_VERSION})"
+	fi
+fi
+
+echo "== nouveau is out of the way =="
+if grep -rqs 'blacklist nouveau' "${NV_ROOT}/usr/lib/modprobe.d" "${NV_ROOT}/etc/modprobe.d" 2>/dev/null; then
+	pass "nouveau blacklisted in modprobe.d"
+else
+	fail "no 'blacklist nouveau' under /usr/lib/modprobe.d or /etc/modprobe.d"
+fi
+if grep -rqs 'nvidia-drm.modeset=1' "${NV_ROOT}/usr/lib/bootc/kargs.d" 2>/dev/null; then
+	pass "nvidia-drm.modeset=1 karg declared in /usr/lib/bootc/kargs.d"
+else
+	fail "nvidia-drm.modeset=1 missing from /usr/lib/bootc/kargs.d — Wayland/KMS will not engage"
+fi
+
+echo "== GL/Vulkan/Wayland plumbing =="
+# Debian's driver libraries live under the alternatives-managed "current"
+# symlink at this multiarch-triplet path — not RPM's /usr/lib64, not
+# Arch's flat /usr/lib.
+NVLIB="${NV_ROOT}/usr/lib/x86_64-linux-gnu/nvidia/current"
+if compgen -G "${NV_ROOT}/usr/share/glvnd/egl_vendor.d/10_nvidia.json" >/dev/null; then
+	pass "glvnd EGL vendor JSON present"
+else
+	fail "missing /usr/share/glvnd/egl_vendor.d/10_nvidia.json"
+fi
+if compgen -G "${NVLIB}/libEGL_nvidia.so.0" >/dev/null; then
+	pass "libEGL_nvidia.so.0 present"
+else
+	fail "missing /usr/lib/x86_64-linux-gnu/nvidia/current/libEGL_nvidia.so.0"
+fi
+if compgen -G "${NV_ROOT}/usr/share/vulkan/icd.d/nvidia_icd.json" >/dev/null; then
+	pass "Vulkan ICD JSON present"
+else
+	fail "missing /usr/share/vulkan/icd.d/nvidia_icd.json"
+fi
+if compgen -G "${NVLIB}/libGLX_nvidia.so.0" >/dev/null; then
+	pass "libGLX_nvidia.so.0 present"
+else
+	fail "missing /usr/lib/x86_64-linux-gnu/nvidia/current/libGLX_nvidia.so.0"
+fi
+if compgen -G "${NVLIB}/nvidia-drm_gbm.so" >/dev/null; then
+	pass "GBM backend nvidia-drm_gbm.so present"
+else
+	fail "missing /usr/lib/x86_64-linux-gnu/nvidia/current/nvidia-drm_gbm.so — Wayland compositors cannot use the driver"
+fi
+
+echo "== initramfs policy =="
+DRACUT_CONF="${NV_ROOT}/usr/lib/dracut/dracut.conf.d/99-nvidia.conf"
+if [[ ! -f "$DRACUT_CONF" ]]; then
+	fail "missing /usr/lib/dracut/dracut.conf.d/99-nvidia.conf"
+elif grep -q 'force_drivers' "$DRACUT_CONF"; then
+	pass "dracut force_drivers set for nvidia"
+else
+	fail "99-nvidia.conf does not force_drivers — black screen at boot on nvidia desktops"
+fi
+
+echo "== initramfs present for the shipped kernel =="
+if [[ -n "$KVER" ]]; then
+	INITRAMFS="${NV_ROOT}/usr/lib/modules/${KVER}/initramfs.img"
+	if [[ -s "$INITRAMFS" ]]; then
+		pass "initramfs present for ${KVER}"
+	else
+		fail "missing or empty initramfs for the installed kernel: /usr/lib/modules/${KVER}/initramfs.img"
+	fi
+fi
+
+echo
+if [[ "$fails" -gt 0 ]]; then
+	echo "TUNAOS_NVIDIA_DEBIAN_CONTRACT_FAIL failures=${fails}"
+	exit 1
+fi
+echo "TUNAOS_NVIDIA_DEBIAN_CONTRACT_OK"

--- a/build_scripts/overlay/nvidia.sh
+++ b/build_scripts/overlay/nvidia.sh
@@ -19,18 +19,50 @@ elif [[ "${DESKTOP_FLAVOR}" == "niri" ]]; then
 	run_buildscripts_for niri-nvidia
 fi
 
+# Generic VS Code setup hooks (system_files_overrides/nvidia) apply to every
+# family, so this stays unconditional.
 copy_systemfiles_for nvidia
-run_buildscripts_for nvidia
 
-# Independent audit of what the overlay just did. run_buildscripts_for
-# returns 0 when its overrides directory is missing — exactly how driverless
-# "*-nvidia" images shipped for months — so the contract below is a bare call
-# under `set -e`: an nvidia overlay that did not actually install the driver
-# stack fails the build here rather than publishing. Installed into the image
-# too, so desktop-contract-sweep can re-run it against published tags.
-/run/context/build_scripts/checks/verify-nvidia.sh
-install -Dm0755 /run/context/build_scripts/checks/verify-nvidia.sh \
-	/usr/libexec/tunaos/verify-nvidia
+# Package-manager dispatch (tunaOS#624): the akmods/RPM path below is the
+# original one and stays exactly as it was — marlin (Arch) and
+# flounder/flounder-sid (Debian) have no akmods bundle to consume and use
+# pacman/dkms and apt/dkms respectively instead. IS_ARCH/IS_DEBIAN/PKG_MGR
+# come from lib.sh's cached OS detection, already sourced above.
+#
+# Each branch runs its OWN install override directory (run_buildscripts_for
+# nvidia-arch / nvidia-debian / nvidia, never all three — the RPM overrides
+# call rpm/dnf directly and would fail outright on a pacman or apt base) and
+# its own fatal contract script. Every branch's contract call is a bare
+# statement under `set -e`, same as before this dispatch existed: an nvidia
+# overlay that did not actually install the driver stack fails the build
+# here rather than publishing (that silent-skip is the exact failure mode
+# verify-nvidia.sh's header documents). Each contract script is also
+# installed into the image so desktop-contract-sweep can re-run it against
+# published tags.
+if [[ "${IS_ARCH:-false}" == "true" ]]; then
+	run_buildscripts_for nvidia-arch
+	/run/context/build_scripts/checks/verify-nvidia-arch.sh
+	install -Dm0755 /run/context/build_scripts/checks/verify-nvidia-arch.sh \
+		/usr/libexec/tunaos/verify-nvidia
+elif [[ "${IS_DEBIAN:-false}" == "true" ]]; then
+	run_buildscripts_for nvidia-debian
+	/run/context/build_scripts/checks/verify-nvidia-debian.sh
+	install -Dm0755 /run/context/build_scripts/checks/verify-nvidia-debian.sh \
+		/usr/libexec/tunaos/verify-nvidia
+else
+	run_buildscripts_for nvidia
+
+	# Independent audit of what the overlay just did. run_buildscripts_for
+	# returns 0 when its overrides directory is missing — exactly how
+	# driverless "*-nvidia" images shipped for months — so the contract below
+	# is a bare call under `set -e`: an nvidia overlay that did not actually
+	# install the driver stack fails the build here rather than publishing.
+	# Installed into the image too, so desktop-contract-sweep can re-run it
+	# against published tags.
+	/run/context/build_scripts/checks/verify-nvidia.sh
+	install -Dm0755 /run/context/build_scripts/checks/verify-nvidia.sh \
+		/usr/libexec/tunaos/verify-nvidia
+fi
 
 if command -v jq >/dev/null 2>&1; then
 	jq . /usr/share/ublue-os/image-info.json || true

--- a/build_scripts/overlay/overrides/nvidia-arch/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia-arch/20-nvidia.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# 20-nvidia.sh — install the NVIDIA driver stack on a marlin (Arch) *-nvidia
+# overlay. Companion to the RPM/akmods path in overrides/nvidia/20-nvidia.sh
+# (tunaOS#624: marlin/flounder/flounder-sid had no *-nvidia flavor at all).
+#
+# WHY nvidia-open-dkms, not nvidia-open or nvidia-dkms:
+#   - nvidia-open ties the module to the EXACT `linux` package version
+#     installed at transaction time (Arch's non-dkms nvidia packages rebuild
+#     per point-release, like an akmods kmod). That is the exact-EVR problem
+#     the RPM overlay's 10-kernel-swap.sh exists to solve for akmods; dkms
+#     sidesteps it by building against whatever kernel headers are present
+#     instead of requiring a pre-built binary for one exact kernel build.
+#   - nvidia-dkms (the legacy proprietary DKMS package) does not exist in
+#     Arch's repos any more — verified via the archweb package search API
+#     (2026-08-08): only nvidia-open, nvidia-open-dkms and nvidia-open-lts
+#     are published. Pre-Turing GPUs need the AUR-only 470xx/390xx legacy
+#     branches, out of scope here.
+#   - "open" also matches this repo's existing RPM nvidia branding
+#     (ghcr.io/ublue-os/akmods-nvidia-OPEN).
+#
+# dkms builds against whatever /usr/lib/modules/<KVER>/build points at, not
+# against the container's own running kernel — Containerfile.arch installs
+# `<kernel>-headers` alongside the kernel package for exactly this, so the
+# build tree is already there when this overlay runs.
+#
+# The exact dkms module name nvidia-open-dkms registers is NOT assumed here:
+# archweb's file list for nvidia-open-dkms (2026-08-08) shows
+# /usr/src/nvidia-<pkgver>/dkms.conf, so the registered name is derived from
+# that directory rather than hardcoded — a point release could rename it
+# without warning, and asserting a name never seen resolve is exactly what
+# this repo's contract scripts avoid (see verify-nvidia.sh's header).
+
+set -xeuo pipefail
+
+source /run/context/build_scripts/lib.sh
+
+if [[ "${IS_ARCH:-false}" != "true" ]]; then
+	echo "ERROR: nvidia-arch overlay ran on a non-Arch image (IS_ARCH=${IS_ARCH:-unset})." >&2
+	exit 1
+fi
+
+KVER="$(basename "$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d ! -name '*.img' 2>/dev/null | sort -V | tail -1)")"
+if [[ -z "$KVER" ]]; then
+	echo "ERROR: no kernel module directory found under /usr/lib/modules" >&2
+	exit 1
+fi
+echo "==> target kernel: ${KVER}"
+
+# dkms needs a build tree for this exact kernel. Containerfile.arch installs
+# <kernel-pkg>-headers alongside the kernel; a missing build symlink here
+# means that pairing broke (e.g. a cachyos/-hwe parent whose headers package
+# does not match this overlay's kernel), and a dkms build would silently
+# fail into "nothing to build against" rather than producing a driverless
+# image — fail loudly instead.
+if [[ ! -e "/usr/lib/modules/${KVER}/build" ]]; then
+	echo "ERROR: /usr/lib/modules/${KVER}/build is missing — dkms has no headers to build" >&2
+	echo "       the nvidia module against. Expected the base image's <kernel>-headers" >&2
+	echo "       package (Containerfile.arch) to provide it for ${KVER}." >&2
+	exit 1
+fi
+
+pacman -Sy --noconfirm
+pacman -S --noconfirm --needed \
+	dkms \
+	nvidia-open-dkms \
+	nvidia-utils \
+	nvidia-settings \
+	egl-wayland \
+	libva-nvidia-driver
+
+echo "==> dkms status before build:"
+dkms status || true
+
+# Explicit build+install rather than trusting nvidia-open-dkms's pacman
+# hooks to fire correctly in a container build with no running system bus —
+# same reasoning as this repo's other overlays doing their own explicit
+# dracut/mkinitcpio-equivalent runs instead of relying on package scriptlets
+# (10-kernel-swap.sh, cachyos.sh, asahi.sh).
+dkms autoinstall -k "${KVER}"
+
+echo "==> dkms status after build:"
+dkms status
+
+# Prove the module actually landed for THIS kernel by finding the built
+# file, not by string-matching dkms status output (whose module name and
+# exact phrasing are not a stable contract — see header). A missing .ko
+# here is a black screen on real hardware, so this is a hard failure.
+NVIDIA_KO="$(find "/usr/lib/modules/${KVER}" -name 'nvidia.ko*' -print -quit)"
+if [[ -z "$NVIDIA_KO" ]]; then
+	echo "ERROR: dkms did not produce nvidia.ko for ${KVER} — dkms status above shows why." >&2
+	exit 1
+fi
+echo "==> built module: ${NVIDIA_KO}"
+if command -v modinfo >/dev/null 2>&1; then
+	modinfo "$NVIDIA_KO" | grep -E '^(version|vermagic):' || true
+fi
+
+tee /usr/lib/modprobe.d/00-nouveau-blacklist.conf <<'EOF'
+blacklist nouveau
+options nouveau modeset=0
+EOF
+
+install -d /usr/lib/bootc/kargs.d
+tee /usr/lib/bootc/kargs.d/00-nvidia.toml <<'EOF'
+kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-drm.modeset=1"]
+EOF
+
+# Force the driver into the initramfs. Every TunaOS bootc variant builds its
+# initramfs with dracut, marlin included (Containerfile.arch's own dracut
+# step) — nvidia-open-dkms ships no dracut integration of its own (it is
+# Arch; mkinitcpio is the distro default, but this image never uses it), so
+# this file has to be written directly, same as the RPM overlay's approach
+# after its sed rewrite of the negativo17-shipped 99-nvidia.conf. i915/amdgpu
+# are preloaded first so Chromium's hardware acceleration still finds an
+# iGPU on hybrid-graphics laptops (same ordering as
+# overrides/nvidia/20-nvidia.sh).
+install -d /usr/lib/dracut/dracut.conf.d
+tee /usr/lib/dracut/dracut.conf.d/99-nvidia.conf <<'EOF'
+force_drivers+=" i915 amdgpu nvidia nvidia_modeset nvidia_uvm nvidia_drm "
+EOF
+
+# --tmpdir /boot: dracut defaults to /var/tmp, which is not guaranteed to
+# exist when this runs outside the base image's own build (99-cleanup.sh's
+# header documents the same landmine for the live-ISO rebuild path). /boot
+# is always present in this stage. Positional path+kver invocation matches
+# Containerfile.debian's own overlay-adjacent dracut call; compression and
+# the bootc/composefs module set come from the persisted
+# dracut.conf.d/30-bootc-container-build.conf the base image already wrote.
+dracut --force --no-hostonly --reproducible --tmpdir /boot \
+	"/usr/lib/modules/${KVER}/initramfs.img" "${KVER}"
+
+pacman -Scc --noconfirm || true

--- a/build_scripts/overlay/overrides/nvidia-debian/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia-debian/20-nvidia.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# 20-nvidia.sh — install the NVIDIA driver stack on a flounder/flounder-sid
+# (Debian) *-nvidia overlay. Companion to the RPM/akmods path in
+# overrides/nvidia/20-nvidia.sh and the Arch path in
+# overrides/nvidia-arch/20-nvidia.sh (tunaOS#624).
+#
+# Package source: the OFFICIAL Debian archive, non-free component — NOT a
+# third-party repo (unlike overlay/asahi.sh's debian branch, which needs the
+# Bananas team's side archive for a kernel Debian does not ship). Verified
+# against the live archive via madison (2026-08-08):
+#   nvidia-driver 550.163.01-2   in stable/non-free   (flounder  = trixie)
+#   nvidia-driver 550.163.01-5.1 in unstable/non-free (flounder-sid = sid)
+# nvidia-kernel-dkms, nvidia-driver-libs, nvidia-vulkan-icd and dkms itself
+# are all in the same archive, so nothing here needs a new signing key or
+# sources file — only enabling components already-present sources.list(.d)
+# entries don't turn on by default.
+#
+# dkms builds against whatever kernel headers are present, not the
+# container's own running kernel: Containerfile.debian's linux-image-generic
+# is a virtual package resolving to linux-image-amd64 (verified via
+# packages.debian.org, 2026-08-08), and linux-headers-generic resolves to
+# the matching linux-headers-amd64 the SAME way — both are kept in lockstep
+# by the linux source package, so installing them together always pairs a
+# kernel with its own headers, no exact-EVR juggling required.
+#
+# The exact dkms module name nvidia-kernel-dkms registers is NOT assumed:
+# the Debian Contents index (2026-08-08) shows
+# /usr/src/nvidia-current-<version>/Kbuild, so the registered name is
+# derived from that directory rather than hardcoded — see the module-name
+# note in overrides/nvidia-arch/20-nvidia.sh for why.
+
+set -xeuo pipefail
+
+source /run/context/build_scripts/lib.sh
+
+if [[ "${IS_DEBIAN:-false}" != "true" ]]; then
+	echo "ERROR: nvidia-debian overlay ran on a non-Debian image (IS_DEBIAN=${IS_DEBIAN:-unset})." >&2
+	exit 1
+fi
+
+KVER="$(basename "$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d ! -name '*.img' 2>/dev/null | sort -V | tail -1)")"
+if [[ -z "$KVER" ]]; then
+	echo "ERROR: no kernel module directory found under /usr/lib/modules" >&2
+	exit 1
+fi
+echo "==> target kernel: ${KVER}"
+
+# Enable contrib/non-free/non-free-firmware on whatever debian.org source
+# file(s) the base image ships, without assuming a filename: Debian's
+# official Docker images have used the deb822 debian.sources format since
+# bookworm, but probing rather than hardcoding the path survives that
+# changing again the way it already has once. A legacy one-line
+# /etc/apt/sources.list, if present instead, is handled the same way.
+_found_components=0
+for f in /etc/apt/sources.list.d/*.sources; do
+	[[ -f "$f" ]] || continue
+	if grep -qE '^Components:' "$f"; then
+		sed -i -E 's/^(Components:.*)$/\1 contrib non-free non-free-firmware/' "$f"
+		_found_components=1
+	fi
+done
+if [[ -f /etc/apt/sources.list ]] && grep -qE '^deb ' /etc/apt/sources.list; then
+	sed -i -E '/^deb .*/{/non-free-firmware/!s/$/ contrib non-free non-free-firmware/}' /etc/apt/sources.list
+	_found_components=1
+fi
+if [[ "$_found_components" -eq 0 ]]; then
+	echo "ERROR: found no /etc/apt/sources.list(.d) entry to add contrib/non-free/non-free-firmware to." >&2
+	echo "       nvidia-driver ships in Debian's non-free component; without it enabled the" >&2
+	echo "       install below cannot resolve any nvidia package at all." >&2
+	exit 1
+fi
+echo "==> apt sources after enabling components:"
+cat /etc/apt/sources.list.d/*.sources /etc/apt/sources.list 2>/dev/null || true
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+
+# linux-headers-generic is a virtual package resolving to the arch-specific
+# real one (linux-headers-amd64 here) — see header. dkms needs it present
+# under /usr/lib/modules/${KVER}/build before autoinstall below has
+# anything to build against.
+apt-get install -y --no-install-recommends \
+	dkms \
+	linux-headers-generic \
+	nvidia-kernel-dkms \
+	nvidia-driver-libs \
+	nvidia-vulkan-icd \
+	nvidia-settings \
+	libgl1-nvidia-glvnd-glx
+
+if [[ ! -e "/usr/lib/modules/${KVER}/build" ]]; then
+	echo "ERROR: /usr/lib/modules/${KVER}/build is missing after installing linux-headers-generic —" >&2
+	echo "       dkms has no headers to build the nvidia module against for ${KVER}." >&2
+	exit 1
+fi
+
+echo "==> dkms status before build:"
+dkms status || true
+
+# Explicit build+install rather than trusting apt/dkms triggers to fire
+# correctly in a container build with no running system bus — same
+# reasoning as the RPM and Arch overlays' explicit dracut/dkms runs instead
+# of relying on package postinst scriptlets.
+dkms autoinstall -k "${KVER}"
+
+echo "==> dkms status after build:"
+dkms status
+
+# Prove the module actually landed for THIS kernel by finding the built
+# file, not by string-matching dkms status output (whose module name and
+# phrasing are not a stable contract — see header). A missing .ko here is a
+# black screen on real hardware, so this is a hard failure.
+NVIDIA_KO="$(find "/usr/lib/modules/${KVER}" -name 'nvidia.ko*' -print -quit)"
+if [[ -z "$NVIDIA_KO" ]]; then
+	echo "ERROR: dkms did not produce nvidia.ko for ${KVER} — dkms status above shows why." >&2
+	exit 1
+fi
+echo "==> built module: ${NVIDIA_KO}"
+if command -v modinfo >/dev/null 2>&1; then
+	modinfo "$NVIDIA_KO" | grep -E '^(version|vermagic):' || true
+fi
+
+# Written directly rather than relying on nvidia-kernel-support's
+# alternatives-managed /etc/nvidia/current/nvidia-blacklists-nouveau.conf:
+# that file's presence at /etc/modprobe.d is contingent on the alternatives
+# symlink the package sets up, one more moving part this overlay does not
+# need. Same approach as the RPM and Arch overlays.
+tee /usr/lib/modprobe.d/00-nouveau-blacklist.conf <<'EOF'
+blacklist nouveau
+options nouveau modeset=0
+EOF
+
+install -d /usr/lib/bootc/kargs.d
+tee /usr/lib/bootc/kargs.d/00-nvidia.toml <<'EOF'
+kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-drm.modeset=1"]
+EOF
+
+# Force the driver into the initramfs. Debian's nvidia packaging assumes
+# initramfs-tools (update-initramfs), never dracut — every TunaOS bootc
+# variant, flounder/flounder-sid included, builds its initramfs with dracut
+# instead (Containerfile.debian's own dracut step), so this file has to be
+# written directly rather than adjusted from a package-shipped one, same as
+# the Arch overlay. i915/amdgpu are preloaded first so Chromium's hardware
+# acceleration still finds an iGPU on hybrid-graphics laptops (same ordering
+# as overrides/nvidia/20-nvidia.sh).
+install -d /usr/lib/dracut/dracut.conf.d
+tee /usr/lib/dracut/dracut.conf.d/99-nvidia.conf <<'EOF'
+force_drivers+=" i915 amdgpu nvidia nvidia_modeset nvidia_uvm nvidia_drm "
+EOF
+
+# --tmpdir /boot: dracut defaults to /var/tmp, not guaranteed to exist
+# outside the base image's own build (99-cleanup.sh's header documents the
+# same landmine for the live-ISO rebuild path). /boot is always present in
+# this stage. Positional path+kver invocation matches Containerfile.debian's
+# own dracut call; compression and the bootc/composefs module set come from
+# the persisted dracut.conf.d/30-bootc-container-build.conf the base image
+# already wrote.
+dracut --force --no-hostonly --reproducible --tmpdir /boot \
+	"/usr/lib/modules/${KVER}/initramfs.img" "${KVER}"
+
+apt-get clean -y
+rm -rf /var/lib/apt/lists/*

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -42,12 +42,33 @@ OVERLAY_SH="${REPO_ROOT}/build_scripts/overlay/nvidia.sh"
 @test "overlay nvidia.sh runs the overrides and then the fatal contract" {
   run grep -F 'run_buildscripts_for nvidia' "$OVERLAY_SH"
   [ "$status" -eq 0 ]
-  # Bare call (no `|| true`, no `-`): under set -e a failed contract fails
-  # the build.
-  run grep -E '^/run/context/build_scripts/checks/verify-nvidia\.sh$' "$OVERLAY_SH"
+  # Bare call (no `|| true`, no `-`, only leading whitespace allowed): under
+  # set -e a failed contract fails the build. tunaOS#624 split this into a
+  # per-family dispatch (rpm/pacman/apt), so each family's own contract
+  # script must appear this way, not just the rpm one.
+  run grep -E '^[[:space:]]*/run/context/build_scripts/checks/verify-nvidia\.sh$' "$OVERLAY_SH"
   [ "$status" -eq 0 ]
-  # And the auditor ships in the image for the published-image sweep.
-  run grep -F '/usr/libexec/tunaos/verify-nvidia' "$OVERLAY_SH"
+  run grep -E '^[[:space:]]*/run/context/build_scripts/checks/verify-nvidia-arch\.sh$' "$OVERLAY_SH"
+  [ "$status" -eq 0 ]
+  run grep -E '^[[:space:]]*/run/context/build_scripts/checks/verify-nvidia-debian\.sh$' "$OVERLAY_SH"
+  [ "$status" -eq 0 ]
+  # And each auditor ships in the image for the published-image sweep.
+  run grep -c -F '/usr/libexec/tunaos/verify-nvidia' "$OVERLAY_SH"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 3 ]
+}
+
+@test "overlay nvidia.sh dispatches by package family, never runs two families' overrides" {
+  # Each branch must call exactly one of nvidia / nvidia-arch / nvidia-debian
+  # overrides — running the rpm overrides on a pacman or apt base would fail
+  # outright (they invoke rpm/dnf directly), not silently no-op.
+  run grep -F 'IS_ARCH' "$OVERLAY_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'IS_DEBIAN' "$OVERLAY_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'run_buildscripts_for nvidia-arch' "$OVERLAY_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'run_buildscripts_for nvidia-debian' "$OVERLAY_SH"
   [ "$status" -eq 0 ]
 }
 

--- a/tests/bats/test_nvidia_overlay_arch_debian.bats
+++ b/tests/bats/test_nvidia_overlay_arch_debian.bats
@@ -1,0 +1,367 @@
+#!/usr/bin/env bats
+# tunaOS#624 — marlin (Arch) and flounder/flounder-sid (Debian) had no
+# *-nvidia flavor at all: Containerfile.overlay's nvidia path only ever
+# consumed akmods RPMs. This pins the two new package-family overlays the
+# same way test_nvidia_overlay.bats pins the rpm/akmods one: a missing or
+# mis-named overrides directory must be a TEST failure, never a silent
+# run_buildscripts_for no-op (the exact failure mode that shipped
+# driverless "*-nvidia" images on the rpm family for months).
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+ARCH_DIR="${REPO_ROOT}/build_scripts/overlay/overrides/nvidia-arch"
+DEBIAN_DIR="${REPO_ROOT}/build_scripts/overlay/overrides/nvidia-debian"
+ARCH_INSTALL_SH="${ARCH_DIR}/20-nvidia.sh"
+DEBIAN_INSTALL_SH="${DEBIAN_DIR}/20-nvidia.sh"
+VERIFY_ARCH_SH="${REPO_ROOT}/build_scripts/checks/verify-nvidia-arch.sh"
+VERIFY_DEBIAN_SH="${REPO_ROOT}/build_scripts/checks/verify-nvidia-debian.sh"
+
+# ── wiring: the silent-skip hole stays closed for both new families ───────
+
+@test "nvidia-arch overrides directory exists and contains an executable matching run_buildscripts_for's pattern" {
+  [ -d "$ARCH_DIR" ]
+  local found=0 f
+  for f in "$ARCH_DIR"/*-*.sh; do
+    [ -f "$f" ] || continue
+    [ -x "$f" ] || { echo "not executable: $f" >&2; continue; }
+    found=1
+  done
+  [ "$found" -eq 1 ]
+}
+
+@test "nvidia-debian overrides directory exists and contains an executable matching run_buildscripts_for's pattern" {
+  [ -d "$DEBIAN_DIR" ]
+  local found=0 f
+  for f in "$DEBIAN_DIR"/*-*.sh; do
+    [ -f "$f" ] || continue
+    [ -x "$f" ] || { echo "not executable: $f" >&2; continue; }
+    found=1
+  done
+  [ "$found" -eq 1 ]
+}
+
+@test "verify-nvidia-arch.sh and verify-nvidia-debian.sh are executable" {
+  [ -x "$VERIFY_ARCH_SH" ]
+  [ -x "$VERIFY_DEBIAN_SH" ]
+}
+
+# ── install layer: the load-bearing lines of each 20-nvidia.sh ────────────
+
+@test "nvidia-arch 20-nvidia.sh installs nvidia-open-dkms via pacman, not nvidia-open or nvidia-dkms" {
+  run grep -F 'nvidia-open-dkms' "$ARCH_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  # nvidia-dkms no longer exists in Arch's repos (verified 2026-08-08) — a
+  # regression toward it would silently break every marlin nvidia build.
+  run grep -E '^\s*nvidia-dkms\s*\\?\s*$' "$ARCH_INSTALL_SH"
+  [ "$status" -ne 0 ]
+}
+
+@test "nvidia-arch 20-nvidia.sh guards on IS_ARCH and asserts the dkms build tree before building" {
+  run grep -F 'IS_ARCH' "$ARCH_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F '/build' "$ARCH_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'dkms autoinstall' "$ARCH_INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "nvidia-arch 20-nvidia.sh proves the module by finding nvidia.ko, not by trusting dkms status text" {
+  run grep -F "find \"/usr/lib/modules/\${KVER}\" -name 'nvidia.ko*'" "$ARCH_INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "nvidia-arch 20-nvidia.sh blacklists nouveau and sets the modeset karg" {
+  run grep -F 'blacklist nouveau' "$ARCH_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'nvidia-drm.modeset=1' "$ARCH_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F '/usr/lib/bootc/kargs.d/00-nvidia.toml' "$ARCH_INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "nvidia-arch 20-nvidia.sh rebuilds the initramfs with dracut" {
+  # This image never invokes mkinitcpio (the Arch default) — the file's own
+  # comments say so, but the invariant that matters is that dracut actually
+  # runs and force_drivers is actually set.
+  run grep -E '^\s*dracut --force' "$ARCH_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'force_drivers' "$ARCH_INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "nvidia-debian 20-nvidia.sh enables contrib/non-free/non-free-firmware before installing" {
+  run grep -F 'non-free-firmware' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  # The component-enable step must run before apt-get update, which must run
+  # before the driver install.
+  local comp_line update_line install_line
+  comp_line="$(grep -n 'non-free-firmware' "$DEBIAN_INSTALL_SH" | tail -1 | cut -d: -f1)"
+  update_line="$(grep -n '^apt-get update' "$DEBIAN_INSTALL_SH" | head -1 | cut -d: -f1)"
+  # The package-list line, not the header comment mentioning the same name.
+  install_line="$(grep -n '^\s*nvidia-kernel-dkms \\$' "$DEBIAN_INSTALL_SH" | head -1 | cut -d: -f1)"
+  [ -n "$comp_line" ] && [ -n "$update_line" ] && [ -n "$install_line" ]
+  [ "$comp_line" -lt "$update_line" ]
+  [ "$update_line" -lt "$install_line" ]
+}
+
+@test "nvidia-debian 20-nvidia.sh fails loudly when no apt source file has a Components: line" {
+  run grep -F 'found no /etc/apt/sources.list' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -A4 -F 'if [[ "$_found_components" -eq 0 ]]; then' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"exit 1"* ]]
+}
+
+@test "nvidia-debian 20-nvidia.sh guards on IS_DEBIAN and asserts the dkms build tree before building" {
+  run grep -F 'IS_DEBIAN' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'linux-headers-generic' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'dkms autoinstall' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "nvidia-debian 20-nvidia.sh proves the module by finding nvidia.ko, not by trusting dkms status text" {
+  run grep -F "find \"/usr/lib/modules/\${KVER}\" -name 'nvidia.ko*'" "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "nvidia-debian 20-nvidia.sh blacklists nouveau and sets the modeset karg" {
+  run grep -F 'blacklist nouveau' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'nvidia-drm.modeset=1' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F '/usr/lib/bootc/kargs.d/00-nvidia.toml' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "nvidia-debian 20-nvidia.sh rebuilds the initramfs with dracut" {
+  # This image never invokes update-initramfs (the Debian default) — the
+  # file's own comments say so, but the invariant that matters is that
+  # dracut actually runs and force_drivers is actually set.
+  run grep -E '^\s*dracut --force' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'force_drivers' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+# ── contract: verify-nvidia-arch.sh / verify-nvidia-debian.sh behavioral ──
+#
+# Same pattern as verify-nvidia.sh's own tests: TUNAOS_NVIDIA_VERIFY_ROOT
+# points the real script at a fixture tree, with pacman/dpkg-query/modinfo
+# stubbed on PATH.
+
+KVER="7.1.6-arch1-1"
+
+make_good_arch_root() {
+  local r="${BATS_TEST_TMPDIR}/arch-root"
+  mkdir -p \
+    "$r/usr/lib/modules/${KVER}" \
+    "$r/usr/lib/modprobe.d" \
+    "$r/usr/lib/bootc/kargs.d" \
+    "$r/usr/share/glvnd/egl_vendor.d" \
+    "$r/usr/share/vulkan/icd.d" \
+    "$r/usr/lib/gbm" \
+    "$r/usr/lib/dracut/dracut.conf.d"
+  touch "$r/usr/lib/modules/${KVER}/nvidia.ko.zst"
+  echo initrd >"$r/usr/lib/modules/${KVER}/initramfs.img"
+  echo "blacklist nouveau" >"$r/usr/lib/modprobe.d/00-nouveau-blacklist.conf"
+  echo 'kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-drm.modeset=1"]' \
+    >"$r/usr/lib/bootc/kargs.d/00-nvidia.toml"
+  echo '{}' >"$r/usr/share/glvnd/egl_vendor.d/10_nvidia.json"
+  echo '{}' >"$r/usr/share/vulkan/icd.d/nvidia_icd.json"
+  touch "$r/usr/lib/libEGL_nvidia.so.0" "$r/usr/lib/libGLX_nvidia.so.0"
+  touch "$r/usr/lib/gbm/nvidia-drm_gbm.so"
+  echo 'force_drivers+=" i915 amdgpu nvidia nvidia_modeset nvidia_uvm nvidia_drm "' \
+    >"$r/usr/lib/dracut/dracut.conf.d/99-nvidia.conf"
+  echo "$r"
+}
+
+make_arch_stub_tools() {
+  mkdir -p "${BATS_TEST_TMPDIR}/bin"
+  cat >"${BATS_TEST_TMPDIR}/bin/pacman" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "-Q" ]]; then
+  case "$*" in
+    *nvidia-open-dkms*|*nvidia-utils*|*nvidia-settings*|*dkms*|*egl-wayland*)
+      echo "Version        : 610.57.04-1" ;;
+    *) exit 1 ;;
+  esac
+fi
+STUB
+  cat >"${BATS_TEST_TMPDIR}/bin/modinfo" <<'STUB'
+#!/usr/bin/env bash
+echo "610.57.04"
+STUB
+  chmod +x "${BATS_TEST_TMPDIR}/bin/"*
+}
+
+run_verify_arch() {
+  PATH="${BATS_TEST_TMPDIR}/bin:$PATH" \
+    TUNAOS_NVIDIA_VERIFY_ROOT="$1" \
+    run bash "$VERIFY_ARCH_SH"
+}
+
+@test "verify-nvidia-arch passes on a complete driver install" {
+  make_arch_stub_tools
+  root="$(make_good_arch_root)"
+  run_verify_arch "$root"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TUNAOS_NVIDIA_ARCH_CONTRACT_OK"* ]]
+}
+
+@test "verify-nvidia-arch refuses to run without pacman on PATH" {
+  root="$(make_good_arch_root)"
+  # Empty PATH, script invoked by absolute interpreter path so bash itself
+  # doesn't need a PATH lookup — pacman must be absent here regardless of
+  # what the CI/dev host happens to have installed.
+  local bash_bin
+  bash_bin="$(command -v bash)"
+  PATH="" TUNAOS_NVIDIA_VERIFY_ROOT="$root" run "$bash_bin" "$VERIFY_ARCH_SH"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"only knows the pacman family"* ]]
+}
+
+@test "verify-nvidia-arch fails when the dkms module is missing" {
+  make_arch_stub_tools
+  root="$(make_good_arch_root)"
+  rm "$root/usr/lib/modules/${KVER}/nvidia.ko.zst"
+  run_verify_arch "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"TUNAOS_NVIDIA_ARCH_CONTRACT_FAIL"* ]]
+  [[ "$output" == *"dkms did not build for this kernel"* ]]
+}
+
+@test "verify-nvidia-arch fails when the Wayland GBM backend is missing" {
+  make_arch_stub_tools
+  root="$(make_good_arch_root)"
+  rm "$root/usr/lib/gbm/nvidia-drm_gbm.so"
+  run_verify_arch "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"nvidia-drm_gbm.so"* ]]
+}
+
+@test "verify-nvidia-arch fails when the modeset karg is absent" {
+  make_arch_stub_tools
+  root="$(make_good_arch_root)"
+  echo 'kargs = ["rd.driver.blacklist=nouveau"]' >"$root/usr/lib/bootc/kargs.d/00-nvidia.toml"
+  run_verify_arch "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"nvidia-drm.modeset=1"* ]]
+}
+
+@test "verify-nvidia-arch fails when dracut force_drivers is missing" {
+  make_arch_stub_tools
+  root="$(make_good_arch_root)"
+  rm "$root/usr/lib/dracut/dracut.conf.d/99-nvidia.conf"
+  run_verify_arch "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"99-nvidia.conf"* ]]
+}
+
+make_good_debian_root() {
+  local r="${BATS_TEST_TMPDIR}/debian-root"
+  local nvlib="$r/usr/lib/x86_64-linux-gnu/nvidia/current"
+  mkdir -p \
+    "$r/usr/lib/modules/${KVER}" \
+    "$r/usr/lib/modprobe.d" \
+    "$r/usr/lib/bootc/kargs.d" \
+    "$r/usr/share/glvnd/egl_vendor.d" \
+    "$r/usr/share/vulkan/icd.d" \
+    "$r/usr/lib/dracut/dracut.conf.d" \
+    "$nvlib"
+  touch "$r/usr/lib/modules/${KVER}/nvidia.ko.zst"
+  echo initrd >"$r/usr/lib/modules/${KVER}/initramfs.img"
+  echo "blacklist nouveau" >"$r/usr/lib/modprobe.d/00-nouveau-blacklist.conf"
+  echo 'kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-drm.modeset=1"]' \
+    >"$r/usr/lib/bootc/kargs.d/00-nvidia.toml"
+  echo '{}' >"$r/usr/share/glvnd/egl_vendor.d/10_nvidia.json"
+  echo '{}' >"$r/usr/share/vulkan/icd.d/nvidia_icd.json"
+  touch "$nvlib/libEGL_nvidia.so.0" "$nvlib/libGLX_nvidia.so.0" "$nvlib/nvidia-drm_gbm.so"
+  echo 'force_drivers+=" i915 amdgpu nvidia nvidia_modeset nvidia_uvm nvidia_drm "' \
+    >"$r/usr/lib/dracut/dracut.conf.d/99-nvidia.conf"
+  echo "$r"
+}
+
+make_debian_stub_tools() {
+  mkdir -p "${BATS_TEST_TMPDIR}/bin"
+  cat >"${BATS_TEST_TMPDIR}/bin/dpkg" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  cat >"${BATS_TEST_TMPDIR}/bin/dpkg-query" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *nvidia-kernel-dkms*|*nvidia-driver-libs*|*nvidia-vulkan-icd*|*nvidia-settings*|*" dkms"*)
+    printf '550.163.01-2' ;;
+  *) exit 1 ;;
+esac
+STUB
+  cat >"${BATS_TEST_TMPDIR}/bin/modinfo" <<'STUB'
+#!/usr/bin/env bash
+echo "550.163.01"
+STUB
+  chmod +x "${BATS_TEST_TMPDIR}/bin/"*
+}
+
+run_verify_debian() {
+  PATH="${BATS_TEST_TMPDIR}/bin:$PATH" \
+    TUNAOS_NVIDIA_VERIFY_ROOT="$1" \
+    run bash "$VERIFY_DEBIAN_SH"
+}
+
+@test "verify-nvidia-debian passes on a complete driver install" {
+  make_debian_stub_tools
+  root="$(make_good_debian_root)"
+  run_verify_debian "$root"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TUNAOS_NVIDIA_DEBIAN_CONTRACT_OK"* ]]
+}
+
+@test "verify-nvidia-debian refuses to run without dpkg on PATH" {
+  root="$(make_good_debian_root)"
+  # Empty PATH, script invoked by absolute interpreter path so bash itself
+  # doesn't need a PATH lookup — dpkg must be absent here regardless of
+  # whether the CI/dev host is itself Debian-based (this sandbox is).
+  local bash_bin
+  bash_bin="$(command -v bash)"
+  PATH="" TUNAOS_NVIDIA_VERIFY_ROOT="$root" run "$bash_bin" "$VERIFY_DEBIAN_SH"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"only knows the dpkg family"* ]]
+}
+
+@test "verify-nvidia-debian fails when the dkms module is missing" {
+  make_debian_stub_tools
+  root="$(make_good_debian_root)"
+  rm "$root/usr/lib/modules/${KVER}/nvidia.ko.zst"
+  run_verify_debian "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"TUNAOS_NVIDIA_DEBIAN_CONTRACT_FAIL"* ]]
+  [[ "$output" == *"dkms did not build for this kernel"* ]]
+}
+
+@test "verify-nvidia-debian fails when the Wayland GBM backend is missing" {
+  make_debian_stub_tools
+  root="$(make_good_debian_root)"
+  rm "$root/usr/lib/x86_64-linux-gnu/nvidia/current/nvidia-drm_gbm.so"
+  run_verify_debian "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"nvidia-drm_gbm.so"* ]]
+}
+
+@test "verify-nvidia-debian fails when the modeset karg is absent" {
+  make_debian_stub_tools
+  root="$(make_good_debian_root)"
+  echo 'kargs = ["rd.driver.blacklist=nouveau"]' >"$root/usr/lib/bootc/kargs.d/00-nvidia.toml"
+  run_verify_debian "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"nvidia-drm.modeset=1"* ]]
+}
+
+@test "verify-nvidia-debian fails when a stale second kernel tree survives" {
+  make_debian_stub_tools
+  root="$(make_good_debian_root)"
+  mkdir -p "$root/usr/lib/modules/6.12.41-amd64"
+  run_verify_debian "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"kernel module trees under /usr/lib/modules"* ]]
+}


### PR DESCRIPTION
Closes #624.

## What

Adds `*-nvidia` image flavors for **marlin** (Arch), **flounder** (Debian trixie), and **flounder-sid** (Debian sid) — the three variants that had none, since `Containerfile.overlay`'s nvidia path only ever consumed akmods RPMs (the EL10 family's mechanism).

## Package source & driver choice (verified against the live archives, not guessed)

- **Arch (marlin):** `nvidia-open-dkms` via pacman + `dkms`. `nvidia-dkms` (the legacy proprietary DKMS package) no longer exists in Arch's repos — checked via the archweb search API; only `nvidia-open`, `nvidia-open-dkms`, `nvidia-open-lts` are published. `nvidia-open-dkms` (not plain `nvidia-open`) avoids the exact-kernel-EVR problem `10-kernel-swap.sh` exists to solve on the RPM side — dkms builds against whatever `linux-headers` is present instead of requiring a package built for one exact kernel.
- **Debian (flounder/flounder-sid):** `nvidia-driver` stack via apt. This ships in the **official** Debian archive's `non-free` component for both trixie and sid (confirmed via `madison` and the `Contents-amd64` index) — so this only enables `contrib non-free non-free-firmware` on the existing `debian.org` sources, no third-party repo or new signing key needed.

Neither package family ships dracut integration (Arch defaults to mkinitcpio, Debian to initramfs-tools), so both overlays write `nouveau` blacklist, bootc kargs, and `dracut.conf.d/99-nvidia.conf` `force_drivers` directly — every TunaOS variant, these included, actually builds its initramfs with dracut.

## Safety contract

Both new install scripts (`build_scripts/overlay/overrides/nvidia-arch/20-nvidia.sh`, `nvidia-debian/20-nvidia.sh`):
- fail loudly when their distro guard, apt component enablement, or the dkms build tree (`/usr/lib/modules/<kver>/build`) are missing
- build explicitly via `dkms autoinstall`, then prove success by **finding the built `.ko`**, not by parsing `dkms status` text — the dkms module name each package registers (`nvidia` on Arch, `nvidia-current` on Debian, both read out of their real `/usr/src/...` paths) isn't a stable contract across point releases, so it's never hardcoded

New build-time contracts `build_scripts/checks/verify-nvidia-arch.sh` and `verify-nvidia-debian.sh` mirror the existing `verify-nvidia.sh`'s rigor for the RPM family (dispatched from `nvidia.sh` via `IS_ARCH`/`IS_DEBIAN`): they check real driver files on disk, not install-script exit codes. GL/EGL/Vulkan asset paths for each were read out of the **live Arch package file list** and the **live Debian Contents index** rather than assumed — Arch's `/usr/lib` has no lib64/multiarch split; Debian's driver libs live under `/usr/lib/x86_64-linux-gnu/nvidia/current/`.

## build-config.yml

Stage-3 `gnome-nvidia`/`kde-nvidia`/(+`cosmic-nvidia`/`niri-nvidia`/`xfce-nvidia` on marlin) added for all three variants, `platforms: ["linux/amd64"]` pinned explicitly on every one (an existing bats test asserts this). No `*-nvidia-hwe`: none of these three variants has an HWE kernel layer to begin with (Arch/Debian each ship one current kernel per suite), so there's nothing for an nvidia overlay to stack on top of — matches the issue's own "Blockers" note.

## Test plan

- [x] `bash -n` on all new/modified scripts
- [x] `shellcheck --exclude=SC1091,SC2114` (same excludes as `just lint`) — clean
- [x] YAML validated with js-yaml (pyyaml unavailable in this sandbox); confirmed every new `*-nvidia` flavor's underlying desktop (`gnome`/`kde`/`cosmic`/`niri`/`xfce`) is already declared for its variant, so `test_declared_flavors_installable.bats` shouldn't regress
- [x] `tests/bats/test_nvidia_overlay.bats` (existing RPM suite, updated for the new per-family dispatch) — 32/32 pass
- [x] `tests/bats/test_resolve_flavor.bats` — 18/18 pass, unmodified (its existing `*-nvidia` routing is already variant-agnostic)
- [x] New `tests/bats/test_nvidia_overlay_arch_debian.bats` — 26/26 pass (wiring + fixture-driven behavioral tests for both new verify scripts)
- [ ] Real image build/boot on Arch and Debian NVIDIA hardware — I don't have build-farm or hardware access from here; this is source-verified and unit-tested, not build-verified. Please run the actual matrix build before merging.

🐝 Hive Agent: `contributor`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->