### PR TITLE
fix(el10): re-run 90-image-info.sh in desktop stages to preserve VERSION_CODENAME

### DIFF
--- a/Containerfile.el10
+++ b/Containerfile.el10
@@ -177,6 +177,14 @@ RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
   /run/context/build_scripts/desktop/gnome-extensions.sh
+# Desktop packages (e.g. redhat-release / almalinux-release / centos-stream-release)
+# can overwrite /usr/lib/os-release during install-desktop.sh, blowing away
+# VERSION_CODENAME written by 90-image-info.sh in base-no-de. Re-run it here
+# to ensure branding is preserved on standard desktop cells.
+RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
+  --mount=type=tmpfs,dst=/boot \
+  --mount=type=bind,from=context,source=/,target=/run/context \
+  /run/context/build_scripts/90-image-info.sh
 RUN rm -rf /opt && ln -s /var/opt /opt
 
 FROM base-no-de AS cosmic
@@ -184,6 +192,10 @@ RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
   /run/context/build_scripts/desktop/install-desktop.sh cosmic
+RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
+  --mount=type=tmpfs,dst=/boot \
+  --mount=type=bind,from=context,source=/,target=/run/context \
+  /run/context/build_scripts/90-image-info.sh
 RUN rm -rf /opt && ln -s /var/opt /opt
 
 FROM base-no-de AS kde
@@ -195,6 +207,10 @@ RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
   /run/context/build_scripts/desktop/install-desktop.sh kde
+RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
+  --mount=type=tmpfs,dst=/boot \
+  --mount=type=bind,from=context,source=/,target=/run/context \
+  /run/context/build_scripts/90-image-info.sh
 RUN rm -rf /opt && ln -s /var/opt /opt
 
 FROM base-no-de AS niri
@@ -210,6 +226,10 @@ RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
   /run/context/build_scripts/desktop/install-desktop.sh niri
+RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
+  --mount=type=tmpfs,dst=/boot \
+  --mount=type=bind,from=context,source=/,target=/run/context \
+  /run/context/build_scripts/90-image-info.sh
 RUN rm -rf /opt && ln -s /var/opt /opt
 
 FROM base-no-de AS xfce
@@ -217,4 +237,8 @@ RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \
   /run/context/build_scripts/desktop/install-desktop.sh xfce
+RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
+  --mount=type=tmpfs,dst=/boot \
+  --mount=type=bind,from=context,source=/,target=/run/context \
+  /run/context/build_scripts/90-image-info.sh
 RUN rm -rf /opt && ln -s /var/opt /opt


### PR DESCRIPTION
Fixes #1007.

## Root Cause
In `Containerfile.el10`, `90-image-info.sh` was previously only invoked in `base-no-de`. When standard desktop stages (`gnome`, `cosmic`, `kde`, `niri`, `xfce`) ran `install-desktop.sh`, package installations (such as release packages for AlmaLinux / CentOS Stream) overwrote `/usr/lib/os-release`, removing the `VERSION_CODENAME` field set by `90-image-info.sh`.

Overlay variants (`gnome-hwe`, `gnome-nvidia`, etc.) passed the branding contract check because `Containerfile.overlay` re-runs `90-image-info.sh`, but standard desktop cells on EL10 bases (`yellowfin`, `skipjack`, `albacore`) failed with `VERSION_CODENAME is ''`.

## Solution
Re-run `90-image-info.sh` at the end of each desktop stage in `Containerfile.el10` (`gnome`, `cosmic`, `kde`, `niri`, `xfce`) after `install-desktop.sh` completes.