### PR TITLE
fix(asahi): force conflicting stock kernel out on install, hard-fail if two survive (tunaOS#912)

### DIFF
--- a/build_scripts/overlay/asahi.sh
+++ b/build_scripts/overlay/asahi.sh
@@ -68,7 +68,17 @@ fedora)
 	mkdir -p /boot/dtb
 	dnf -y remove --noautoremove kernel kernel-core kernel-modules \
 		kernel-modules-core kernel-modules-extra || true
-	dnf -y install kernel-16k kernel-16k-modules-extra \
+	# --allowerasing: asahi-platform-metapackage Conflicts with kernel-core
+	# (and kernel-devel, kernel-debug-core, …) — verified directly against
+	# the real package's Conflicts list. Without --allowerasing, dnf will
+	# not erase a conflicting already-installed package to satisfy an
+	# install (that requires explicit permission); with it, if the removal
+	# above didn't fully take (silently, via the `|| true` — e.g. a stock
+	# kernel-core the removal step couldn't drop), this install step still
+	# forces the stock kernel out here instead of installing the asahi
+	# kernel *alongside* it. Belt-and-braces with the hard verification
+	# below, which is the actual guarantee (tunaOS#912).
+	dnf -y install --allowerasing kernel-16k kernel-16k-modules-extra \
 		asahi-platform-metapackage \
 		alsa-ucm-asahi tiny-dfr \
 		grub2-efi-aa64-modules uboot-images-armv8 \
@@ -116,7 +126,26 @@ centos)
 		kernel-modules-core kernel-modules-extra || true
 	# metapackage-core pulls kernel-16k, dracut-asahi, update-m1n1 (-> m1n1 +
 	# uboot-images-armv8), alsa-ucm-asahi, asahi-fwupdate.
-	dnf -y install kernel-16k kernel-16k-modules-extra \
+	#
+	# --allowerasing: fetched the real Hyperscale packages-asahi repodata
+	# (repo.almalinux.org / mirror.stream.centos.org, 2026-08-08) and
+	# confirmed asahi-platform-metapackage-core's rpm:conflicts list
+	# includes kernel-core, kernel-devel, kernel-debug-core,
+	# kernel-64k-core, and their kernel-rt-* counterparts — but NOT plain
+	# kernel-modules/-core/-extra. dnf5 does not auto-erase a conflicting
+	# already-installed package during `install` without this flag (would
+	# instead fail outright with "problem: conflicting requests", or on
+	# some solver paths just silently leave the stock kernel-core in
+	# place alongside the new one — tunaOS#912, the AlmaLinux-10-stable
+	# case where the earlier `remove --noautoremove ... || true` step's
+	# silently-swallowed failure meant kernel-core was still installed
+	# right here). Real fix belongs upstream in the earlier removal step
+	# too, but that failure is opaque from outside a live build; forcing
+	# the conflict to resolve here — where we know exactly what must not
+	# coexist with the asahi kernel — is the actionable half. The hard
+	# verification a few lines down (common to every family) is the actual
+	# guarantee that two kernels can never again ship silently.
+	dnf -y install --allowerasing kernel-16k kernel-16k-modules-extra \
 		asahi-platform-metapackage-core
 	install_best_effort "dnf -y install" \
 		asahi-platform-metapackage-audio asahi-scripts \
@@ -284,6 +313,26 @@ esac
 	# dead weight in the final image — no vmlinuz/initramfs gets built for
 	# them and bootc only ever deploys $KVER. Drop them.
 	find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d ! -name "$KVER" -exec rm -rf {} +
+	# Hard verification, not a hope: tunaOS#912 is exactly this rm -rf line
+	# *not* actually leaving only one kernel — on albacore (AlmaLinux 10
+	# stable) the stock EL10 kernel-core rpm survived the earlier
+	# `dnf remove ... || true` (silently, package-manager-level) and the
+	# published image shipped two full /usr/lib/modules/<kver> trees, an
+	# ambiguous-boot hazard on hardware with no working stock-kernel path.
+	# The asahi-verify harness caught it after publish; that is one build
+	# too late. Fail the build itself instead: after the cleanup above,
+	# exactly one directory may remain, and it must be the one we selected.
+	# A silently-wrong image is worse than a loud build failure — same
+	# reasoning as every other hard gate in this file (the KVER-naming
+	# WARNING above, the "no kernel image found" checks below).
+	REMAINING_KVERS=$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d -printf '%f\n')
+	REMAINING_COUNT=$(printf '%s\n' "$REMAINING_KVERS" | grep -c .)
+	if [ "$REMAINING_COUNT" -ne 1 ] || [ "$REMAINING_KVERS" != "$KVER" ]; then
+		echo "ERROR: expected exactly 1 kernel in /usr/lib/modules (${KVER}) after cleanup, found ${REMAINING_COUNT}:" >&2
+		printf '%s\n' "$REMAINING_KVERS" >&2
+		echo "ERROR: this means a stock/base-distro kernel package survived removal (see the dnf remove/install above) even though its module directory should have been deleted — an ambiguous-boot image must not be published (tunaOS#912)." >&2
+		exit 1
+	fi
 	# Stage vmlinuz where bootc expects it (Fedora/EL RPMs do this natively;
 	# Debian kernels put it in /boot; Arch names it after the package).
 	if [ ! -f "/usr/lib/modules/${KVER}/vmlinuz" ]; then


### PR DESCRIPTION
## What

`albacore:gnome-asahi` ships two kernels — the stock EL10 `kernel-core` was never removed, sitting alongside a correctly-installed asahi kernel:

```
FAIL expected exactly 1 kernel in /usr/lib/modules, found 2:
     6.12.0-211.33.1.el10_2.aarch64
     6.16.4-0.hs100.hs+asahi.el10.aarch64+16k
```

Same failure *family* as #800 (dnf5's flag is `--noautoremove`, not `--no-autoremove`) — I confirmed that flag is still correctly spelled on both the fedora and centos branches of `build_scripts/overlay/asahi.sh`, so this is a distinct gap in the same area, not a re-regression of the typo.

## Root cause

I could not run a real EL10 build (no podman/buildah, no root, in this sandbox), so this is the best evidence I could gather without one:

The kernel-removal step (`dnf -y remove --noautoremove kernel kernel-core ... || true`) can fail silently for reasons opaque outside a live build — dependency issues, or AlmaLinux-10-**stable**-specific state (the harness shows yellowfin/skipjack, same code branch, same EL10 stack, do *not* have this bug — only stable AlmaLinux 10 does; something about that specific point-release differs from Kitten/Stream10, though I could not pin the exact mechanism without a real build).

When that removal underperforms, the *next* step — `dnf -y install kernel-16k ... asahi-platform-metapackage(-core)` — has no way to actually force the stock kernel out. I fetched the real Hyperscale `packages-asahi` repodata directly (`repo.almalinux.org` / `mirror.stream.centos.org`, 2026-08-08) and confirmed `asahi-platform-metapackage(-core)`'s `rpm:conflicts` list includes `kernel-core`, `kernel-devel`, `kernel-debug-core`, `kernel-64k-core`, and their `kernel-rt-*` counterparts. dnf5 does **not** auto-erase a conflicting already-installed package during `install` without `--allowerasing` — I verified this against dnf5's actual documented behavior rather than assuming it, after first checking (and ruling out) two other theories:
- that `kernel`/`kernel-core` might be a *protected package* on AlmaLinux 10 (`/etc/dnf/protected.d/`) — fetched and grepped the real AlmaLinux 10 BaseOS/AppStream aarch64 filelists directly; no such file exists for any kernel package.
- that some already-installed BaseOS/AppStream package hard-`Requires: kernel-core` (which would make dnf's solver refuse the whole removal transaction) — fetched and parsed the real primary.xml for both repos; nothing outside the `kernel` metapackage itself does.

So without `--allowerasing`, an install-time conflict this severe either fails outright, or on some solver path leaves the stock kernel in place — which is exactly what the harness found.

## Changes

1. **`dnf -y install --allowerasing ...`** on both the fedora and centos branches of `asahi.sh`. This forces the confirmed conflict to resolve at install time regardless of *why* the earlier removal step underperformed. It's a no-op when there's nothing to erase — bonito is already 36/36 and this doesn't touch that path's behavior.
2. **A hard, loud verification** immediately after the existing mtime-based "drop every `/usr/lib/modules/<kver>` except the selected one" cleanup (already common to every family this script supports, filesystem-level and distro-agnostic): assert exactly one kernel directory remains, and it's the one selected. If not, fail the build with a clear diagnostic instead of silently publishing an ambiguous-boot image. This is the actual guarantee the issue asks for — *"nothing guarantees the bootloader picks the asahi one"* — and it makes a two-kernel asahi image structurally impossible to ship silently again, for **any** family, not just this one case on albacore.

## Testing

- `bash -n` + a freshly built `shellcheck` (0.11.0): zero findings
- Verified dnf5's actual conflict-resolution and remove-nonexistent-package semantics against real documentation before writing the fix (not assumed)
- Fetched and inspected real AlmaLinux 10 BaseOS/AppStream aarch64 repodata directly to rule out the protected-package and hard-Requires theories
- Fetched and inspected the real Hyperscale `packages-asahi` repodata directly to confirm the exact `Conflicts:` list the `--allowerasing` fix targets
- Exercised the new verification snippet standalone against three simulated `/usr/lib/modules` states (one correct kernel / two kernels / zero kernels) — passes and fails exactly as intended in each case
- Could **not** run an actual buildah/podman image build or a real EL10 dnf5 transaction in this sandbox (no container-build tooling, no root)

**Suggested check after merge**, per the issue: re-dispatch the asahi-verify harness for albacore and expect 36/36, matching bonito (same EL10 stack).

🐝 **Hive Agent**: `contributor`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->