### PR TITLE
fix(luks-e2e): transfer fallback onto scratch disk

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -2250,51 +2250,26 @@ run_install() {
 		# SLIRP pathology and a far faster link (2m54s) — the timing tracks
 		# bytes written, not network conditions. See #941.
 		#
-		# Do not "fix" this with a longer timeout, MTU clamping (already
-		# applied above) or retries. Any image larger than guest RAM cannot be
-		# delivered this way. Make the offline store resolve, or raise --memory
-		# above the image size.
+		# The fix is to use the already-mounted scratch disk for the fallback,
+		# not to increase timeouts or retry a write into the RAM-backed overlay.
 		echo "==> No local image in offline store — transferring from host via SSH"
 		local host_img="localhost/${VARIANT:-}:${FLAVOR:-}"
 		local host_tar="/tmp/luks-image-${VARIANT:-}-${FLAVOR:-}.tar"
+		local guest_tar_dir="/var/lib/containers/tunaos-e2e-transfer"
+		local guest_tar="${guest_tar_dir}/${host_tar##*/}"
 		if podman image exists "$host_img" 2>/dev/null; then
 			echo "==> Saving $host_img on host..."
 			podman save "$host_img" -o "$host_tar"
 
-			# Pre-flight: refuse a transfer the comment above already proves is
-			# doomed, instead of discovering it the same way #941 did — a
-			# silent multi-hour hang ending in the kernel OOM-killing the
-			# guest. The scp destination is GUEST_HOME (/home/liveuser), which
-			# is the live overlay's upperdir: a RAM-backed tmpfs, not disk.
-			# `df` on the guest reports 8G free there because that is the
-			# tmpfs's ADVERTISED size, not real backing store — every byte
-			# written to it is guest RAM. Compare the tar we are about to ship
-			# against the guest's live MemAvailable (not MemTotal: some RAM is
-			# already spoken for by the live session before we start copying)
-			# and fail fast with an actionable message if it cannot possibly
-			# fit, rather than burning the rest of the job's timeout budget on
-			# a transfer that ends in `scp: write remote ...: Failure`.
-			#
-			# 70% headroom, not 100%: podman load on the guest side still has
-			# to hold the tar AND unpack layers concurrently, plus whatever
-			# the live session itself needs to keep running. The one measured
-			# data point (#941) was a ~4.9G image against ~2.9G available —
-			# 169% of available, nowhere near this line — so 70% is a
-			# deliberately conservative guess, not a proven boundary.
-			local host_tar_bytes guest_mem_avail_kb
-			host_tar_bytes="$(stat -c%s "$host_tar" 2>/dev/null || echo 0)"
-			guest_mem_avail_kb="$("${ssh_cmd[@]}" "awk '/^MemAvailable:/{print \$2}' /proc/meminfo" 2>/dev/null || echo 0)"
-			if [[ "$host_tar_bytes" -gt 0 && "$guest_mem_avail_kb" -gt 0 ]]; then
-				local guest_mem_avail_bytes=$((guest_mem_avail_kb * 1024))
-				local safe_limit_bytes=$((guest_mem_avail_bytes * 70 / 100))
-				if [[ "$host_tar_bytes" -ge "$safe_limit_bytes" ]]; then
-					echo "ERROR: image tar (${host_tar_bytes} bytes / $((host_tar_bytes / 1024 / 1024))M) is too large for the guest's available RAM ($((guest_mem_avail_bytes / 1024 / 1024))M) to receive safely." >&2
-					echo "The SSH-transfer fallback writes into a RAM-backed tmpfs (${GUEST_HOME}) and will OOM-kill the guest partway through — this is a measured failure mode, not a guess (see #941)." >&2
-					echo "This path should not have been taken at all: make the offline store resolve so Fisherman can install directly from containers-storage (#941), or re-run with --memory well above the image size." >&2
-					rm -f "$host_tar" || true
-					return 3
-				fi
-			fi
+			# The scratch disk is mounted at /var/lib/containers above. Give the
+			# live user a temporary directory there so scp writes to disk rather
+			# than the RAM-backed GUEST_HOME overlay tmpfs. The previous destination
+			# caused multi-GB images to exhaust guest memory (#882).
+			"${ssh_cmd[@]}" "sudo install -d -o liveuser -g liveuser ${guest_tar_dir}" || {
+				echo "ERROR: scratch-disk transfer directory could not be prepared" >&2
+				rm -f "$host_tar" || true
+				return 3
+			}
 
 			# Bounded, like the fisherman call below. This is a multi-GB copy
 			# over a QEMU SLIRP hostfwd, so it is legitimately slow — but the
@@ -2305,20 +2280,20 @@ run_install() {
 			# readiness wait and the installed-boot wait.
 			e2e_phase "Transferring image to guest (this may take a few minutes)..."
 			if ! timeout 1800 "${scp_cmd[@]}" "$host_tar" \
-				"${GUEST_SCP_DEST}:${GUEST_HOME}/"; then
+				"${GUEST_SCP_DEST}:${guest_tar}"; then
 				echo "ERROR: image transfer to guest timed out or failed" >&2
 				rm -f "$host_tar" || true
 				return 3
 			fi
 			echo "==> Loading image into guest podman..."
-			if timeout 1800 "${ssh_cmd[@]}" "sudo podman load -i ${GUEST_HOME}/${host_tar##*/} 2>&1" 2>&1 | tee -a "${SERIAL_LOG}"; then
+			if timeout 1800 "${ssh_cmd[@]}" "sudo podman load -i ${guest_tar} 2>&1" 2>&1 | tee -a "${SERIAL_LOG}"; then
 				echo "==> Image loaded, using local containers-storage ref"
 				recipe_image="containers-storage:${host_img}"
 			else
 				echo "ERROR: podman load failed on guest"
 				return 3
 			fi
-			"${ssh_cmd[@]}" "rm -f ${GUEST_HOME}/${host_tar##*/}" || true
+			"${ssh_cmd[@]}" "sudo rm -f ${guest_tar}" || true
 			rm -f "$host_tar" || true
 		else
 			echo "ERROR: host image $host_img not found — was ISO build successful?"

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -913,6 +913,17 @@ setup_runtime_check_stubs() {
   grep -q 'mount ${SCRATCH_DISK_BYID} /var/lib/containers' "$SCRIPT"
 }
 
+@test "fisherman fallback transfers the image onto the scratch disk" {
+  # /home/liveuser is the live overlay upperdir and therefore RAM-backed. The
+  # fallback must stage the tar under the disk already mounted at
+  # /var/lib/containers, or a multi-GB image will exhaust the guest tmpfs.
+  grep -q 'guest_tar_dir="/var/lib/containers/tunaos-e2e-transfer"' "$SCRIPT"
+  grep -q 'sudo install -d -o liveuser -g liveuser ${guest_tar_dir}' "$SCRIPT"
+  grep -q '"${GUEST_SCP_DEST}:${guest_tar}"' "$SCRIPT"
+  grep -q 'sudo podman load -i ${guest_tar}' "$SCRIPT"
+  ! grep -q '"${GUEST_SCP_DEST}:${GUEST_HOME}/"' "$SCRIPT"
+}
+
 @test "generic: bootc install bakes serial kargs and tpm2-luks under --luks" {
   grep -q 'bootc install to-disk --wipe' "$SCRIPT"
   grep -qF 'block_setup="--block-setup tpm2-luks"' "$SCRIPT"


### PR DESCRIPTION
## What changed

- Stage the host image tar in a writable directory on the guest scratch disk (`/var/lib/containers`) instead of `/home/liveuser`.
- Load the image from that disk path and remove it after `podman load`.
- Add regression assertions preventing a return to the tmpfs destination.

## Why

The fallback copied multi-GB images into the live overlay upperdir, a RAM-backed tmpfs. This caused `scp: write remote ...: Failure` and guest OOMs even though the E2E path already attached and mounted a 32G scratch disk. The transfer now uses that disk while retaining bounded transfer/load timeouts.

## Validation

- `bash -n scripts/iso-e2e.sh`
- `git diff --check`
- Static regression assertions passed.
- Bats was unavailable in the checkout environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->