### PR TITLE
ci: adopt corral for boot gates

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -251,7 +251,15 @@ jobs:
             sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm || true
-          sudo apt-get install -y qemu-system-x86 qemu-utils ovmf socat imagemagick
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86 qemu-utils ovmf podman
+
+      - name: Install corral for verification
+        if: github.event_name == 'pull_request' && contains(matrix.platform, 'amd64')
+        run: |
+          go install github.com/tuna-os/corral@latest
+          sudo install -m 0755 "$(go env GOPATH)/bin/corral" /usr/local/bin/corral
+          corral --version
 
       - name: Boot-verify image (PR gate)
         if: github.event_name == 'pull_request' && contains(matrix.platform, 'amd64')
@@ -260,14 +268,13 @@ jobs:
           IMAGE_VARIANT: ${{ inputs.image-variant }}
           DEFAULT_TAG: ${{ inputs.default-tag }}
         run: |
-          # The image was built under sudo, so it lives in root podman
-          # storage; just qcow2 detects that and skips the save/load sync.
-          just qcow2 "localhost/${IMAGE_VARIANT}:${DEFAULT_TAG}"
-          QCOW2=$(find . -maxdepth 1 -name "*.qcow2" | head -1)
           mkdir -p verify-out
-          sudo ./scripts/iso-e2e.sh "$QCOW2" --disk \
-            --output verify-out \
-            --timeout 600
+          IMAGE="localhost/${IMAGE_VARIANT}:${DEFAULT_TAG}"
+          sed "s|^bootc:.*|bootc: ${IMAGE}|" tests/corral/verify.yaml > verify.yaml
+          cleanup() { corral delete gate --force >/dev/null 2>&1 || true; }
+          trap cleanup EXIT
+          corral create gate -f verify.yaml --wait-ssh --timeout 900
+          corral screenshot gate --output verify-out/boot.png || true
 
       - name: Upload PR verification evidence
         if: always() && github.event_name == 'pull_request' && contains(matrix.platform, 'amd64')
@@ -275,8 +282,7 @@ jobs:
         with:
           name: pr-boot-verify-${{ inputs.image-name }}-${{ inputs.default-tag }}-${{ matrix.safeplatform }}
           path: |
-            verify-out/serial.log
-            verify-out/*.ppm
+            verify-out/boot.png
           if-no-files-found: warn
           retention-days: 7
 
@@ -802,11 +808,10 @@ jobs:
   # at a 20-concurrent-job org limit that slot starves real builds. When
   # signing is reinstated, add it back between manifest and tag-image.
   # ── Boot gate ───────────────────────────────────────────────────────────────
-  # Pull the just-pushed :<tag>-testing manifest, install it to a qcow2 with
-  # bootc, boot it in QEMU, and require a graphical session (serial marker or
-  # screenshot sanity — scripts/iso-e2e.sh --disk). Promotion of the bare
-  # tags is blocked while this fails. Skipped for base* flavors (no desktop
-  # to verify; they are exercised by every desktop build layered on them).
+  # Pull the just-pushed :<tag>-testing manifest, have corral build its boot
+  # disk, and wait for SSH in QEMU. Promotion of the bare tags is blocked
+  # while this fails. Skipped for base* flavors (no desktop to verify; they
+  # are exercised by every desktop build layered on them).
   verify_boot:
     name: Gate
     needs: manifest
@@ -878,7 +883,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          pkgs=(just jq qemu-system-x86 qemu-utils ovmf socat imagemagick)
+          pkgs=(jq qemu-system-x86 qemu-utils ovmf)
           if sudo sh -c 'command -v podman' >/dev/null 2>&1; then
             echo "podman already present: $(sudo sh -c 'command -v podman') ($(sudo podman --version))"
           else
@@ -886,28 +891,21 @@ jobs:
           fi
           sudo apt-get install -y "${pkgs[@]}"
 
-      - name: Build qcow2 from testing image
-        env:
-          TEST_IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}-testing
+      - name: Install corral
         run: |
-          just qcow2 "${TEST_IMAGE}"
+          go install github.com/tuna-os/corral@latest
+          sudo install -m 0755 "$(go env GOPATH)/bin/corral" /usr/local/bin/corral
+          corral --version
 
       - name: Boot and verify
         run: |
-          QCOW2=$(find . -maxdepth 1 -name "*.qcow2" | head -1)
           mkdir -p verify-out
-          sudo ./scripts/iso-e2e.sh "$QCOW2" --disk \
-            --output verify-out \
-            --timeout 900
-
-      - name: Collect evidence
-        if: always()
-        run: |
-          sudo chown -R "$USER:$(id -gn)" verify-out 2>/dev/null || true
-          for ppm in verify-out/*.ppm; do
-            [[ -f "$ppm" ]] || continue
-            convert "$ppm" "${ppm%.ppm}.png" || true
-          done
+          IMAGE="${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-testing"
+          sed "s|^bootc:.*|bootc: ${IMAGE}|" tests/corral/verify.yaml > verify.yaml
+          cleanup() { corral delete gate --force >/dev/null 2>&1 || true; }
+          trap cleanup EXIT
+          corral create gate -f verify.yaml --wait-ssh --timeout 900
+          corral screenshot gate --output verify-out/boot.png || true
 
       - name: Upload boot evidence
         if: always()
@@ -915,8 +913,7 @@ jobs:
         with:
           name: boot-gate-${{ inputs.image-name }}-${{ inputs.default-tag }}
           path: |
-            verify-out/serial.log
-            verify-out/*.png
+            verify-out/boot.png
           if-no-files-found: warn
           retention-days: 7
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -124,6 +124,30 @@ just verify-disk ./yellowfin-gnome.qcow2  # QEMU boot check
 just iso yellowfin gnome               # build ISO via tacklebox
 ```
 
+## Tooling
+
+Corral is the boot-gate runner for bootc images. It builds the boot disk,
+boots it, and waits for root SSH; the canonical Lima-style scenario is
+[`tests/corral/verify.yaml`](../tests/corral/verify.yaml). The `provision`
+step enables `sshd` in the installed disk before first boot, so the published
+image is not modified.
+
+Install corral from its latest release or with `go install`, then run the same
+scenario locally with QEMU:
+
+```bash
+corral create gate -f tests/corral/verify.yaml --wait-ssh --timeout 900
+corral screenshot gate --output verify.png
+corral delete gate --force
+```
+
+For local KubeVirt parity, add `--kubevirt` to the create command. Change the
+`bootc:` reference in the YAML to the image and tag under test; CI performs
+that substitution automatically. The reusable image workflow uses this same
+scenario and corral's `--wait-ssh` exit status as the promotion gate. ISO
+gates continue to use `scripts/iso-e2e.sh`, since corral boots disks/images,
+not live ISOs.
+
 ---
 
 ## Renovate (Automated Updates)

--- a/tests/corral/verify.yaml
+++ b/tests/corral/verify.yaml
@@ -1,0 +1,13 @@
+# Canonical TunaOS boot-gate scenario.
+# CI substitutes the bootc image with the image built by the current job.
+bootc: ghcr.io/tuna-os/yellowfin:gnome-testing
+cpus: 4
+memory: 4GiB
+disk: 32GiB
+provision:
+  - mode: system
+    script: |
+      #!/bin/sh
+      # Enable SSH in the installed disk before its first boot. This does not
+      # modify the published image.
+      systemctl enable sshd


### PR DESCRIPTION
## Summary

- replace the raw QEMU/qcow2 disk gates in the PR and publish paths with corral
- add `tests/corral/verify.yaml` as the canonical boot-gate scenario, including pre-first-boot SSH provisioning
- capture corral screenshot evidence and document local QEMU/KubeVirt parity in `docs/PIPELINE.md`

## Why

Corral owns the bootc disk build and provides the same boot-gate command locally and in CI. This removes duplicated Justfile/QEMU plumbing while keeping ISO verification on `scripts/iso-e2e.sh`.

## Validation

- `git diff --cached --check`
- verified the canonical YAML and workflow references by inspection
- attempted `go install github.com/tuna-os/corral@latest`; the environment auto-selected Go 1.26.5 because the local Go 1.24.4 is older than corral's declared Go 1.26.3 requirement

Closes tuna-os/tunaos#578

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788938782&installation_model_id=429180&pr_number=1273&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1273&signature=7e3d22f727c9987a31644f273c065c4b4b1719bb34c53630ee1233d48dc255ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->