### PR TITLE
contract(cosmic): require cosmic-files + xdg-desktop-portal-cosmic where the manifest actually requires them (tunaOS#916)

### DIFF
--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -255,13 +255,51 @@ cosmic)
 	require_command cosmic-comp
 	require_glob '/usr/share/wayland-sessions/*cosmic*.desktop'
 	require_unit greetd
-	# NOT extended. cosmic-files and xdg-desktop-portal-cosmic look like the
-	# obvious requirements, but on el10 they are installed from a COPR, and
-	# copr installs are best-effort — a flaky COPR would turn a requirement
-	# into a hard build failure on a variant that has always built. Nor is
-	# either path measured on any published cosmic image yet. Measure
-	# bonito:cosmic (fedora) and flounder:cosmic (apt) first, then decide.
+	# Extended per tunaOS#916's own checklist item, with the same discipline
+	# GNOME/KDE/XFCE were held to: measure the manifest first, then require.
 	#
+	# cosmic-files and xdg-desktop-portal-cosmic are explicit, non-optional
+	# entries in manifests/desktops/cosmic.yaml's apt, fedora and zypper
+	# sections, and in cosmic-arch.yaml's pacman section — the same bar
+	# dolphin/konsole (kde) and thunar (xfce) were required on ("explicit in
+	# every manifest section that builds"). Without a file manager COSMIC is
+	# not merely sparse, it is unusable the same way sailfin:gnome was
+	# (tunaos-packages#132, the issue that started this whole contract).
+	#
+	# el10 (yellowfin/albacore/skipjack/redfin) is deliberately excluded:
+	# there both packages come from the yselkowitz/cosmic-epel COPR
+	# (cosmic.yaml's el10.copr section), and install-desktop.sh installs
+	# every copr block with `|| true` (the exact "COPR packages" step,
+	# distinct from the regular `dnf_retry -y install` used for fedora/apt/
+	# zypper/pacman, which has no such fallback) — a flaky COPR there can
+	# legitimately produce a build that has always shipped correctly. The
+	# condition below reproduces install-desktop.sh's own _TD_OS="el10"
+	# fallback exactly (dnf-based, not Fedora, not Hummingbird) rather than
+	# re-deriving it from a distro-name enumeration that could drift out of
+	# sync with the real branching logic.
+	#
+	# Binary path for cosmic-files confirmed live (mdapi.fedoraproject.org
+	# rawhide file list, 2026-08-08): /usr/bin/cosmic-files, so a plain PATH
+	# check is correct. xdg-desktop-portal-cosmic confirmed the same way:
+	# /usr/libexec/xdg-desktop-portal-cosmic on Fedora — matching this same
+	# file's already-twice-measured portal convention (libexec on Fedora/EL/
+	# Debian/Ubuntu/openSUSE, lib on Arch, see the table above the case
+	# statement), which xdg-desktop-portal-cosmic packaging follows for the
+	# same reason its sibling backends (-gnome, -gtk) do: all three build
+	# from the same upstream xdg-desktop-portal libexecdir convention per
+	# distro. Not independently re-measured on Ubuntu/openSUSE/Arch in this
+	# change (no zstd tooling available to read their repodata here) — recorded
+	# so the next person knows which half of this is live-verified and which
+	# is carried over from an already-established pattern, same as this
+	# file's own stated rule asks for.
+	if [[ "${PKG_MGR:-}" == "dnf" && "${IS_FEDORA:-false}" != true && "${IS_HUMMINGBIRD:-false}" != true ]]; then
+		echo "info: skipping cosmic-files/xdg-desktop-portal-cosmic on the el10 family — cosmic.yaml sources them from a best-effort COPR here (tunaOS#916)"
+	else
+		require_command cosmic-files
+		require_any_glob \
+			'/usr/libexec/xdg-desktop-portal-cosmic' \
+			'/usr/lib/xdg-desktop-portal-cosmic'
+	fi
 	# cosmic-greeter.service is accepted alongside greetd.service because it is
 	# greetd: `ExecStart=greetd --config /etc/greetd/cosmic-greeter.toml`, with
 	# `Provides: x-display-manager` and `Pre-Depends: greetd` on the deb. On


### PR DESCRIPTION
## What

Follow-up to issue #916's GNOME/KDE/XFCE usability requirements: *"a session can start"* and *"this is a desktop someone can use"* are different assertions, and cosmic's contract was only making the first one. The script itself flagged this:

> NOT extended. cosmic-files and xdg-desktop-portal-cosmic look like the obvious requirements, but on el10 they are installed from a COPR, and copr installs are best-effort... Measure bonito:cosmic (fedora) and flounder:cosmic (apt) first, then decide.

This PR is that measurement (flounder doesn't actually build a `cosmic` flavor — Debian has no COSMIC packaging at all, per `build-config.yml`'s own comment — so I checked every family that *does* build it instead: fedora, apt/Ubuntu, zypper/openSUSE, pacman/Arch, and el10).

## What I found

Checking `manifests/desktops/cosmic.yaml` and `cosmic-arch.yaml` directly — the same bar `dolphin`/`konsole` (kde) and `thunar` (xfce) were required on ("explicit in every manifest section that builds"):

- **apt (Ubuntu), fedora, zypper (openSUSE), and pacman (Arch)** all list `cosmic-files` and `xdg-desktop-portal-cosmic` as plain required packages — not `optional:`, not COPR-sourced.
- **Only el10** (yellowfin/albacore/skipjack/redfin) sources them from a COPR (`yselkowitz/cosmic-epel`), and `install-desktop.sh` installs every `copr:` block with `|| true` — genuinely best-effort there, distinct from the regular `dnf_retry -y install` path the other four families use. So the script's existing worry about a flaky COPR turning a working build red is correct, but only for that one family.

## Fix

Require both `cosmic-files` and `xdg-desktop-portal-cosmic` on every family **except** el10, using the exact same `dnf-based / not-Fedora / not-Hummingbird` condition `install-desktop.sh` itself uses to pick its `"el10"` manifest section (`_TD_OS`) — rather than re-deriving the distro list separately where it could drift out of sync.

Verified the actual install paths **live**, not guessed: queried `mdapi.fedoraproject.org`'s rawhide file listing for both packages.
- `cosmic-files` → `/usr/bin/cosmic-files` (plain PATH check is correct)
- `xdg-desktop-portal-cosmic` → `/usr/libexec/xdg-desktop-portal-cosmic`, matching this file's own already-measured portal convention (libexec on Fedora/EL/Debian/Ubuntu/openSUSE, lib on Arch — the same split already proven for `xdg-desktop-portal-gnome`/`-gtk`).

The Ubuntu/openSUSE/Arch paths are carried over from that established convention, **not independently re-measured** in this change — this sandbox has no `zstd` tooling to read their repodata (Fedora's own repodata is also zstd; `mdapi.fedoraproject.org` happens to expose a plain-JSON file list, which is why only Fedora is a live measurement here). Recorded explicitly in the code comment so the next person knows which half is measured and which is inferred — matching this file's own stated discipline of "never add a glob you have not seen resolve."

## Testing

- `bash -n` + a freshly built `shellcheck` (0.11.0): zero new findings (one pre-existing SC1091 info-level finding, unrelated — confirmed via a before/after diff of shellcheck's own output against the unmodified file)
- Exercised the new el10-vs-everyone-else gating logic standalone against five simulated `(PKG_MGR, IS_FEDORA, cosmic-files-present)` combinations: el10 always skips regardless of package state (never turns a working el10 build red); fedora/apt both correctly pass when present and correctly fail loudly when absent — i.e. it *discriminates*, the same property the issue's own GNOME fix was checked for (`yellowfin:gnome -> exit=0` ... `sailfin:gnome -> exit=1`)
- Could **not** run an actual buildah/podman image build against a real cosmic image in this sandbox (no container-build tooling, no root)

## Not addressed here

Niri already carries portal+keyring requirements from an earlier commit (`78c6ff096`), with the shell itself left unasserted for a documented, still-valid reason (quickshell/DMS vs. openSUSE's wlroots stack diverge per distro). I don't think that checklist item needs further work right now, but I'm leaving that call to a maintainer rather than asserting it myself.

🐝 **Hive Agent**: `contributor`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->