### PR TITLE
ci: gate Asahi promotion on boot manifest

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -916,13 +916,31 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+  # Asahi images are arm64-only, so the x86 QEMU gate above is skipped. Do not
+  # treat that skip as proof of an Apple Silicon image: the boot-chain
+  # manifest must pass against the just-pushed testing tag before promotion.
+  # This is also the repository-side safety valve for tunaOS#777: until the
+  # EL10 OBS packages provide the missing m1n1/update hooks and userspace,
+  # these images remain available as -testing but cannot become catalog tags.
+  verify_asahi:
+    name: Asahi manifest gate
+    needs: manifest
+    if: >-
+      inputs.publish && github.event_name != 'pull_request' &&
+      endsWith(inputs.flavor, '-asahi')
+    uses: ./.github/workflows/verify-asahi-one.yml
+    with:
+      image: ${{ vars.IMAGE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}/${{ inputs.image-name }}:${{ inputs.default-tag }}-testing
+    secrets: inherit
+
   tag-image:
     name: Promote
-    needs: [manifest, verify_boot]
+    needs: [manifest, verify_boot, verify_asahi]
     if: >-
       !cancelled() && github.event_name != 'pull_request' &&
       needs.manifest.result == 'success' &&
-      (needs.verify_boot.result == 'success' || needs.verify_boot.result == 'skipped')
+      (needs.verify_boot.result == 'success' || needs.verify_boot.result == 'skipped') &&
+      (needs.verify_asahi.result == 'success' || needs.verify_asahi.result == 'skipped')
     # Temporarily off RunsOn: the tuna-os AWS account is capped to Free Tier,
     # so CreateFleet rejects every 8-vCPU type it tries and the job dies in
     # "Set up runner" before a single step executes. This is registry and

--- a/tests/bats/test_asahi_promotion_gate.bats
+++ b/tests/bats/test_asahi_promotion_gate.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+# Arm64 Asahi images cannot use the x86 QEMU promotion gate. They therefore
+# need their own mandatory verification before the testing tag is copied to a
+# user-facing tag; otherwise an incomplete EL10 boot stack can be promoted
+# merely because its build completed.
+
+WORKFLOW="${BATS_TEST_DIRNAME}/../../.github/workflows/reusable-build-image.yml"
+
+@test "Asahi promotion calls the golden manifest gate" {
+  grep -q '^  verify_asahi:' "$WORKFLOW"
+  grep -q 'endsWith(inputs.flavor, '\''-asahi'\'')' "$WORKFLOW"
+  grep -q 'uses: ./\.github/workflows/verify-asahi-one.yml' "$WORKFLOW"
+  grep -q 'image: .*default-tag.*-testing' "$WORKFLOW"
+}
+
+@test "promotion waits for the Asahi gate" {
+  grep -q 'needs: \[manifest, verify_boot, verify_asahi\]' "$WORKFLOW"
+  grep -q 'needs.verify_asahi.result == '\''success'\''' "$WORKFLOW"
+  grep -q 'needs.verify_asahi.result == '\''skipped'\''' "$WORKFLOW"
+}


### PR DESCRIPTION
## What changed

- Add a mandatory Asahi golden-manifest gate for every `*-asahi` image promotion.
- Verify the just-pushed `-testing` image with `verify-asahi-one.yml` before copying it to user-facing tags.
- Add regression coverage for the workflow dependency and condition.

## Why

Asahi images are arm64-only, so they skip the x86 QEMU promotion gate. That previously allowed EL10 images with the documented m1n1/update-m1n1 and userspace package gaps to be promoted. This keeps those builds available under `-testing` while preventing them from entering catalog-facing tags until the OBS packages land and the manifest passes.

## Validation

- Static workflow assertions passed.
- `git diff --check` passed.
- Bats and actionlint were unavailable in the checkout environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->