### PR TITLE
test(scripts): add BATS coverage for published-image-ref.sh (#457)

### DIFF
--- a/tests/bats/test_published_image_ref.bats
+++ b/tests/bats/test_published_image_ref.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/published-image-ref.sh
+#
+# Exercises the real script against a fixture TUNAOS_BUILD_CONFIG rather
+# than the live .github/build-config.yml, so these tests do not drift when
+# variants are added/renamed there.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  SCRIPT="${REPO_ROOT}/scripts/published-image-ref.sh"
+  TEST_ROOT="$(mktemp -d)"
+  CONFIG="${TEST_ROOT}/build-config.yml"
+  cat >"$CONFIG" <<'EOF'
+variants:
+  - id: plainvariant
+    flavors: []
+  - id: bonito-rawhide
+    publish_name: bonito
+    tag_suffix: rawhide
+    flavors: []
+EOF
+  export TUNAOS_BUILD_CONFIG="$CONFIG"
+}
+
+teardown() {
+  rm -rf "${TEST_ROOT}" 2>/dev/null || true
+}
+
+@test "published-image-ref: ghcr defaults to GITHUB_REPOSITORY_OWNER=tuna-os" {
+  unset GITHUB_REPOSITORY_OWNER
+  run bash "$SCRIPT" plainvariant gnome ghcr
+  [ "$status" -eq 0 ]
+  [ "$output" = "ghcr.io/tuna-os/plainvariant:gnome" ]
+}
+
+@test "published-image-ref: ghcr honors GITHUB_REPOSITORY_OWNER override" {
+  GITHUB_REPOSITORY_OWNER=someorg run bash "$SCRIPT" plainvariant gnome ghcr
+  [ "$status" -eq 0 ]
+  [ "$output" = "ghcr.io/someorg/plainvariant:gnome" ]
+}
+
+@test "published-image-ref: repo argument defaults to ghcr when omitted" {
+  unset GITHUB_REPOSITORY_OWNER
+  run bash "$SCRIPT" plainvariant gnome
+  [ "$status" -eq 0 ]
+  [ "$output" = "ghcr.io/tuna-os/plainvariant:gnome" ]
+}
+
+@test "published-image-ref: local repo uses localhost/<variant-id>" {
+  run bash "$SCRIPT" plainvariant gnome local
+  [ "$status" -eq 0 ]
+  # local intentionally keys off the raw variant id, not publish_name --
+  # it addresses the image this host just built, before anything is pushed.
+  [ "$output" = "localhost/plainvariant:gnome" ]
+}
+
+@test "published-image-ref: registry repo defaults host to localhost:5000" {
+  unset REGISTRY
+  run bash "$SCRIPT" plainvariant gnome registry
+  [ "$status" -eq 0 ]
+  [ "$output" = "localhost:5000/plainvariant:gnome" ]
+}
+
+@test "published-image-ref: registry repo honors REGISTRY override" {
+  REGISTRY=example.com:443 run bash "$SCRIPT" plainvariant gnome registry
+  [ "$status" -eq 0 ]
+  [ "$output" = "example.com:443/plainvariant:gnome" ]
+}
+
+@test "published-image-ref: publish_name substitutes the variant id in the ref" {
+  unset GITHUB_REPOSITORY_OWNER
+  run bash "$SCRIPT" bonito-rawhide gnome ghcr
+  [ "$status" -eq 0 ]
+  [ "$output" = "ghcr.io/tuna-os/bonito:gnome-rawhide" ]
+}
+
+@test "published-image-ref: tag_suffix is not duplicated if already present" {
+  unset GITHUB_REPOSITORY_OWNER
+  run bash "$SCRIPT" bonito-rawhide gnome-rawhide ghcr
+  [ "$status" -eq 0 ]
+  [ "$output" = "ghcr.io/tuna-os/bonito:gnome-rawhide" ]
+}
+
+@test "published-image-ref: tag_suffix is inserted before a -testing suffix" {
+  unset GITHUB_REPOSITORY_OWNER
+  run bash "$SCRIPT" bonito-rawhide gnome-testing ghcr
+  [ "$status" -eq 0 ]
+  [ "$output" = "ghcr.io/tuna-os/bonito:gnome-rawhide-testing" ]
+}
+
+@test "published-image-ref: unknown variant fails with exit 1" {
+  run bash "$SCRIPT" nonexistent gnome ghcr
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unknown variant: nonexistent"* ]]
+}
+
+@test "published-image-ref: unknown repo target fails with exit 1" {
+  run bash "$SCRIPT" plainvariant gnome bogus
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unknown repo: bogus"* ]]
+}
+
+@test "published-image-ref: missing variant argument fails with usage error" {
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"usage: published-image-ref.sh"* ]]
+}
+
+@test "published-image-ref: missing tag argument fails" {
+  run bash "$SCRIPT" plainvariant
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

Picked up #457 (the standing Hive Advisory Report digest). It's a living
document, not a single actionable task, so rather than treating the whole
537-finding backlog as a to-do list I spot-audited the findings that were
specific to this repo (the ones I could actually verify with a checkout)
against current `main`.

Most turned out stale: `build_scripts/*.sh`, `scripts/verify-iso.sh`,
`scripts/iso-e2e.sh`, and `scripts/{setup,sync}-build-cache.sh` all showed
up repeatedly across digest cycles as "0% coverage" / "no BATS test", but
all already have dedicated test files in `tests/bats/`. A full sweep
(`scripts/*.sh` and `build_scripts/*.sh` against `tests/bats/*.bats`)
confirmed `build_scripts/` is now fully covered, and found nine scripts
under `scripts/` that are still genuinely uncovered:
`bench-gdm-paint.sh`, `boot-gate-matrix.sh`, `e2e-installer-gui-checks.sh`,
`gen-screenshot-gallery.sh`, `iso-e2e-gpu.sh`, `package-parity.sh`,
`published-image-ref.sh`, `resolve-image.sh`, `run-walkthrough.sh` — plus
three `.github/scripts/*.py` files.

This PR covers the smallest, most tractable one:
`scripts/published-image-ref.sh` (32 lines) — resolves a variant id +
flavor/tag to a publishable image reference for `local`/`ghcr`/`registry`,
including the `publish_name`/`tag_suffix` aliasing that `bonito-rawhide`
and `flounder-sid` use to publish under their parent variant's name.

Tests run the **real script** against a fixture `TUNAOS_BUILD_CONFIG`
(not a bash reimplementation of its logic, so they can't drift from the
real behavior) covering all three repo targets and their env-var
overrides, the `tag_suffix` substitution cases (plain, already-present,
and the `-testing` insertion point), and both error paths.

Didn't touch the other 8 uncovered scripts or the Python ones — keeping
this PR to one script kept it reviewable; happy to follow up on the rest
if useful.

## Test plan

- [x] No `bats`/`yq` preinstalled in this environment — bootstrapped both
      from their upstream release artifacts (bats-core 1.14.0, yq 4.53.3)
      to actually run this rather than eyeballing it.
- [x] `bats tests/bats/test_published_image_ref.bats` — 13/13 pass.
- [x] Verified expected output against the real script + real
      `.github/build-config.yml` first (`bash scripts/published-image-ref.sh
      bonito-rawhide gnome-testing ghcr` etc.) before writing assertions,
      so the fixture config's expected outputs are anchored to observed
      real behavior, not assumptions.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `1d6b1ca4`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->