### PR TITLE
ci: require browser ISO catalog parity

### DIFF
--- a/.github/workflows/catalog-facts.yml
+++ b/.github/workflows/catalog-facts.yml
@@ -155,7 +155,7 @@ jobs:
         with:
           pattern: facts-*
           path: shards
-      - name: Merge shards
+      - name: Merge shards and validate browser catalog completeness
         run: |
           set -euo pipefail
           jq -s 'add // {}' shards/*/shard.json > merged.json
@@ -163,6 +163,48 @@ jobs:
              '{generated:$t, images:.}' merged.json > catalog-facts.json
           echo "entries: $(jq '.images | length' catalog-facts.json)"
           jq -r '.images | to_entries[] | "  \(.key): \(.value.desktop) \(.value.kernelVer)"' catalog-facts.json
+
+          python3 <<'PY'
+          import json
+          import subprocess
+          import sys
+
+          config = json.loads(
+              subprocess.check_output(
+                  ["yq", "-o=json", ".", ".github/build-config.yml"]
+              )
+          )
+          facts = json.load(open("catalog-facts.json"))["images"]
+
+          browser_flavors = set()
+          for group in config.get("iso_groups", []):
+              if group.get("publish", True):
+                  continue
+              browser_flavors.update(group.get("flavors", []))
+              browser_flavors.update(group.get("offline_flavors", []))
+
+          expected = {
+              f"tuna-os/{variant['id']}:{flavor['id']}"
+              for variant in config.get("variants", [])
+              for flavor in variant.get("flavors", [])
+              if flavor.get("build_image")
+              and flavor["id"] in browser_flavors
+          }
+          missing = sorted(expected - facts.keys())
+
+          print(
+              f"Catalog completeness check: "
+              f"{len(expected) - len(missing)}/{len(expected)} flavors covered."
+          )
+          if missing:
+              print(
+                  "ERROR: Missing catalog entries for browser/on-demand flavors:",
+                  *missing,
+                  sep="\n  ",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          PY
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: catalog-facts


### PR DESCRIPTION
## What changed

Make catalog generation fail when any browser/on-demand flavor lacks a published catalog fact.

The expected set is derived from non-published `iso_groups` in `.github/build-config.yml`, including both normal and offline flavors. This avoids a hardcoded desktop allowlist and automatically covers future additions to the browser ISO group.

## Why

#1314 only emitted a warning and therefore could remain green with missing images. It also embedded Python in a shell single-quoted string that contained nested single quotes. This version is a real required gate and uses a quoted heredoc.

## Validation

- based directly on current `main`
- expected flavors are intersected with `build_image: true`
- missing entries exit non-zero and list exact image tags
- workflow lint will run in CI

Supersedes #1314.
Closes #1281.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->