### PR TITLE
docs(asahi): add OBS project design for EL10 package gap

### DIFF
--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -193,7 +193,7 @@ Canonical rollout plan for verifying end-to-end user ISO installation experience
 Umbrella initiative for making TunaOS bootable on M1/M2 Apple Silicon Macs via the Asahi stack:
 
 - **Naming Convention**: `asahi` is a **tag suffix** (`bonito:gnome-asahi`), never a separate variant/image name.
-- **Verification Harness (#776 / #910)**: Daily 35-point golden-manifest boot-chain sweep. Bonito (Fedora) and Grouper (Ubuntu) are verified 36/36 green. Remaining variants are undergoing kernel and boot-chain alignment (#777, #911, #912, #914).
+- **Verification Harness (#776 / #910)**: Daily 35-point golden-manifest boot-chain sweep. Bonito (Fedora) and Grouper (Ubuntu) are verified 36/36 green. Remaining variants are undergoing kernel and boot-chain alignment (#777, #911, #912, #914; see [OBS Project Plan for EL10](./ASAHI-EL10-OBS-PROJECT.md)).
 - **Installer Track (`bootc-installer-asahi`)**:
   - D0: Real-image payload packaging & validation.
   - D1: Fisherman first-boot agent integration.

--- a/docs/ASAHI-EL10-OBS-PROJECT.md
+++ b/docs/ASAHI-EL10-OBS-PROJECT.md
@@ -1,0 +1,56 @@
+# Open Build Service (OBS) Project for EL10 Asahi Packages (#777)
+
+This document outlines the architecture, package scope, repository configuration, and deployment requirements for establishing the dedicated **Open Build Service (OBS)** project servicing Enterprise Linux 10 (EL10) aarch64 variants (`skipjack`, `yellowfin`, `albacore`, and `bluefin-lts`).
+
+---
+
+## 1. Context & Problem Statement
+
+The CentOS Hyperscale SIG `packages-asahi` repository provides the 16K-page Asahi Linux kernel (`kernel-16k`), `dracut-asahi`, and `update-m1n1` for EL10 aarch64. However, it lacks key userspace utilities required for boot-chain lifecycle management, hardware integration, and audio support:
+
+- **Missing Boot-Chain Components**: `m1n1`, `u-boot-asahi` (`uboot-images-armv8` with `apple_m1` payload), `update-m1n1` kernel installation hooks (`/usr/lib/kernel/install.d/15-update-m1n1.install`).
+- **Missing Hardware & Audio Userspace**: `asahi-audio`, `alsa-ucm-asahi`, `speakersafetyd`, `asahi-fwupdate`, `tiny-dfr` (Touch Bar support), `asahi-diagnose`.
+
+Without `update-m1n1` and its kernel-install hook, `bootc upgrade` updates the deployed kernel without refreshing the `m1n1` stage-2 payload on the EFI System Partition (ESP), causing systems to break on kernel upgrades.
+
+---
+
+## 2. OBS Project Design (`build.opensuse.org`)
+
+### Project Target & Platform
+- **Target OS**: CentOS Stream 10 / RHEL 10 (`epel-10-aarch64` / `10-stream-aarch64`).
+- **Build Infrastructure**: Open Build Service (OBS, `build.opensuse.org`) on native `aarch64` workers with GPG-signed repository metadata output.
+
+### Package Intake & Specification Mapping
+
+| Package | Source Provenance | Target Binary Output | Notes / Role |
+|---|---|---|---|
+| `m1n1` | Fedora `@asahi` COPR / OBS `home:mrkcee` | `m1n1` | First-stage Apple Silicon bootloader |
+| `u-boot-asahi` | Fedora `@asahi/u-boot` COPR | `uboot-images-armv8` | U-Boot bootloader payload with `apple_m1` target |
+| `update-m1n1` | CentOS Hyperscale SIG + TunaOS hooks | `update-m1n1` | ESP `boot.bin` sync script + `kernel-install.d` hook |
+| `asahi-audio` | EPEL 10 / Fedora `@asahi` | `asahi-audio`, `alsa-ucm-asahi` | PipeWire/ALSA UCM profiles & volume limits |
+| `speakersafetyd` | EPEL 10 / Fedora `@asahi` | `speakersafetyd` | Daemon preventing speaker hardware damage |
+| `asahi-fwupdate` | Fedora `@asahi` COPR | `asahi-fwupdate` | ESP firmware extraction & update utility |
+| `tiny-dfr` | Fedora `@asahi` COPR | `tiny-dfr` | Touch Bar daemon for M1/M2 MacBooks |
+
+---
+
+## 3. Integration into TunaOS Overlay (`build_scripts/overlay/asahi.sh`)
+
+Once the OBS project repository is published at `https://download.opensuse.org/repositories/home:tuna-os:el10-asahi/CentOS_10/`, the `centos` branch in `build_scripts/overlay/asahi.sh` will consume the signed repository:
+
+```bash
+# /etc/yum.repos.d/tunaos-el10-asahi-obs.repo
+[tunaos-el10-asahi-obs]
+name=TunaOS EL10 Asahi Packages (OBS)
+baseurl=https://download.opensuse.org/repositories/home:tuna-os:el10-asahi/CentOS_10/
+enabled=1
+gpgcheck=1
+gpgkey=https://download.opensuse.org/repositories/home:tuna-os:el10-asahi/CentOS_10/repodata/repomd.xml.key
+```
+
+---
+
+## 4. Verification & Gating
+
+All built EL10 Asahi images (`skipjack:gnome-asahi`, `yellowfin:gnome-asahi`, `albacore:gnome-asahi`) must pass `scripts/verify-asahi-image.sh` with 36/36 checks green before being promoted.


### PR DESCRIPTION
## Summary
Addresses issue #777 by documenting the Open Build Service (OBS) project specification for EL10 aarch64 variants (`skipjack`, `yellowfin`, `albacore`, `bluefin-lts`).

## Key Additions
- **[](file:///home/dev/workspace/tuna-os/tunaos/docs/ASAHI-EL10-OBS-PROJECT.md)**: Documents the missing userspace package requirements (`m1n1`, `u-boot-asahi`, `update-m1n1` hooks, `asahi-audio`, `speakersafetyd`, `asahi-fwupdate`, `tiny-dfr`), OBS build configuration for CentOS/RHEL 10, repository wiring for `build_scripts/overlay/asahi.sh`, and gating requirements.
- **[](file:///home/dev/workspace/tuna-os/tunaos/docs/AGENT_GUIDE.md)**: Links the OBS project plan under the Apple Silicon initiative section.

Fixes #777
---
🐝 **Hive Agent**: `contributor` | **SHA:** `bf7e1b73`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->