### PR TITLE
refactor(ci): migrate stale ghcr.io/hanthor container registry references to ghcr.io/tuna-os (#519)

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -6,7 +6,7 @@ from typing import Any
 import re
 from collections import defaultdict
 
-REGISTRY = "docker://ghcr.io/hanthor/"
+REGISTRY = "docker://ghcr.io/tuna-os/"
 
 IMAGE_MATRIX = {
     "experience": ["base", "dx", "gdx"],
@@ -67,10 +67,10 @@ For current users, type the following to rebase to this version:
 IMAGE_NAME=$(jq -r '.["image-name"]' < /usr/share/ublue-os/image-info.json)
 
 # For this Stream
-sudo bootc switch --enforce-container-sigpolicy ghcr.io/hanthor/$IMAGE_NAME:{target}
+sudo bootc switch --enforce-container-sigpolicy ghcr.io/tuna-os/$IMAGE_NAME:{target}
 
 # For this Specific Image:
-sudo bootc switch --enforce-container-sigpolicy ghcr.io/hanthor/$IMAGE_NAME:{curr}
+sudo bootc switch --enforce-container-sigpolicy ghcr.io/tuna-os/$IMAGE_NAME:{curr}
 ```
 
 ### Documentation

--- a/system_files/usr/local/bin/zfs-install
+++ b/system_files/usr/local/bin/zfs-install
@@ -69,7 +69,7 @@ if [[ -z "${IMGREF}" ]]; then
     if [[ -f /etc/bootc-installer/images.json ]]; then
         IMGREF=$(python3 -c "import json; print(json.load(open('/etc/bootc-installer/images.json'))['local_imgref'])" 2>/dev/null) || true
     fi
-    [[ -n "${IMGREF}" ]] || IMGREF="ghcr.io/hanthor/ubuntu-26.04-desktop-bootc:latest"
+    [[ -n "${IMGREF}" ]] || IMGREF="ghcr.io/tuna-os/ubuntu-26.04-desktop-bootc:latest"
 fi
 
 HOSTID_HEX=$(hostid 2>/dev/null || echo "00000000")

--- a/tests/test_changelogs.py
+++ b/tests/test_changelogs.py
@@ -248,7 +248,7 @@ From previous `{target}` version `{prev}` there have been the following changes.
 
 ### How to rebase
 ```bash
-sudo bootc switch --enforce-container-sigpolicy ghcr.io/hanthor/$IMAGE_NAME:{target}
+sudo bootc switch --enforce-container-sigpolicy ghcr.io/tuna-os/$IMAGE_NAME:{target}
 ```"""
     assert "### Major packages" in format_str
     assert "### How to rebase" in format_str


### PR DESCRIPTION
Resolves #519.

### Summary
- Updated stale `ghcr.io/hanthor/...` container registry references in `.github/changelogs.py`, `system_files/usr/local/bin/zfs-install`, and `tests/test_changelogs.py` to point to `ghcr.io/tuna-os/...`.
- Verified changelog unit test suite (`python3 -m unittest tests/test_matrix_status.py`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->