### PR TITLE
docs: establish contributor onboarding pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,30 @@ git clone https://github.com/tuna-os/tunaOS.git && cd tunaOS
 just fix && just check
 ```
 
-## Good First Issues
+## Contributor onboarding
 
-New here? Start with issues tagged **[good first issue](https://github.com/tuna-os/tunaOS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)** — a curated, maintainer-sized set of starter tasks covering documentation parity, small script fixes, and test coverage. They are deliberately small, well-scoped, and safe to attempt without deep image-factory knowledge.
+New here? Start with a **[good first issue](https://github.com/tuna-os/tunaOS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)** — a curated, maintainer-sized task covering documentation parity, a small script fix, or test coverage. Before starting, leave a comment saying you are taking the issue so the work is not duplicated.
+
+The current starter runway includes:
+
+- [#1308](https://github.com/tuna-os/tunaOS/issues/1308) — build a documentation-parity checklist for published editions
+- [#1350](https://github.com/tuna-os/tunaOS/issues/1350) — document the `pantheon` desktop suffix
+- [#1351](https://github.com/tuna-os/tunaOS/issues/1351) — add a Gurnard/Pantheon desktop guide
+- [#1366](https://github.com/tuna-os/tunaOS/issues/1366) — document checksum and SBOM verification
+- [#1385](https://github.com/tuna-os/tunaOS/issues/1385) — document supported ARM laptop hardware
+
+These tasks are intentionally independent of the image build pipeline. If one is claimed or closed, use the same issue search to choose another bounded task.
+
+### Fork → PR loop
+
+1. Fork `tuna-os/tunaos` on GitHub and clone your fork.
+2. Create a focused branch: `git switch -c docs/short-description`.
+3. Make the smallest change that satisfies the issue's acceptance criteria.
+4. Run the checks listed below, then commit and push the branch to your fork.
+5. Open a PR against `tuna-os/tunaos:main`, link the issue with `Fixes #NNN`, and include the checks you ran.
+6. Keep the branch available while review is in progress; follow-up fixes can be pushed to the same PR.
+
+You do not need write access to the upstream repository. GitHub's fork-based PR flow is the normal path for external contributors. If CI fails, include the failing job and a short reproduction in the PR rather than silently retrying it.
 
 Ways to contribute without touching the build pipeline:
 
@@ -21,6 +42,17 @@ Ways to contribute without touching the build pipeline:
 - **Labels** — issues tagged `help wanted` are explicitly open for external contribution
 
 When you pick an issue, say so in a comment (prevents double work) and ask in Matrix if you get stuck — someone is usually around.
+
+### Weekly contributor triage
+
+The maintainer reserves one 30-minute slot each week for contributor work. During that slot:
+
+1. Review new issues and label at least one bounded task `good first issue` when its scope and acceptance criteria are clear.
+2. Check claimed starter issues for unanswered questions, stale claims, or duplicate work.
+3. Review open contributor PRs, respond to blockers, and keep CI failures distinguishable from code-review requests.
+4. Refresh the starter links above when tasks are completed, superseded, or moved to another repository.
+
+This is a lightweight queue-management commitment, not a promise of immediate review. Contributors should expect an acknowledgement or status update within the next weekly triage slot.
 
 ## Pre-Commit (mandatory)
 


### PR DESCRIPTION
## Summary

- turn the existing good-first-issue link into a concrete five-task starter runway
- document the fork → branch → checks → PR loop for contributors without upstream write access
- add a lightweight weekly triage checklist for maintaining the contributor queue

Closes #1095.

## Validation

- `git diff --check`
- Confirmed the five linked issues are labeled `good first issue` upstream.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789193522&installation_model_id=429180&pr_number=1425&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1425&signature=8888f0fe4f7c9d1211bfef909ab264780bb428e479e1cd7e29a82c9301527799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->