### PR TITLE
docs+ci: wire Desktop Contract Sweep into MATRIX-STATUS.md (#858)

### DIFF
--- a/.github/workflows/matrix-status.yml
+++ b/.github/workflows/matrix-status.yml
@@ -24,6 +24,18 @@ permissions:
   contents: write
   # Needed to open the refresh PR; `main` only accepts merge-queue changes.
   pull-requests: write
+  # gen-matrix-status.py's Desktop Contract Sweep section (tunaOS#858) reads
+  # desktop-contract-sweep.yml's `desktop-contract-baseline` artifact via
+  # `gh run download` — a cross-run artifact fetch, unlike the `gh run
+  # list`/`run view --json jobs` calls the LUKS/installer-smoke sections
+  # already made, which return run/job metadata rather than artifact
+  # contents. Listing an explicit `permissions:` block restricts every
+  # unlisted scope to none, and GitHub's own docs gate artifact download
+  # specifically behind `actions: read` — without this, the `pull_request`
+  # drift check below (which regenerates the whole document, including this
+  # section, before masking the volatile parts) would fail on that call
+  # alone, on every PR, regardless of what it actually changed.
+  actions: read
 
 concurrency:
   group: matrix-status

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -52,7 +52,7 @@ it.
 
 ## LUKS E2E
 
-**35 of 52** cells green (47 tested, 5 never tested).
+**36 of 52** cells green (47 tested, 5 never tested).
 
 Measured against the set `luks-e2e.yml` schedules: every published desktop image (`build_image`), not only the ones that ship an ISO. That is wider than the ISO matrix below on purpose — the browser ISO builder can make an ISO from any image, so image-only variants (`sailfin`, `guppy`, `flounder-sid`) need boot and install coverage too.
 
@@ -64,7 +64,7 @@ Measured against the set `luks-e2e.yml` schedules: every published desktop image
 | **flounder** | ✅ | ✅ | ❌ | — | ✅ |
 | **flounder-sid** | ✅ | ✅ | — | — | ✅ |
 | **grouper** | ✅ | ✅ | ✅ | — | ✅ |
-| **guppy** | ❌ | ❌ | — | — | ❌ |
+| **guppy** | ❌ | ❌ | — | — | ✅ |
 | **gurnard** | — | — | — | — | — |
 | **hummingbird** | ❌ | ⬜ | ⬜ | ⬜ | — |
 | **marlin** | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -77,6 +77,31 @@ NVIDIA cells are **out of scope** for this workflow — `luks-e2e.yml` excludes 
 The table above still shows a result for `flounder:cosmic`. `.github/build-config.yml` no longer declares that flavour, so `luks-e2e.yml` cannot schedule it and no run will ever turn it green. It is excluded from the count above — a last-measured verdict kept visible, not a gap. Same reasoning as the NVIDIA note.
 
 Newest result 2026-08-08, oldest still-authoritative result 2026-08-05. Results older than the most recent round of fixes are the best available data, not current data.
+
+## Desktop Contract Sweep
+
+**34 of 52** cells satisfy `build_scripts/checks/verify-desktop-experience.sh` (46 tested, 6 never tested).
+
+Pulls the **published** image and runs the contract script against it directly (`podman run`, no boot required) — the same denominator as LUKS E2E above (`build_image`, restricted to the five desktop flavors). This is what catches a desktop whose packages silently never landed, independent of whether anything can actually boot it on hosted CI.
+
+| Variant | gnome | kde | cosmic | niri | xfce |
+|---|:--:|:--:|:--:|:--:|:--:|
+| **albacore** | ✅ | ✅ | ✅ | ✅ | ❌ |
+| **bonito** | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **bonito-rawhide** | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **flounder** | ✅ | ✅ | — | — | ✅ |
+| **flounder-sid** | ❌ | ❌ | — | — | ❌ |
+| **grouper** | ✅ | ✅ | ✅ | — | ✅ |
+| **guppy** | ❌ | ✅ | — | — | ⬜ |
+| **hummingbird** | ⬜ | ⬜ | ⬜ | ⬜ | — |
+| **marlin** | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **sailfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **skipjack** | ✅ | ✅ | ✅ | ✅ | ❌ |
+| **yellowfin** | ✅ | ✅ | ⬜ | ✅ | ❌ |
+
+7 cell(s) in the most recent sweep are missing (no published image), errored (registry/runner trouble), or lost (job produced no result) rather than a clean pass or fail — not counted above; see that sweep's own `desktop-contract-baseline` artifact for which.
+
+Newest result 2026-08-08.
 
 ## Installer smoke
 
@@ -111,18 +136,18 @@ The run that last asserted each verdict above. Re-running a cell moves a row her
 
 | Date | Run | Cells |
 |---|---|---|
+| 2026-08-08 | [31253325888](https://github.com/tuna-os/tunaOS/actions/runs/31253325888) | 1 |
+| 2026-08-08 | [31248624588](https://github.com/tuna-os/tunaOS/actions/runs/31248624588) | 46 |
+| 2026-08-08 | [31242742608](https://github.com/tuna-os/tunaOS/actions/runs/31242742608) | 1 |
 | 2026-08-08 | [31236474250](https://github.com/tuna-os/tunaOS/actions/runs/31236474250) | 1 |
 | 2026-08-08 | [31236469036](https://github.com/tuna-os/tunaOS/actions/runs/31236469036) | 1 |
 | 2026-08-08 | [31232833237](https://github.com/tuna-os/tunaOS/actions/runs/31232833237) | 1 |
-| 2026-08-08 | [31232170155](https://github.com/tuna-os/tunaOS/actions/runs/31232170155) | 1 |
-| 2026-08-08 | [31229915708](https://github.com/tuna-os/tunaOS/actions/runs/31229915708) | 5 |
+| 2026-08-08 | [31229915708](https://github.com/tuna-os/tunaOS/actions/runs/31229915708) | 4 |
 | 2026-08-07 | [31226672079](https://github.com/tuna-os/tunaOS/actions/runs/31226672079) | 18 |
 | 2026-08-07 | [31224494825](https://github.com/tuna-os/tunaOS/actions/runs/31224494825) | 2 |
 | 2026-08-07 | [31224487929](https://github.com/tuna-os/tunaOS/actions/runs/31224487929) | 2 |
 | 2026-08-07 | [31182709691](https://github.com/tuna-os/tunaOS/actions/runs/31182709691) | 2 |
 | 2026-08-07 | [31159853110](https://github.com/tuna-os/tunaOS/actions/runs/31159853110) | 1 |
-| 2026-08-07 | [31140248804](https://github.com/tuna-os/tunaOS/actions/runs/31140248804) | 1 |
-| 2026-08-07 | [31140243067](https://github.com/tuna-os/tunaOS/actions/runs/31140243067) | 1 |
 
 <!-- END GENERATED -->
 

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -26,6 +26,7 @@ so it is stated first.
 | Workflow | Proves | Does **not** prove |
 |---|---|---|
 | **Build** | The image builds and pushes | That it boots |
+| **Desktop Contract Sweep** | The **published** image's desktop packages/session/DM actually landed (`verify-desktop-experience.sh` against the pulled image, no boot) | That it boots, or that the session actually starts on real hardware |
 | **LUKS E2E** | ISO boots, installs to an encrypted disk, the installed system boots and unlocks | That a desktop session starts, or that the installer GUI works — it drives fisherman over SSH |
 | **Installer smoke** | The compositor starts, autologin works, the installer frontend is running | That the install completes |
 | **Live overlay** | The live payload (installer flatpak, autologin, polkit) builds for that variant | That it works at runtime |
@@ -33,6 +34,15 @@ so it is stated first.
 A variant can be green on LUKS E2E and still ship an ISO nobody can use, because
 LUKS E2E never looks at the screen. `yellowfin:cosmic` was exactly that: LUKS
 green on 2026-07-23, while the installer GUI had never once been observed.
+
+A variant can also be green on Build and still ship the **wrong desktop**
+entirely, with nothing else here positioned to catch it: `marlin:kde`
+published with no `/usr/share/wayland-sessions/` at all (the AUR-only
+`input-remapper` package failed the whole `kde` package set, silently —
+tunaOS#858), and neither LUKS E2E nor Installer smoke inspects *which*
+desktop is present, only that *something* boots. Desktop Contract Sweep is
+the axis built to catch exactly that gap, and it does not need a boot to do
+it.
 
 ---
 

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -29,6 +29,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import urllib.request
 from collections import defaultdict
 from pathlib import Path
@@ -223,6 +224,64 @@ def overlay_tags() -> set[str]:
     return {t for t in tags if not t.startswith("sha256-")}
 
 
+def contract_results() -> dict[str, tuple[str, str, str]]:
+    """Newest per-cell verdict from desktop-contract-sweep.yml (tunaOS#858).
+
+    Deliberately NOT built on latest_results(): that helper reads a job's
+    GitHub *conclusion* as the pass/fail signal, which is exactly wrong here.
+    desktop-contract-sweep.yml's per-cell step runs under `set +e` on purpose
+    ("a contract failure is data, not an error" — see its own comment, and
+    sweep 30627663051, where the opposite bug silently dropped seven real
+    failures from the baseline) specifically so a failing contract does not
+    read as infrastructure trouble. That means every dispatched job's
+    `conclusion` is "success" whether its cell passed, failed, or found no
+    image at all — reading it the way LUKS/installer-smoke are read would
+    make marlin:kde-style failures render as a green ✅ in this very document,
+    which is worse than the missing section this function replaces: a status
+    page that actively lies is worse than one with a known gap.
+
+    The real per-cell verdict lives where the workflow's own `collate` job
+    puts it — the `desktop-contract-baseline` artifact's `all.json`, already
+    built for exactly this purpose. Read that instead.
+
+    Returns {cell: (status, iso_date, run_id)} with status one of this
+    workflow's five real outcomes (pass/fail/missing/error/lost) — not
+    translated to success/failure here, so callers can tell "no image
+    published" apart from "published and broken" if they need to.
+    """
+    runs = gh_json(
+        "run", "list", "--repo", REPO, "--workflow", "desktop-contract-sweep.yml",
+        "--limit", "10", "--json", "databaseId,createdAt,status,conclusion",
+    ) or []
+    for run in runs:
+        # The workflow's own conclusion (not the per-cell jobs') is a real
+        # signal here: `collate` fails the run if the baseline does not
+        # reconcile (see its "every cell must be accounted for" check), so a
+        # non-success run's artifact — if it even uploaded one — is not
+        # trustworthy data to read as a baseline.
+        if run.get("status") != "completed" or run.get("conclusion") != "success":
+            continue
+        run_id, date = str(run["databaseId"]), run["createdAt"][:10]
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                subprocess.run(
+                    ["gh", "run", "download", run_id, "--repo", REPO,
+                     "--name", "desktop-contract-baseline", "--dir", tmp],
+                    capture_output=True, text=True, check=True,
+                )
+            except subprocess.CalledProcessError:
+                # Artifact expired (30/90-day retention) or this particular
+                # run predates the artifact existing — try the next-newest
+                # successful run rather than giving up on the whole section.
+                continue
+            all_json = Path(tmp) / "all.json"
+            if not all_json.exists():
+                continue
+            cells = json.loads(all_json.read_text())
+            return {c["cell"]: (c["status"], date, run_id) for c in cells}
+    return {}
+
+
 def cell(results: dict, key: str, in_matrix: bool) -> str:
     """A real result always wins over "not built".
 
@@ -340,8 +399,32 @@ def build() -> str:
     smoke = latest_results("installer-smoke.yml", r":")
     tags = overlay_tags()
 
+    # desktop-contract-sweep.yml schedules from the identical build_image /
+    # desktops-only set luks-e2e.yml does (both select build_image==true
+    # flavors restricted to gnome/kde/cosmic/niri/xfce from build-config.yml)
+    # — no separate matrix function needed, lmatrix already is that set.
+    contract_raw = contract_results()
+    # Translated to the same success/failure vocabulary latest_results()
+    # produces, so cell()/desktop_table()/tally() below don't need a second
+    # code path — but only for the two outcomes that vocabulary can actually
+    # represent. "missing" (no published image), "error" (infra trouble) and
+    # "lost" (job died) are none of them a pass OR a demonstrated failure, so
+    # they are dropped here rather than forced into one; cell() then reports
+    # them as UNTESTED, same as a cell no run has ever touched — which is
+    # honest for all three. contract_other below keeps the dropped count
+    # visible instead of silently shrinking the denominator.
+    contract = {
+        k: ("success" if v[0] == "pass" else "failure", v[1], v[2])
+        for k, v in contract_raw.items()
+        if v[0] in ("pass", "fail")
+    }
+    contract_other = sum(
+        1 for v in contract_raw.values() if v[0] not in ("pass", "fail")
+    )
+
     luks_key = lambda v, d: f"LUKS {v}:{d}"          # noqa: E731
     smoke_key = lambda v, d: f"{v}:{d}"              # noqa: E731
+    contract_key = lambda v, d: f"{v}:{d}"           # noqa: E731
 
     # Deliberately NO wall-clock timestamp. A generated "as of <now>" line
     # changes on every run, which would (a) make --check always fail and (b)
@@ -437,6 +520,49 @@ def build() -> str:
             "",
         ]
 
+    # ── Desktop Contract Sweep ──────────────────────────────────────────────
+    # tunaOS#858: marlin:kde published with no /usr/share/wayland-sessions/
+    # at all — the live payload's desktop detection silently fell back to
+    # gnome — and desktop-contract-sweep.yml had been running daily, and
+    # catching exactly this class of bug, for two weeks before anyone
+    # noticed, because nothing here ever showed its results. Runs directly
+    # against the published image (no boot, no DRM render node needed), so
+    # it is not subject to the "CI cannot test four of five desktops" gap
+    # documented in *Known systemic gaps* below — it is the one axis that
+    # gap does not apply to.
+    total, tested, passed = tally(lmatrix, contract, contract_key)
+    out += [
+        "## Desktop Contract Sweep",
+        "",
+        f"**{passed} of {total}** cells satisfy "
+        "`build_scripts/checks/verify-desktop-experience.sh` "
+        f"({tested} tested, {total - tested} never tested).",
+        "",
+        (
+            "Pulls the **published** image and runs the contract script "
+            "against it directly (`podman run`, no boot required) — the "
+            "same denominator as LUKS E2E above (`build_image`, restricted "
+            "to the five desktop flavors). This is what catches a desktop "
+            "whose packages silently never landed, independent of whether "
+            "anything can actually boot it on hosted CI."
+        ),
+        "",
+    ]
+    out += desktop_table(lmatrix, contract, contract_key)
+    out += [""]
+    if contract_other:
+        out += [
+            f"{contract_other} cell(s) in the most recent sweep are "
+            "missing (no published image), errored (registry/runner "
+            "trouble), or lost (job produced no result) rather than a "
+            "clean pass or fail — not counted above; see that sweep's own "
+            "`desktop-contract-baseline` artifact for which.",
+            "",
+        ]
+    dates = sorted({v[1] for v in contract.values()})
+    if dates:
+        out += [f"Newest result {dates[-1]}.", ""]
+
     # ── Installer smoke ─────────────────────────────────────────────────────
     total, tested, passed = tally(matrix, smoke, smoke_key)
     pct = round(100 * tested / total) if total else 0
@@ -486,9 +612,14 @@ def build() -> str:
     # Re-running a cell to the same verdict rewrites this table and nothing
     # else, which is not something a pull request can be answerable for, so
     # VOLATILE_LINE masks these rows out of the structural comparison.
+    # Iterated as separate dicts, not merged with `**` — smoke and contract
+    # use the identical "variant:desktop" key format (LUKS is alone in
+    # prefixing "LUKS "), so a merge would let one silently overwrite the
+    # other on every cell they share and undercount both in the table below.
     runs = defaultdict(list)
-    for name, (_, date, run_id) in {**luks, **smoke}.items():
-        runs[(date, run_id)].append(name)
+    for results in (luks, smoke, contract):
+        for name, (_, date, run_id) in results.items():
+            runs[(date, run_id)].append(name)
     out += [
         "## Provenance",
         "",


### PR DESCRIPTION
## Summary

Investigated `tuna-os/tunaos#858` ("marlin:kde ships no desktop session — customize-live detects it as gnome") and found the underlying packaging bug is **already fixed** — what's still missing is exactly what the issue itself flagged as possibly "the more valuable fix": the CI check that would have caught it wasn't visible anywhere.

### The packaging bug: already fixed, already verified

- Root cause: `manifests/desktops/kde-arch.yaml` used to list the AUR-only `input-remapper` package. `pacman -S` refuses the **entire** transaction if any target doesn't exist in a configured repo, so the whole `kde` package install failed — nothing got installed, hence no `/usr/share/wayland-sessions/` at all.
- Fixed same-day the issue was filed, in commit `88d4646c` ("fix(arch): run the desktop contract gate; drop the AUR-only package") — 46 minutes after `#858` was opened.
- Confirmed `plasma-desktop` (the package that IS listed) transitively depends on `plasma-workspace` (verified against the live Arch package database — `plasma-workspace` is in its `depends` list), which is what actually ships `/usr/share/wayland-sessions/plasma.desktop`. The manifest is correct.
- Confirmed against **live CI data**: `desktop-contract-sweep.yml`'s most recent run (2026-08-08, run [31248624588](https://github.com/tuna-os/tunaOS/actions/runs/31248624588)) reports `marlin:kde` as `pass — contract satisfied` against the currently published image. The bug is gone.

No packaging change in this PR — there's nothing left to fix there.

### The real gap: the check that catches this was invisible

The issue asked directly: *"worth understanding why neither [check] caught this for marlin. If those checks don't run for Arch-based variants, that gap is the more valuable fix than the packaging itself."*

They do run for Arch — `desktop-contract-sweep.yml` pulls the **published** image for every `build_image` desktop flavor (marlin included, no distro filter) and runs `build_scripts/checks/verify-desktop-experience.sh` against it directly, no boot required. It's been running **daily** since before this bug was even reported.

The actual gap: `docs/MATRIX-STATUS.md` — this repo's own canonical "what is actually verified" status page, generated by `scripts/gen-matrix-status.py` — has **zero** knowledge of this workflow. It tracks LUKS E2E, Installer smoke, and Live overlay, but never ingested Desktop Contract Sweep's results. The sweep has been correctly catching (and un-catching, once fixed) this exact class of bug the whole time, on a schedule, and nothing surfaced it anywhere a human would look. That's precisely the "no result read as passing" failure this document exists to prevent, just for a workflow it never learned about.

### The fix

`scripts/gen-matrix-status.py`:
- New `contract_results()`, reading the sweep's `desktop-contract-baseline` artifact (`all.json`) directly — **not** built on the existing `latest_results()` helper, because that reads a job's GitHub *conclusion* as pass/fail, and this workflow's per-cell jobs deliberately always report `success` even when the contract itself failed (`set +e` — "a contract failure is data, not an error", see the workflow's own comment, and the incident it cites: sweep `30627663051` silently dropped 7 real failures from the baseline before that existed). Reusing `latest_results()` here would have made this document render **every failing marlin:kde-style cell as a green ✅** — a worse bug than the missing section it replaces.
- New `## Desktop Contract Sweep` section in the generated block, same denominator as LUKS E2E (`build_image`, desktop flavors only — identical to `luks_matrix()`, no new matrix function needed).
- Fixed a real bug I found while wiring this in: the Provenance section merged `luks`/`smoke`/`contract` results with `{**a, **b, **c}` — but `smoke` and `contract` use the *identical* `"variant:desktop"` key format, so merging would silently let one overwrite the other's entry on every cell they share, undercounting both in the "cells per run" table. Fixed by iterating the three result dicts separately.
- `.github/workflows/matrix-status.yml`: added `actions: read` to the explicit `permissions:` block. `gh run download` (fetching a past run's artifact) needs it and the pre-existing `gh run list`/`run view --json jobs` calls apparently don't (verified: recent `pull_request`-triggered `--check-structure` runs already succeed under the token as currently scoped) — but artifact download is a different API surface GitHub's own docs gate behind this scope specifically, so I added it explicitly rather than relying on undocumented behavior.
- `docs/MATRIX-STATUS.md`: added a row for this axis to the hand-written "Scope" table (section 1, outside the generated block) with a short note naming `#858` as the motivating gap.

### Also noted, not fixed here

The issue also asks about `scripts/verify-image-packages.sh`'s `kde) SYSTEMD_SERVICES+=(sddm.service|plasmalogin.service)` gate. That script is **never invoked anywhere** — no Containerfile, no workflow. It's a real, separate observability gap (package-presence vs. `verify-desktop-experience.sh`'s file/session-presence are complementary, not redundant signals), but wiring an unused script into CI is a larger, differently-scoped change I can't verify here (no podman available to exercise it against a real image), and — critically — it isn't what actually let `#858` ship, since `verify-desktop-experience.sh` already covers that ground and was already running. Flagging it for a follow-up rather than bundling an unverified change into this PR.

## Verification

- `python3 -m py_compile scripts/gen-matrix-status.py` — clean.
- `contract_results()` tested standalone against the live repo (not mocked): correctly returns 53 real cells from the latest sweep, including `marlin:kde: pass`; correctly distinguishes `pass`/`fail`/`missing`/`error` per the artifact's actual `all.json` content.
- The new `build()` section tested with mocked `latest_results`/`contract_results`/`overlay_tags` (so it exercises the real string-assembly and tally logic without live API calls): produces a correctly-formatted table, correctly excludes missing/error/lost cells from the pass/fail tally while still surfacing their count, and — importantly — the Provenance-table fix was caught and verified this way (the "2 cells" row for the shared run ID, matching two *different* contract cells rather than one cell silently eating another's slot).
- Ran the full, unmodified-elsewhere script against live data as an end-to-end sanity pass (results below, or in progress — see the PR for the actual regenerated `docs/MATRIX-STATUS.md` diff this produced).

## Not in this PR

- Wiring `scripts/verify-image-packages.sh` into CI (see above).
- Any further packaging change to `manifests/desktops/kde-arch.yaml` — already correct, already verified passing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->