### PR TITLE
build(just): extract customization-overlay recipes into just/custom-overlay.just (#508)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -10,6 +10,7 @@ yq := `which yq`
 export platform := env("PLATFORM", if arch == "x86_64" { if `rpm -q kernel 2>/dev/null | grep -q "x86_64_v2$"; echo $?` == "0" { "linux/amd64/v2" } else { "linux/amd64" } } else if arch == "arm64" { "linux/arm64" } else if arch == "aarch64" { "linux/arm64" } else { error("Unsupported ARCH '" + arch + "'. Supported values are 'x86_64', 'aarch64', and 'arm64'.") })
 
 import 'just/utilities.just'
+import 'just/custom-overlay.just'
 
 # ==============================================================================
 #  BUILD PIPELINE
@@ -49,36 +50,6 @@ _build target_tag_with_version target_tag container_file base_image_for_build ta
     export YQ="{{ yq }}"
     # OVERLAY_TYPE inherited from parent shell (exported by build recipe)
     ./scripts/build-image-inner.sh
-
-# Build a custom TunaOS overlay using the configuration in custom/
-build-custom base="" tag="": _ensure-deps
-    #!/usr/bin/env bash
-    set -euo pipefail
-    BASE_IMAGE="{{ base }}"
-    if [[ -z "${BASE_IMAGE}" ]]; then
-        BASE_IMAGE=$(python3 -c "import re; open_f = open('custom/image.yaml').read(); print(re.search(r'base:\s*(\S+)', open_f).group(1))" 2>/dev/null || echo "ghcr.io/tuna-os/yellowfin:gnome")
-    fi
-    TARGET_TAG="{{ tag }}"
-    if [[ -z "${TARGET_TAG}" ]]; then
-        TARGET_TAG=$(python3 -c "import re; open_f = open('custom/image.yaml').read(); print(re.search(r'tag:\s*(\S+)', open_f).group(1))" 2>/dev/null || echo "my-custom-os")
-    fi
-    echo "==> Building custom image based on ${BASE_IMAGE} as localhost/${TARGET_TAG}..."
-    podman build \
-        --file Containerfile.custom \
-        --build-arg BASE_IMAGE="${BASE_IMAGE}" \
-        --tag "localhost/${TARGET_TAG}" \
-        .
-
-# Build QCOW2 from custom TunaOS image
-run-custom-vm tag="":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    TARGET_TAG="{{ tag }}"
-    if [[ -z "${TARGET_TAG}" ]]; then
-        TARGET_TAG=$(python3 -c "import re; open_f = open('custom/image.yaml').read(); print(re.search(r'tag:\s*(\S+)', open_f).group(1))" 2>/dev/null || echo "my-custom-os")
-    fi
-    # Use scripts/build-qcow2.sh to build the QCOW2 from local image
-    ./scripts/build-qcow2.sh "localhost/${TARGET_TAG}"
 
 # Build a TunaOS variant
 build variant='albacore' flavor='gnome' target_platform='' is_ci="0" tag='latest' chain_base_image='' enable_sshd="0": _ensure-deps
@@ -417,40 +388,12 @@ qcow2 variant flavor='gnome' repo='local' tag='':
     echo "✓ Created $OUTPUT"
 
 # ==============================================================================
-#  CUSTOMIZATION OVERLAY PIPELINE
+#  RUN / VM PIPELINE
 # ==============================================================================
-
-# Validate custom/ directory schema, syntax, and flatpaks
-check-custom:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    echo "==> Validating custom/ overlay configuration..."
-    if [[ -f custom/packages.yaml ]]; then
-        if INVALID=$(grep -nvE '^[[:space:]]*(#.*)?$|^[a-zA-Z0-9_-]+[[:space:]]*:|^[[:space:]]*-[[:space:]]*' custom/packages.yaml); then
-            printf 'Warning: custom/packages.yaml lines that are neither a mapping key nor a list item:\n%s\n' "$INVALID"
-        fi
-        echo "✓ custom/packages.yaml parsed successfully"
-    fi
-    for hook in custom/build.pre.sh custom/build.post.sh; do
-        if [[ -f "$hook" ]]; then
-            bash -n "$hook"
-            echo "✓ $hook syntax valid"
-        fi
-    done
-    echo "✓ Custom configuration check passed."
-
-# Build a live ISO from a custom overlay image
-custom-iso base_image='':
-    #!/usr/bin/env bash
-    set -euo pipefail
-    {{ just }} build-custom "{{ base_image }}"
-    TAG="my-custom-os"
-    if [[ -f "custom/image.yaml" ]]; then
-        T=$(python3 -c "import re; m = re.search(r'^tag:\s*(.+)$', open('custom/image.yaml').read(), re.M); print(m.group(1).strip() if m else '')")
-        [[ -n "$T" ]] && TAG="$T"
-    fi
-    echo "==> Generating live ISO for localhost/${TAG}:latest..."
-    sudo -E bash ./scripts/build-iso-tacklebox.sh "custom" "${TAG}" "local" "${TAG}" "1"
+# (build-custom, run-custom-vm, check-custom, custom-iso moved to
+#  just/custom-overlay.just — #508, this banner previously mislabeled this
+#  whole section "CUSTOMIZATION OVERLAY PIPELINE" though only those four
+#  recipes were customization-specific; everything below is VM/run/demo.)
 
 # Boot an image in QEMU via browser (uses ghcr.io/qemus/qemu)
 run-qcow2 variant flavor='gnome':

--- a/just/custom-overlay.just
+++ b/just/custom-overlay.just
@@ -1,0 +1,67 @@
+# --- Customization overlay pipeline (custom/) ---
+# Extracted from the root Justfile (#508: cross-repo Justfile inflation).
+# _ensure-deps stays in the root Justfile (also used by build/_build); just's
+# import shares one flat recipe/variable namespace, so referencing it here
+# and calling `just build-custom` from custom-iso both still resolve.
+
+# Build a custom TunaOS overlay using the configuration in custom/
+build-custom base="" tag="": _ensure-deps
+    #!/usr/bin/env bash
+    set -euo pipefail
+    BASE_IMAGE="{{ base }}"
+    if [[ -z "${BASE_IMAGE}" ]]; then
+        BASE_IMAGE=$(python3 -c "import re; open_f = open('custom/image.yaml').read(); print(re.search(r'base:\s*(\S+)', open_f).group(1))" 2>/dev/null || echo "ghcr.io/tuna-os/yellowfin:gnome")
+    fi
+    TARGET_TAG="{{ tag }}"
+    if [[ -z "${TARGET_TAG}" ]]; then
+        TARGET_TAG=$(python3 -c "import re; open_f = open('custom/image.yaml').read(); print(re.search(r'tag:\s*(\S+)', open_f).group(1))" 2>/dev/null || echo "my-custom-os")
+    fi
+    echo "==> Building custom image based on ${BASE_IMAGE} as localhost/${TARGET_TAG}..."
+    podman build \
+        --file Containerfile.custom \
+        --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+        --tag "localhost/${TARGET_TAG}" \
+        .
+
+# Build QCOW2 from custom TunaOS image
+run-custom-vm tag="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    TARGET_TAG="{{ tag }}"
+    if [[ -z "${TARGET_TAG}" ]]; then
+        TARGET_TAG=$(python3 -c "import re; open_f = open('custom/image.yaml').read(); print(re.search(r'tag:\s*(\S+)', open_f).group(1))" 2>/dev/null || echo "my-custom-os")
+    fi
+    # Use scripts/build-qcow2.sh to build the QCOW2 from local image
+    ./scripts/build-qcow2.sh "localhost/${TARGET_TAG}"
+
+# Validate custom/ directory schema, syntax, and flatpaks
+check-custom:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "==> Validating custom/ overlay configuration..."
+    if [[ -f custom/packages.yaml ]]; then
+        if INVALID=$(grep -nvE '^[[:space:]]*(#.*)?$|^[a-zA-Z0-9_-]+[[:space:]]*:|^[[:space:]]*-[[:space:]]*' custom/packages.yaml); then
+            printf 'Warning: custom/packages.yaml lines that are neither a mapping key nor a list item:\n%s\n' "$INVALID"
+        fi
+        echo "✓ custom/packages.yaml parsed successfully"
+    fi
+    for hook in custom/build.pre.sh custom/build.post.sh; do
+        if [[ -f "$hook" ]]; then
+            bash -n "$hook"
+            echo "✓ $hook syntax valid"
+        fi
+    done
+    echo "✓ Custom configuration check passed."
+
+# Build a live ISO from a custom overlay image
+custom-iso base_image='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{ just }} build-custom "{{ base_image }}"
+    TAG="my-custom-os"
+    if [[ -f "custom/image.yaml" ]]; then
+        T=$(python3 -c "import re; m = re.search(r'^tag:\s*(.+)$', open('custom/image.yaml').read(), re.M); print(m.group(1).strip() if m else '')")
+        [[ -n "$T" ]] && TAG="$T"
+    fi
+    echo "==> Generating live ISO for localhost/${TAG}:latest..."
+    sudo -E bash ./scripts/build-iso-tacklebox.sh "custom" "${TAG}" "local" "${TAG}" "1"


### PR DESCRIPTION
## Summary

Small, verified step on #508 (cross-repo Justfile inflation), scoped to
what's actually in reach: the issue's headline recommendation is a new
`tuna-os/just-recipes` shared repo importable from all seven repos, which
I can't create (no org admin rights as a fork-based contributor). So this
PR does the part that's real progress within this one repo, on the
pattern this repo had already started (`just/utilities.just`, imported at
the top of `Justfile`).

Moved the four recipes that are genuinely customization-specific --
`build-custom`, `run-custom-vm`, `check-custom`, `custom-iso` -- into
`just/custom-overlay.just`, imported the same way as the existing module.
`_ensure-deps` stays in the root `Justfile` since `build`/`_build` also
depend on it; `just`'s `import` shares one flat recipe/variable namespace
across files, so `build-custom: _ensure-deps` and `custom-iso`'s `{{ just
}} build-custom ...` call both still resolve regardless of which file
they're in. I verified this empirically (a toy justfile + submodule)
rather than assuming it from the docs, since I didn't want to guess on a
CI-relied-on file.

While in there: the "CUSTOMIZATION OVERLAY PIPELINE" section banner these
four recipes sat under was itself stale -- everything else under it
(`run-qcow2`, `run-iso`, `demo`, `boot-gate`, `verify-iso`, etc.) is
VM/run/demo tooling, not customization-specific. Relabeled the banner to
match what's actually there rather than guessing at a bigger
reorganization of those recipes too in the same pass.

Root `Justfile`: 784 -> 727 lines.

## A correction on #508's proposed mechanism

The issue recommends `import 'git@github.com:tuna-os/just-recipes.git'`.
That doesn't work -- `just`'s `import` directive only resolves local file
paths:

```
$ just --version
just 1.58.0
$ echo "import 'git@github.com:tuna-os/just-recipes.git'" > justfile && just --list
error: could not find source file for import
 ——▶ justfile:1:8
  │
1 │ import 'git@github.com:tuna-os/just-recipes.git'
  │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

A real shared-recipes setup would need something like a git submodule
checked out locally in each consuming repo, then `import
'just-recipes/foo.just'` against that local path. Worth knowing before
anyone scaffolds `tuna-os/just-recipes` around the literal syntax in the
issue.

## Test plan

- [x] Bootstrapped `just` 1.58.0 locally (not preinstalled in this
      sandbox) to actually verify this rather than eyeballing a text move.
- [x] `just --show <recipe>` output byte-identical before/after for all
      four moved recipes.
- [x] `just --list` output identical before/after (compared via `git
      stash`) -- confirms no recipe, signature, or doc-comment changed.
- [x] `just --unstable --fmt --check -f Justfile` — passes (this is the
      exact command `lint.yml`'s "Check Justfile formatting" step runs).
- [x] `just --dump` — the merged justfile parses cleanly end to end.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `4dbfe5e7`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->