### PR TITLE
test(network): guard apt path for Grouper SSH

### DIFF
--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -969,6 +969,25 @@ _run_lnf() { # $1 = file
   [ "$output" -eq 0 ]
 }
 
+@test "40-services.sh enables networking before the apt path returns" {
+  # tunaOS#1013: the Ubuntu/Grouper path exits before the non-apt branch. A
+  # helper call elsewhere in the file is therefore not enough to give the
+  # installed LUKS guest an address for its SSH check.
+  local script="${REPO_ROOT}/build_scripts/40-services.sh"
+  local apt_block
+  apt_block="$(awk '/^if \[\[ "\$\{PKG_MGR:-\}" == "apt" \]\]/,/^fi$/' "$script")"
+  [ -n "$apt_block" ]
+
+  # Keep the assertion tied to the actual early-return boundary rather than
+  # merely counting helper calls across unrelated package-manager branches.
+  grep -qF 'tunaos_enable_network_manager' <<<"$apt_block"
+  local network_line return_line
+  network_line="$(grep -nF 'tunaos_enable_network_manager' <<<"$apt_block" | head -1 | cut -d: -f1)"
+  return_line="$(grep -nE '^[[:space:]]*exit 0$' <<<"$apt_block" | head -1 | cut -d: -f1)"
+  [ -n "$return_line" ]
+  [ "$network_line" -lt "$return_line" ]
+}
+
 @test "40-services.sh installs networkd on zypper, which splits it out" {
   # The unit openSUSE needs is not in the `systemd` package. Measured in a
   # tumbleweed container: after `zypper install systemd` there is no


### PR DESCRIPTION
Closes #1013

The Grouper GNOME LUKS failure presented as an SSH banner timeout because the Ubuntu/apt service path returned before enabling a network manager. The implementation fix is already on main; this adds a focused regression assertion that extracts the apt branch and verifies networking is enabled before its early return.

Validation: bash -n build_scripts/40-services.sh; bash -n scripts/iso-e2e.sh; git diff --check. Bats was unavailable in the checkout environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->