### PR TITLE
fix(live): run installer recipe backend without an executable source mount

### DIFF
--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -632,7 +632,7 @@ if [[ -f "$RECIPE_FILE" ]]; then
 	# a guessed recipe: 10 seconds of ISO build is a better place to learn this
 	# than hour three of a matrix cell, the same rule the sudo and podman
 	# assertions above follow.
-	_backend_kv="$("${SCRIPT_DIR}/installer-recipe-backend.sh")"
+	_backend_kv="$(bash "${SCRIPT_DIR}/installer-recipe-backend.sh")"
 	_bootloader="$(sed -n 's/^bootloader=//p' <<<"$_backend_kv")"
 	_composefs_backend="$(sed -n 's/^composeFsBackend=//p' <<<"$_backend_kv")"
 	_filesystem="$(sed -n 's/^filesystem=//p' <<<"$_backend_kv")"

--- a/tests/bats/test_live_installer_launch.bats
+++ b/tests/bats/test_live_installer_launch.bats
@@ -94,3 +94,12 @@ launcher_app() {
   ! grep -q 'pgrep -af' "$WORKFLOW"
   grep -Fq 'grep -Fx' "$WORKFLOW"
 }
+
+
+@test "installer recipe backend does not need an executable source mount" {
+  # Tacklebox bind-mounts live-customize read-only. Git may retain this helper
+  # without the execute bit, so invoking it directly turns every flavor's ISO
+  # build into exit 126 before the LUKS test even starts.
+  grep -Fq '_backend_kv="$(bash "${SCRIPT_DIR}/installer-recipe-backend.sh")"' \
+    "${SRC}/customize-live.sh"
+}


### PR DESCRIPTION
Fixes the common Flounder ISO-build failure from LUKS E2E run 31287377558.

All `flounder:{gnome,xfce,kde}` cells failed before boot because `customize-live.sh` directly executed `installer-recipe-backend.sh` from Tacklebox's read-only customization mount, which returned exit 126 (`Permission denied`). Invoke the helper through `bash` instead, so its Git executable bit is no longer a runtime prerequisite.

Includes a Bats regression assertion for the interpreter-explicit invocation.

Validation: exact source-level regression test added; the affected live ISO build remains the required CI verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->