### PR TITLE
fix(ci): install rclone reliably for installer screenshot publishing

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -515,7 +515,13 @@ jobs:
             echo "::notice::R2 credentials not configured; skipping publish."
             exit 0
           fi
-          sudo apt-get install -y -qq rclone 2>/dev/null || true
+          # Do not mask package-install failures: otherwise the next line reports
+          # only `rclone: command not found`, hiding the actual cause.
+          if ! command -v rclone >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq rclone
+          fi
+          rclone version
           while IFS= read -r base; do
             [[ -n "$base" ]] || continue
             png="docs/images/installer/${base}.png"


### PR DESCRIPTION
Fixes the screenshot-publish failure in [Installer Smoke run 31229915708](https://github.com/tuna-os/tunaOS/actions/runs/31229915708): the job masked an `apt-get install rclone` failure and then failed later with `rclone: command not found`.

The job now installs rclone only when absent, does not hide package-manager failures, and prints `rclone version` before publishing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->