### PR TITLE
fix(debian): recreate apt log directory after /var reset

### DIFF
--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -242,7 +242,7 @@ RUN --mount=type=bind,from=context,source=/,target=/run/context \
     # there, so a /var reset re-establishes the link rather than leaving apt
     # pointing at an empty directory. /var/lib must be created first —
     # tmpfiles does not build parents for L+.
-    printf 'd /var/lib 0755 root root -\nL+ /var/lib/dpkg - - - - ../../usr/lib/sysimage/dpkg\n' \
+    printf 'd /var/lib 0755 root root -\nd /var/log/apt 0755 root root -\nL+ /var/lib/dpkg - - - - ../../usr/lib/sysimage/dpkg\n' \
         > /usr/lib/tmpfiles.d/dpkg-sysimage.conf && \
     # Image-build time too: apt/dpkg run in later layers (and in
     # live_customize) before tmpfiles has ever executed.


### PR DESCRIPTION
## What changed

Add `/var/log/apt` to the Debian tmpfiles contract alongside the sysimage-backed dpkg state.

## Why

After a factory reset or deployment transition that recreates `/var`, apt and dpkg maintainer scripts expect `/var/log/apt` to exist. Missing it can break package configuration on flounder and flounder-sid.

This is the focused portion of #1313; unrelated Asahi documentation was intentionally excluded.

## Validation

- based directly on current `main`
- single-file Containerfile change
- existing lint and Bats contracts will run in CI

Fixes #880.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->