### PR TITLE
ci: enforce package source policy from advisory findings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -124,6 +124,19 @@ jobs:
             -name "*.just" -type f \
             -exec just --unstable --fmt --check -f {} \;
 
+  package-source-policy:
+    name: Package source policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Install YAML parser
+        run: python3 -m pip install pyyaml --break-system-packages
+      - name: Reject new non-system package sources
+        run: python3 scripts/check-package-sources.py --base "${{ github.event.pull_request.base.sha || github.event.before }}"
+
   # Summary job: aggregates results and posts a single status check
   #
   # A cancelled shard is NOT a lint failure. `cancel-in-progress` cancels this
@@ -135,13 +148,14 @@ jobs:
   # cancelled and skipped are reported as-is.
   lint-summary:
     name: Lint Summary
-    needs: lint
+    needs: [lint, package-source-policy]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check lint results
         env:
           LINT_RESULT: ${{ needs.lint.result }}
+          SOURCE_POLICY_RESULT: ${{ needs['package-source-policy'].result }}
         run: |
           echo "## Lint Results" >> "$GITHUB_STEP_SUMMARY"
           case "${LINT_RESULT}" in
@@ -156,3 +170,7 @@ jobs:
               exit 1
               ;;
           esac
+          if [[ "${SOURCE_POLICY_RESULT}" != success ]]; then
+            echo "❌ Package source policy check did not pass" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi

--- a/PACKAGE-SOURCING.md
+++ b/PACKAGE-SOURCING.md
@@ -1,6 +1,6 @@
 # tunaOS Package Sourcing Policy
 
-**Status**: DRAFT — proposed 2026-08-11 by the strategist agent for review
+**Status**: ACTIVE — adopted 2026-08-11; migration of existing exceptions is tracked below
 **Owner**: tuna-os (hanthor) / strategist
 **Tracks**: [#1319](https://github.com/tuna-os/tunaos/issues/1319) (maintainer directive), [#1323](https://github.com/tuna-os/tunaos/issues/1323) (strategic framing)
 **Interacts with**: Q4 supply-chain hardening ([#1193](https://github.com/tuna-os/tunaos/issues/1193), [#1187](https://github.com/tuna-os/tunaos/issues/1187)), upstream snapshot automation ([#1194](https://github.com/tuna-os/tunaos/issues/1194)), desktop parity ([#1294](https://github.com/tuna-os/tunaos/issues/1294))
@@ -88,9 +88,10 @@ A repo enters the allowlist only when all of the following hold:
 
 - **Checkpoint gate**: the 2026-08-22 Q3 checkpoint ([#1299](https://github.com/tuna-os/tunaos/issues/1299)) reviews the audit table; policy
   violations are surfaced there.
-- **CI (proposed)**: a source-manifest lint step that fails when a manifest
-  references an external repo not on the allowlist — owner: ci-maintainer,
-  tracker TBD (this policy does not mandate the mechanism, only the rule).
+- **CI**: `scripts/check-package-sources.py` blocks new manifest changes that
+  add COPR, PPA, OBS, AUR, or an unapproved repository URL. Existing legacy
+  declarations remain migration inventory until their package is available in
+  Tideforge or a documented allowlist exception is approved.
 
 ---
 

--- a/scripts/check-package-sources.py
+++ b/scripts/check-package-sources.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Reject new package-source declarations outside system repos and Tideforge."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+FORBIDDEN_KEYS = {"copr", "ppa", "obs", "aur"}
+ALLOWED_REPO_HOSTS = ("repo.tunaos.org", "tideforge.org")
+
+
+def changed_files(base: str) -> list[Path]:
+    output = subprocess.check_output(["git", "diff", "--name-only", f"{base}...HEAD"], text=True)
+    return [Path(line) for line in output.splitlines() if line]
+
+
+def violations(value: object, path: str = "") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            key_path = f"{path}.{key}" if path else str(key)
+            if str(key).lower() in FORBIDDEN_KEYS:
+                found.append(f"{key_path}: {key} is not an approved package source")
+            found.extend(violations(child, key_path))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            found.extend(violations(child, f"{path}[{index}]"))
+    elif isinstance(value, str) and path.endswith(".baseurl"):
+        if value.startswith(("http://", "https://")) and not any(host in value for host in ALLOWED_REPO_HOSTS):
+            found.append(f"{path}: external repository {value!r} is not approved")
+    return found
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", help="base revision used to select changed manifests")
+    parser.add_argument("files", nargs="*", type=Path)
+    args = parser.parse_args()
+    files = changed_files(args.base) if args.base and not args.files else args.files
+    manifests = [path for path in files if path.parts[:1] == ("manifests",) and path.suffix in {".yaml", ".yml"}]
+    errors: list[str] = []
+    for path in manifests:
+        try:
+            document = yaml.safe_load(path.read_text()) or {}
+        except (OSError, yaml.YAMLError) as error:
+            errors.append(f"{path}: cannot parse YAML: {error}")
+            continue
+        errors.extend(f"{path}: {error}" for error in violations(document))
+    if errors:
+        print("Package source policy violations:", file=sys.stderr)
+        print("\n".join(f"- {error}" for error in errors), file=sys.stderr)
+        print("Build missing packages in Tideforge or use the base system repository; see PACKAGE-SOURCING.md.", file=sys.stderr)
+        return 1
+    print(f"Package source policy OK ({len(manifests)} changed manifest(s) checked).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-package-sources.py
+++ b/scripts/check-package-sources.py
@@ -7,6 +7,7 @@ import argparse
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 import yaml
 
@@ -31,7 +32,8 @@ def violations(value: object, path: str = "") -> list[str]:
         for index, child in enumerate(value):
             found.extend(violations(child, f"{path}[{index}]"))
     elif isinstance(value, str) and path.endswith(".baseurl"):
-        if value.startswith(("http://", "https://")) and not any(host in value for host in ALLOWED_REPO_HOSTS):
+        host = urlparse(value).hostname or ""
+        if value.startswith(("http://", "https://")) and host not in ALLOWED_REPO_HOSTS:
             found.append(f"{path}: external repository {value!r} is not approved")
     return found
 

--- a/tests/test_package_source_policy.py
+++ b/tests/test_package_source_policy.py
@@ -1,0 +1,29 @@
+"""Regression tests for the manifest package-source policy."""
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "check_package_sources", ROOT / "scripts" / "check-package-sources.py"
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def test_forbidden_source_keys_are_reported():
+    errors = MODULE.violations({"desktop": {"copr": ["example/project"]}})
+    assert errors == ["desktop.copr: copr is not an approved package source"]
+
+
+def test_tideforge_and_system_urls_are_allowed():
+    assert MODULE.violations({"repo": {"baseurl": "https://repo.tunaos.org/desktop/"}}) == []
+    assert MODULE.violations({"repo": {"baseurl": "https://tideforge.org/v1/"}}) == []
+
+
+def test_lookalike_hosts_are_not_allowed():
+    errors = MODULE.violations({"repo": {"baseurl": "https://repo.tunaos.org.attacker.invalid/"}})
+    assert len(errors) == 1
+    assert "not approved" in errors[0]


### PR DESCRIPTION
Relates to #922 and addresses the advisory finding about uncontrolled external package sources.

- Activates the package-source policy in CI for changed manifests.
- Rejects new COPR/PPA/OBS/AUR declarations and unapproved repository URLs.
- Uses exact hostname matching to reject lookalike domains.
- Adds regression tests for forbidden keys, approved hosts, and attacker lookalikes.

Validation: Python syntax checks and git diff --check. Runtime tests require the CI-installed PyYAML dependency, which is unavailable in this environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789192829&installation_model_id=429180&pr_number=1421&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1421&signature=9e83328a64ce1f1f432999c54cdfa615716b2a2b8ac3cfe0476999508025b828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->