### PR TITLE
docs: establish flavor equality by removing GNOME primary tiering (#1315)

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -14,14 +14,14 @@ config:
 # Variants that lack certain desktops simply get a smaller ISO — no group
 # needs per-variant tailoring here.
 iso_groups:
-  # Flagship: the 90%-of-users ISO. Boots GNOME NVIDIA by default, and embeds
+  # Desktop ISO group: boots GNOME NVIDIA by default, and embeds
   # both NVIDIA and non-NVIDIA flavors in the offline store for installer auto-detection.
   # Published as `<variant>.iso`.
   - suffix: ""
     flavors: [gnome-nvidia, gnome-nvidia-hwe]
     offline_flavors: [gnome, gnome-hwe, gnome-nvidia, gnome-nvidia-hwe]
-  # Community: niche desktops (KDE/COSMIC/Niri/XFCE). NOT published as an
-  # ISO — the browser ISO Builder (https://iso.tunaos.org) covers these on
+  # Additional desktop ISO group (KDE/COSMIC/Niri/XFCE). NOT published as a
+  # single grouped ISO — the browser ISO Builder (https://iso.tunaos.org) covers these on
   # demand from the published images, so we don't carry the cost of a
   # 5-flavor offline-store ISO for the long tail. The images still build
   # and publish to GHCR; only the grouped ISO is skipped.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ TunaOS builds **bootc-based desktop operating systems** with atomic updates and 
 
 ### Features
 
-- **Modern Desktops**: GNOME, KDE Plasma, COSMIC, and Niri — your choice, on Enterprise Linux
-- **Latest GNOME**: Don't get stuck on a 3-year-old GNOME. We backport the latest desktop features to the Enterprise Desktop
+- **Modern Desktops**: GNOME, KDE Plasma, COSMIC, Niri, and XFCE — equal first-class options across distribution bases
+- **Up-to-Date Desktop Stack**: Fresh desktop features and updates backported to Enterprise and community bases
 - **Homebrew**: Baked into the image — all your CLI apps and fonts are just a `brew` command away
 - **Flathub by Default**: Full Flathub access out of the box — get any Flatpak available on the net
 - **HWE Option**: Hardware Enablement kernel for newer hardware support


### PR DESCRIPTION
Closes #1315

### Summary of Changes
- Updated  to present GNOME, KDE Plasma, COSMIC, Niri, and XFCE as equal, first-class options without framing GNOME as the primary/special desktop.
- Re-worded comments in  to remove references framing GNOME as 'flagship / 90%-of-users' and other desktop environments as 'niche community' flavors.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `f6ab90d0`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->