### PR TITLE
fix(niri): install DMS greeter from danklinux

### DIFF
--- a/manifests/desktops/niri.yaml
+++ b/manifests/desktops/niri.yaml
@@ -22,19 +22,19 @@ packages:
       # all — tunaOS#1009 and #637. The el10 section below already had this
       # right; the fedora section never got the same treatment.
       #
-      # Install the suite in ONE transaction with both repos enabled, the
-      # shape el10 uses, so a cross-repo dependency can never split it again.
-      # The danklinux block is enable-only so its repo file exists for
-      # --enablerepo.
+      # Keep each transaction aligned with the repository that publishes its
+      # packages. In particular, dms-greeter is only in danklinux; putting it
+      # in a dms-git transaction made dnf reject the whole request and the
+      # best-effort install then silently shipped bonito without DMSGreeter.qml
+      # (tunaOS#1009).
       - repo: avengemedia/danklinux
-        packages: []
-      - repo: avengemedia/dms-git
         packages:
           - quickshell-git
+          - dms-greeter
+      - repo: avengemedia/dms-git
+        packages:
           - dms
           - dms-cli
-          - dms-greeter
-        options: "--enablerepo=copr:copr.fedorainfracloud.org:avengemedia:danklinux"
     packages:
       - greetd
       - greetd-selinux
@@ -92,21 +92,19 @@ packages:
           - adw-gtk3-theme
         options: "--nobest --allowerasing"
       # DMS (DankMaterialShell) suite: quickshell-git + dms-greeter live in the
-      # danklinux COPR, dms/dms-cli in dms-git, and they cross-depend. Installing
-      # dms-greeter from the dms-git block alone fails ("no match") and, because
-      # copr installs are best-effort, silently drops the whole shell. Install
-      # the suite from one block with danklinux (+ cosmic-epel for the
-      # dms-greeter→greetd dep) enabled, mirroring build_scripts/desktop/niri.sh. The
-      # danklinux block is enable-only so its repo file exists for --enablerepo.
+      # danklinux COPR, while dms/dms-cli live in dms-git. Keep the package
+      # lists with their provider repos: a missing name rejects the whole dnf
+      # transaction, and this path is best-effort by design. That exact drift
+      # left the image without DMSGreeter.qml (tunaOS#1009).
       - repo: avengemedia/danklinux
-        packages: []
-      - repo: avengemedia/dms-git
         packages:
           - quickshell-git
+          - dms-greeter
+      - repo: avengemedia/dms-git
+        packages:
           - dms
           - dms-cli
-          - dms-greeter
-        options: "--enablerepo=copr:copr.fedorainfracloud.org:avengemedia:danklinux --enablerepo=copr:copr.fedorainfracloud.org:yselkowitz:cosmic-epel"
+        options: "--enablerepo=copr:copr.fedorainfracloud.org:yselkowitz:cosmic-epel"
     packages:
       - xdg-desktop-portal-gnome
       - xdg-desktop-portal-gtk

--- a/tests/bats/test_niri_dms_payload.bats
+++ b/tests/bats/test_niri_dms_payload.bats
@@ -73,6 +73,33 @@ _code() { grep -v '^[[:space:]]*#' "$1"; }
   done
 }
 
+@test "DMS packages stay in their publishing COPRs" {
+  if ! command -v "$YQ_BIN" &>/dev/null; then skip "yq not installed"; fi
+  local manifest="${REPO_ROOT}/manifests/desktops/niri.yaml"
+  local os n i repo pkgs
+  for os in fedora el10; do
+    n="$($YQ_BIN -r ".packages.${os}.copr | length" "$manifest")"
+    local danklinux=0 dmsgit=0
+    for ((i = 0; i < n; i++)); do
+      repo="$($YQ_BIN -r ".packages.${os}.copr[$i].repo" "$manifest")"
+      pkgs="$($YQ_BIN -r ".packages.${os}.copr[$i].packages[]?" "$manifest")"
+      [[ "$repo" == avengemedia/danklinux ]] && danklinux=1
+      [[ "$repo" == avengemedia/dms-git ]] && dmsgit=1
+      if [[ "$repo" == avengemedia/danklinux ]]; then
+        grep -qx 'dms-greeter' <<<"$pkgs"
+        grep -qx 'quickshell-git' <<<"$pkgs"
+        ! grep -qxE 'dms(-cli)?' <<<"$pkgs"
+      elif [[ "$repo" == avengemedia/dms-git ]]; then
+        grep -qx 'dms' <<<"$pkgs"
+        grep -qx 'dms-cli' <<<"$pkgs"
+        ! grep -qxE 'dms-greeter|quickshell(-git)?' <<<"$pkgs"
+      fi
+    done
+    [ "$danklinux" -eq 1 ]
+    [ "$dmsgit" -eq 1 ]
+  done
+}
+
 @test "install-desktop.sh does not run a package-less dnf install" {
   # `packages: []` is the enable-only idiom (write the repo file so a later
   # block can --enablerepo it). Running dnf install with no arguments there


### PR DESCRIPTION
Closes tuna-os/tunaos#1009.

## Summary

- assign `quickshell-git` and `dms-greeter` to the `avengemedia/danklinux` COPR that publishes them
- keep `dms` and `dms-cli` in `avengemedia/dms-git`
- add regression coverage preventing provider drift that can silently omit `DMSGreeter.qml`

The existing Zirconium installer already lays down `/etc/greetd/niri/config.kdl`; the missing QML is supplied by the DMS greeter RPM, so the fix is in the manifest provider mapping.

## Validation

- `git diff --check`
- verified the current danklinux Fedora-44 metadata publishes `dms-greeter` and `quickshell-git`
- Bats and yq are not installed locally; focused test is included for CI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->