### PR TITLE
fix(build): clean buildah storage before retrying the index.json race (#638)

### DIFF
--- a/scripts/build-image-inner.sh
+++ b/scripts/build-image-inner.sh
@@ -170,6 +170,13 @@ until build_primary_image; do
 		echo "ERROR: image build failed after ${build_attempt} attempt(s)" >&2
 		exit 1
 	fi
+	# tuna-os/tunaOS#638: the amd64/v2 failure (`open out/index.json: no such
+	# file or directory`) is a buildah containers-storage OCI-layout race; a
+	# partially-written container from the failed attempt can fail the same
+	# way again. Drop buildah's working containers before retrying.
+	if [[ "${BUILDER}" == "buildah" ]]; then
+		buildah rm -a >/dev/null 2>&1 || true
+	fi
 	echo "${BUILDER} build attempt ${build_attempt} failed; retrying in $((build_attempt * 10))s..." >&2
 	sleep "$((build_attempt * 10))"
 	build_attempt=$((build_attempt + 1))

--- a/tests/bats/test_build_image_retry.bats
+++ b/tests/bats/test_build_image_retry.bats
@@ -23,6 +23,14 @@
 REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
 SCRIPT="${REPO_ROOT}/scripts/build-image-inner.sh"
 
+setup() {
+	TEST_ROOT="$(mktemp -d)"
+}
+
+teardown() {
+	rm -rf "${TEST_ROOT}"
+}
+
 # The until-loop as it appears in the script: from the `build_attempt=1`
 # initialiser through the closing `done`. Extracted rather than restated so a
 # future edit to the loop is what these tests run.
@@ -96,9 +104,56 @@ run_loop() {
 
 # The builder-specific gate is what caused the bug. Assert it is gone from the
 # source, so reintroducing it fails here with an explanation rather than
-# silently halving the retry coverage again.
+# silently halving the retry coverage again. (A buildah-only storage clean
+# inside the loop is fine — see the next test — what must not return is the
+# `!= buildah` early-exit that gave podman zero retries.)
 @test "the retry is not gated on the builder name" {
 	run retry_loop
 	[[ "$output" != *'!= "buildah"'* ]]
-	[[ "$output" != *'== "buildah"'* ]]
+}
+
+@test "buildah storage is cleaned before a retry, not on first success" {
+	cat >"${TEST_ROOT}/buildah" <<'EOF'
+#!/usr/bin/env bash
+echo "buildah $*" >> "${BUILDAH_LOG:?}"
+EOF
+	chmod +x "${TEST_ROOT}/buildah"
+	export BUILDAH_LOG="${TEST_ROOT}/buildah.log"
+	export PATH="${TEST_ROOT}:${PATH}"
+	run bash -c "
+		BUILDER=buildah
+		attempts=0
+		sleep() { :; }
+		build_primary_image() {
+			attempts=\$((attempts + 1))
+			[ \$attempts -gt 1 ]
+		}
+		$(retry_loop)
+	"
+	[ "$status" -eq 0 ]
+	run cat "${BUILDAH_LOG}"
+	# exactly one clean, between attempt 1 and attempt 2
+	[ "$(wc -l <<<"$output")" -eq 1 ]
+	[[ "$output" == *"rm -a"* ]]
+}
+
+@test "podman retries do not invoke buildah rm" {
+	cat >"${TEST_ROOT}/buildah" <<'EOF'
+#!/usr/bin/env bash
+echo "buildah called" > "${TEST_ROOT}/buildah.log"
+EOF
+	chmod +x "${TEST_ROOT}/buildah"
+	export PATH="${TEST_ROOT}:${PATH}"
+	run bash -c "
+		BUILDER=podman
+		attempts=0
+		sleep() { :; }
+		build_primary_image() {
+			attempts=\$((attempts + 1))
+			[ \$attempts -gt 1 ]
+		}
+		$(retry_loop)
+	"
+	[ "$status" -eq 0 ]
+	[[ ! -f "${TEST_ROOT}/buildah.log" ]]
 }


### PR DESCRIPTION
## Summary

tuna-os/tunaos#638: intermittent buildah exit-125 on linux/amd64/v2 — `open out/index.json: no such file or directory`. The issue asks for resiliency in `scripts/build-image-inner.sh`: "wrap the `buildah build` in a small retry, **or clean/re-init buildah storage on the out/index.json error before retrying**".

The 3-attempt retry loop already exists (8d8a2218), but it re-runs `buildah build` blindly — a partially-written containers-storage container from the failed attempt can keep failing identically, burning all attempts against the same corrupted state.

**`scripts/build-image-inner.sh`**: before retrying, drop buildah's working containers with `buildah rm -a` (buildah-only branch), so the next attempt starts from clean storage. Podman builds are untouched, and the retry itself remains builder-agnostic — the old `!= buildah` early-exit that gave podman zero retries stays gone.

**`tests/bats/test_build_image_retry.bats`**: the extracted retry loop now has two new tests — buildah storage is cleaned exactly once between the failed attempt and the successful retry, and podman retries never invoke `buildah`. (Also relaxed the "not gated on builder" assertion, which previously banned the legitimate buildah-only storage clean.)

## Verification

- `bats tests/bats/test_build_image_retry.bats` — 8/8 pass (with a minimal awk shim for this sandbox; CI runners have real awk).
- `bash -n` on the script — clean.
- Loop extraction verified byte-for-byte (build_attempt=1 → done).

- [x] I am using an agent and I take responsibility for this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->