### PR TITLE
feat(redfin): ship the local image-factory systemd timer units (tunaOS#609)

### DIFF
--- a/docs/rhel-setup.md
+++ b/docs/rhel-setup.md
@@ -105,11 +105,14 @@ The ISO uses tacklebox (same as all other TunaOS variants) — UEFI live boot wi
 ### Option 2: bootc switch (from an existing RHEL system)
 
 ```bash
-# Switch a running RHEL 10 system to any redfin flavor
-sudo bootc switch localhost/redfin:gnome
-sudo bootc switch localhost/redfin:kde
-sudo bootc switch localhost/redfin:niri
-sudo bootc switch localhost/redfin:cosmic
+# Switch a running RHEL 10 system to any locally-built redfin flavor.
+# --transport=containers-storage is load-bearing: these refs live in root's
+# podman storage, and without it bootc would try to pull "localhost" as a
+# registry (the renner0e/server image-factory pattern uses the same flag).
+sudo bootc switch --transport=containers-storage localhost/redfin:gnome
+sudo bootc switch --transport=containers-storage localhost/redfin:kde
+sudo bootc switch --transport=containers-storage localhost/redfin:niri
+sudo bootc switch --transport=containers-storage localhost/redfin:cosmic
 ```
 
 ### Option 3: Direct disk install (VMs)
@@ -154,9 +157,48 @@ sudo bootc switch registry.internal.example.com/redfin:gnome
 # After first switch, updates happen automatically via uupd timer
 ```
 
-See [renner0e/server](https://github.com/renner0e/server) for a systemd timer pattern that automates this.
-
 Each deployed system must be covered by a RHEL subscription (the same free Developer Subscription works).
+
+### Systemd timer (self-hosted rebuild + switch)
+
+For a single machine that both builds and runs redfin (a corral VM, a QEMU
+install), the repo ships a TunaOS adaptation of the
+[renner0e/server](https://github.com/renner0e/server) image-factory pattern
+under `examples/redfin-image-factory/`: a timer rebuilds
+`localhost/redfin:gnome` daily, `bootc switch`es the machine to the fresh
+image, and prunes bootc images older than a week (rollback targets stay).
+
+```bash
+# 1. Check out the tunaos source where the unit expects it
+sudo git clone https://github.com/tuna-os/tunaos /var/lib/tunaos-image-factory
+
+# 2. Give the factory its RHSM credentials (mode 0600 — never inline)
+sudo install -m 0600 /dev/null /etc/bootc-image-factory/rhsm.env
+sudoedit /etc/bootc-image-factory/rhsm.env
+#   RHSM_USER=your-rh-username
+#   RHSM_PASSWORD=your-rh-password
+#   (or the activation-key form: RHSM_ORG=... RHSM_ACTIVATION_KEY=...)
+
+# 3. Make sure root can pull from registry.redhat.io — copy your auth.json to
+#    root's store (see "Using auth.json on builder VMs" above)
+
+# 4. Install and start the timer
+sudo cp examples/redfin-image-factory/bootc-image-factory-build.{service,timer} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now bootc-image-factory-build.timer
+
+# Inspect / trigger manually
+systemctl list-timers bootc-image-factory-build.timer
+sudo systemctl start bootc-image-factory-build.service   # run once now
+journalctl -u bootc-image-factory-build.service -f       # watch the rebuild
+```
+
+The build runs as a oneshot and `bootc switch` is an `ExecStartPost`, so the
+machine only switches after a successful build — a broken image is never
+switched to. `--transport=containers-storage` reads root's podman storage,
+which is where the root-run build stores `localhost/redfin:gnome`. If `just`
+lives outside the unit's `PATH` (e.g. under `~/.cargo`), add its directory to
+the `Environment=PATH=` line in the service file.
 
 ## Why No Public Images?
 

--- a/examples/redfin-image-factory/bootc-image-factory-build.service
+++ b/examples/redfin-image-factory/bootc-image-factory-build.service
@@ -1,0 +1,59 @@
+# TunaOS adaptation of renner0e/server's bootc image-factory pattern
+# (https://github.com/renner0e/server — system_files/etc/containers/systemd/
+# bootc-image-factory.build + .../bootc-image-factory-build.timer).
+#
+# Rebuilds the local redfin (RHEL 10) image from a tunaos source checkout on
+# a schedule, then switches THIS machine to the freshly built image. Redfin
+# images cannot be published to ghcr.io (RHEL EULA — see docs/rhel-setup.md),
+# so for a machine that both builds and runs redfin, the local image factory
+# IS the update path; for multi-machine deployments, push the built image to
+# a private registry instead and let deployed systems pull via uupd.
+#
+# This is the build-host side of the pattern. renner0e uses a podman quadlet
+# [Build] section; TunaOS builds through `just build redfin gnome` (the same
+# pipeline CI uses, RHSM creds passed via BuildKit secrets), so the build is
+# a plain ExecStart instead.
+#
+# Requirements (full walkthrough in docs/rhel-setup.md "Auto-Update"):
+#   * a tunaos checkout at WorkingDirectory, with `just` and `yq` on PATH
+#     (add just's directory to the Environment=PATH line if it lives under
+#     ~/.cargo or ~/.local/bin on the build user)
+#   * root's `podman login registry.redhat.io` done (auth.json — the embedded
+#     entitlement certs in the rhel-bootc base grant CDN access during build)
+#   * RHSM credentials in /etc/bootc-image-factory/rhsm.env (mode 0600):
+#       RHSM_USER=... RHSM_PASSWORD=...
+#     or the activation-key form: RHSM_ORG=... RHSM_ACTIVATION_KEY=...
+#   * the machine is itself bootc-managed (deployed from a redfin image — a
+#     corral VM or a QEMU install), so `bootc switch` has a deployment to
+#     replace
+#
+# Type=oneshot + ExecStartPost ordering is load-bearing: the switch only
+# fires after the build succeeds, so a broken build is never switched to.
+# bootc switch --transport=containers-storage reads root's podman storage,
+# which is where the root-run `just build` stores localhost/redfin:gnome.
+
+[Unit]
+Description=Rebuild localhost/redfin:gnome and switch this machine to it
+Documentation=https://github.com/tuna-os/tunaos/blob/main/docs/rhel-setup.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/var/lib/tunaos-image-factory
+EnvironmentFile=/etc/bootc-image-factory/rhsm.env
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=SKIP_SUBMODULES=1
+# `just build redfin gnome` produces localhost/redfin:gnome in root podman
+# storage. RHSM_* come from the EnvironmentFile; registry.redhat.io auth is
+# root's auth.json. SKIP_SUBMODULES=1 matches the CI build path (the gnome
+# flavor would otherwise run `git submodule update --init` on every tick).
+ExecStart=/usr/bin/env just build redfin gnome
+# Only after a successful build: point the running system at the new image,
+# and prune bootc images older than a week so rollback targets stay.
+ExecStartPost=/usr/bin/bootc switch --quiet --transport=containers-storage localhost/redfin:gnome
+ExecStartPost=/usr/bin/podman image prune --force --filter=label=containers.bootc=1 --filter until=168h
+Nice=0
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/redfin-image-factory/bootc-image-factory-build.timer
+++ b/examples/redfin-image-factory/bootc-image-factory-build.timer
@@ -1,0 +1,24 @@
+# Daily trigger for bootc-image-factory-build.service — TunaOS adaptation of
+# renner0e/server's bootc-image-factory-build.timer
+# (https://github.com/renner0e/server).
+#
+# Install alongside the service:
+#   sudo cp examples/redfin-image-factory/bootc-image-factory-build.{service,timer} /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now bootc-image-factory-build.timer
+# Full walkthrough: docs/rhel-setup.md "Auto-Update".
+
+[Unit]
+Description=Daily rebuild of localhost/redfin:gnome (local image factory)
+
+[Timer]
+# Rebuild daily at 04:00.
+OnCalendar=*-*-* 04:00:00
+# If the machine was off/suspended at 04:00, trigger immediately on the next
+# boot/resume rather than waiting a full day.
+Persistent=true
+# Spread the load (and let a slow nightly build start cleanly).
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes tuna-os/tunaos#609.

## Context

Most of #609 landed before this PR: `docs/rhel-setup.md` covers ISO generation (tacklebox), local image builds with RHSM BuildKit secrets, corral VM testing, and the private-registry push path; `scripts/corral-build.sh` handles redfin + RHSM; the roadmap entry was restored via #1124. The concrete gap was the issue's **step 3 — the auto-update systemd timer**: the docs only linked out to [renner0e/server](https://github.com/renner0e/server), the adapted units did not exist in this repo.

## Change

**`examples/redfin-image-factory/bootc-image-factory-build.service`** — TunaOS adaptation of renner0e's `bootc-image-factory` quadlet:

- `ExecStart=/usr/bin/env just build redfin gnome` from a tunaos checkout (`WorkingDirectory=/var/lib/tunaos-image-factory`) — the same pipeline CI uses, so the build is `just` rather than a podman quadlet `[Build]`.
- `ExecStartPost=/usr/bin/bootc switch --quiet --transport=containers-storage localhost/redfin:gnome` — only fires **after** a successful build (oneshot + ExecStartPost ordering), so a broken image is never switched to. `--transport=containers-storage` is load-bearing: the ref lives in root's podman storage, and a bare `localhost/` ref would resolve as a registry pull (renner0e uses the same flag).
- `ExecStartPost=podman image prune --force --filter=label=containers.bootc=1 --filter until=168h` — keeps a week of rollback targets.
- RHSM creds via `EnvironmentFile=/etc/bootc-image-factory/rhsm.env` (mode 0600, matching the BuildKit-secret flow in `build-image-inner.sh`); `SKIP_SUBMODULES=1` matches the CI build path.

**`examples/redfin-image-factory/bootc-image-factory-build.timer`** — daily 04:00, `Persistent=true` (fires on next boot if missed), `RandomizedDelaySec=15m`, adapted from renner0e.

**`docs/rhel-setup.md`**:

- New **"Systemd timer (self-hosted rebuild + switch)"** subsection: full install walkthrough — checkout, `rhsm.env`, root `auth.json` for registry.redhat.io, `cp` the units, `daemon-reload`, `enable --now`, plus manual trigger/inspect commands.
- **Option 2 (bootc switch)** now uses `--transport=containers-storage` for locally-built images, with the reasoning documented.

## Validation

- Both units parse as valid INI with the expected sections/keys; multiple `ExecStartPost` lines preserved.
- `just build redfin gnome` runs non-interactively (`_ensure-deps` only requires `yq`, which is a documented build-host requirement).
- Docs-only + new example files: no tests reference the changed paths; no test impact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->