### PR TITLE
feat(ci): wire tier-1 functional checks advisory into reusable-build-image workflow (#576)

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -900,6 +900,29 @@ jobs:
             --output verify-out \
             --timeout 900
 
+      - name: Run tier-1 functional checks (advisory)
+        if: always() && hashFiles('verify-out/serial.log') != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          IMAGE_VARIANT: ${{ inputs.image-variant }}
+          FLAVOR: ${{ inputs.flavor }}
+        run: |
+          # Strip overlay suffixes from flavor (e.g. gnome-nvidia -> gnome)
+          DESKTOP="${FLAVOR}"
+          for _suffix in -nvidia-hwe -nvidia -hwe -cachyos -asahi -zfs; do
+            if [[ "$DESKTOP" == *"$_suffix" ]]; then
+              DESKTOP="${DESKTOP%"$_suffix"}"
+              break
+            fi
+          done
+          echo "### 🧪 Tier-1 Functional Checks (advisory) — ${IMAGE_VARIANT}:${FLAVOR} (${DESKTOP})" >> "$GITHUB_STEP_SUMMARY"
+          if grep -q "TUNAOS_DESKTOP_CONTRACT_OK" verify-out/serial.log 2>/dev/null; then
+            echo "Desktop experience contract: PASS" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Desktop experience contract: UNVERIFIED / FAIL" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Collect evidence
         if: always()
         run: |


### PR DESCRIPTION
## Summary
Follow-up to #1184 for issue tuna-os/tunaos#576 ("Functional test suite: per-image feature checks so every published image is provably working").

Wires the advisory tier-1 functional check summary into the `verify_boot` gate job in `reusable-build-image.yml`. Also updates `docs/TESTING.md` to reflect the CI integration step.

### Changes
- `.github/workflows/reusable-build-image.yml`: Added a `Run tier-1 functional checks (advisory)` step to `verify_boot` after QEMU boot verification that parses desktop contract results into the step summary.
- `docs/TESTING.md`: Updated documentation noting that CI now executes this step in `reusable-build-image.yml`.

Refs tuna-os/tunaos#576
[✓] I am using an agent and I take responsibility for this PR
---
🐝 **Hive Agent**: `contributor` | **SHA:** `bb1b8cd8`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->