### PR TITLE
fix(boot-gate): resume the corral build when virt-launcher eats the marker (#627)

### DIFF
--- a/scripts/boot-gate.sh
+++ b/scripts/boot-gate.sh
@@ -51,7 +51,36 @@ cleanup() { corral delete "$NAME" -f >/dev/null 2>&1 || true; }
 trap cleanup EXIT
 
 echo "==> boot-gate ${IMG}  (vm=${NAME}${CORRAL_NODE:+ node=$CORRAL_NODE})"
-corral create "$NAME" --bootc "$IMG" --disk "$DISK" --wait-ssh --timeout "$TIMEOUT" "${NODE_ARGS[@]}"
+if ! corral create "$NAME" --bootc "$IMG" --disk "$DISK" --wait-ssh --timeout "$TIMEOUT" "${NODE_ARGS[@]}"; then
+	# tuna-os/tunaOS#627: KubeVirt virt-launcher teardown can destroy the
+	# builder's serial log before corral reads the build-success marker, so a
+	# build that actually finished reports "builder VM ended (Succeeded)
+	# without a build marker" (the disk-size fallback has the same race via a
+	# separate size-check pod). The disk PVC is valid — resume the build from
+	# the completed disk instead of failing the gate. --resume errors cleanly
+	# when there is genuinely nothing to resume (no completed builder + disk
+	# PVC), so attempting it on any bootc-build failure is safe.
+	echo "==> corral build failed; attempting --resume from the completed disk (#627)"
+	if ! corral bootc create "$NAME" --image "$IMG" --resume "${NODE_ARGS[@]}"; then
+		echo "FAIL: bootc build failed and no resumable build was found" >&2
+		exit 1
+	fi
+	corral start "$NAME"
+	# --resume finishes the VM but does not start it or wait for SSH;
+	# replicate the --wait-ssh loop from the main CLI.
+	ssh_ok=0
+	for _ in $(seq 1 $((TIMEOUT / 10))); do
+		if corral ssh "$NAME" -u root -c true 2>/dev/null; then
+			ssh_ok=1
+			break
+		fi
+		sleep 10
+	done
+	[[ "$ssh_ok" == 1 ]] || {
+		echo "FAIL: SSH not reachable after --resume (timeout ${TIMEOUT}s)" >&2
+		exit 1
+	}
+fi
 
 check() { corral ssh "$NAME" -u root -c "$1"; }
 

--- a/tests/bats/test_boot_gate_resume.bats
+++ b/tests/bats/test_boot_gate_resume.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/boot-gate.sh — the corral boot-gate runner, focused
+# on the --resume retry path for tuna-os/tunaOS#627 (KubeVirt virt-launcher
+# teardown destroys the builder's serial log before corral reads the build
+# marker, so a finished build can fail with "builder VM ended (Succeeded)
+# without a build marker" even though the disk PVC is valid).
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+GATE_SCRIPT="${REPO_ROOT}/scripts/boot-gate.sh"
+
+setup() {
+	TEST_ROOT="$(mktemp -d)"
+	STUB_BIN="${TEST_ROOT}/stub-bin"
+	mkdir -p "${STUB_BIN}"
+	export PATH="${STUB_BIN}:${PATH}"
+
+	# Default stubs: corral create succeeds on first try, ssh answers, delete
+	# cleans up. Individual tests override create/resume/start as needed.
+	cat >"${STUB_BIN}/corral" <<'CORRAL'
+#!/usr/bin/env bash
+echo "corral $*" >>"${CORRAL_LOG:-/dev/null}"
+case "$1" in
+create)
+	# Version probe: the gate requires --bootc in `corral create --help`.
+	if [[ "$*" == *"--help"* ]]; then
+		echo "  --bootc  Bootc container image to run"
+		exit 0
+	fi
+	# First arg after subcommand is the VM name; --bootc means the gate path.
+	exit "${CORRAL_CREATE_RC:-0}"
+	;;
+bootc) exit "${CORRAL_BOOTC_RC:-0}" ;;
+start) exit 0 ;;
+ssh)
+	# Desktop checks probe `systemctl is-active ...`; answer active.
+	if [[ "$*" == *"is-active"* ]]; then
+		echo "active"
+		exit 0
+	fi
+	exit "${CORRAL_SSH_RC:-0}"
+	;;
+delete) exit 0 ;;
+*) exit 0 ;;
+esac
+CORRAL
+	chmod +x "${STUB_BIN}/corral"
+
+	export CORRAL_LOG="${TEST_ROOT}/corral.log"
+}
+
+teardown() {
+	rm -rf "${TEST_ROOT}"
+}
+
+@test "boot-gate.sh: passes through when corral create succeeds" {
+	run bash "${GATE_SCRIPT}" yellowfin gnome
+	[ "$status" -eq 0 ]
+	grep -q "create" "${CORRAL_LOG}"
+	grep -q -- "--resume" "${CORRAL_LOG}" && return 1 || true
+	[[ "$output" == *"boot-gate PASS"* ]]
+}
+
+@test "boot-gate.sh: retries with --resume when create fails and resume succeeds" {
+	export CORRAL_CREATE_RC=1
+	export CORRAL_BOOTC_RC=0
+	run bash "${GATE_SCRIPT}" yellowfin gnome
+	[ "$status" -eq 0 ]
+	grep -q "bootc create" "${CORRAL_LOG}"
+	grep -q -- "--resume" "${CORRAL_LOG}"
+	grep -q "start" "${CORRAL_LOG}"
+	[[ "$output" == *"--resume from the completed disk"* ]]
+	[[ "$output" == *"boot-gate PASS"* ]]
+}
+
+@test "boot-gate.sh: fails when both create and resume fail" {
+	export CORRAL_CREATE_RC=1
+	export CORRAL_BOOTC_RC=1
+	run bash "${GATE_SCRIPT}" yellowfin gnome
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"no resumable build was found"* ]]
+}
+
+@test "boot-gate.sh: fails when SSH never answers after resume" {
+	export CORRAL_CREATE_RC=1
+	export CORRAL_BOOTC_RC=0
+	export CORRAL_SSH_RC=1
+	export GATE_TIMEOUT=15
+	run bash "${GATE_SCRIPT}" yellowfin gnome
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"SSH not reachable after --resume"* ]]
+}


### PR DESCRIPTION
## Summary

tuna-os/tunaos#627: `corral create --bootc` intermittently fails with `builder VM ended (Succeeded) without a build marker` because KubeVirt virt-launcher pod teardown destroys the builder's serial log before corral can read the success marker — the disk PVC is actually built and valid (the disk-size fallback has the same race via a separate size-check pod). The issue's own workaround is to retry with `--resume`.

**`scripts/boot-gate.sh`**: when the initial `corral create --bootc ... --wait-ssh` fails, retry via the bootc plugin's `--resume` (`corral bootc create <name> --image <img> --resume`), which finishes the VM from the completed disk — skipping the rebuild entirely — and errors cleanly when there is genuinely nothing to resume (so attempting it on any bootc-build failure is safe). Then `corral start` the VM and replicate the `--wait-ssh` loop, since `--resume` creates the VM stopped.

**`tests/bats/test_boot_gate_resume.bats`**: 4 tests with a stubbed `corral` CLI covering the pass-through path, the resume-retry path, hard failure when resume also fails, and failure when SSH never answers after resume.

## Verification

- `bats tests/bats/test_boot_gate_resume.bats` — 4/4 pass.
- `bash -n` clean; shellcheck shows only the two pre-existing warnings (cleanup trap, `for i` loop) already present on main.
- No CI wiring changes — the gate scripts are the local/corral tools the issue references.

- [x] I am using an agent and I take responsibility for this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->