### PR TITLE
fix boot report E2E status accuracy

### DIFF
--- a/scripts/generate-boot-report.py
+++ b/scripts/generate-boot-report.py
@@ -271,9 +271,10 @@ def e2e_status_for(variant: str, flavor: str) -> dict | None:
                 "conclusion": job.get("conclusion"),
                 "html_url": job.get("html_url") or run.get("html_url"),
             }
-    # No matrix cell ran for this combo — fall back to the workflow's
-    # top-level conclusion so the cell still shows *some* signal.
-    return run
+    # No matrix cell ran for this combo.  Do not use the workflow's
+    # top-level conclusion here: a successful run only proves the cells
+    # that were actually in its matrix, not every flavor in build-config.
+    return None
 
 
 # ── Missing-package wishlist ────────────────────────────────────────────────
@@ -502,11 +503,11 @@ def render_report(
             fresh.append(rendered)
 
     if fresh:
-        out.append("## Fresh builds")
+        out.append("## Fresh screenshots")
         out.append("")
         out.extend(fresh)
     if stale:
-        out.append("## ⚠️ Stale or missing builds")
+        out.append("## ⚠️ Stale or missing screenshots")
         out.append("")
         out.append(
             "These combos have screenshots older than 7 days (or none at all). "

--- a/tests/python/test_generate_boot_report.py
+++ b/tests/python/test_generate_boot_report.py
@@ -34,6 +34,7 @@ age_marker = _rep.age_marker
 status_emoji = _rep.status_emoji
 render_combo_row = _rep.render_combo_row
 render_report = _rep.render_report
+e2e_status_for = _rep.e2e_status_for
 
 
 # ── age_marker ──────────────────────────────────────────────────────────
@@ -89,6 +90,29 @@ def test_status_emoji_unknown_and_missing():
     assert status_emoji(None) == "❓"
     assert status_emoji("") == "❓"
     assert status_emoji("in_progress") == "❓"
+
+
+def test_e2e_status_does_not_claim_unrun_matrix_cells(monkeypatch):
+    run = {"id": 123, "conclusion": "success", "html_url": "https://github.com/run/123"}
+    monkeypatch.setattr(_rep, "latest_workflow_run", lambda _workflow: run)
+    _rep._E2E_JOBS_CACHE = {123: [{"name": "E2E yellowfin:gnome", "conclusion": "success"}]}
+
+    assert e2e_status_for("yellowfin", "kde") is None
+
+
+def test_e2e_status_uses_matching_matrix_cell(monkeypatch):
+    run = {"id": 123, "conclusion": "success", "html_url": "https://github.com/run/123"}
+    monkeypatch.setattr(_rep, "latest_workflow_run", lambda _workflow: run)
+    _rep._E2E_JOBS_CACHE = {123: [{
+        "name": "E2E yellowfin:gnome",
+        "conclusion": "failure",
+        "html_url": "https://github.com/job/456",
+    }]}
+
+    assert e2e_status_for("yellowfin", "gnome") == {
+        "conclusion": "failure",
+        "html_url": "https://github.com/job/456",
+    }
 
 
 # ── Combo ───────────────────────────────────────────────────────────────
@@ -151,9 +175,9 @@ def test_render_report_sections_and_wishlist():
     out = render_report(combos, wishlist)
 
     assert "# 🖥️ Weekly Boot Screenshot Report" in out
-    assert "## Fresh builds" in out
+    assert "## Fresh screenshots" in out
     assert "R-FRESH" in out
-    assert "## ⚠️ Stale or missing builds" in out
+    assert "## ⚠️ Stale or missing screenshots" in out
     assert "R-STALE" in out
     assert "## 📦 EL10 packaging wishlist" in out
     assert "| `pkg-a` | letters, tables |" in out
@@ -163,7 +187,7 @@ def test_render_report_sections_and_wishlist():
 def test_render_report_empty_inputs():
     out = render_report([], {})
     assert "# 🖥️ Weekly Boot Screenshot Report" in out
-    assert "## Fresh builds" not in out
-    assert "## ⚠️ Stale or missing builds" not in out
+    assert "## Fresh screenshots" not in out
+    assert "## ⚠️ Stale or missing screenshots" not in out
     assert "## 📦 EL10 packaging wishlist" not in out
     assert "## 🚀 Release ISOs" in out


### PR DESCRIPTION
## Summary

- report `iso-e2e` status only for matrix cells that actually ran
- show untested flavor combinations as unknown instead of inheriting the workflow-level result
- rename report sections to describe screenshot freshness accurately

This addresses the misleading `e2e ✅` entries in #989, where the workflow only tests a subset of the reported combinations.

## Validation

- `python3 -m py_compile scripts/generate-boot-report.py`
- `git diff --check`
- manual generator checks for matching and unrun matrix cells
- The repository test runner could not be run because this environment has no `pytest` or `pip`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789193107&installation_model_id=429180&pr_number=1422&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1422&signature=b5003b4d220d5f4a9a865e2247862ca9b0de62db638892fb86433c5995a2dd2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->