### PR TITLE
docs(ci): a red LUKS E2E cell can be stale evidence, not a live bug (#979)

### DIFF
--- a/docs/ci-troubleshooting.md
+++ b/docs/ci-troubleshooting.md
@@ -760,3 +760,28 @@ Published container images built green in CI but shipped missing essential deskt
    - `missing`: No published image tag in registry.
    - `error`: Network or registry pull failure.
 3. **Display Manager Enablement Assertion**: Verifies display manager units (`gdm`, `sddm`, `plasmalogin`, `greetd`) are actively enabled in the image layer rather than merely present as installed unit files.
+
+---
+
+### 16. A red LUKS E2E cell can be stale evidence, not a live bug (#979, 2026-08-09)
+
+**Affected cells (as measured):** `yellowfin:gnome/kde/niri/cosmic`, `albacore:gnome/kde/cosmic` — all four/three shown red in `docs/MATRIX-STATUS.md` as of its 2026-08-08 snapshot.
+
+**Symptom (identical across all six jobs checked):**
+```
+TUNAOS_LUKS_E2E_PASS encrypted=1 passphrase_unlock=1 installed_boot=1
+TUNAOS_LUKS_E2E_DESKTOP_CONTRACT desktop_contract=ok fatal=0
+TUNAOS_LUKS_E2E_PIXEL_GATE result=absent frames=<200-400> stddev=na fatal=1
+ERROR: pixel gate FAILED — the encrypted install unlocked and reached
+       login, but nothing provably rendered (...).
+##[error]Process completed with exit code 6.
+```
+Encryption, unlock, boot and the in-guest desktop contract all genuinely passed — the *only* failing signal is `scripts/lib/pixel-gate.sh`'s pixel gate, and specifically its `shot=absent` path.
+
+**Root cause — not a new defect, a timing gap:** `scripts/lib/pixel-gate.sh` commit `e20fd037` (#1102, merged 2026-08-08T02:42 UTC) added exactly this case — `shot=absent` *and* `contract=ok` — as an advisory `absent_contract_ok` verdict (`fatal=0`), on the evidence of `gurnard:pantheon` and `grouper:xfce` hitting the identical pattern. Every one of the six failing job logs checked here (`yellowfin:gnome` run 31226672079, `yellowfin:kde`/`niri`/`cosmic` same run, `albacore:gnome`/`kde`/`cosmic` runs 31224487929/31224494825) is timestamped **before** `e20fd037` landed — they ran the *old* pixel-gate logic, which had no `contract=ok` carve-out and fell through to the fatal `absent` branch instead. None of these cells has been re-dispatched since the fix merged, so `MATRIX-STATUS.md`'s "35/52 green" — sourced from the newest available run per cell — is reporting genuinely stale verdicts for these six, not current ones.
+
+**Lesson:** before treating a red LUKS E2E cell as an open bug to diagnose, check the failing job's evidence lines against `git log` for `scripts/lib/pixel-gate.sh` (or whatever check actually failed) — `fatal=1` on an old run doesn't mean the current tree would still produce it. A cell only needs new investigation once it fails again on a run that started *after* the relevant fix.
+
+**Action taken:** re-dispatched `LUKS E2E` (`workflow_dispatch`) for `variant=yellowfin,flavor=all` (run [31286843546](https://github.com/tuna-os/tunaOS/actions/runs/31286843546)) and `variant=albacore,flavor=all` (run [31286849405](https://github.com/tuna-os/tunaOS/actions/runs/31286849405)) to get fresh, post-fix verdicts. Not yet observed to completion — a multi-cell LUKS sweep runs well past a single investigation session; check those runs' actual conclusions before assuming this note means the cells are already green.
+
+**Separate, still-open, NOT covered by the above:** `yellowfin:xfce` (same run, job 93022287474) fails during the **image build** itself — `dracut-install: ERROR: installing '/root'` plus `error: Linting: Checks failed: 2`, retried 3 times, never reaching the LUKS/pixel-gate stage at all. `albacore:gnome/kde/cosmic` log the identical `dracut-install`/lint messages during their own builds but the build still *succeeds* there (non-fatal, matching `bootc container lint`'s documented warn-only default — see #10 above), so this is not simply "the same bug, sometimes fatal" — `yellowfin:xfce`'s build genuinely dies and needs its own root-cause pass, not a re-dispatch.


### PR DESCRIPTION
## What

`tuna-os/tunaos#979` tracks driving every published desktop cell to 100% LUKS E2E green. Its own "Verified Green"/"Pending" lists are stale, and the live `docs/MATRIX-STATUS.md` snapshot shows the real picture is worse in places (`yellowfin` 0/5, `albacore` 2/5) — so before treating any of that as new work to diagnose, I pulled the actual failing job logs rather than assume.

## What I found

Checked six failing jobs directly — `yellowfin:gnome/kde/niri/cosmic` (run 31226672079) and `albacore:gnome/kde/cosmic` (runs 31224487929/31224494825) — and every one fails **identically**:

```
TUNAOS_LUKS_E2E_PASS encrypted=1 passphrase_unlock=1 installed_boot=1
TUNAOS_LUKS_E2E_DESKTOP_CONTRACT desktop_contract=ok fatal=0
TUNAOS_LUKS_E2E_PIXEL_GATE result=absent frames=<200-400> stddev=na fatal=1
ERROR: pixel gate FAILED — ...
##[error]Process completed with exit code 6.
```

Encryption, unlock, boot, and the **in-guest desktop contract all genuinely pass** — the only failing signal is `scripts/lib/pixel-gate.sh`'s pixel gate, specifically its `shot=absent` path.

That is exactly the case `scripts/lib/pixel-gate.sh`'s commit `e20fd037` (#1102, merged **2026-08-08T02:42 UTC**) added an advisory carve-out for: `contract=ok` downgrades an `absent` screenshot to `absent_contract_ok` (`fatal=0`), on the evidence of `gurnard:pantheon` and `grouper:xfce` hitting the same pattern.

**Every one of the six job runs I checked is timestamped *before* that fix landed.** They ran the old fatal-by-default logic. None of these cells has been re-dispatched since, so `MATRIX-STATUS.md`'s per-cell verdicts (sourced from the newest available run per cell) are reporting pre-fix results as if they were current.

## Action taken (not just documented)

Re-dispatched `LUKS E2E` via `workflow_dispatch`:
- `variant=yellowfin,flavor=all` → run [31286843546](https://github.com/tuna-os/tunaOS/actions/runs/31286843546)
- `variant=albacore,flavor=all` → run [31286849405](https://github.com/tuna-os/tunaOS/actions/runs/31286849405)

I did **not** wait for these to complete — a multi-cell LUKS sweep runs well past a single investigation session. This PR does not claim those cells are now green, only that they're running against the fixed code. Check the runs' actual conclusions (or the next `MATRIX-STATUS.md` regeneration) before assuming either way.

## What this does NOT cover

`yellowfin:xfce` (same run, job 93022287474) fails during the **image build itself** — `dracut-install: ERROR: installing '/root'` plus `error: Linting: Checks failed: 2`, retried 3 times, never reaching the LUKS/pixel-gate stage at all. `albacore:gnome/kde/cosmic` log the identical dracut/lint messages during their own builds, but those builds still *succeed* (non-fatal, matching `bootc container lint`'s documented warn-only default — see ci-troubleshooting.md #10). So `yellowfin:xfce` is a genuinely separate, still-open defect that needs its own root-cause pass — not covered by the pixel-gate finding above, and not something I chased further in this PR to keep the higher-confidence finding from getting diluted.

## Changes

- `docs/ci-troubleshooting.md`: new numbered entry (#16) recording the finding, matching the file's existing format — so the general lesson (check whether a relevant fix already landed, by commit timestamp, before re-diagnosing a red cell as a live bug) and the specific evidence are both preserved for whoever picks up #979 next.

## Not touched

`docs/MATRIX-STATUS.md` itself — it's fully auto-generated (`scripts/gen-matrix-status.py`, scheduled/dispatched via `matrix-status.yml`) specifically so it never carries stale hand-edits. The next scheduled or dispatched regeneration will pick up whatever the two re-dispatched runs above actually produce.

🐝 **Hive Agent**: `contributor`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->