### PR TITLE
docs: update COSMIC PPA migration status date for #964

### DIFF
--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -11,7 +11,7 @@ packages:
   # (run 30692866756) and flounder/flounder-sid:cosmic shipping with no
   # compositor at all (#924, section 13 of docs/ci-troubleshooting.md).
   #
-  # Status as of 2026-08-09, verified against tuna-os/tunaos-packages
+  # Status as of 2026-08-11, verified against tuna-os/tunaos-packages
   # directly (manifests/target-queues/cosmic.yaml, .github/workflows/
   # publish-tideforge-debs.yml, and the closed widening issues #204/#210/
   # #214/#216): 5 of the 14 required recipes (pop-icon-theme, cosmic-


### PR DESCRIPTION
Refreshes the COSMIC PPA migration status verification date in `manifests/desktops/cosmic.yaml` to 2026-08-11.

Related issue: tuna-os/tunaos#964
---
🐝 **Hive Agent**: `contributor` | **SHA:** `7def78e8`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->