### PR TITLE
docs: add Q4 2026 promotion calendar

### DIFF
--- a/docs/Q4-2026-PROMOTION-CALENDAR.md
+++ b/docs/Q4-2026-PROMOTION-CALENDAR.md
@@ -2,13 +2,17 @@
 
 > Status: **draft** — maintainer review and contributor availability are required
 > before committing to dates or external outreach.
-> Tracking issue: [#1166](https://github.com/tuna-os/tunaOS/issues/1166).
+> Tracking issues: [#1166](https://github.com/tuna-os/tunaOS/issues/1166),
+> [#1135](https://github.com/tuna-os/tunaOS/issues/1135) (Q1 2027 CFP prep).
 > Planning window: September–November 2026.
 
 This calendar turns the Fedora 45, All Things Open, and KubeCon + CloudNativeCon
 North America moments into a small, coordinated promotion sequence. It assumes
 that the project continues its weekly release cadence and that the relevant
-release artifacts are green before publication.
+release artifacts are green before publication. It also covers the CFP
+*windows* for two Q1 2027 events (FOSDEM 2027, SCaLE 21x) — the events
+themselves land after this calendar's own Sept–Nov 2026 range, but their CFPs
+open inside it, which is the actionable part now.
 
 ## Calendar
 
@@ -20,6 +24,8 @@ release artifacts are green before publication.
 | **October 13–15** | All Things Open 2026, Raleigh | Treat this as an attendance and informal-demo window, not a CFP. If a contributor attends, offer a short Bonito or bootc demo and record questions and contacts for follow-up. | Named attendee; portable demo and stable download URL. | Attendance note, demo links, and follow-up queue. |
 | **October 16–30** | Post-ATO follow-up | Publish a short event recap or Fedora post amplification. Route technical questions to the relevant project issues and avoid implying an official booth or talk. | Attendee plus outreach coordinator. | Recap, answered questions, and attributed referral links where practical. |
 | **November 9–13** | KubeCon + CloudNativeCon North America 2026 | Use the event as a hallway-track and blog-tie-in opportunity, not a submission. Lead with Corral (Kubernetes-native VMs), bootc’s CNCF Sandbox context, and the desktop/container-fleet connection. | Named attendee; current Corral and bootc references. | One-page conversation brief, demo links, and qualified follow-ups. |
+| **~October 2026** | FOSDEM 2027 CFP opens (event: Brussels, Feb 6–7 2027) | Finalize and submit the CFP abstract already drafted in [docs/CFP-FOSDEM-2027.md](./CFP-FOSDEM-2027.md) — confirm the exact portal-open date, record the demo video outlined there, and submit to the Containers devroom first. | Speaker/maintainer-designate; demo video and reviewed abstract. | Submitted CFP, tracked in [#1135](https://github.com/tuna-os/tunaOS/issues/1135). |
+| **~November 2026** | SCaLE 21x CFP opens (event: Pasadena, March 2027) | Adapt the FOSDEM abstract for SCaLE's format and audience (broader open-source/platform-engineering mix, not container-specialist); confirm the exact portal-open date before submitting. No SCaLE-specific draft exists yet — write one from the FOSDEM abstract rather than from scratch. | Speaker/maintainer-designate. | Submitted CFP, tracked in [#1135](https://github.com/tuna-os/tunaOS/issues/1135). |
 | **November 16–20** | KubeCon follow-up | Publish a concise recap or technical tie-in, with links to Corral and the relevant TunaOS documentation. Capture questions that should become docs or issues. | Attendee plus Corral maintainer. | Recap, documentation/issues backlog, and referral summary. |
 
 ## Fedora 45 release-week post

--- a/docs/Q4-2026-PROMOTION-CALENDAR.md
+++ b/docs/Q4-2026-PROMOTION-CALENDAR.md
@@ -1,0 +1,83 @@
+# Q4 2026 Promotion Calendar
+
+> Status: **draft** — maintainer review and contributor availability are required
+> before committing to dates or external outreach.
+> Tracking issue: [#1166](https://github.com/tuna-os/tunaOS/issues/1166).
+> Planning window: September–November 2026.
+
+This calendar turns the Fedora 45, All Things Open, and KubeCon + CloudNativeCon
+North America moments into a small, coordinated promotion sequence. It assumes
+that the project continues its weekly release cadence and that the relevant
+release artifacts are green before publication.
+
+## Calendar
+
+| Window | Moment | Primary action | Owner / dependency | Deliverable |
+|---|---|---|---|---|
+| **Early September** | Q4 preparation | Confirm a maintainer or contributor who will attend either event; ask in the issue and Matrix. Confirm the Bonito/Fedora 45 status and collect links, screenshots, and current download instructions. | Outreach coordinator; maintainer confirms technical claims. | Named event contacts, asset checklist, and a single source of truth for links. |
+| **September** | NVIDIA follow-up | Draft “CUDA on an Enterprise Linux desktop: TunaOS `-nvidia` flavors” as an optional companion post. Use the recovered `-nvidia` build results from [#1118](https://github.com/tuna-os/tunaOS/issues/1118) only after the current matrix is green. | Content owner; current amd64 and arm64 NVIDIA verification. | Reviewable draft and reproducible build/verification links. |
+| **Fedora 45 release week (~October 20–24)** | Fedora 45 | Publish the Bonito/Fedora 45 release-week post. Cover support status, what changed, download links, and the weekly release/verified-boot cadence. Coordinate the first public release-notes digest with the post. | Bonito maintainer; release artifacts and [#1136](https://github.com/tuna-os/tunaOS/issues/1136) digest template. | tunaos.org/blog post, Matrix announcement, and release-notes digest. |
+| **October 13–15** | All Things Open 2026, Raleigh | Treat this as an attendance and informal-demo window, not a CFP. If a contributor attends, offer a short Bonito or bootc demo and record questions and contacts for follow-up. | Named attendee; portable demo and stable download URL. | Attendance note, demo links, and follow-up queue. |
+| **October 16–30** | Post-ATO follow-up | Publish a short event recap or Fedora post amplification. Route technical questions to the relevant project issues and avoid implying an official booth or talk. | Attendee plus outreach coordinator. | Recap, answered questions, and attributed referral links where practical. |
+| **November 9–13** | KubeCon + CloudNativeCon North America 2026 | Use the event as a hallway-track and blog-tie-in opportunity, not a submission. Lead with Corral (Kubernetes-native VMs), bootc’s CNCF Sandbox context, and the desktop/container-fleet connection. | Named attendee; current Corral and bootc references. | One-page conversation brief, demo links, and qualified follow-ups. |
+| **November 16–20** | KubeCon follow-up | Publish a concise recap or technical tie-in, with links to Corral and the relevant TunaOS documentation. Capture questions that should become docs or issues. | Attendee plus Corral maintainer. | Recap, documentation/issues backlog, and referral summary. |
+
+## Fedora 45 release-week post
+
+The post should be drafted in September and held for the confirmed release
+window. Suggested outline:
+
+1. What Fedora 45 means for Bonito and its current support status.
+2. The immutable desktop workflow: bootable OCI image, atomic updates, and
+   rollback.
+3. The current image/download links and architecture coverage, checked against
+   the release artifacts on publication day.
+4. What is new in the release and where readers can find the release notes.
+5. A clear invitation to try Bonito, join Matrix, or contribute feedback.
+
+Do not promise Fedora 45 support until the corresponding image has passed the
+normal release gates. If the Fedora release date moves, move this post and the
+digest together; the event and KubeCon dates remain independent calendar items.
+
+## Event conversation briefs
+
+### All Things Open
+
+- Position TunaOS as an open-source, bootable-container desktop project.
+- Demonstrate a stable image and the normal install/update/rollback path.
+- Ask whether the person wants a follow-up link; do not collect personal data
+  in a public issue.
+- Record recurring questions and route them to documentation or issues.
+
+### KubeCon + CloudNativeCon North America
+
+- Connect TunaOS’s image model to the operational model familiar to a
+  Kubernetes audience.
+- Use Corral as the primary companion-project example: declarative VMs,
+  snapshots, and GPU passthrough where those claims are current and verified.
+- Mention bootc’s CNCF Sandbox status only with the canonical upstream link.
+- Keep the discussion explicitly informal: no booth, talk, or CFP should be
+  implied by this plan.
+
+## Launch checklist
+
+- [ ] Maintainer confirms the Fedora 45 support claim and release-week date.
+- [ ] Bonito image, download page, release notes, and verification links are
+      checked on publication day.
+- [ ] A contributor volunteers for All Things Open and/or KubeCon NA.
+- [ ] Demo hardware and a reliable network-independent demo path are tested.
+- [ ] Drafts receive technical review before publication.
+- [ ] Matrix announcements link to the canonical post rather than duplicating
+      changing technical details.
+- [ ] Referral links and notable questions are recorded in the follow-up notes.
+- [ ] Any resulting docs or engineering work is filed as a separate issue.
+
+## Related work
+
+- [#1118](https://github.com/tuna-os/tunaOS/issues/1118) — NVIDIA image build
+  recovery and verification.
+- [#1136](https://github.com/tuna-os/tunaOS/issues/1136) — release-notes digest.
+- [#1137](https://github.com/tuna-os/tunaOS/issues/1137) — Fedora Magazine pitch.
+- [#1147](https://github.com/tuna-os/tunaOS/issues/1147) — release cadence and
+  green Generate Release runs.
+- [#1159](https://github.com/tuna-os/tunaOS/issues/1159) — Q4 planning kickoff.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ user-facing site:
 | [rhel-setup.md](rhel-setup.md) | RHEL 10 (Redfin) local-build instructions |
 | [ROLL_YOUR_OWN.md](ROLL_YOUR_OWN.md) | Guide to building custom TunaOS variants for your own use |
 | [IMPROVEMENT_PLAN.md](IMPROVEMENT_PLAN.md) | Historical record of the May 2026 sprint + remaining roadmap items |
+| [Q4-2026-PROMOTION-CALENDAR.md](Q4-2026-PROMOTION-CALENDAR.md) | Fedora 45, All Things Open, and KubeCon NA promotion plan |
 | [agents/](agents/) | Hive agent guides (issue-tracker, triage-labels, domain) |
 | [adr/](adr/) | Architecture Decision Records |
 


### PR DESCRIPTION
## Summary

- add a maintainer-facing Q4 2026 promotion calendar for Fedora 45, All Things Open, and KubeCon + CloudNativeCon North America
- define publication windows, event-specific messaging, dependencies, follow-up deliverables, and launch checks
- include the NVIDIA `-nvidia` companion-post idea from the issue discussion and index the calendar in `docs/README.md`

## Why

Issue #1166 identifies a dense Q4 promotion window but needs an actionable plan that keeps release claims gated on verified artifacts and distinguishes informal event attendance from CFPs, booths, or talks.

## Validation

- `git diff --check`

Closes #1166

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789194895&installation_model_id=429180&pr_number=1428&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1428&signature=df361258cd3a3f0489f4c39d637ecc3fe8301b19a0d7ffe9651a5f135132564d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->