### PR TITLE
docs(rfc): fix RFC-PROCESS.md's own stale DRAFT status (#1093)

### DIFF
--- a/RFC-PROCESS.md
+++ b/RFC-PROCESS.md
@@ -1,8 +1,8 @@
 # tunaOS RFC Lifecycle Policy
 
-**Status**: DRAFT — proposed 2026-08-11 by the strategist agent for review
+**Status**: ACCEPTED — merged 2026-08-11 via [#1352](https://github.com/tuna-os/tunaOS/pull/1352), recorded in [ADR 0004](docs/adr/0004-rfc-lifecycle.md)
 **Owner**: tuna-os (hanthor) / strategist
-**Tracks**: #1093 (RFC lifecycle governance), #1094 (ADR coverage)
+**Tracks**: #1093 (RFC lifecycle governance), #1094 (ADR coverage), #1363 (11-branch disposition pass)
 
 ## Purpose
 


### PR DESCRIPTION
## Summary

#1093's STAFF-test deliverable (an RFC lifecycle policy doc) already
landed — `RFC-PROCESS.md` merged via #1352 on 2026-08-11, and
`docs/adr/0004-rfc-lifecycle.md` already records it as "accepted (policy
merged)". But the policy doc's own header still says:

> **Status**: DRAFT — proposed 2026-08-11 by the strategist agent for review

which is the one place that hadn't caught up to its own adoption —
someone reading `RFC-PROCESS.md` on its own, without also checking the
ADR, would reasonably conclude the policy isn't in effect yet.

Updated the status line to match ADR 0004 and linked #1363, the
follow-up issue that actually tracks the remaining work (disposing of
the 11 pre-existing `rfc*` branches this policy exists to unblock).
Confirmed #1363 is still open and all 11 branches are still present and
untriaged (`git branch -r | grep rfc[0-9]`), so linking it here doesn't
overstate progress on that front — the branches genuinely still need
the 08-22 checkpoint's disposition pass.

Left the dated "Current state (2026-08-11)" paragraph further down
alone — it's explicitly a timestamped snapshot ("as of 2026-08-11"),
not an ongoing claim, so it isn't stale the way the top status line was.

## Test plan

- [x] Docs-only change, one line + one line.
- [x] Verified against ADR 0004 and PR #1352's actual merge state
      (`gh pr view 1352 --json state,mergedAt`) rather than assuming.
- [x] Verified #1363 and the 11 branches' current state before adding
      the reference, so the new "Tracks" line is accurate today, not
      just accurate when #1352 merged.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `20c3b620`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->