### PR TITLE
docs(installer-frontends): update KDE/COSMIC encryption status for #734

### DIFF
--- a/docs/INSTALLER-FRONTENDS.md
+++ b/docs/INSTALLER-FRONTENDS.md
@@ -117,6 +117,12 @@ list. The keywords now match headings rather than bare nouns, so this shows as
 the genuine feature gap it is. This is precisely the drift the matrix exists
 to expose, and the matcher was concealing it.
 
+**Status update (tuna-os/tunaOS#734).** Fixed since this run —
+[tuna-installer-kde#6](https://github.com/tuna-os/tuna-installer-kde/pull/6)
+adds a new `EncryptionPage` (the same four choices, wired between disk-select
+and confirm) and is live on `main`. Left as ❌ above rather than flipped, for
+the same reason as COSMIC's row: no walkthrough run has re-measured it since.
+
 `install` and `done` are unmeasured: the walkthrough stops before starting a
 real install, by design.
 
@@ -137,6 +143,35 @@ specifically is mapped is what checks 4 and 5 do, and here they correctly
 failed. The walkthrough now also prints an explicit diagnosis when the gate
 passed but nothing advanced and no screen matched, rather than leaving six
 identical "not reached" lines to interpret.
+
+**Status update (tuna-os/tunaOS#734).** Two things have moved since this run,
+neither of which changes the row above yet:
+
+- The encryption picker itself is done —
+  [tuna-installer-cosmic#20](https://github.com/tuna-os/tuna-installer-cosmic/pull/20)
+  (merged) ports XFCE's four-choice `ENCRYPTION_CHOICES` value-for-value, with
+  the same `/sys/class/tpm/tpm0` TPM gating and a Continue-button validation
+  gate that XFCE doesn't even have. This was blocked on nothing except the
+  window bug below actually letting anyone reach the Options page.
+- A root-cause fix for the window bug is open —
+  [tuna-installer-cosmic#25](https://github.com/tuna-os/tuna-installer-cosmic/pull/25):
+  `init()` was calling `offline::live_iso_image()` synchronously, which shells
+  out to the host over flatpak-spawn; iced/libcosmic only creates the window
+  *after* `init()` returns, so a slow or hung host call there is
+  indistinguishable from "no window ever appears" — exactly this run's
+  symptom. The fix defers it to a `tokio::task::spawn_blocking` + `Task`,
+  matching the pattern already used elsewhere in `main.rs`. Reviewed in
+  detail; the diagnosis and fix both look correct on read-through.
+
+**Why the parity matrix above still reads 0/8, not fixed.** #25's own CI
+(`capture`/`screenshots`) is green, but that check runs the app's synthetic
+capture-mode fixtures, which take a different branch and never call
+`live_iso_image()` — so it cannot prove the real hang is gone. What actually
+caught this bug was `scripts/installer-walkthrough.py` driving a real QEMU
+boot of a `*:cosmic` ISO (this run). That is the check that needs to go green
+before this row moves off 0/8 — per this doc's own rule above, a cell should
+say what has genuinely been measured, not what a plausible-looking fix implies
+should now be true.
 
 ### KDE — run 29681255102 (yellowfin, strict)
 


### PR DESCRIPTION
## Summary

`tuna-os/tunaos#734` ("COSMIC installer cannot enable disk encryption at all") is, per the issue's own most recent comment, down to **1 of 4 frontends (COSMIC)**, specifically blocked on `tuna-os/tuna-installer-cosmic#4` ("installer process runs but no window ever appears"). That's a bug in a different repo, so there's no direct COSMIC-encryption-UI code change to make here — the UI itself already merged in [tuna-installer-cosmic#20](https://github.com/tuna-os/tuna-installer-cosmic/pull/20).

What this PR does instead, entirely within `tuna-os/tunaos`:

- **Updates `docs/INSTALLER-FRONTENDS.md`**, which is this repo's own audit trail for exactly this kind of frontend feature drift, but was frozen at a run predating both fixes that have since landed:
  - KDE: fixed by `tuna-installer-kde#6` (merged).
  - COSMIC: the encryption picker itself is done (`tuna-installer-cosmic#20`, merged); what's still open is the window bug, with a root-cause fix now up as `tuna-installer-cosmic#25`.
- Deliberately does **not** flip either parity-matrix row to ✅ — I reviewed `#25`'s fix in detail (see below) and it looks correct, but its own CI is green for a reason that doesn't actually prove the real bug is gone (see the new "Why the parity matrix above still reads 0/8" note), and this doc's own stated philosophy is explicit that claiming coverage nobody has is worse than a blank/stale cell. The new notes link the PRs so the next real walkthrough run knows what it's confirming.

## Investigation (for context, not part of this diff)

I also cross-checked `tuna-installer-cosmic#25` in detail, since it's the actual blocker:

- The diagnosis matches `#4`'s symptom exactly: `offline::live_iso_image()` shells a host command via flatpak-spawn synchronously inside `init()`; iced/libcosmic only creates the window after `init()` returns, so a hung/slow call there is indistinguishable from "no window ever appears."
- The fix (deferring via `tokio::task::spawn_blocking` + `Task::perform`) matches the exact pattern already used elsewhere in that file for other host calls — nothing novel introduced.
- Struct fields (`live_image: Option<String>`, `recipe: Recipe`) line up with the new `Message::LiveImageResolved` handler.
- **Caveat I flagged there**: `#25`'s green `capture`/`screenshots` check never exercises the code path being fixed (capture mode takes fixtures, skipping `live_iso_image()` entirely) — the actual proof needs `tunaOS`'s own QEMU + OCR installer-walkthrough re-run against it.

Left that as a review comment on `#25` (I have no merge rights on that repo, only a fork): https://github.com/tuna-os/tuna-installer-cosmic/pull/25#issuecomment-5228463629

## Not in this PR

- Merging `tuna-installer-cosmic#25` — outside this repo, and outside my access.
- Re-running the installer-walkthrough against COSMIC to confirm the window bug is actually fixed and flipping the parity-matrix row — needs `#25` merged first, plus a rebuilt `*:cosmic` ISO and the QEMU/GPU harness this environment doesn't have.
- Closing `tuna-os/tunaOS#734` itself — that should wait for the walkthrough confirmation above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->