### PR TITLE
docs: integrate package sourcing policy references (#1319)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Related Communities:
 
 ### Policies & Planning
 - [Roadmap](ROADMAP.md) — project direction and feature status
+- [Package Sourcing Policy](PACKAGE-SOURCING.md) — package origin rules, Tideforge-first, and allowlist (#1319)
 - [Versioning](VERSIONING.md) — tag scheme and stability tiers
 - [Migration Guide](MIGRATION.md) — switching from other distros
 - [Security Policy](SECURITY.md) — vulnerability reporting and supported versions

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -157,6 +157,7 @@ No new shell script needed. `install-desktop.sh` handles it.
 | File | What it controls |
 |------|-----------------|
 | `.github/build-config.yml` | The build matrix (variants × flavors × platforms × stages) |
+| `PACKAGE-SOURCING.md` | Package sourcing policy (tiering, Tideforge-first, allowlist, #1319) |
 | `image-versions.yaml` | Pinned image digests + download versions |
 | `registry-map.yaml` | Registry mirror overrides |
 | `renovate.json` | Automated dependency updates (automerge all) |

--- a/manifests/desktops/gnome.yaml
+++ b/manifests/desktops/gnome.yaml
@@ -126,6 +126,8 @@ packages:
   el10:
     # COPR repos for GNOME 50 backport — EL10 ships GNOME 48 natively.
     # Brings modern GNOME to Enterprise Linux without waiting 3 years.
+    # Policy exception per PACKAGE-SOURCING.md / #1319 (tier-3 temporary source;
+    # scheduled for Tideforge migration in Q4 #1187).
     copr:
       - repo: jreilly1821/c10s-gnome-50-fresh
         extra_repos:


### PR DESCRIPTION
Closes #1319

### Summary of Changes
- Added references to  across project documentation ([README.md](README.md), [docs/AGENT_GUIDE.md](docs/AGENT_GUIDE.md)).
- Documented policy compliance exception in [manifests/desktops/gnome.yaml](manifests/desktops/gnome.yaml) for the EL10 GNOME 50 COPR backport repository.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `b354498a`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->