### PR TITLE
ci: add keyless image signing and signed SBOM attestations

### DIFF
--- a/.github/workflows/build-albacore.yml
+++ b/.github/workflows/build-albacore.yml
@@ -21,7 +21,6 @@ jobs:
       variant: 'albacore'
       flavor: ${{ inputs.flavor || 'all' }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/build-bonito-rawhide.yml
+++ b/.github/workflows/build-bonito-rawhide.yml
@@ -21,7 +21,6 @@ jobs:
       variant: 'bonito-rawhide'
       flavor: ${{ inputs.flavor || 'all' }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/build-bonito.yml
+++ b/.github/workflows/build-bonito.yml
@@ -21,7 +21,6 @@ jobs:
       variant: 'bonito'
       flavor: ${{ inputs.flavor || 'all' }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/build-flavor.yml
+++ b/.github/workflows/build-flavor.yml
@@ -51,7 +51,6 @@ jobs:
       variant: ${{ matrix.variant }}
       flavor: ${{ needs.validate.outputs.flavor }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/build-flounder-sid.yml
+++ b/.github/workflows/build-flounder-sid.yml
@@ -21,7 +21,6 @@ jobs:
       variant: 'flounder-sid'
       flavor: ${{ inputs.flavor || 'all' }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/build-flounder.yml
+++ b/.github/workflows/build-flounder.yml
@@ -21,7 +21,6 @@ jobs:
       variant: 'flounder'
       flavor: ${{ inputs.flavor || 'all' }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/build-grouper.yml
+++ b/.github/workflows/build-grouper.yml
@@ -21,7 +21,6 @@ jobs:
       variant: 'grouper'
       flavor: ${{ inputs.flavor || 'all' }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/build-guppy.yml
+++ b/.github/workflows/build-guppy.yml
@@ -21,7 +21,6 @@ jobs:
       variant: 'guppy'
       flavor: ${{ inputs.flavor || 'all' }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/build-gurnard.yml
+++ b/.github/workflows/build-gurnard.yml
@@ -21,7 +21,6 @@ jobs:
       variant: 'gurnard'
       flavor: ${{ inputs.flavor || 'all' }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/build-hummingbird.yml
+++ b/.github/workflows/build-hummingbird.yml
@@ -21,7 +21,6 @@ jobs:
       variant: 'hummingbird'
       flavor: ${{ inputs.flavor || 'all' }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/build-marlin.yml
+++ b/.github/workflows/build-marlin.yml
@@ -21,7 +21,6 @@ jobs:
       variant: 'marlin'
       flavor: ${{ inputs.flavor || 'all' }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/build-sailfin.yml
+++ b/.github/workflows/build-sailfin.yml
@@ -21,7 +21,6 @@ jobs:
       variant: 'sailfin'
       flavor: ${{ inputs.flavor || 'all' }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/build-skipjack.yml
+++ b/.github/workflows/build-skipjack.yml
@@ -21,7 +21,6 @@ jobs:
       variant: 'skipjack'
       flavor: ${{ inputs.flavor || 'all' }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -25,8 +25,6 @@ on:
         default: 'all'
         type: string
     secrets:
-      SIGNING_SECRET:
-        required: false
       R2_ACCESS_KEY_ID:
         required: false
       R2_SECRET_ACCESS_KEY:
@@ -202,8 +200,6 @@ jobs:
       default-tag: ${{ matrix.published_tag }}
       publish: ${{ github.event_name != 'pull_request' }}
       sbom: ${{ github.event_name != 'pull_request' }}
-    secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
 
   # ── Stage 2: base-hwe, base-nvidia, and desktop base flavors ──────────────────
   # Runs only after ALL stage-1 jobs pass. Includes:
@@ -238,8 +234,6 @@ jobs:
       default-tag: ${{ matrix.published_tag }}
       publish: true
       sbom: true
-    secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
 
   # ── Stage 3: Desktop HWE and nvidia flavors ───────────────────────────────────
   # Layers on stage-2 images:
@@ -274,8 +268,6 @@ jobs:
       default-tag: ${{ matrix.published_tag }}
       publish: true
       sbom: true
-    secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
 
   # ── Stage 4: Combined nvidia+HWE flavors ──────────────────────────────────────
   # Layers on stage-3 images:
@@ -304,8 +296,6 @@ jobs:
       default-tag: ${{ matrix.published_tag }}
       publish: true
       sbom: true
-    secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
 
   # ── Artifact builds per stage (ISO + QCOW2) ───────────────────────────────
   # Each stage's artifacts depend only on that stage's image builds.

--- a/.github/workflows/build-yellowfin.yml
+++ b/.github/workflows/build-yellowfin.yml
@@ -21,7 +21,6 @@ jobs:
       variant: 'yellowfin'
       flavor: ${{ inputs.flavor || 'all' }}
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -84,12 +84,6 @@ on:
         required: false
         type: string
         default: ""
-    secrets:
-      SIGNING_SECRET:
-        description: "The private key used to sign the image"
-        required: false
-
-
 jobs:
   build_push:
     name: ${{ matrix.safeplatform }}
@@ -351,12 +345,9 @@ jobs:
       # package list can, and it also confirms the real failures: marlin:kde
       # carries 338 packages against its base's 480, and zero KDE packages.
       #
-      # Not derived from the Syft SBOM below: that step is continue-on-error
-      # and time-boxed because Syft mmaps the whole image and OOMs on desktop
-      # sizes, so the SBOM is frequently absent. Asking the package manager
-      # directly costs a second and always works. Its artifact also expires in
-      # 7 days and needs GitHub auth, which is no good for comparing editions
-      # built weeks apart.
+      # Not derived from the Syft SBOM below: this compact package inventory is
+      # intended for quick edition-to-edition diffs. The complete SPDX SBOM is
+      # separately validated and signed as an in-toto attestation.
       #
       # Pushed as an OCI artifact next to the image, so it is durable, is
       # versioned with the image, and is readable by anyone who can pull it.
@@ -434,25 +425,30 @@ jobs:
 
       - name: Generate SBOM
         if: inputs.sbom && github.event_name != 'pull_request'
-        # Syft mmaps the multi-GB OCI image and can OOM-kill the runner on
-        # desktop-sized images; cap Go memory and time-box it, and never
-        # fail the build over an SBOM (projectbluefin/actions#294/#300).
-        # The package manifest above already records every installed package.
+        # Scan the published, immutable platform image. Stable publication is
+        # intentionally fail-closed: an image without its SBOM cannot be
+        # signed or promoted by the supply-chain gate below.
         # Scan the final filesystem view rather than every historical layer:
         # the latter made the Gentoo base job spend its remaining runner time
         # in Syft after the image had already built and pushed (tunaOS#956).
-        continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 20
         env:
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           DEFAULT_TAG: ${{ inputs.default-tag }}
           SAFE_PLATFORM: ${{ matrix.safeplatform }}
           GOMEMLIMIT: 3GiB
           GOGC: "25"
         run: |
-          IMAGE="ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}:${DEFAULT_TAG}-${SAFE_PLATFORM}"
-          $SYFT_CMD "$IMAGE" --scope squashed -o spdx-json="sbom-${IMAGE_NAME}-${DEFAULT_TAG}-${SAFE_PLATFORM}.spdx.json"
+          set -euo pipefail
+          IMAGE="${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${SAFE_PLATFORM}"
+          OUT="sbom-${IMAGE_NAME}-${DEFAULT_TAG}-${SAFE_PLATFORM}.spdx.json"
+          $SYFT_CMD "$IMAGE" --scope squashed -o spdx-json="$OUT"
+          jq -e '
+            .spdxVersion | startswith("SPDX-")
+          ' "$OUT" >/dev/null
+          jq -e '(.packages // []) | length > 0' "$OUT" >/dev/null
 
       - name: Upload SBOM
         if: inputs.sbom && github.event_name != 'pull_request'
@@ -460,12 +456,8 @@ jobs:
         with:
           name: sbom-${{ env.IMAGE_NAME }}-${{ inputs.default-tag }}-${{ matrix.safeplatform }}
           path: sbom-*.spdx.json
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 7
-
-      # TODO: reinstate sign-and-publish when key propagation through composite
-      # actions is resolved. The COSIGN_PRIVATE_KEY env var is masked but
-      # arrives empty at runtime in the composite action.
 
       - name: PR Testing Instructions
         if: github.event_name == 'pull_request'
@@ -807,11 +799,103 @@ jobs:
           echo "DIGEST=$DIGEST" >> $GITHUB_OUTPUT
           echo "IMAGE=$IMAGE_REGISTRY/$IMAGE_NAME" >> $GITHUB_OUTPUT
 
-  # NOTE: the former `sign` job is gone. It had been reduced to a single
-  # `echo "Manifest signing skipped"` while cosign key propagation is broken
-  # (see the TODO above Promote), yet still spun up a runner per flavor —
-  # at a 20-concurrent-job org limit that slot starves real builds. When
-  # signing is reinstated, add it back between manifest and tag-image.
+  # Sign the immutable platform manifests and the final multi-arch index with
+  # GitHub's OIDC identity. Fulcio issues an ephemeral certificate and Rekor
+  # records the event: there is no private key, password, or repository secret.
+  # This can run beside the boot gate; both must pass before promotion.
+  sign:
+    name: Sign + attest
+    needs: manifest
+    if: >-
+      inputs.publish && github.event_name != 'pull_request' &&
+      needs.manifest.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    env:
+      IMAGE_NAME: ${{ inputs.image-name }}
+      IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}
+      DEFAULT_TAG: ${{ inputs.default-tag }}
+      INDEX_DIGEST: ${{ needs.manifest.outputs.digest }}
+      COSIGN_YES: "true"
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
+
+      - name: Login to GitHub Container Registry
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GITHUB_TOKEN" | cosign login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Fetch platform digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: ${{ env.IMAGE_NAME }}-${{ env.DEFAULT_TAG }}-*
+          merge-multiple: true
+          path: supply-chain/digests
+
+      - name: Fetch SPDX SBOMs
+        if: inputs.sbom
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: sbom-${{ env.IMAGE_NAME }}-${{ env.DEFAULT_TAG }}-*
+          merge-multiple: true
+          path: supply-chain/sboms
+
+      - name: Sign images and attest SBOMs
+        env:
+          REQUIRE_SBOM: ${{ inputs.sbom }}
+        run: |
+          set -euo pipefail
+          identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/reusable-build-image.yml@${GITHUB_REF}"
+          issuer="https://token.actions.githubusercontent.com"
+          index_ref="${IMAGE_REGISTRY}/${IMAGE_NAME}@${INDEX_DIGEST}"
+
+          cosign sign "$index_ref"
+          cosign verify "$index_ref" \
+            --certificate-identity "$identity" \
+            --certificate-oidc-issuer "$issuer" >/dev/null
+
+          signed=0
+          attested=0
+          shopt -s nullglob
+          for digest_file in supply-chain/digests/*.txt; do
+            filename="$(basename "$digest_file" .txt)"
+            safeplatform="${filename#${IMAGE_NAME}-${DEFAULT_TAG}-}"
+            digest="$(<"$digest_file")"
+            ref="${IMAGE_REGISTRY}/${IMAGE_NAME}@${digest}"
+            sbom="supply-chain/sboms/sbom-${IMAGE_NAME}-${DEFAULT_TAG}-${safeplatform}.spdx.json"
+
+            cosign sign "$ref"
+            cosign verify "$ref" \
+              --certificate-identity "$identity" \
+              --certificate-oidc-issuer "$issuer" >/dev/null
+            signed=$((signed + 1))
+
+            if [[ -f "$sbom" ]]; then
+              cosign attest --type spdxjson --predicate "$sbom" "$ref"
+              cosign verify-attestation "$ref" \
+                --type spdxjson \
+                --certificate-identity "$identity" \
+                --certificate-oidc-issuer "$issuer" >/dev/null
+              attested=$((attested + 1))
+            elif [[ "$REQUIRE_SBOM" == "true" ]]; then
+              echo "::error::missing SPDX SBOM for ${safeplatform}"
+              exit 1
+            fi
+          done
+
+          [[ "$signed" -gt 0 ]] || { echo "::error::no platform digests found"; exit 1; }
+          if [[ "$REQUIRE_SBOM" == "true" && "$attested" -ne "$signed" ]]; then
+            echo "::error::attested ${attested}/${signed} platform SBOMs"
+            exit 1
+          fi
+          echo "Signed index plus ${signed} platform image(s); attested ${attested} SPDX SBOM(s)." >> "$GITHUB_STEP_SUMMARY"
+
   # ── Boot gate ───────────────────────────────────────────────────────────────
   # Pull the just-pushed :<tag>-testing manifest, install it to a qcow2 with
   # bootc, boot it in QEMU, and require a graphical session (serial marker or
@@ -973,10 +1057,11 @@ jobs:
 
   tag-image:
     name: Promote
-    needs: [manifest, verify_boot, verify_asahi]
+    needs: [manifest, sign, verify_boot, verify_asahi]
     if: >-
       !cancelled() && github.event_name != 'pull_request' &&
       needs.manifest.result == 'success' &&
+      needs.sign.result == 'success' &&
       (needs.verify_boot.result == 'success' || needs.verify_boot.result == 'skipped') &&
       (needs.verify_asahi.result == 'success' || needs.verify_asahi.result == 'skipped')
     # Temporarily off RunsOn: the tuna-os AWS account is capped to Free Tier,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,14 +34,22 @@ You can expect:
 
 TunaOS images are:
 - Built in CI from pinned base images (see `image-versions.yaml`)
-- Signed with [cosign](https://github.com/sigstore/cosign) (public key: `cosign.pub`)
+- Signed keylessly with [Sigstore Cosign](https://github.com/sigstore/cosign)
+  using the protected TunaOS GitHub Actions workflow identity
 - Scanned for vulnerabilities via GitHub's built-in scanning
-- Published as SBOM-attested OCI images
+- Published with signed SPDX SBOM attestations
+
+There is no long-lived TunaOS signing key or password to leak or rotate.
+Fulcio issues a short-lived certificate for the GitHub Actions OIDC identity,
+and the signature is recorded in Sigstore's transparency infrastructure. See
+[`docs/VERIFY-ARTIFACTS.md`](docs/VERIFY-ARTIFACTS.md) for verification commands.
 
 ## Supply Chain Security
 
 - Base images pinned by digest in `image-versions.yaml`
 - Third-party GitHub Actions pinned to commit SHAs
+- Release promotion requires successful keyless signature and SBOM-attestation
+  verification against the expected repository workflow and protected ref
 - Build secrets use BuildKit secret mounts, never environment variables
 - RPM packages from official AlmaLinux/CentOS/Fedora repositories and verified COPRs
 

--- a/docs/VERIFY-ARTIFACTS.md
+++ b/docs/VERIFY-ARTIFACTS.md
@@ -1,0 +1,60 @@
+# Verify TunaOS artifacts
+
+TunaOS OCI images are signed with Sigstore Cosign's keyless GitHub Actions
+identity. No project signing key or password is required. Verification checks
+both the artifact digest and the identity of the protected workflow that built
+it.
+
+## Install Cosign
+
+Use Cosign 3.0.6 or newer. Follow the upstream installation instructions and
+verify the Cosign binary before using it.
+
+## Verify an OCI image
+
+Always resolve and verify an immutable digest, even when starting from a
+friendly tag:
+
+```bash
+image=ghcr.io/tuna-os/yellowfin:gnome
+digest=$(skopeo inspect "docker://${image}" | jq -r .Digest)
+ref="ghcr.io/tuna-os/yellowfin@${digest}"
+
+cosign verify "${ref}" \
+  --certificate-identity \
+    "https://github.com/tuna-os/tunaOS/.github/workflows/reusable-build-image.yml@refs/heads/main" \
+  --certificate-oidc-issuer \
+    "https://token.actions.githubusercontent.com"
+```
+
+The command must exit successfully. Do not replace the identity or issuer with
+an unrestricted regular expression.
+
+## Verify the SPDX SBOM attestation
+
+Each published platform image has a signed SPDX JSON attestation:
+
+```bash
+cosign verify-attestation "${ref}" \
+  --type spdxjson \
+  --certificate-identity \
+    "https://github.com/tuna-os/tunaOS/.github/workflows/reusable-build-image.yml@refs/heads/main" \
+  --certificate-oidc-issuer \
+    "https://token.actions.githubusercontent.com"
+```
+
+Cosign prints the verified in-toto statement. Its `subject[].digest.sha256`
+must match the digest in `ref`. The predicate contains the SPDX document for
+that platform image.
+
+## Trust boundary
+
+The accepted identity is intentionally narrow:
+
+- repository: `tuna-os/tunaOS`;
+- workflow: `.github/workflows/reusable-build-image.yml`;
+- ref: protected `refs/heads/main`;
+- OIDC issuer: GitHub Actions.
+
+A signature from a fork, pull-request ref, another repository, another
+workflow, or another identity provider does not satisfy this policy.

--- a/scripts/generate-workflows.py
+++ b/scripts/generate-workflows.py
@@ -35,7 +35,6 @@ jobs:
       variant: '{name}'
       flavor: ${{{{ inputs.flavor || 'all' }}}}
     secrets:
-      SIGNING_SECRET: ${{{{ secrets.SIGNING_SECRET }}}}
       R2_ACCESS_KEY_ID: ${{{{ secrets.R2_ACCESS_KEY_ID }}}}
       R2_SECRET_ACCESS_KEY: ${{{{ secrets.R2_SECRET_ACCESS_KEY }}}}
       R2_ENDPOINT: ${{{{ secrets.R2_ENDPOINT }}}}
@@ -64,7 +63,6 @@ jobs:
       variant: '{name}'
       flavor: ${{{{ inputs.flavor || 'all' }}}}
     secrets:
-      SIGNING_SECRET: ${{{{ secrets.SIGNING_SECRET }}}}
       R2_ACCESS_KEY_ID: ${{{{ secrets.R2_ACCESS_KEY_ID }}}}
       R2_SECRET_ACCESS_KEY: ${{{{ secrets.R2_SECRET_ACCESS_KEY }}}}
       R2_ENDPOINT: ${{{{ secrets.R2_ENDPOINT }}}}

--- a/tests/bats/test_sbom_scope.bats
+++ b/tests/bats/test_sbom_scope.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
-# SBOM generation must describe the final image without making a large,
-# layered source-based image unpublishable.
+# SBOM generation must describe the final image and fail closed before a
+# stable image is signed or promoted.
 
 REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
 WORKFLOW="${REPO_ROOT}/.github/workflows/reusable-build-image.yml"
@@ -12,7 +12,31 @@ WORKFLOW="${REPO_ROOT}/.github/workflows/reusable-build-image.yml"
   [ "$status" -ne 0 ]
 }
 
-@test "SBOM remains non-blocking and time-bounded" {
-  grep -q '^        continue-on-error: true$' "$WORKFLOW"
-  grep -q '^        timeout-minutes: 10$' "$WORKFLOW"
+@test "SBOM is blocking, validated, and time-bounded" {
+  run bash -c "sed -n '/- name: Generate SBOM/,/- name: Upload SBOM/p' '$WORKFLOW' | grep 'continue-on-error'"
+  [ "$status" -ne 0 ]
+  grep -q '^        timeout-minutes: 20$' "$WORKFLOW"
+  grep -q 'if-no-files-found: error' "$WORKFLOW"
+  grep -q 'length > 0' "$WORKFLOW"
+}
+
+@test "published images use keyless signing and signed SPDX attestations" {
+  grep -q 'id-token: write' "$WORKFLOW"
+  grep -q 'cosign sign "$index_ref"' "$WORKFLOW"
+  grep -q 'cosign attest --type spdxjson' "$WORKFLOW"
+  grep -q 'cosign verify-attestation' "$WORKFLOW"
+  run grep -E 'COSIGN_PRIVATE_KEY|SIGNING_SECRET' "$WORKFLOW"
+  [ "$status" -ne 0 ]
+}
+
+@test "active workflows no longer pass a signing key secret" {
+  run grep -R -E 'COSIGN_PRIVATE_KEY|SIGNING_SECRET' \
+    "${REPO_ROOT}/.github/workflows" \
+    --exclude-dir=archive
+  [ "$status" -ne 0 ]
+}
+
+@test "promotion requires the signing gate" {
+  grep -q 'needs: \[manifest, sign, verify_boot, verify_asahi\]' "$WORKFLOW"
+  grep -q "needs.sign.result == 'success'" "$WORKFLOW"
 }


### PR DESCRIPTION
## What changed

- replaces the dormant `SIGNING_SECRET` / `COSIGN_PRIVATE_KEY` path with GitHub Actions OIDC keyless Cosign signing;
- signs every immutable platform manifest plus the final multi-architecture index;
- validates SPDX JSON and attaches each platform SBOM as a signed in-toto attestation;
- verifies signatures and attestations against the exact TunaOS reusable workflow identity, protected `main` ref, and GitHub OIDC issuer;
- makes the signing gate mandatory before stable tag/alias promotion;
- removes signing-key secret plumbing from active generated and reusable workflows;
- documents user verification commands and the trust boundary.

## Why

The image workflow explicitly skipped signing because a private key could not propagate through composite actions. Keyless Sigstore uses the job's short-lived GitHub OIDC identity, so there is no private key, password, KMS credential, or repository signing secret to propagate or rotate.

SBOM production was also advisory. A published image could therefore be promoted without the artifact that release and security workflows claim exists. This change fails closed for published builds: the SPDX document must be valid and non-empty, and the attestation must verify before promotion.

## Validation

- parsed all 58 active workflow YAML files;
- checked the workflow generator emits no signing-key secret;
- checked active workflows contain no `SIGNING_SECRET` or `COSIGN_PRIVATE_KEY`;
- compiled the generator;
- ran focused static assertions for fail-closed SBOM generation, keyless signing/attestation, and promotion dependency;
- ran `git diff --check`;
- locally confirmed Cosign v3.0.6 supports the used keyless `sign`, `attest --type spdxjson`, `verify`, and `verify-attestation` interfaces.

The runtime did not include pytest, Bats, Actionlint, or GitHub CLI. Repository CI remains authoritative, and a main-branch publish is required to exercise ambient GitHub OIDC plus GHCR referrers end to end.

This PR completes the OCI-image and SBOM-attestation portion of #1187. ISO/QCOW2 checksum and keyless blob-bundle signing remain tracked there.

Part of #1187.
Part of #1283.