### PR TITLE
fix(ci): keep Guppy SBOM generation bounded

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -429,6 +429,10 @@ jobs:
         # Syft mmaps the multi-GB OCI image and can OOM-kill the runner on
         # desktop-sized images; cap Go memory and time-box it, and never
         # fail the build over an SBOM (projectbluefin/actions#294/#300).
+        # The package manifest above already records every installed package.
+        # Scan the final filesystem view rather than every historical layer:
+        # the latter made the Gentoo base job spend its remaining runner time
+        # in Syft after the image had already built and pushed (tunaOS#956).
         continue-on-error: true
         timeout-minutes: 10
         env:
@@ -440,7 +444,7 @@ jobs:
           GOGC: "25"
         run: |
           IMAGE="ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}:${DEFAULT_TAG}-${SAFE_PLATFORM}"
-          $SYFT_CMD "$IMAGE" --scope all-layers -o spdx-json="sbom-${IMAGE_NAME}-${DEFAULT_TAG}-${SAFE_PLATFORM}.spdx.json"
+          $SYFT_CMD "$IMAGE" --scope squashed -o spdx-json="sbom-${IMAGE_NAME}-${DEFAULT_TAG}-${SAFE_PLATFORM}.spdx.json"
 
       - name: Upload SBOM
         if: inputs.sbom && github.event_name != 'pull_request'

--- a/tests/bats/test_sbom_scope.bats
+++ b/tests/bats/test_sbom_scope.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# SBOM generation must describe the final image without making a large,
+# layered source-based image unpublishable.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+WORKFLOW="${REPO_ROOT}/.github/workflows/reusable-build-image.yml"
+
+@test "SBOM scans the squashed image view" {
+  run grep -E -- '--scope squashed' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  run grep -E -- '--scope all-layers' "$WORKFLOW"
+  [ "$status" -ne 0 ]
+}
+
+@test "SBOM remains non-blocking and time-bounded" {
+  grep -q '^        continue-on-error: true$' "$WORKFLOW"
+  grep -q '^        timeout-minutes: 10$' "$WORKFLOW"
+}


### PR DESCRIPTION
Closes tuna-os/tunaos#956.

## Summary

- change the reusable image SBOM scan from `all-layers` to `squashed`, describing the final filesystem view instead of replaying every historical layer
- retain the existing 10-minute timeout and `continue-on-error` guard
- add a regression test for the scope and non-blocking timeout

The issue's Grouper GNOME keyring failure is already fixed on current `main` by the existing `gnome-keyring` and `libpam-gnome-keyring` manifest entries. The remaining Guppy failure built and pushed the image, then exhausted the runner during the all-layer Syft scan.

## Validation

- `bash -n build_scripts/desktop/install-desktop.sh`
- `git diff --check`
- focused static assertions passed
- Bats/actionlint are not installed in the local environment

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->