### PR TITLE
ci: gate browser and CI ISO parity with the same LUKS E2E

### DIFF
--- a/.github/workflows/iso-builder-parity.yml
+++ b/.github/workflows/iso-builder-parity.yml
@@ -1,0 +1,127 @@
+# Browser/CI ISO parity gate (tunaOS#673).
+#
+# ISO-builder publishes an ISO and experience manifest as an artifact. This
+# reusable workflow downloads that artifact and a CI-built reference artifact,
+# validates that their inputs and GUI/install contracts match, then runs the
+# exact same LUKS harness against both ISO paths. There is intentionally no
+# browser-specific E2E implementation here.
+name: ISO Builder Parity
+
+on:
+  workflow_call:
+    inputs:
+      ci_run_id:
+        description: "Actions run containing the CI-built ISO artifact"
+        required: true
+        type: string
+      browser_run_id:
+        description: "Actions run containing the browser-built ISO artifact"
+        required: true
+        type: string
+      ci_repository:
+        description: "owner/repository containing the CI artifact"
+        required: false
+        default: "tuna-os/tunaos"
+        type: string
+      browser_repository:
+        description: "owner/repository containing the browser artifact"
+        required: false
+        default: "tuna-os/iso-builder"
+        type: string
+      ci_artifact:
+        description: "Artifact containing ci.iso and experience-manifest.json"
+        required: true
+        type: string
+      browser_artifact:
+        description: "Artifact containing browser.iso and experience-manifest.json"
+        required: true
+        type: string
+      variant:
+        required: true
+        type: string
+      flavor:
+        required: true
+        type: string
+    secrets:
+      artifact_token:
+        required: false
+
+jobs:
+  parity:
+    name: ${{ inputs.variant }}:${{ inputs.flavor }} browser/CI LUKS parity
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      actions: read
+      packages: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download CI ISO and manifest
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ inputs.ci_artifact }}
+          path: parity/ci
+          repository: ${{ inputs.ci_repository }}
+          run-id: ${{ inputs.ci_run_id }}
+          github-token: ${{ secrets.artifact_token || github.token }}
+
+      - name: Download browser ISO and manifest
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ inputs.browser_artifact }}
+          path: parity/browser
+          repository: ${{ inputs.browser_repository }}
+          run-id: ${{ inputs.browser_run_id }}
+          github-token: ${{ secrets.artifact_token || github.token }}
+
+      - name: Install E2E dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends qemu-system-x86 qemu-utils ovmf socat sshpass imagemagick swtpm
+
+      - name: Validate and compare experience manifests
+        env:
+          VARIANT: ${{ inputs.variant }}
+          FLAVOR: ${{ inputs.flavor }}
+        run: |
+          set -euo pipefail
+          for source in ci browser; do
+            manifest="parity/${source}/experience-manifest.json"
+            test -f "$manifest" || { echo "missing $manifest" >&2; exit 1; }
+            python3 scripts/verify-experience-manifest.py "$manifest"
+            jq -e --arg v "$VARIANT" --arg f "$FLAVOR" \
+              '.variant == $v and .flavor == $f' "$manifest" >/dev/null
+          done
+          python3 scripts/verify-experience-manifest.py \
+            parity/ci/experience-manifest.json \
+            --compare parity/browser/experience-manifest.json
+
+      - name: Run the identical LUKS E2E against CI ISO
+        env:
+          VARIANT: ${{ inputs.variant }}
+          FLAVOR: ${{ inputs.flavor }}
+        run: |
+          set -euo pipefail
+          iso="parity/ci/ci.iso"
+          test -f "$iso" || { echo "missing $iso" >&2; exit 1; }
+          ./scripts/iso-e2e.sh "$iso" --luks --output parity/ci-e2e
+
+      - name: Run the identical LUKS E2E against browser ISO
+        env:
+          VARIANT: ${{ inputs.variant }}
+          FLAVOR: ${{ inputs.flavor }}
+        run: |
+          set -euo pipefail
+          iso="parity/browser/browser.iso"
+          test -f "$iso" || { echo "missing $iso" >&2; exit 1; }
+          ./scripts/iso-e2e.sh "$iso" --luks --output parity/browser-e2e
+
+      - name: Upload parity evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: iso-builder-parity-${{ inputs.variant }}-${{ inputs.flavor }}
+          path: parity/*-e2e
+          if-no-files-found: warn

--- a/scripts/verify-experience-manifest.py
+++ b/scripts/verify-experience-manifest.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Validate and compare ISO-builder experience manifests.
+
+The ISO itself is deliberately treated as an opaque input by the parity gate.
+This file validates the small, machine-readable contract emitted alongside it
+and compares the CI and browser results before either result can be accepted.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+REQUIRED_SCREENS = ["welcome", "disk", "encryption", "summary", "install", "done"]
+INSTALLER_IDS = {
+    "org.bootcinstaller.Installer",
+    "org.tunaos.Installer",
+    "org.tunaos.InstallerKde",
+    "org.tunaos.InstallerCosmic",
+    "org.tunaos.InstallerNiri",
+    "org.tunaos.InstallerXfce",
+}
+DIGEST_RE = re.compile(r"^sha256:[0-9a-fA-F]{64}$")
+
+
+def load(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: manifest must be a JSON object")
+    return value
+
+
+def validate(manifest: dict, label: str) -> None:
+    required = {
+        "variant", "flavor", "source_image_digest", "installer_app_id",
+        "screens", "luks", "installed_boot", "desktop_contract",
+    }
+    missing = sorted(required - manifest.keys())
+    if missing:
+        raise ValueError(f"{label}: missing fields: {', '.join(missing)}")
+    for field in ("variant", "flavor"):
+        if not isinstance(manifest[field], str) or not manifest[field].strip():
+            raise ValueError(f"{label}: {field} must be a non-empty string")
+    digest = manifest["source_image_digest"]
+    if not isinstance(digest, str) or not DIGEST_RE.fullmatch(digest):
+        raise ValueError(f"{label}: source_image_digest must be a sha256 digest")
+    if manifest["installer_app_id"] not in INSTALLER_IDS:
+        raise ValueError(f"{label}: unsupported installer_app_id: {manifest['installer_app_id']}")
+    if manifest["screens"] != REQUIRED_SCREENS:
+        raise ValueError(
+            f"{label}: screens must be exactly {REQUIRED_SCREENS}, got {manifest['screens']!r}"
+        )
+    for field in ("luks", "installed_boot", "desktop_contract"):
+        if manifest[field] is not True:
+            raise ValueError(f"{label}: {field} must be true")
+
+
+def compare(left: dict, right: dict) -> list[str]:
+    fields = (
+        "variant", "flavor", "source_image_digest", "installer_app_id", "screens",
+        "luks", "installed_boot", "desktop_contract",
+    )
+    return [field for field in fields if left[field] != right[field]]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--compare", type=Path, help="compare against a second manifest")
+    args = parser.parse_args()
+    try:
+        first = load(args.manifest)
+        validate(first, str(args.manifest))
+        if args.compare:
+            second = load(args.compare)
+            validate(second, str(args.compare))
+            differences = compare(first, second)
+            if differences:
+                raise ValueError(
+                    "parity mismatch in: " + ", ".join(differences)
+                )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(f"ok - validated {args.manifest}")
+    if args.compare:
+        print(f"ok - {args.manifest} matches {args.compare}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_experience_manifest.py
+++ b/tests/test_experience_manifest.py
@@ -1,0 +1,50 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "verify-experience-manifest.py"
+SPEC = importlib.util.spec_from_file_location("experience_manifest", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def manifest(**overrides):
+    value = {
+        "variant": "yellowfin",
+        "flavor": "gnome",
+        "source_image_digest": "sha256:" + "a" * 64,
+        "installer_app_id": "org.bootcinstaller.Installer",
+        "screens": MODULE.REQUIRED_SCREENS,
+        "luks": True,
+        "installed_boot": True,
+        "desktop_contract": True,
+    }
+    value.update(overrides)
+    return value
+
+
+def test_accepts_complete_manifest(tmp_path):
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest()))
+    assert MODULE.main.__name__ == "main"
+    MODULE.validate(MODULE.load(path), str(path))
+
+
+@pytest.mark.parametrize("field", ["luks", "installed_boot", "desktop_contract"])
+def test_requires_successful_install_contract(field):
+    with pytest.raises(ValueError, match=field):
+        MODULE.validate(manifest(**{field: False}), "test")
+
+
+def test_rejects_wrong_screen_order():
+    with pytest.raises(ValueError, match="screens"):
+        MODULE.validate(manifest(screens=["welcome", "disk", "summary"]), "test")
+
+
+def test_compare_reports_digest_mismatch():
+    left = manifest()
+    right = manifest(source_image_digest="sha256:" + "b" * 64)
+    assert MODULE.compare(left, right) == ["source_image_digest"]


### PR DESCRIPTION
Closes #673

Add the TunaOS-side reusable parity gate for browser-built ISOs:

- downloads CI and browser ISO artifacts plus their experience manifests;
- validates variant/flavor, source image digest, installer identity, required GUI screens, LUKS, installed boot, and desktop contract;
- compares both manifests before execution;
- runs the exact same `scripts/iso-e2e.sh --luks` harness against both ISO paths;
- uploads evidence from both runs.

The per-flavor `live-overlay` and `live-initramfs` OCI parity producers are already on `main`; this supplies the acceptance gate that consumes their matching browser/CI inputs without adding a browser-specific test path.

Validation: `python3 -m py_compile scripts/verify-experience-manifest.py`, positive/negative manifest validation checks, and `git diff --check`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->