### PR TITLE
ci: require flavor-matched installer sessions

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -137,13 +137,20 @@ jobs:
           FLAVOR: ${{ matrix.flavor }}
         run: |
           SSH="sshpass -p live ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null liveuser@127.0.0.1"
-          # GROUND TRUTH = the compositor process is actually running. The
-          # old check accepted "a wayland socket + any liveuser session",
-          # which a bare greetd VT with a stale socket satisfies — so Niri
-          # falling through to a TTY still PASSED (run 29645108966: gate
-          # green, screenshot showed a black console). pgrep -x the exact
-          # compositor binary is the only signal that survives that.
-          COMPS="niri xfwl4 cosmic-comp kwin_wayland gnome-shell xfwm4 sway Hyprland labwc wayfire"
+          # GROUND TRUTH = the compositor for THIS flavor is actually running.
+          # The old check accepted any compositor: a KDE session could make a
+          # broken COSMIC leg green, and a cosmic-greeter's own cosmic-comp
+          # made the COSMIC login prompt look like a real desktop. A stale
+          # Wayland socket also let Niri falling through to a TTY pass.
+          # Require the exact compositor family selected by the matrix cell.
+          case "${FLAVOR}" in
+            kde)    COMPS="kwin_wayland" ;;
+            cosmic) COMPS="cosmic-comp" ;;
+            niri)   COMPS="niri" ;;
+            xfce)   COMPS="xfwl4 labwc wayfire xfwm4" ;;
+            gnome)  COMPS="gnome-shell" ;;
+            *)      echo "::error::unsupported installer-smoke flavor: ${FLAVOR}"; exit 1 ;;
+          esac
           session_ok=0; COMP=""
           for i in $(seq 1 36); do
             COMP=$($SSH "for p in $COMPS; do pgrep -x \"\$p\" >/dev/null 2>&1 && { echo \"\$p\"; break; }; done" 2>/dev/null || true)
@@ -173,12 +180,11 @@ jobs:
           fi
           echo "== ${FLAVOR}: compositor running: ${COMP}"
 
-          # Then the DESKTOP-MATCHED installer frontend must actually be running.
-          # The old check (`pgrep -af "Installer|..."`) ran through `bash -c`, so
-          # the pattern matched its OWN command line and passed unconditionally —
-          # it never verified anything (run 29645820128 "installer processes:
-          # 2330 bash -c pgrep -af ..."). Assert the specific app id for this
-          # desktop via `flatpak ps`, with a self-match-proof pgrep fallback.
+          # Then the DESKTOP-MATCHED installer frontend must actually be
+          # running. The old fallback accepted any TunaOS installer after the
+          # exact flatpak lookup failed, so the wrong frontend could satisfy a
+          # matrix cell. There is no generic fallback now: an app-id mismatch
+          # is a real per-frontend failure.
           case "${FLAVOR}" in
             kde)    APP=org.tunaos.InstallerKde ;;
             cosmic) APP=org.tunaos.InstallerCosmic ;;
@@ -189,9 +195,10 @@ jobs:
           echo "expecting installer frontend: ${APP}"
           PROCS=""
           for i in $(seq 1 18); do
-            # flatpak ps is authoritative (app id, not a substring guess); the
-            # bracket trick ([o]rg) keeps the fallback from matching itself.
-            PROCS=$($SSH "flatpak ps --columns=application 2>/dev/null | grep -Fx '${APP}' || pgrep -af '[o]rg\.(tunaos|bootcinstaller)\.Installer' || true" 2>/dev/null || true)
+            # flatpak ps is authoritative (app id, not a substring guess).
+            # `pgrep -f` is intentionally absent: its shell command line can
+            # self-match and it cannot distinguish the four frontends.
+            PROCS=$($SSH "flatpak ps --columns=application 2>/dev/null | grep -Fx '${APP}' || true" 2>/dev/null || true)
             [ -n "$PROCS" ] && break
             sleep 10
           done

--- a/tests/bats/test_live_installer_launch.bats
+++ b/tests/bats/test_live_installer_launch.bats
@@ -23,6 +23,7 @@
 # have blocked niri — where a partial config.kdl would clobber niri's defaults.
 
 SRC="${BATS_TEST_DIRNAME}/../../live-iso/common/src"
+WORKFLOW="${BATS_TEST_DIRNAME}/../../.github/workflows/installer-smoke.yml"
 
 # Flavor -> the app id its adapter must launch. Mirrors the case statement in
 # customize-live.sh; if that mapping changes, this fails and points at both.
@@ -77,4 +78,19 @@ launcher_app() {
     printf '  %s\n' "${wrong[@]}" >&2
     false
   fi
+}
+
+@test "installer smoke selects a compositor per flavor" {
+  [ -f "$WORKFLOW" ]
+  grep -q 'kde)    COMPS="kwin_wayland"' "$WORKFLOW"
+  grep -q 'cosmic) COMPS="cosmic-comp"' "$WORKFLOW"
+  grep -q 'niri)   COMPS="niri"' "$WORKFLOW"
+  grep -q 'xfce)   COMPS="xfwl4 labwc wayfire xfwm4"' "$WORKFLOW"
+  grep -q 'gnome)  COMPS="gnome-shell"' "$WORKFLOW"
+}
+
+@test "installer smoke does not accept a different frontend as a fallback" {
+  [ -f "$WORKFLOW" ]
+  ! grep -q 'pgrep -af' "$WORKFLOW"
+  grep -Fq 'grep -Fx' "$WORKFLOW"
 }


### PR DESCRIPTION
## What changed

- Require the compositor expected for each installer-smoke flavor: KDE/KWin, COSMIC/cosmic-comp, Niri/niri, XFCE/Wayland or X11 compositor, and GNOME/GNOME Shell.
- Remove the generic installer-process fallback and require the exact flavor frontend Flatpak app ID.
- Add regression checks covering compositor selection and frontend mismatch protection.

## Why

The previous matrix could report a cell green when another compositor or another TunaOS installer was running. That made a greeter, TTY, or wrong frontend look like proof that the selected KDE/COSMIC/Niri/XFCE frontend was usable.

## Validation

- Shell syntax checks passed for the affected desktop adapters.
- Static regression assertions passed.
- `git diff --check` passed.
- Bats and actionlint were unavailable in the checkout environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->