### PR TITLE
feat(build): emit installed-package manifest into /usr at build time

### DIFF
--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -742,4 +742,7 @@ EOF
 	safe_enable tunaos-desktop-contract.service
 fi
 
+emit_packages_manifest
+
 printf "::endgroup::\n"
+

--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -766,3 +766,68 @@ _yq_array() {
 	shift
 	readarray -t "$_arr_name" < <($YQ "$@" 2>/dev/null || true)
 }
+
+# emit_packages_manifest — Write normalized JSON package manifest to /usr/share/tunaos/packages.json
+# Usage: emit_packages_manifest
+emit_packages_manifest() {
+	local img_name="${IMAGE_NAME:-unknown}"
+	local img_flavor="${DESKTOP_FLAVOR:-gnome}"
+	local pkg_mgr="${PKG_MGR:-unknown}"
+	local target_dir="/usr/share/tunaos"
+	local target_file="${target_dir}/packages.json"
+	local tmp_file="/tmp/packages.json.tmp"
+
+	mkdir -p "${target_dir}"
+
+	local raw_pkgs=""
+	if command -v rpm >/dev/null 2>&1; then
+		raw_pkgs="$(rpm -qa --qf '%{NAME}\t%{VERSION}-%{RELEASE}\n' 2>/dev/null | LC_ALL=C sort -u || true)"
+	elif command -v dpkg-query >/dev/null 2>&1; then
+		raw_pkgs="$(dpkg-query -W -f '${Package}\t${Version}\n' 2>/dev/null | LC_ALL=C sort -u || true)"
+	elif command -v pacman >/dev/null 2>&1; then
+		raw_pkgs="$(pacman -Q 2>/dev/null | tr ' ' '\t' | LC_ALL=C sort -u || true)"
+	elif command -v qlist >/dev/null 2>&1; then
+		raw_pkgs="$(qlist -ICv 2>/dev/null | awk '{
+			name=$0;
+			sub(/-[0-9].*/, "", name);
+			sub(/^[^\/]*\//, "", name);
+			ver=$0;
+			sub(/^.*-/, "", ver);
+			print name "\t" ver;
+		}' | LC_ALL=C sort -u || true)"
+	fi
+
+	python3 -c '
+import json, sys
+
+img_name = sys.argv[1]
+img_flavor = sys.argv[2]
+pkg_mgr = sys.argv[3]
+raw = sys.stdin.read().strip()
+
+packages = []
+if raw:
+    for line in raw.split("\n"):
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            packages.append({"name": parts[0], "version": parts[1]})
+        elif len(parts) == 1 and parts[0]:
+            packages.append({"name": parts[0], "version": ""})
+
+manifest = {
+    "image": img_name,
+    "flavor": img_flavor,
+    "pkg_manager": pkg_mgr,
+    "count": len(packages),
+    "packages": packages
+}
+
+with open(sys.argv[4], "w") as f:
+    json.dump(manifest, f, indent=2)
+' "$img_name" "$img_flavor" "$pkg_mgr" "$tmp_file" < <(printf '%s\n' "$raw_pkgs")
+
+	mv "$tmp_file" "$target_file"
+	chmod 0644 "$target_file"
+	echo "emit_packages_manifest: wrote $(wc -l <"$target_file") lines to ${target_file}"
+}
+

--- a/scripts/package-parity.sh
+++ b/scripts/package-parity.sh
@@ -43,7 +43,13 @@ fetch() {
 		echo "  (no published manifest for $ref — querying the image)" >&2
 		command -v podman >/dev/null || die "podman needed to query $ref"
 		podman run --rm --entrypoint sh "${REGISTRY}/${repo}:${tag}" -c '
-			if   command -v rpm        >/dev/null 2>&1; then rpm -qa --qf "%{NAME}\t%{VERSION}-%{RELEASE}\n"
+			if [ -s /usr/share/tunaos/packages.json ]; then
+				if command -v jq >/dev/null 2>&1; then
+					jq -r ".packages[] | \(.name)\t\(.version)" /usr/share/tunaos/packages.json
+				elif command -v python3 >/dev/null 2>&1; then
+					python3 -c "import json; [print(f\"{p[\"name\"]}\t{p.get(\"version\", \"\")}\") for p in json.load(open(\"/usr/share/tunaos/packages.json\")).get(\"packages\", [])]"
+				fi
+			elif command -v rpm        >/dev/null 2>&1; then rpm -qa --qf "%{NAME}\t%{VERSION}-%{RELEASE}\n"
 			elif command -v dpkg-query >/dev/null 2>&1; then dpkg-query -W -f "${Package}\t${Version}\n"
 			elif command -v pacman     >/dev/null 2>&1; then pacman -Q | tr " " "\t"
 			elif command -v qlist      >/dev/null 2>&1; then qlist -ICv

--- a/tests/bats/test_build_scripts.bats
+++ b/tests/bats/test_build_scripts.bats
@@ -34,6 +34,11 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
   [ "$status" -eq 0 ]
 }
 
+@test "build_scripts/lib.sh: defines emit_packages_manifest function" {
+  run grep 'emit_packages_manifest()' "${REPO_ROOT}/build_scripts/lib.sh"
+  [ "$status" -eq 0 ]
+}
+
 @test "build_scripts/lib.sh: computes CONTEXT_PATH" {
   run grep 'CONTEXT_PATH=' "${REPO_ROOT}/build_scripts/lib.sh"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Closes #928

### Summary

- **Helper Function**: Added `emit_packages_manifest` in [build_scripts/lib.sh](file:///home/dev/workspace/tuna-os/tunaos/build_scripts/lib.sh) to query installed packages (`rpm`, `dpkg-query`, `pacman`, or `qlist`) and format a normalized JSON manifest containing `image`, `flavor`, `pkg_manager`, `count`, and `packages` (`[{"name": "...", "version": "..."}]`).
- **Build Step Integration**: Invoked `emit_packages_manifest` at the end of [build_scripts/desktop/install-desktop.sh](file:///home/dev/workspace/tuna-os/tunaos/build_scripts/desktop/install-desktop.sh), ensuring the manifest is emitted into `/usr/share/tunaos/packages.json` before `finalize.sh` / bootcification.
- **Parity Auditing Script**: Updated [scripts/package-parity.sh](file:///home/dev/workspace/tuna-os/tunaos/scripts/package-parity.sh) to attempt reading `/usr/share/tunaos/packages.json` when querying image packages over `podman run`, solving the issue where apt-based bootc images return empty package sets due to uncommitted `/var/lib/dpkg`.
- **Unit Testing**: Added unit test in [tests/bats/test_build_scripts.bats](file:///home/dev/workspace/tuna-os/tunaos/tests/bats/test_build_scripts.bats) verifying `emit_packages_manifest` function definition.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `0b93f00c`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->