### PR TITLE
fix(guppy): explain unsupported Gentoo desktop flavors

### DIFF
--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -172,6 +172,11 @@ if [[ "${_TD_OS}" == "emerge" ]]; then
 	# declared the flavor. Fail loudly instead of relying on that.
 	if ((${#_TD_EMERGE_PKGS[@]} == 0)); then
 		echo "ERROR: no emerge packages parsed from ${_TD_MANIFEST}" >&2
+		if [[ "${_TD_DESKTOP}" == "niri" || "${_TD_DESKTOP}" == "cosmic" ]]; then
+			echo "       Gentoo has no ${_TD_DESKTOP} ebuilds in the main tree;" >&2
+			echo "       do not declare guppy:${_TD_DESKTOP} until an upstream or" >&2
+			echo "       explicitly maintained overlay provides and tests the packages." >&2
+		fi
 		echo "       This would yield an image tagged ${_TD_DESKTOP} with no desktop in it." >&2
 		exit 1
 	fi

--- a/tests/bats/test_guppy_unsupported_desktops.bats
+++ b/tests/bats/test_guppy_unsupported_desktops.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# Gentoo's main tree does not currently provide the packages needed by the
+# Niri or COSMIC manifests. Keep those flavors out of Guppy's published matrix
+# until there is a maintained package source and a passing build.
+#
+# This is deliberately a repository-level guard: adding a flavor is otherwise
+# easy to do in build-config.yml, while the failure only appears after the
+# Gentoo image has spent time compiling its base.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+
+@test "guppy does not publish Gentoo desktops without main-tree ebuilds" {
+  run python3 - "${REPO_ROOT}" <<'EOF'
+import os, sys
+import yaml
+
+root = sys.argv[1]
+cfg = yaml.safe_load(open(os.path.join(root, '.github/build-config.yml')))
+guppy = next(v for v in cfg['variants'] if v['id'] == 'guppy')
+flavors = {f['id'] for f in guppy.get('flavors', [])}
+unsupported = {'niri', 'cosmic'}
+found = sorted(flavors & unsupported)
+assert not found, f'guppy declares unsupported Gentoo flavors: {found}'
+assert {'gnome', 'kde', 'xfce'} <= flavors, 'known Gentoo desktop coverage disappeared'
+print(','.join(sorted(flavors)))
+EOF
+  [ "$status" -eq 0 ]
+}
+
+@test "the Gentoo installer explains the Niri and COSMIC ebuild gap" {
+  local script="${REPO_ROOT}/build_scripts/desktop/install-desktop.sh"
+  grep -qF 'Gentoo has no ${_TD_DESKTOP} ebuilds in the main tree' "$script"
+  grep -qF 'do not declare guppy:${_TD_DESKTOP}' "$script"
+  grep -qF 'until an upstream or' "$script"
+}
+


### PR DESCRIPTION
Closes tuna-os/tunaos#923.

## Summary

- keep Guppy's Gentoo matrix explicitly guarded against declaring Niri or COSMIC before main-tree ebuilds exist
- make the Gentoo desktop installer explain that missing ebuild source when either unsupported flavor is requested
- add a regression test for the Guppy flavor set and the targeted diagnostic

This does not add unmaintained overlay packages. The existing Gentoo matrix remains limited to desktops with verified package sources; Niri and COSMIC can be declared once an upstream or explicitly maintained overlay is available and tested.

## Validation

- `bash -n build_scripts/desktop/install-desktop.sh`
- `git diff --check`
- focused Python assertion could not run locally because PyYAML is not installed; the Bats suite was also unavailable locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->