### PR TITLE
docs(community): add Matrix to Communication list, document room cadence (#1136)

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -26,6 +26,50 @@ tunaOS is an open-source project building OCI-based Enterprise Linux desktops. W
 - **GitHub Issues**: Bug reports, feature requests, discussion
 - **GitHub Discussions**: General topics, ideas, Q&A
 - **PR Reviews**: All contributions reviewed within 48 hours
+- **Matrix**: [#tunaos:reilly.asia](https://matrix.to/#/%23tunaos:reilly.asia) — real-time chat, weekly release notes, monthly office hours (see below)
+
+### Matrix room cadence
+
+The Matrix room is the project's real-time channel; this section documents
+its recurring structure so it doesn't rely on any one person's memory to
+keep going (#1136).
+
+- **Weekly release notes** (Fridays, mirroring the [weekly boot
+  report](https://github.com/tuna-os/tunaOS/issues?q=is%3Aissue+label%3Aboot-report)
+  cadence): post a short summary of the week's [Generate
+  Release](.github/workflows/generate-changelog-release.yml) runs and any
+  notable boot-report findings. Template:
+
+  ```
+  📦 This week in tunaOS — <date>
+
+  - Released: <variant/flavor list + dates, from `gh release list`>
+  - Boot health: <link to this week's boot-report issue>
+  - Notable changes: <1-3 bullets — new variant, fixed regression, etc.>
+  - Full changelog: <link to the release/CHANGELOG.md entry>
+  ```
+
+- **Monthly office hours** (~30 min, announced 1 week ahead in the room):
+  open Q&A / walkthrough slot. No fixed agenda beyond "bring questions."
+
+- **`#new-to-tunaos` pinned message** — the three best entry points for
+  someone new to the room:
+
+  ```
+  👋 New here? Start with one of these:
+
+  1. Try it: bootc switch --enforce-container-sigpolicy ghcr.io/tuna-os/yellowfin:gnome
+  2. Pick a starter task: issues labeled "good first issue"
+     → https://github.com/tuna-os/tunaOS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+  3. Read CONTRIBUTING.md and COMMUNITY.md (this file) before your first PR
+
+  Questions are welcome any time — you don't need to wait for office hours.
+  ```
+
+- **Cross-posting GitHub Discussions**: when a Discussions thread gets real
+  engagement (multiple replies, a maintainer answer, a decision), drop a
+  one-line summary + link into the room. Keeps the room aware of
+  async-first conversations without duplicating them live.
 
 ### Adoption Metrics
 


### PR DESCRIPTION
## Summary

#1136 proposes a Matrix growth campaign: weekly release notes, monthly
office hours, a `#new-to-tunaos` pinned message, and cross-posting
GitHub Discussions into the room. None of that is something a repo PR
can execute — it needs an actual human (or agent with room access)
posting into the live Matrix room and running a live call, which is out
of reach for this session. So this PR doesn't claim any of the four
actions happened; it gives the campaign a durable, reusable artifact
instead of relying on someone's memory of the plan.

**Real gap found first**: `COMMUNITY.md`'s "Communication" section
listed GitHub Issues/Discussions/PR reviews but not Matrix at all —
even though `README.md:215` and `ADOPTERS.md:54` both already point
people to the room as the project's real-time channel. Added it.

**Then, for the campaign itself**:
- A weekly release-notes template, sourced from the real [Generate
  Release](.github/workflows/generate-changelog-release.yml) workflow
  and the existing weekly-boot-report cadence (not invented) — someone
  fills in the blanks and posts it Fridays.
- The actual drafted `#new-to-tunaos` pinned-message text (the "3 best
  entry points" the issue asks for). Verified the `good first issue`
  label exists and the query link resolves to real open issues
  (`gh label list` / `gh issue list --label "good first issue"`)
  before including it, rather than assuming.
- A documented monthly office-hours cadence and a Discussions
  cross-posting guideline.

## Test plan

- [x] Verified Matrix was genuinely missing from `COMMUNITY.md` (it's
      present in `README.md`/`ADOPTERS.md`, absent here) before adding it.
- [x] Verified the `good first issue` label and its query link resolve
      to real, currently-open issues.
- [x] Verified `.github/workflows/generate-changelog-release.yml` is
      the actual "Generate Release" workflow referenced in #1136's prior
      comment, and that real releases exist to summarize
      (`gh release list`).
- [ ] N/A — no code changed; the actual room posting/office-hours
      execution is outside what a PR can do.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `e6098208`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->