### PR TITLE
ci: keylessly sign published ISOs

### DIFF
--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -313,6 +313,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write
     uses: ./.github/workflows/reusable-build-artifacts.yml
     with:
       variant: ${{ matrix.variant }}
@@ -341,6 +342,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write
     uses: ./.github/workflows/reusable-build-artifacts.yml
     with:
       variant: ${{ matrix.variant }}
@@ -367,6 +369,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write
     uses: ./.github/workflows/reusable-build-artifacts.yml
     with:
       variant: ${{ matrix.variant }}

--- a/.github/workflows/publish-iso-groups.yml
+++ b/.github/workflows/publish-iso-groups.yml
@@ -123,6 +123,7 @@ jobs:
     permissions:
       contents: write
       packages: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
@@ -197,6 +198,31 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
+
+      - name: Checksum, sign, and verify grouped ISO
+        env:
+          COSIGN_YES: "true"
+        run: |
+          set -euo pipefail
+          ISO=$(find . -maxdepth 1 -name "${{ matrix.basename }}-*.iso" -print -quit)
+          [[ -n "$ISO" ]] || { echo "::error::ISO not found"; exit 1; }
+          CHECKSUM="${ISO}.sha256"
+          BUNDLE="${ISO}.sigstore.json"
+          identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/publish-iso-groups.yml@${GITHUB_REF}"
+          issuer="https://token.actions.githubusercontent.com"
+
+          sha256sum "$(basename "$ISO")" > "$CHECKSUM"
+          sha256sum --check --strict "$CHECKSUM"
+          cosign sign-blob --bundle "$BUNDLE" "$ISO"
+          cosign verify-blob "$ISO" \
+            --bundle "$BUNDLE" \
+            --certificate-identity "$identity" \
+            --certificate-oidc-issuer "$issuer"
+
       # Only reached if the boot gate passed.
       - name: Upload ISO to Cloudflare R2
         if: ${{ inputs.skip_upload != true }}
@@ -213,19 +239,32 @@ jobs:
             echo "ERROR: No ISO found for ${{ matrix.basename }}"
             exit 1
           fi
+          CHECKSUM="${ISO}.sha256"
+          BUNDLE="${ISO}.sigstore.json"
           echo "==> Uploading $ISO to R2..."
-          rclone copy --log-level INFO --checksum --s3-no-check-bucket \
-            "$ISO" R2:${{ secrets.R2_BUCKET }}/live-isos/
+          for artifact in "$ISO" "$CHECKSUM" "$BUNDLE"; do
+            rclone copy --log-level INFO --checksum --s3-no-check-bucket \
+              "$artifact" R2:${{ secrets.R2_BUCKET }}/live-isos/
+          done
           LATEST="${{ matrix.basename }}-latest.iso"
           rclone copyto --log-level INFO --s3-no-check-bucket \
             "$ISO" "R2:${{ secrets.R2_BUCKET }}/live-isos/${LATEST}"
-          echo "==> Upload complete: $(basename "$ISO") (latest → ${LATEST})"
+          DIGEST=$(sha256sum "$ISO" | awk '{print $1}')
+          printf '%s  %s\n' "$DIGEST" "$LATEST" > "${LATEST}.sha256"
+          rclone copyto --log-level INFO --s3-no-check-bucket \
+            "${LATEST}.sha256" "R2:${{ secrets.R2_BUCKET }}/live-isos/${LATEST}.sha256"
+          rclone copyto --log-level INFO --s3-no-check-bucket \
+            "$BUNDLE" "R2:${{ secrets.R2_BUCKET }}/live-isos/${LATEST}.sigstore.json"
+          echo "==> Upload complete: $(basename "$ISO") (latest → ${LATEST}) with signed sidecars"
 
       - name: Upload ISO as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.basename }}-iso
-          path: "${{ matrix.basename }}-*.iso"
+          path: |
+            ${{ matrix.basename }}-*.iso
+            ${{ matrix.basename }}-*.iso.sha256
+            ${{ matrix.basename }}-*.iso.sigstore.json
           if-no-files-found: error
           retention-days: 7
 
@@ -249,12 +288,14 @@ jobs:
           RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: |
           echo "==> Pruning grouped ISOs older than 14 days from R2..."
-          # Delete versioned ISOs older than 14 days.
-          # Excludes -latest.iso pointers (always current, never pruned).
+          # Delete versioned ISOs and their sidecars together. Exclude every
+          # latest pointer and sidecar (always current).
           rclone delete --log-level INFO \
             --min-age 14d \
+            --exclude "*-latest.iso*" \
             --include "*.iso" \
-            --exclude "*-latest.iso" \
+            --include "*.iso.sha256" \
+            --include "*.iso.sigstore.json" \
             --s3-no-check-bucket \
             "R2:${{ secrets.R2_BUCKET }}/live-isos/"
           echo "==> Prune complete. Remaining objects:"

--- a/.github/workflows/publish-isos.yml
+++ b/.github/workflows/publish-isos.yml
@@ -84,6 +84,7 @@ jobs:
     permissions:
       contents: write
       packages: read
+      id-token: write
     # Builds the ISO from the promoted :<flavor> image, boot-gates it in
     # QEMU, and only publishes (R2 + GitHub Release) if the gate passes.
     uses: ./.github/workflows/reusable-build-artifacts.yml

--- a/.github/workflows/reusable-build-artifacts.yml
+++ b/.github/workflows/reusable-build-artifacts.yml
@@ -108,14 +108,6 @@ jobs:
           sudo -E bash ./scripts/build-iso-tacklebox.sh \
             "${VARIANT}" "${FLAVOR}" ghcr "${TAG}"
 
-      - name: Upload ISO Artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: iso-${{ inputs.variant }}-${{ inputs.flavor }}
-          path: "*.iso"
-          if-no-files-found: error
-          retention-days: 7
-
       - name: Install QEMU for boot verification
         run: |
           sudo apt-get install -y qemu-system-x86 ovmf socat imagemagick qemu-utils sshpass python3-pip
@@ -137,6 +129,46 @@ jobs:
             ./scripts/iso-e2e.sh "$ISO" \
               --output iso-e2e-out \
               --timeout 900
+
+      # The booted bytes are the signed bytes. Sign only after the QEMU gate
+      # succeeds, then verify locally before either release backend sees them.
+      # GitHub OIDC + Fulcio supplies an ephemeral identity: no key/password.
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
+
+      - name: Checksum, sign, and verify ISO
+        env:
+          COSIGN_YES: "true"
+        run: |
+          set -euo pipefail
+          ISO=$(find . -maxdepth 1 -name "*.iso" -print -quit)
+          [[ -n "$ISO" ]] || { echo "::error::ISO not found"; exit 1; }
+          CHECKSUM="${ISO}.sha256"
+          BUNDLE="${ISO}.sigstore.json"
+          identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/reusable-build-artifacts.yml@${GITHUB_REF}"
+          issuer="https://token.actions.githubusercontent.com"
+
+          sha256sum "$(basename "$ISO")" > "$CHECKSUM"
+          sha256sum --check --strict "$CHECKSUM"
+          cosign sign-blob --bundle "$BUNDLE" "$ISO"
+          cosign verify-blob "$ISO" \
+            --bundle "$BUNDLE" \
+            --certificate-identity "$identity" \
+            --certificate-oidc-issuer "$issuer"
+
+      - name: Upload signed ISO artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: iso-${{ inputs.variant }}-${{ inputs.flavor }}
+          path: |
+            *.iso
+            *.iso.sha256
+            *.iso.sigstore.json
+          if-no-files-found: error
+          retention-days: 7
 
       # Installer-flow captures join the boot evidence so every visual the
       # pipeline can produce lands in ONE artifact (and, via the weekly
@@ -194,13 +226,23 @@ jobs:
             exit 0
           fi
           ISO=$(find . -maxdepth 1 -name "*.iso" | head -1)
+          CHECKSUM="${ISO}.sha256"
+          BUNDLE="${ISO}.sigstore.json"
           echo "==> Uploading $ISO to R2..."
-          rclone copy --log-level INFO --checksum --s3-no-check-bucket \
-            "$ISO" "R2:${R2_BUCKET}/live-isos/"
+          for artifact in "$ISO" "$CHECKSUM" "$BUNDLE"; do
+            rclone copy --log-level INFO --checksum --s3-no-check-bucket \
+              "$artifact" "R2:${R2_BUCKET}/live-isos/"
+          done
           LATEST="${VARIANT}-${FLAVOR}-latest.iso"
           rclone copyto --log-level INFO --s3-no-check-bucket \
             "$ISO" "R2:${R2_BUCKET}/live-isos/${LATEST}"
-          echo "==> Published $(basename "$ISO") and ${LATEST}"
+          DIGEST=$(sha256sum "$ISO" | awk '{print $1}')
+          printf '%s  %s\n' "$DIGEST" "$LATEST" > "${LATEST}.sha256"
+          rclone copyto --log-level INFO --s3-no-check-bucket \
+            "${LATEST}.sha256" "R2:${R2_BUCKET}/live-isos/${LATEST}.sha256"
+          rclone copyto --log-level INFO --s3-no-check-bucket \
+            "$BUNDLE" "R2:${R2_BUCKET}/live-isos/${LATEST}.sigstore.json"
+          echo "==> Published $(basename "$ISO") and ${LATEST}, with checksum + Sigstore bundle sidecars"
 
       - name: Attach ISO to GitHub Release
         if: inputs.attach-release
@@ -226,11 +268,15 @@ jobs:
           # the same name already exists and was uploaded in the same API
           # session. Explicitly delete first, then upload to avoid the race.
           ISO_NAME=$(basename "$ISO")
-          if gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" --json assets \
-              | python3 -c "import json,sys; assets=json.load(sys.stdin)['assets']; [print(a['name']) for a in assets]" \
-              | grep -qxF "$ISO_NAME"; then
-            echo "==> Deleting existing asset ${ISO_NAME} from release ${TAG}..."
-            gh release delete-asset "$TAG" "$ISO_NAME" --repo "${GITHUB_REPOSITORY}" --yes
-          fi
-          gh release upload "$TAG" --repo "${GITHUB_REPOSITORY}" "$ISO"
-          echo "==> Attached ${ISO_NAME} to release $TAG"
+          ASSETS=("$ISO_NAME" "${ISO_NAME}.sha256" "${ISO_NAME}.sigstore.json")
+          EXISTING=$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" --json assets \
+            | python3 -c "import json,sys; assets=json.load(sys.stdin)['assets']; [print(a['name']) for a in assets]")
+          for asset in "${ASSETS[@]}"; do
+            if grep -qxF "$asset" <<< "$EXISTING"; then
+              echo "==> Deleting existing asset ${asset} from release ${TAG}..."
+              gh release delete-asset "$TAG" "$asset" --repo "${GITHUB_REPOSITORY}" --yes
+            fi
+          done
+          gh release upload "$TAG" --repo "${GITHUB_REPOSITORY}" \
+            "$ISO" "${ISO}.sha256" "${ISO}.sigstore.json"
+          echo "==> Attached ${ISO_NAME} plus checksum and Sigstore bundle to release $TAG"

--- a/docs/VERIFY-ARTIFACTS.md
+++ b/docs/VERIFY-ARTIFACTS.md
@@ -58,3 +58,35 @@ The accepted identity is intentionally narrow:
 
 A signature from a fork, pull-request ref, another repository, another
 workflow, or another identity provider does not satisfy this policy.
+
+## Verify an ISO
+
+Every published ISO has two adjacent files:
+
+- `<name>.iso.sha256` — the SHA-256 checksum manifest;
+- `<name>.iso.sigstore.json` — the Cosign v3 keyless verification bundle.
+
+Download all three files into the same directory, then run:
+
+```bash
+sha256sum --check --strict tunaos-example.iso.sha256
+
+cosign verify-blob tunaos-example.iso \
+  --bundle tunaos-example.iso.sigstore.json \
+  --certificate-identity \
+    "https://github.com/tuna-os/tunaOS/.github/workflows/reusable-build-artifacts.yml@refs/heads/main" \
+  --certificate-oidc-issuer \
+    "https://token.actions.githubusercontent.com"
+```
+
+Scheduled combined/deduplicated media is produced directly by
+`publish-iso-groups.yml`. For those ISOs, use this exact identity instead:
+
+```text
+https://github.com/tuna-os/tunaOS/.github/workflows/publish-iso-groups.yml@refs/heads/main
+```
+
+The reusable artifact workflow signs only after the ISO passes its QEMU boot
+gate; the grouped workflow follows the same ordering. The verified ISO,
+checksum, and bundle are then uploaded together. A signing or local
+verification failure prevents publication.

--- a/tests/bats/test_artifact_signing.bats
+++ b/tests/bats/test_artifact_signing.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+# Release ISOs must be checksummed and keylessly signed after boot verification
+# and before either publication backend runs.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+WORKFLOW="${REPO_ROOT}/.github/workflows/reusable-build-artifacts.yml"
+
+@test "ISO signing uses GitHub OIDC without a private key" {
+  grep -q 'cosign sign-blob --bundle' "$WORKFLOW"
+  grep -q 'cosign verify-blob' "$WORKFLOW"
+  run grep -E 'COSIGN_PRIVATE_KEY|SIGNING_SECRET|COSIGN_PASSWORD' "$WORKFLOW"
+  [ "$status" -ne 0 ]
+}
+
+@test "ISO boot gate precedes signing and publication" {
+  boot=$(grep -n 'name: "Boot gate: verify ISO readiness"' "$WORKFLOW" | cut -d: -f1)
+  sign=$(grep -n 'name: Checksum, sign, and verify ISO' "$WORKFLOW" | cut -d: -f1)
+  r2=$(grep -n 'name: Upload ISO to Cloudflare R2' "$WORKFLOW" | cut -d: -f1)
+  release=$(grep -n 'name: Attach ISO to GitHub Release' "$WORKFLOW" | cut -d: -f1)
+  [ "$boot" -lt "$sign" ]
+  [ "$sign" -lt "$r2" ]
+  [ "$sign" -lt "$release" ]
+}
+
+@test "both publication backends include checksum and bundle sidecars" {
+  grep -q 'live-isos/${LATEST}.sha256' "$WORKFLOW"
+  grep -q 'live-isos/${LATEST}.sigstore.json' "$WORKFLOW"
+  grep -q '"${ISO}.sha256" "${ISO}.sigstore.json"' "$WORKFLOW"
+}
+
+@test "all reusable artifact callers grant OIDC token access" {
+  [ "$(grep -c 'id-token: write' "${REPO_ROOT}/.github/workflows/build-variant.yml")" -eq 3 ]
+  grep -q 'id-token: write' "${REPO_ROOT}/.github/workflows/publish-isos.yml"
+}
+
+@test "scheduled grouped ISOs are also signed with sidecars" {
+  grouped="${REPO_ROOT}/.github/workflows/publish-iso-groups.yml"
+  grep -q 'cosign sign-blob --bundle' "$grouped"
+  grep -q 'cosign verify-blob' "$grouped"
+  grep -q 'id-token: write' "$grouped"
+  grep -q 'iso.sigstore.json' "$grouped"
+}


### PR DESCRIPTION
## What changed

- after each ISO passes its QEMU boot gate, generates and verifies a SHA-256 manifest;
- signs the exact boot-tested ISO bytes with Cosign v3 and GitHub Actions OIDC;
- verifies the bundle locally against the exact approved workflow identity and GitHub issuer;
- publishes the ISO, checksum, and `.sigstore.json` bundle together;
- covers both the reusable per-flavor/emergency path and the scheduled grouped/deduplicated ISO path;
- gives reusable callers the narrow `id-token: write` permission required for keyless signing;
- uploads sidecars to R2, latest aliases, workflow artifacts, and GitHub Releases;
- prunes versioned grouped-ISO sidecars with their corresponding old ISO;
- documents verification for both approved workflow identities.

## Why

#1303 secured OCI images and SPDX attestations without a stored key. ISO publication was still unsigned, so users could not cryptographically connect downloaded boot media to a protected TunaOS workflow. This completes the blob-signing portion without adding a private key, password, KMS secret, or signing-key rotation burden.

## Validation

- parsed all 58 active workflow YAML files;
- verified signing occurs after boot gates and before publication;
- verified both publication paths upload checksum and bundle sidecars;
- verified all reusable callers grant OIDC access;
- verified no private-key/password signing variables exist in either workflow;
- ran `git diff --check`;
- added focused Bats contract tests.

A real main-branch ISO build remains the authoritative end-to-end proof for GitHub OIDC, Fulcio, and published bundles.

Part of #1187.
Part of #1283.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->