### PR TITLE
docs(matrix-status): regenerate with the Bootc Lifecycle section

### DIFF
--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -101,7 +101,28 @@ Pulls the **published** image and runs the contract script against it directly (
 
 6 cell(s) in the most recent sweep are missing (no published image), errored (registry/runner trouble), or lost (job produced no result) rather than a clean pass or fail — not counted above; see that sweep's own `desktop-contract-baseline` artifact for which.
 
-Newest result 2026-08-09.
+Newest result 2026-08-10.
+
+## Bootc Lifecycle
+
+**0 of 52** cells green (0 tested, 52 never tested).
+
+Validates bootc image update, rebase, rollback, alias resolution, and post-switch system contracts across published stream deployments.
+
+| Variant | gnome | kde | cosmic | niri | xfce |
+|---|:--:|:--:|:--:|:--:|:--:|
+| **albacore** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **bonito** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **bonito-rawhide** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **flounder** | ⬜ | ⬜ | — | — | ⬜ |
+| **flounder-sid** | ⬜ | ⬜ | — | — | ⬜ |
+| **grouper** | ⬜ | ⬜ | ⬜ | — | ⬜ |
+| **guppy** | ⬜ | ⬜ | — | — | ⬜ |
+| **hummingbird** | ⬜ | ⬜ | ⬜ | ⬜ | — |
+| **marlin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **sailfin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **skipjack** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **yellowfin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 
 ## Installer smoke
 
@@ -136,7 +157,7 @@ The run that last asserted each verdict above. Re-running a cell moves a row her
 
 | Date | Run | Cells |
 |---|---|---|
-| 2026-08-09 | [31303827255](https://github.com/tuna-os/tunaOS/actions/runs/31303827255) | 47 |
+| 2026-08-10 | [31373454633](https://github.com/tuna-os/tunaOS/actions/runs/31373454633) | 47 |
 | 2026-08-09 | [31287377558](https://github.com/tuna-os/tunaOS/actions/runs/31287377558) | 3 |
 | 2026-08-09 | [31286849405](https://github.com/tuna-os/tunaOS/actions/runs/31286849405) | 18 |
 | 2026-08-09 | [31286843546](https://github.com/tuna-os/tunaOS/actions/runs/31286843546) | 18 |


### PR DESCRIPTION
#1293 added a `## Bootc Lifecycle` section to `scripts/gen-matrix-status.py` but merged without regenerating `docs/MATRIX-STATUS.md`, so the committed doc is missing a section the generator now emits. The Matrix Status `regenerate` job fails the structure gate on that difference:

```
docs/MATRIX-STATUS.md differs from the generator in content a pull request controls
+## Bootc Lifecycle
+**N of N** cells green (N tested, N never tested).
```

This is the generator's own output committed verbatim (`scripts/gen-matrix-status.py`, no hand edits). The new section reports 0 of 52 cells green because `bootc-lifecycle.yml` has not run yet, which is the intended "never tested" state rather than a failure. The only other movement is live freshness: the contract section's newest-result date and the top provenance row, both masked by `--check-structure` anyway.

Verified with `./scripts/gen-matrix-status.py --check-structure`, which now reports the structure current.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->