### PR TITLE
fix(e2e): wait for the desktop to actually paint before the evidence screenshot (tunaOS#581)

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -98,4 +98,4 @@ For desktop environment changes:
 | ISO doesn't boot | Missing KVM support; try adding `--no-kvm` to the QEMU command |
 | Timeout waiting for desktop | Desktop environment failed to start; check serial logs |
 | `qemu-img` not found | Install `qemu-utils` package |
-| Screenshot is blank | Display manager may not have started; increase timeout |
+| Screenshot is blank | **Not necessarily a failure.** Under plain virtio-vga (no render node) the guest paints with Mesa's llvmpipe software rasteriser, and first paint can trail the serial markers by a minute or more on a 2-4 vCPU runner (tunaOS#581). The gates key off the serial markers (`TUNAOS_DESKTOP_CONTRACT_OK` / readiness marker); `iso-e2e.sh` waits for the framebuffer to actually paint before the evidence screenshot (`wait_for_paint`, bounded by `TBOX_E2E_PAINT_TIMEOUT`, default 120s) instead of a fixed sleep. A still-blank capture after that cap means the image genuinely never painted — check `serial.log` for whether the display manager started |

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -360,6 +360,20 @@ fi
 # and that belief is now untested rather than demonstrated — the smoke matrix
 # has never run gnome. For everything else use scripts/iso-e2e-gpu.sh on a
 # host with a real render node.
+#
+# WHETHER OR NOT virgl engages, "GDM slow or black" under this GPU-less path
+# is expected and is NOT a boot failure (tunaOS#581). The guest's display
+# stack falls back to Mesa's llvmpipe software rasteriser, whose first frame
+# can trail the serial contract markers by a minute or more on a 2-4 vCPU
+# runner — the VM is healthy and simply has not painted yet. The boot gates
+# therefore key off the serial markers (the #575 mitigation), and the
+# evidence screenshot waits for paint (wait_for_paint / TBOX_E2E_PAINT_TIMEOUT)
+# instead of a fixed sleep. Screendump reads the current scanout buffer, so
+# while llvmpipe is mid-frame the capture is black; VT-switching to a tty
+# other than the compositor's shows black for a different reason — the live
+# squash runs getty only on tty1 and the serial console (ttyS0), so tty3 has
+# no console to switch to; the Wayland compositor holds tty1. The serial log
+# is the source of truth for "is it up", pixels are only for the gallery.
 _gpu_mode="${TBOX_E2E_GPU:-auto}"
 QEMU_GPU_ARGS=(-vga virtio -display none)
 if [[ "$_gpu_mode" != "plain" ]] && { [[ "$_gpu_mode" == "virgl" ]] || [[ -e /dev/dri/renderD128 ]]; } &&
@@ -1238,6 +1252,43 @@ screenshot_sane() {
 		return 0
 	fi
 	echo "==> Screenshot ${label} looks blank (stddev=${stddev} <= 0.02)" >&2
+	return 1
+}
+
+# Give the display manager/desktop time to actually PAINT before the evidence
+# screenshot. Under QEMU's plain virtio-vga there is no render node, so the
+# guest composites with Mesa's llvmpipe software rasteriser; its first frame
+# can trail the serial contract marker by a minute or more on a 2-4 vCPU
+# runner (tunaOS#581). A fixed sleep before the screenshot therefore produced
+# a black "10-ready" in the evidence gallery for an otherwise-healthy gate,
+# and the screenshot-sanity fallback could not tell "slow" from "failed".
+#
+# Poll the framebuffer instead: screenshot, measure (screenshot_sane), retry
+# until the image has structure or the cap is reached. The LAST screenshot is
+# always left on disk as evidence. This is evidence, not a gate — pass/fail
+# stays with the serial marker (the #575 mitigation) — so a machine that
+# genuinely cannot paint extends the wait, it does not fail the run. The
+# per-attempt stddev is logged so a blank result stays diagnosable.
+wait_for_paint() {
+	local label="$1"
+	local cap="${TBOX_E2E_PAINT_TIMEOUT:-120}"
+	local deadline=$(($(date +%s) + cap))
+	local attempt=0
+	while (($(date +%s) < deadline)); do
+		attempt=$((attempt + 1))
+		screenshot "$label"
+		if screenshot_sane "$label"; then
+			echo "==> ${label} painted on attempt ${attempt} (stddev=${SCREENSHOT_STDDEV})"
+			return 0
+		fi
+		sleep 15
+	done
+	# One final capture after the cap so the freshest frame is the evidence.
+	screenshot "$label"
+	if screenshot_sane "$label"; then
+		return 0
+	fi
+	echo "==> ${label} still blank after ${cap}s (stddev=${SCREENSHOT_STDDEV}) — the serial marker, not pixels, is the gate" >&2
 	return 1
 }
 
@@ -2909,8 +2960,12 @@ disk)
 		sleep 10
 	done
 	# Let the display manager finish drawing before capturing evidence.
-	sleep 30
-	screenshot "10-ready"
+	# Poll for paint instead of a fixed 30s sleep: under plain virtio-vga the
+	# guest renders via llvmpipe and first paint can lag the contract marker
+	# by minutes on a 2-4 vCPU runner (tunaOS#581). The verdict above already
+	# came from the serial marker, so this is evidence work — a slow or absent
+	# paint extends the run, it cannot fail it.
+	wait_for_paint "10-ready" || true
 	if [[ "$rc" -eq 2 ]]; then
 		echo "ERROR: desktop experience contract marker was not emitted" >&2
 	fi
@@ -2926,7 +2981,11 @@ ready)
 	# whole recovery story for serial-less kernels. A bare call here
 	# historically aborted the script at exit 2 with only 00-boot captured.
 	wait_for_ready && rc=0 || rc=$?
-	screenshot "10-ready"
+	# Poll for paint so the evidence screenshot — and the screenshot-sanity
+	# fallback below, which re-measures the same file — sees the desktop
+	# rather than a still-llvmpipe black frame (tunaOS#581). Bounded by
+	# TBOX_E2E_PAINT_TIMEOUT; the serial marker, not pixels, stays the gate.
+	wait_for_paint "10-ready" || true
 	# Serial marker missing is expected when the guest kernel has no serial
 	# console support; fall back to verifying the framebuffer actually
 	# rendered a screen. Hard failures (blank/absent screenshot) stay fatal

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -637,6 +637,43 @@ setup_runtime_check_stubs() {
 }
 
 # ═══════════════════════════════════════════════════════════════════════════
+# Paint Wait (tunaOS#581)
+# ═══════════════════════════════════════════════════════════════════════════
+# Under plain virtio-vga the guest paints with llvmpipe, and first paint can
+# trail the serial markers by minutes on a 2-4 vCPU runner. The evidence
+# screenshot must wait for paint (bounded) instead of a fixed sleep, and must
+# never flip a healthy-but-slow boot into a failed gate.
+
+@test "paint-wait: wait_for_paint helper exists and defaults to a 120s cap" {
+  grep -q '^wait_for_paint()' "$SCRIPT"
+  awk '/^wait_for_paint\(\)/,/^}/' "$SCRIPT" | grep -q 'TBOX_E2E_PAINT_TIMEOUT:-120'
+  awk '/^wait_for_paint\(\)/,/^}/' "$SCRIPT" | grep -q 'screenshot_sane'
+}
+
+@test "paint-wait: disk-mode gate polls for paint instead of the fixed 30s sleep" {
+  # The #581 defect: `sleep 30; screenshot` after the contract marker — GDM
+  # under llvmpipe routinely needs longer, so the evidence gallery got black
+  # frames for healthy boots. The fixed sleep must be gone from the disk path.
+  run bash -c "awk '/^disk\)/,/^;;/' \"$SCRIPT\" | grep -c 'sleep 30'"
+  [ "$output" -eq 0 ]
+  awk '/^disk\)/,/^;;/' "$SCRIPT" | grep -q 'wait_for_paint "10-ready"'
+}
+
+@test "paint-wait: ready mode waits for paint before the 10-ready screenshot" {
+  # The screenshot-sanity fallback for serial-less kernels re-measures the
+  # same 10-ready file, so waiting for paint here also makes that fallback
+  # able to distinguish "slow" from "failed".
+  awk '/^ready\)/,/^;;/' "$SCRIPT" | grep -q 'wait_for_paint "10-ready"'
+}
+
+@test "paint-wait: the wait is evidence, never a gate — serial markers decide" {
+  # A machine that cannot paint must extend the run, not fail it. Both call
+  # sites swallow the helper's return.
+  run bash -c "grep -c 'wait_for_paint \"10-ready\" || true' \"$SCRIPT\""
+  [ "$output" -ge 2 ]
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
 # Exit Code Assignments
 # ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
Closes tuna-os/tunaos#581.

## Problem

The issue observed (2026-07-03) that under plain QEMU/virtio-vga, GDM is slow or black: the guest renders with Mesa's llvmpipe software rasteriser, and first paint can trail the serial boot markers by a minute or more on a 2-4 vCPU runner. The boot gate's fixed `sleep 30` after the serial `TUNAOS_DESKTOP_CONTRACT_OK` marker therefore produced **black `10-ready` frames in the evidence gallery for otherwise-healthy boots** — "slow GDM" read as "blank/failed" in screenshots, and the screenshot-sanity fallback could not tell the two apart.

The #575 mitigation (gates key off serial markers, not pixels) already prevents slow paint from failing a gate; what remained was the screenshot-quality and diagnostics half of the issue.

## Change

`scripts/iso-e2e.sh`:

- New `wait_for_paint <label>` helper: screenshot → measure (`screenshot_sane` stddev) → retry until the framebuffer has structure or the cap is reached. The last frame is always kept as evidence, and each attempt's stddev is logged.
- **Bounded**: `TBOX_E2E_PAINT_TIMEOUT` (default 120s; `0` restores an immediate single capture). Common case (paints on attempt 1) adds zero latency.
- **Evidence, never a gate**: pass/fail stays with the serial markers, so a machine that genuinely cannot paint extends the run but cannot fail it. Both call sites are `|| true`.
- Applied to the **disk-mode boot gate** (replaces the fixed `sleep 30`) and **ready-mode ISO gates** (also makes the serial-less screenshot-sanity fallback able to distinguish "slow" from "failed", since it re-measures the same `10-ready` file). `install`/`kickstart` modes keep their immediate pre-install capture so install timing is untouched.
- Documents why "GDM black" is expected on this path, including the issue's open question 3: the live squash runs getty only on tty1 and the serial console (ttyS0), so VT-switching to tty3 shows an unused VT — not a hang; the compositor holds tty1 and screendump reads the current scanout buffer, which is mid-llvmpipe-frame until paint completes.

`docs/TESTING.md`: the "Screenshot is blank" troubleshooting row now explains the llvmpipe first-paint behavior and the paint-wait instead of just "increase timeout".

## Tests

- `tests/bats/test_iso_e2e.bats`: 4 new tests pin the helper (120s default cap), the disk-mode removal of the fixed `sleep 30`, the ready-mode wiring, and that both call sites swallow the return (evidence ≠ gate).
- Stub-verified the helper: paints-on-first-attempt, paints-after-retry, and never-paints (hits cap, returns 1, serial markers remain the verdict).
- `test_iso_e2e.bats`: 82 ok / 4 pre-existing not-ok (the stubbed-guest smoke/runtime checks fail identically on clean main in this sandbox — environmental). `test_iso_e2e_poweroff` 7/7, `test_build_iso_tacklebox` 31/31.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->