### PR TITLE
fix(boot-gate): increase default GATE_TIMEOUT to 1800s for slower DE boots

### DIFF
--- a/scripts/boot-gate.sh
+++ b/scripts/boot-gate.sh
@@ -25,7 +25,7 @@ ORG="${REPO_ORGANIZATION:-tuna-os}"
 IMG="ghcr.io/${ORG}/${VARIANT}:${TAG}"
 NAME="${GATE_NAME:-gate-${VARIANT}-${FLAVOR}-$(date +%H%M%S)}"
 DISK="${GATE_DISK:-32Gi}"
-TIMEOUT="${GATE_TIMEOUT:-1200}"
+TIMEOUT="${GATE_TIMEOUT:-1800}"
 
 command -v corral >/dev/null || {
 	echo "corral not installed: cd ../corral && just install" >&2


### PR DESCRIPTION
Closes #626

### Summary

Heavy desktop environments like COSMIC running without GPU acceleration on virtual hardware can take longer than 1200s to complete boot activation and bring up SSH services during `boot-gate.sh`.

This PR increases the default `GATE_TIMEOUT` in `scripts/boot-gate.sh` from 1200s to 1800s (30 minutes), giving gate VMs sufficient headroom to boot and activate SSH before timing out.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `5e585555`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->