### PR TITLE
fix(asahi): stage Sailfin DTBs and U-Boot payload

### DIFF
--- a/build_scripts/overlay/asahi.sh
+++ b/build_scripts/overlay/asahi.sh
@@ -303,10 +303,33 @@ esac
 		exit 1
 	}
 	# Debian-family kernels ship DTBs under /usr/lib/linux-image-<kver>/;
-	# stage the Apple ones at the layout update-m1n1 harvests.
+	# stage the Apple ones at the layout update-m1n1 harvests. openSUSE's
+	# kernel-asahi package uses /boot/dtb-<kver>/apple instead, so without this
+	# normalization Sailfin has a correct kernel but no DTBs for m1n1 to pass
+	# into it (tunaOS#914).
 	if [ ! -d "/usr/lib/modules/${KVER}/dtb/apple" ] && [ -d "/usr/lib/linux-image-${KVER}/apple" ]; then
 		mkdir -p "/usr/lib/modules/${KVER}/dtb"
 		cp -r "/usr/lib/linux-image-${KVER}/apple" "/usr/lib/modules/${KVER}/dtb/"
+	fi
+	if [ ! -d "/usr/lib/modules/${KVER}/dtb/apple" ]; then
+		for DTB_SRC in \
+			"/boot/dtb-${KVER}/apple" \
+			"/usr/lib/modules/${KVER}/dtbs/apple" \
+			"/lib/firmware/${KVER}/device-tree/apple" \
+			"/boot/dtb/apple"; do
+			if [ -d "$DTB_SRC" ]; then
+				mkdir -p "/usr/lib/modules/${KVER}/dtb"
+				cp -r "$DTB_SRC" "/usr/lib/modules/${KVER}/dtb/apple"
+				break
+			fi
+		done
+	fi
+	# OBS's u-boot-asahi package installs the payload as /boot/u-boot-nodtb.bin,
+	# while update-m1n1/asahi-bootbin-sync use the shared /usr/lib/asahi-boot
+	# location. Normalize that packaging choice before installing the sync unit.
+	if [ ! -f /usr/lib/asahi-boot/u-boot-nodtb.bin ] && [ -f /boot/u-boot-nodtb.bin ]; then
+		mkdir -p /usr/lib/asahi-boot
+		cp /boot/u-boot-nodtb.bin /usr/lib/asahi-boot/u-boot-nodtb.bin
 	fi
 	# Debian/Ubuntu asahi-scripts packaging may target initramfs-tools; vendor
 	# the upstream dracut modules if absent (all TunaOS images build their

--- a/scripts/verify-asahi-image.sh
+++ b/scripts/verify-asahi-image.sh
@@ -95,7 +95,7 @@ check_any "m1n1 payload" /usr/lib64/m1n1/m1n1.bin /usr/lib/m1n1/m1n1.bin /usr/li
 # by downloading uboot-asahi-2026.04.asahi2-1-aarch64.pkg.tar.xz and listing
 # its contents directly) ships u-boot-nodtb.bin there instead, matching the
 # other two families' filename — only the directory differs by family.
-check_any "Apple U-Boot payload" /usr/share/uboot/apple_m1/u-boot-nodtb.bin /usr/lib/u-boot/apple_m1/u-boot-nodtb.bin /usr/lib/asahi-boot/u-boot-nodtb.bin
+check_any "Apple U-Boot payload" /usr/share/uboot/apple_m1/u-boot-nodtb.bin /usr/lib/u-boot/apple_m1/u-boot-nodtb.bin /usr/lib/asahi-boot/u-boot-nodtb.bin /boot/u-boot-nodtb.bin
 # CentOS Hyperscale SIG's update-m1n1 RPM (EL10: skipjack/yellowfin/albacore)
 # installs to /usr/sbin, not /usr/bin like Fedora's — verified by downloading
 # update-m1n1-20250426.1-1.hs+asahi.el10.noarch.rpm from the Hyperscale

--- a/tests/bats/test_asahi_sailfin_staging.bats
+++ b/tests/bats/test_asahi_sailfin_staging.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+OVERLAY="${REPO_ROOT}/build_scripts/overlay/asahi.sh"
+VERIFY="${REPO_ROOT}/scripts/verify-asahi-image.sh"
+
+@test "Asahi overlay normalizes openSUSE Apple DTBs" {
+  grep -q '/boot/dtb-${KVER}/apple' "$OVERLAY"
+  grep -q '/usr/lib/modules/${KVER}/dtbs/apple' "$OVERLAY"
+  grep -q '/usr/lib/modules/${KVER}/dtb/apple' "$OVERLAY"
+}
+
+@test "Asahi overlay normalizes openSUSE U-Boot payload" {
+  grep -q '/boot/u-boot-nodtb.bin' "$OVERLAY"
+  grep -q '/usr/lib/asahi-boot/u-boot-nodtb.bin' "$OVERLAY"
+  grep -q '/boot/u-boot-nodtb.bin' "$VERIFY"
+}


### PR DESCRIPTION
## What changed

- Normalize openSUSE kernel DTBs from `/boot/dtb-<kver>/apple` and other family layouts into `/usr/lib/modules/<kver>/dtb/apple`.
- Normalize OBS `u-boot-asahi`'s `/boot/u-boot-nodtb.bin` into `/usr/lib/asahi-boot/u-boot-nodtb.bin`.
- Teach the Asahi verification harness to recognize the OBS U-Boot path.
- Add static regression coverage.

## Why

Sailfin's OBS kernel and U-Boot packages are present, but their openSUSE filesystem layouts differed from the paths consumed by the Asahi boot-chain sync service. The image therefore contained a kernel and m1n1 but no usable Apple DTB/U-Boot chain.

## Validation

- `bash -n build_scripts/overlay/asahi.sh scripts/verify-asahi-image.sh`
- `git diff --check`
- Static regression assertions passed.
- Bats was unavailable in the checkout environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->