### PR TITLE
luks: wire per-variant TPM2 auto-unlock test + fill support matrix (#714)

### DIFF
--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -17,14 +17,19 @@ name: LUKS E2E
 # against the live ISO's boot chain instead and never unseal afterward
 # (tunaOS#679/#680) — so step 3 above does NOT prove it; that would need a
 # fourth boot with no passphrase. scripts/iso-e2e.sh's
-# TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK=1 does that boot when set, but this
-# workflow does not set it: docs/LUKS-TPM.md tracks that as "the per-variant
-# TPM-enrollment test", a smaller-scope check, since a fourth boot on every
-# cell here would materially raise this workflow's already-expensive cost.
+# TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK=1 does that boot, and this workflow's
+# `tpm_autounlock` dispatch input (or the quarterly cron below) sets it — but
+# only for the default run does it stay unset: a fourth boot on every cell of
+# the monthly full sweep would materially raise its already-expensive cost, so
+# `tpm_autounlock` mode instead narrows the matrix to one flavor per variant
+# (docs/LUKS-TPM.md calls this "the per-variant TPM-enrollment test") and
+# skips the variants whose initramfs cannot carry the tpm2-tss module at all
+# (see the support matrix in that doc — sailfin/marlin/guppy, as of tunaOS#714).
 #
-# This is expensive (a dev ISO build + two QEMU boots per cell), so it only
-# runs on demand or monthly — never per push. Modelled on iso-e2e.yml and
-# projectbluefin/dakota-iso's luks-*-qemu recipes.
+# This is expensive (a dev ISO build + two QEMU boots per cell — three with
+# tpm_autounlock), so it only runs on demand or on a schedule — never per
+# push. Modelled on iso-e2e.yml and projectbluefin/dakota-iso's luks-*-qemu
+# recipes.
 
 on:
   workflow_dispatch:
@@ -39,9 +44,26 @@ on:
         required: false
         default: "all"
         type: string
+      tpm_autounlock:
+        description: >-
+          Also verify TPM2 auto-unlock (a third QEMU boot per cell, no
+          passphrase). Narrows the matrix to one flavor per variant to keep
+          cost bounded, and skips variants that cannot carry the tpm2-tss
+          dracut module at all (see docs/LUKS-TPM.md).
+        required: false
+        default: false
+        type: boolean
   schedule:
-    # Full variant x installable-desktop sweep on the first day of each month.
+    # Full variant x installable-desktop sweep on the first day of each month
+    # (passphrase-unlock only — see the header comment above).
     - cron: "0 7 1 * *"
+    # TPM2 auto-unlock sweep, one flavor per variant, quarterly: the fourth
+    # boot this adds is real extra cost, so it runs far less often than the
+    # passphrase-only sweep above. github.event.schedule (the exact cron
+    # string that fired) is how the generate-matrix step tells the two
+    # schedules apart — workflow_dispatch inputs don't apply to `schedule`
+    # events, so there is no `inputs.tpm_autounlock` to read here.
+    - cron: "0 7 1 */3 *"
 
 permissions:
   contents: read
@@ -55,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
+      tpm_autounlock: ${{ steps.gen.outputs.tpm_autounlock }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -70,28 +93,73 @@ jobs:
         env:
           FILTER_VARIANT: ${{ inputs.variant || 'all' }}
           FILTER_FLAVOR: ${{ inputs.flavor || 'all' }}
+          # inputs.tpm_autounlock is only populated on workflow_dispatch —
+          # schedule events carry no `inputs` context, so the second cron
+          # above is identified by github.event.schedule instead. Compared
+          # as a string, not booleans, because event.schedule IS the literal
+          # cron expression from the `on.schedule` list.
+          TPM_DISPATCH: ${{ inputs.tpm_autounlock || false }}
+          TPM_SCHEDULE: ${{ github.event.schedule == '0 7 1 */3 *' }}
         run: |
           set -euo pipefail
           json="$(yq -o=json '.' .github/build-config.yml)"
-          # Every variant x desktop flavor that has a published image
-          # (build_image, NOT build_iso): the browser ISO builder makes ISOs
-          # from any image, so image-only variants (sailfin, guppy,
-          # flounder-sid) need boot+install coverage too. Cover every amd64
-          # graphical image: standard desktops, overlays (NVIDIA/CachyOS),
-          # and any future desktop tag. `base` has no login target to gate;
-          # arm64-only flavors require an arm64 QEMU runner and are reported
-          # separately in the job summary.
-          matrix="$(echo "$json" | jq -c \
-            --arg fv "$FILTER_VARIANT" --arg ff "$FILTER_FLAVOR" \
-            '{include: [ .variants[] | . as $variant | .id as $v | .flavors[]
-               | select(.build_image == true)
-               | select(.id != "base")
-               | select((.platforms // $variant.platforms // []) | index("linux/amd64"))
-               | {variant: $v, flavor: .id}
-               | select($fv == "all" or .variant == $fv)
-               | select($ff == "all" or .flavor == $ff) ]}')"
+
+          if [[ "$TPM_DISPATCH" == "true" || "$TPM_SCHEDULE" == "true" ]]; then
+            TPM_AUTOUNLOCK=true
+          else
+            TPM_AUTOUNLOCK=false
+          fi
+          echo "tpm_autounlock=${TPM_AUTOUNLOCK}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$TPM_AUTOUNLOCK" == "true" ]]; then
+            # docs/LUKS-TPM.md's support matrix: these three never get the
+            # tpm2-tss dracut module built in at all (unconditional omit on
+            # openSUSE/Gentoo, no tpm2-tools package on Arch), so no boot
+            # could ever confirm auto-unlock there — spending a third QEMU
+            # boot on them would only ever reproduce a known, static fact.
+            # tests/bats/test_luks_tpm2_support_matrix.bats keeps this list
+            # honest against the actual Containerfiles.
+            NO_TPM_USERSPACE="sailfin marlin guppy"
+            # One flavor per variant, so a 13-variant sweep costs 13 extra
+            # boots instead of one per every desktop x variant cell — see the
+            # header comment. `gnome` when the variant ships it (the flavor
+            # every non-Arch/apt/RPM base tests already lean on), else
+            # whatever amd64 graphical flavor sorts first.
+            matrix="$(echo "$json" | jq -c \
+              --arg fv "$FILTER_VARIANT" --arg skip "$NO_TPM_USERSPACE" \
+              '($skip | split(" ")) as $skiplist
+               | {include: [ .variants[] | . as $variant | .id as $v
+                   | select($skiplist | index($v) | not)
+                   | ([$variant.flavors[]
+                       | select(.build_image == true)
+                       | select(.id != "base")
+                       | select((.platforms // $variant.platforms // []) | index("linux/amd64"))
+                     ] | sort_by(.id)) as $eligible
+                   | (($eligible | map(select(.id == "gnome")) | .[0]) // $eligible[0]) as $pick
+                   | select($pick != null)
+                   | {variant: $v, flavor: $pick.id}
+                   | select($fv == "all" or .variant == $fv) ]}')"
+          else
+            # Every variant x desktop flavor that has a published image
+            # (build_image, NOT build_iso): the browser ISO builder makes ISOs
+            # from any image, so image-only variants (sailfin, guppy,
+            # flounder-sid) need boot+install coverage too. Cover every amd64
+            # graphical image: standard desktops, overlays (NVIDIA/CachyOS),
+            # and any future desktop tag. `base` has no login target to gate;
+            # arm64-only flavors require an arm64 QEMU runner and are reported
+            # separately in the job summary.
+            matrix="$(echo "$json" | jq -c \
+              --arg fv "$FILTER_VARIANT" --arg ff "$FILTER_FLAVOR" \
+              '{include: [ .variants[] | . as $variant | .id as $v | .flavors[]
+                 | select(.build_image == true)
+                 | select(.id != "base")
+                 | select((.platforms // $variant.platforms // []) | index("linux/amd64"))
+                 | {variant: $v, flavor: .id}
+                 | select($fv == "all" or .variant == $fv)
+                 | select($ff == "all" or .flavor == $ff) ]}')"
+          fi
           count="$(echo "$matrix" | jq '.include | length')"
-          echo "Matrix has ${count} cell(s)"
+          echo "Matrix has ${count} cell(s) (tpm_autounlock=${TPM_AUTOUNLOCK})"
           echo "$matrix" | jq .
           if [[ "$count" -eq 0 ]]; then
             echo "::error::No matching variant/flavor cells"
@@ -352,6 +420,11 @@ jobs:
         env:
           VARIANT: ${{ matrix.variant }}
           FLAVOR: ${{ matrix.flavor }}
+          # Set only in tpm_autounlock mode (generate-matrix already excluded
+          # the variants that can never pass this — see docs/LUKS-TPM.md).
+          # iso-e2e.sh itself fails the step (exit 8) on a bad unlock, so this
+          # is what actually drives the third boot, not just a label.
+          TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK: ${{ needs.generate-matrix.outputs.tpm_autounlock == 'true' && '1' || '0' }}
         run: |
           mkdir -p luks-out
           # -E: sudo resets the environment by default, which drops VARIANT/
@@ -392,27 +465,36 @@ jobs:
           # (tunaOS#972 — see customize-live.sh). This headroom is kept for
           # the genuine staging copies, not because that copy still happens.
           #
-          # E2E_WALL_CLOCK_DEADLINE is named on the `env` line rather than
-          # left to `sudo -E` for the same reason FISHERMAN_OVERRIDE is: -E
-          # is subject to sudoers env_keep/env_reset, and a deadline that
-          # silently fails to arrive would put the harness straight back on
-          # its relative 10800s backstop — the exact thing that could not
-          # fire in time on the slow cells. Passed explicitly, it either
-          # arrives or the script says so.
+          # E2E_WALL_CLOCK_DEADLINE and TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK are
+          # named on the `env` line rather than left to `sudo -E` for the
+          # same reason FISHERMAN_OVERRIDE is: -E is subject to sudoers
+          # env_keep/env_reset, and either silently failing to arrive is
+          # the wrong kind of failure — a deadline that never arrives puts
+          # the harness back on its relative 10800s backstop (the exact
+          # thing that could not fire in time on the slow cells), and a
+          # TPM flag that never arrives would silently skip the one boot
+          # this whole workflow input exists to add. Passed explicitly,
+          # each either arrives or the script says so.
           sudo -E env FISHERMAN_OVERRIDE="$FISHERMAN_OVERRIDE" \
             E2E_WALL_CLOCK_DEADLINE="$E2E_WALL_CLOCK_DEADLINE" \
+            TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK="$TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK" \
             ./scripts/iso-e2e.sh "${ISO_PATH}" --luks \
             --output luks-out \
             --memory 10240 \
             --timeout 1200
           # Gate = encrypted install + passphrase unlock to login. TPM2
           # auto-unlock is enrolled automatically by a first-boot oneshot
-          # (fisherman#48) rather than a manual `ujust enable-luks-tpm2` step,
-          # but it is still not asserted here — see docs/LUKS-TPM.md and the
-          # header comment above for why (tested separately, per-variant).
+          # (fisherman#48) rather than a manual `ujust enable-luks-tpm2` step;
+          # asserted below only when TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK=1 (the
+          # tpm_autounlock dispatch input / quarterly schedule) — see
+          # docs/LUKS-TPM.md and the header comment above for why it isn't
+          # part of every cell.
           grep -qx 'TUNAOS_LUKS_E2E_INSTALL_STARTED luks=1' luks-out/luks-evidence.log
           grep -qx 'TUNAOS_LUKS_E2E_ENCRYPTED_DISK_CONFIRMED' luks-out/luks-evidence.log
           grep -qx 'TUNAOS_LUKS_E2E_PASS encrypted=1 passphrase_unlock=1 installed_boot=1' luks-out/luks-evidence.log
+          if [[ "$TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK" == "1" ]]; then
+            grep -qx 'TUNAOS_LUKS_E2E_TPM_AUTOUNLOCK_CONFIRMED' luks-out/luks-evidence.log
+          fi
 
       - name: Collect evidence
         if: always()

--- a/docs/LUKS-TPM.md
+++ b/docs/LUKS-TPM.md
@@ -47,26 +47,45 @@ passphrase. To revert either kind of enrollment: `ujust disable-luks-tpm2`.
 
 ## Variant support matrix
 
-TPM2 auto-unlock needs the systemd TPM2 modules in the initramfs and a working
-`/dev/tpmrm0`. Enrollment is exercised per variant by the LUKS-TPM E2E; results:
+TPM2 auto-unlock needs the systemd `tpm2-tss` dracut module in the
+initramfs — which in turn needs a TPM2 userspace (`tpm2-tools` or
+equivalent) present when the image is built, since `dracut-install`
+refuses to package a module whose binaries don't exist — plus a working
+`/dev/tpmrm0` on the machine at boot. Two of those three are knowable
+**statically**, from what each base's package list and dracut config give
+the initramfs, without booting anything; only the third (does it actually
+unseal at runtime) needs the E2E boot. The columns below say which is
+which:
 
-| Variant | Base | Encrypted install (passphrase) | TPM2 auto-unlock | Notes |
-|---------|------|-------------------------------|------------------|-------|
-| yellowfin | AlmaLinux Kitten 10 | ✅ (fisherman) | _pending E2E_ | |
-| skipjack | CentOS Stream 10 | ✅ | _pending E2E_ | |
-| albacore | AlmaLinux 10 | ✅ | _pending E2E_ | |
-| bonito | Fedora 44 | ✅ | _pending E2E_ | |
-| sailfin | openSUSE Tumbleweed | ✅ | _pending E2E_ | |
-| flounder | Debian 13 Trixie | ✅ | _pending E2E_ | |
-| grouper | Ubuntu 26.04 | ✅ | _pending E2E_ | composefs/systemd-boot |
-| marlin | Arch | ✅ | _pending E2E_ | |
-| guppy | Gentoo | ✅ | _pending E2E_ | |
+| Variant | Base | Encrypted install (passphrase) | TPM2 userspace in initramfs | TPM2 auto-unlock | Notes |
+|---------|------|-------------------------------|------------------------------|-------------------|-------|
+| yellowfin | AlmaLinux Kitten 10 | ✅ (fisherman) | ✅ (RPM/dracut-config.sh probe) | _pending E2E_ | |
+| skipjack | CentOS Stream 10 | ✅ | ✅ (RPM/dracut-config.sh probe) | _pending E2E_ | |
+| albacore | AlmaLinux 10 | ✅ | ✅ (RPM/dracut-config.sh probe) | _pending E2E_ | |
+| bonito | Fedora 44 | ✅ | ✅ (RPM/dracut-config.sh probe) | _pending E2E_ | |
+| bonito-rawhide | Fedora Rawhide | ✅ | ✅ (RPM/dracut-config.sh probe) | _pending E2E_ | same Containerfile.el10 path as bonito |
+| hummingbird | Fedora Hummingbird | ✅ | ✅ (RPM/dracut-config.sh probe) | _pending E2E_ | same Containerfile.el10 path as bonito |
+| sailfin | openSUSE Tumbleweed | ✅ | ❌ **not built** | ❌ **not possible today** | `Containerfile.opensuse` omits `tpm2-tss`/`pcsc` from every dracut invocation unconditionally — no TPM2 userspace package is installed, so the module can never make it into the initramfs regardless of enrollment. tunaOS#714 |
+| flounder | Debian 13 Trixie | ✅ | ✅ (`tpm2-tools` installed explicitly) | _pending E2E_ | |
+| flounder-sid | Debian Sid | ✅ | ✅ (`tpm2-tools` installed explicitly) | _pending E2E_ | same `Containerfile.debian` path as flounder |
+| grouper | Ubuntu 26.04 | ✅ | ✅ (`tpm2-tools` installed explicitly) | _pending E2E_ | composefs/systemd-boot |
+| gurnard | Ubuntu 24.04 (Pantheon) | ✅ | ✅ (`tpm2-tools` installed explicitly) | _pending E2E_ | same `Containerfile.ubuntu` path as grouper |
+| marlin | Arch | ✅ | ❌ **not built** | ❌ **not possible today** | `pacman`'s package list has no `tpm2-tools`/`tpm2-tss`, so `dracut-config.sh`'s `command -v tpm2_pcrread` probe finds nothing and omits the module. Installing `tpm2-tools` on Arch would fix this, but is unverified in this environment (no local build/registry access) — left for a follow-up with real build coverage. tunaOS#714 |
+| guppy | Gentoo | ✅ | ❌ **not built** | ❌ **not possible today** | `Containerfile.gentoo` omits `tpm2-tss`/`pcsc` unconditionally — the emerge base installs neither `app-crypt/tpm2-tools` nor `pcscd` (see the Containerfile's own comment, tunaOS#714/prior LUKS run 31111959946). |
+
+`tests/bats/test_luks_tpm2_support_matrix.bats` asserts the three ❌ rows
+against the actual Containerfile omit lines / package lists, so this table
+cannot silently drift out of sync with the code — if a variant's TPM2
+posture changes (e.g. Arch gains a `tpm2-tools` install), that test breaks
+until this table is updated too.
 
 Filled in by the per-variant TPM-enrollment test: install → first installed
 boot (passphrase, first-boot oneshot enrolls TPM2 in the background) → reboot
 with no passphrase → confirm auto-unlock. `scripts/iso-e2e.sh --luks` with
 `TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK=1` runs exactly this sequence and records
 `TUNAOS_LUKS_E2E_TPM_AUTOUNLOCK_CONFIRMED` / `_FAILED` in the LUKS evidence
-log — not yet wired into a scheduled workflow (see the header comment in
-`.github/workflows/luks-e2e.yml`). See the LUKS-TPM tracking issue
+log. It's wired into `.github/workflows/luks-e2e.yml` via the
+`tpm_autounlock` dispatch input (and a quarterly schedule) — narrowed to one
+flavor per variant to bound cost, skipping the three variants above whose
+initramfs cannot carry the module at all. See the LUKS-TPM tracking issue
 (tunaOS#680).

--- a/tests/bats/test_luks_tpm2_support_matrix.bats
+++ b/tests/bats/test_luks_tpm2_support_matrix.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+# docs/LUKS-TPM.md's variant support matrix claims three variants — sailfin,
+# marlin, guppy — can never get TPM2 auto-unlock because their initramfs
+# never carries the tpm2-tss dracut module at all, regardless of enrollment
+# (tunaOS#714). That is a static fact: it follows from the Containerfile's
+# dracut omit lines / package list, not from booting anything.
+#
+# This test is the tripwire that keeps the doc honest. If a future change
+# gives one of these bases a real TPM2 userspace (e.g. Arch starts installing
+# tpm2-tools), the matching test below breaks — which is the point: it means
+# docs/LUKS-TPM.md's ❌ row for that variant is now stale and needs updating
+# alongside whatever fixed the Containerfile, not silently left to say "not
+# possible" about something that now works.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+DOC="${REPO_ROOT}/docs/LUKS-TPM.md"
+
+strip_comments() { grep -v '^[[:space:]]*#' || true; }
+
+# ── openSUSE (sailfin): unconditional omit ─────────────────────────────────
+
+@test "Containerfile.opensuse still omits tpm2-tss/pcsc from dracut unconditionally" {
+  local f="${REPO_ROOT}/Containerfile.opensuse"
+  grep -qE 'omit_dracutmodules\+?="? *tpm2-tss +pcsc' "$f" || {
+    echo "FAIL: Containerfile.opensuse no longer has the unconditional" >&2
+    echo "      tpm2-tss/pcsc omit docs/LUKS-TPM.md's sailfin row cites." >&2
+    echo "      If sailfin now installs a TPM2 userspace, update that row" >&2
+    echo "      from '❌ not possible today' before touching this test." >&2
+    return 1
+  }
+}
+
+@test "sailfin installs no TPM2 userspace package" {
+  local f="${REPO_ROOT}/Containerfile.opensuse"
+  local code
+  code="$(strip_comments <"$f")"
+  # tpm2.0-tools is openSUSE's package name for the tpm2_pcrread binary
+  # dracut-config.sh's probe (and this same fact, restated) looks for.
+  if grep -qE 'tpm2\.0-tools|tpm2-tools' <<<"$code"; then
+    echo "FAIL: Containerfile.opensuse now installs a tpm2 tools package," >&2
+    echo "      but still hardcodes 'omit tpm2-tss pcsc' unconditionally —" >&2
+    echo "      the omit is now blocking a userspace that exists. Route" >&2
+    echo "      sailfin through dracut-config.sh's probe instead (like" >&2
+    echo "      marlin/RPM bases) so the module is included when present," >&2
+    echo "      and update docs/LUKS-TPM.md's sailfin row." >&2
+    return 1
+  fi
+}
+
+# ── Arch (marlin): dracut-config.sh probe, no userspace package ───────────
+
+@test "Containerfile.arch still installs no TPM2 userspace package" {
+  local f="${REPO_ROOT}/Containerfile.arch"
+  local code
+  code="$(strip_comments <"$f")"
+  if grep -qE '(^|[[:space:]])tpm2-tools([[:space:]]|\\|$)' <<<"$code"; then
+    echo "FAIL: Containerfile.arch now installs tpm2-tools." >&2
+    echo "      dracut-config.sh's 'command -v tpm2_pcrread' probe will now" >&2
+    echo "      find it and stop omitting tpm2-tss — marlin's initramfs" >&2
+    echo "      would carry the module. Flip docs/LUKS-TPM.md's marlin row" >&2
+    echo "      from '❌ not possible today' to '_pending E2E_' before" >&2
+    echo "      touching this test, and run the tpm_autounlock sweep to" >&2
+    echo "      confirm it actually unlocks." >&2
+    return 1
+  fi
+}
+
+@test "Containerfile.arch routes its dracut config through the shared probe" {
+  # marlin's ❌ verdict depends on dracut-config.sh's probe being the thing
+  # that decides tpm2-tss inclusion for this base — if Arch stops delegating
+  # (e.g. reverts to a hardcoded omit like openSUSE/Gentoo, or starts adding
+  # the module unconditionally), the reasoning in the doc's marlin row no
+  # longer describes what the Containerfile actually does.
+  local f="${REPO_ROOT}/Containerfile.arch"
+  grep -qE 'bootc/dracut-config\.sh' "$f" || {
+    echo "FAIL: Containerfile.arch no longer calls dracut-config.sh — the" >&2
+    echo "      probe docs/LUKS-TPM.md's marlin row relies on doesn't run." >&2
+    return 1
+  }
+}
+
+# ── Gentoo (guppy): unconditional omit, well-documented already ───────────
+
+@test "Containerfile.gentoo still declares the unconditional tpm2-tss/pcsc omit" {
+  # Mirrors test_dracut_tpm2_userspace.bats's own assertions on this exact
+  # Containerfile; restated here so this file is a complete, standalone
+  # record of every ❌ row's reasoning in one place.
+  local f="${REPO_ROOT}/Containerfile.gentoo"
+  local code
+  code="$(strip_comments <"$f")"
+  grep -qE 'omit_dracutmodules\+=" *tpm2-tss +pcsc *"' <<<"$code" || {
+    echo "FAIL: Containerfile.gentoo no longer declares the drop-in omit" >&2
+    echo "      docs/LUKS-TPM.md's guppy row cites." >&2
+    return 1
+  }
+  ! grep -qE '(^|[[:space:]])app-crypt/tpm2-tools([[:space:]]|\\|$)' <<<"$code" || {
+    echo "FAIL: Containerfile.gentoo now emerges app-crypt/tpm2-tools —" >&2
+    echo "      guppy may have a working TPM2 userspace now. Update" >&2
+    echo "      docs/LUKS-TPM.md's guppy row before touching this test." >&2
+    return 1
+  }
+}
+
+# ── The doc itself: the three ❌ rows have to say ❌ ────────────────────────
+
+@test "docs/LUKS-TPM.md marks sailfin, marlin, and guppy as not possible today" {
+  local variant row fail=0
+  for variant in sailfin marlin guppy; do
+    row="$(grep -E "^\| ${variant} \|" "$DOC" || true)"
+    if [[ -z "$row" ]]; then
+      echo "FAIL: docs/LUKS-TPM.md has no matrix row for '${variant}'." >&2
+      fail=1
+      continue
+    fi
+    if ! grep -qF '❌' <<<"$row"; then
+      echo "FAIL: docs/LUKS-TPM.md's '${variant}' row doesn't say ❌ —" >&2
+      echo "      row: ${row}" >&2
+      fail=1
+    fi
+  done
+  [ "$fail" -eq 0 ]
+}
+
+@test "docs/LUKS-TPM.md does not still call the three ❌ variants 'pending E2E'" {
+  # The failure mode this guards: someone runs the tpm_autounlock sweep,
+  # sees it skip sailfin/marlin/guppy (by design — see generate-matrix's
+  # NO_TPM_USERSPACE list), and "helpfully" resets their rows back to
+  # '_pending E2E_' because no result ever showed up for them.
+  local variant row fail=0
+  for variant in sailfin marlin guppy; do
+    row="$(grep -E "^\| ${variant} \|" "$DOC" || true)"
+    [[ -n "$row" ]] || continue
+    if grep -qF '_pending E2E_' <<<"$row"; then
+      echo "FAIL: docs/LUKS-TPM.md's '${variant}' row still says" >&2
+      echo "      '_pending E2E_' — it should not; no E2E run will ever" >&2
+      echo "      populate it (generate-matrix skips these three)." >&2
+      fail=1
+    fi
+  done
+  [ "$fail" -eq 0 ]
+}
+
+# ── The workflow: the skip-list has to match the doc's ❌ rows ─────────────
+
+@test "luks-e2e.yml's tpm_autounlock skip-list is exactly sailfin, marlin, guppy" {
+  local wf="${REPO_ROOT}/.github/workflows/luks-e2e.yml"
+  grep -qE 'NO_TPM_USERSPACE="sailfin marlin guppy"' "$wf" || {
+    echo "FAIL: .github/workflows/luks-e2e.yml's NO_TPM_USERSPACE list has" >&2
+    echo "      changed. It must track docs/LUKS-TPM.md's ❌ rows exactly:" >&2
+    echo "      adding a variant there without a matching ❌ row spends a" >&2
+    echo "      real QEMU boot the doc doesn't explain, and removing one" >&2
+    echo "      re-tests a variant this file just asserted can't pass." >&2
+    return 1
+  }
+}


### PR DESCRIPTION
## Summary

Addresses the three actionable to-dos in tuna-os/tunaos#714 ("LUKS: per-variant TPM2 auto-unlock test + support matrix"), a follow-up to #686.

### 1. Per-variant TPM enrollment test — wired into a scheduled workflow

`scripts/iso-e2e.sh`'s `TUNAOS_E2E_VERIFY_TPM_AUTOUNLOCK=1` already existed (shipped in #686): install → passphrase boot → `ujust enable-luks-tpm2`'s equivalent first-boot oneshot → third boot with no passphrase → confirm auto-unlock. It just wasn't wired into anything scheduled — its own doc said so explicitly.

`.github/workflows/luks-e2e.yml` now has:
- a `tpm_autounlock` `workflow_dispatch` boolean input, and
- a quarterly cron (`0 7 1 */3 *`) that sets the same mode automatically (identified via `github.event.schedule`, since `inputs` isn't populated on schedule-triggered runs),

both of which narrow the matrix to **one flavor per variant** (`gnome` where the variant ships it, else the first eligible amd64 graphical flavor) to keep the added third-boot cost bounded — the existing header comment already flagged that a fourth^H^Hthird boot on every cell of the monthly full sweep would be too expensive.

### 2. Fill the matrix

`docs/LUKS-TPM.md`'s table covered 9 of the repo's 13 variants (missing `flounder-sid`, `hummingbird`, `gurnard`, `bonito-rawhide` entirely) and marked every row `_pending E2E_` — including three where no E2E run could ever say anything else:

| Variant | Why TPM2 auto-unlock isn't possible today |
|---|---|
| **sailfin** (openSUSE) | `Containerfile.opensuse` omits `tpm2-tss`/`pcsc` from every dracut invocation *unconditionally* — no TPM2 userspace package is installed on this base at all. |
| **guppy** (Gentoo) | `Containerfile.gentoo` does the same, for the same reason (see the Containerfile's own comment + prior LUKS run 31111959946). |
| **marlin** (Arch) | `pacman`'s package list has no `tpm2-tools`/`tpm2-tss`, so `dracut-config.sh`'s shared `command -v tpm2_pcrread` probe finds nothing and omits the module — same mechanism as the RPM bases, different outcome. |

These three now read **"❌ not possible today"** with the specific reason, instead of a `_pending E2E_` that implies the answer just isn't known yet. Everything else (the RPM family via the dracut-config.sh probe, the apt bases which install `tpm2-tools` explicitly) stays `_pending E2E_` — the tpm2-tss module *is* present in their initramfs; only the actual boot-time unseal is unconfirmed, which is exactly what the new workflow mode will confirm.

A new "TPM2 userspace in initramfs" column separates the static half of the picture (buildable from the Containerfiles, no boot required) from the runtime half (does it actually unseal) that only the E2E can answer.

**Note on marlin**: installing `tpm2-tools` on Arch would plausibly fix it, but this environment has no podman/registry access to actually build and verify an Arch image, so I left it documented rather than making a blind package-list change to a Containerfile I can't test.

### 3. "Confirm the image ships what the initramfs needs" — made durable, not one-time

`tests/bats/test_luks_tpm2_support_matrix.bats` ties the three ❌ rows to the actual Containerfile omit lines / package lists (and to the workflow's skip-list). If a future change gives one of these bases a real TPM2 userspace, a test breaks until the doc is updated to match — the fact can't silently drift out of sync with the code the way the original `_pending E2E_` rows already had (all 9 were `_pending E2E_` even though 3 could never leave that state).

### Bullet 4 — already resolved

"Consider whether `tpm2-luks-passphrase` should stop attempting install-time enrollment entirely" — already answered by the issue's own **Decision** section and `docs/LUKS-TPM.md`: fisherman#48's `ConditionFirstBoot` oneshot replaced the install-time attempt. No code change needed here.

## Verification

- `bats tests/bats/test_luks_tpm2_support_matrix.bats` — 8/8 pass.
- Same, plus the two related pre-existing files it cross-references (`test_dracut_tpm2_userspace.bats`, `test_gentoo_dracut_config.bats`) — 22/22 pass.
- Full bats suite (excluding the one file with a pre-existing, main-branch `yq`-not-found failure) — no new failures; the handful of pre-existing failures are all unrelated sandbox-tooling gaps (missing `file`/`shellcheck`/network access), none touch LUKS/TPM/this workflow.
- The new/edited `generate-matrix` jq logic run directly against the real `.github/build-config.yml` (converted via `js-yaml`): TPM mode produces exactly 10 cells (13 variants − 3 skipped), correctly picks `gnome` for every variant that has it and falls back to `pantheon` for `gurnard` (its only desktop flavor); default mode is byte-for-byte the same jq as before and still produces the original 112-cell full sweep.
- `.github/workflows/luks-e2e.yml` re-parsed with `js-yaml` after every edit (no YAML tooling available in this sandbox for a full `actionlint`/`yamllint` pass).

## Not in this PR

- Actually running the TPM auto-unlock E2E — no KVM/podman/GH Actions runner available here. That's what the new dispatchable/scheduled job is for; someone with runner access can trigger it (`workflow_dispatch` → `tpm_autounlock: true`) to start filling in the real `_pending E2E_` rows.
- Fixing marlin's missing `tpm2-tools` package — documented as a real, plausible follow-up (see above) rather than an unverified change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->