### PR TITLE
docs: add Fedora base currency policy for Fedora 45 planning

### DIFF
--- a/FEDORA-BASE-POLICY.md
+++ b/FEDORA-BASE-POLICY.md
@@ -1,0 +1,62 @@
+# Fedora Base Currency Policy
+
+**Status**: DRAFT — proposed 2026-08-13 by the strategist agent for review
+**Owner**: tuna-os (hanthor) / strategist
+**Tracks**: #1171 (Fedora 45 planning), #272 (Bonito / Fedora 44 GA), #637 (rawhide variant)
+
+## Purpose
+
+tunaOS currently builds **two** Fedora-base variants simultaneously — Bonito
+(Fedora 44) and Bonito Rawhide — with no written policy for which Fedora
+release(s) the project commits to tracking, or when a new Fedora release
+starts a base-currency transition. Fedora ships a new release roughly every
+six months (Fedora 45 is expected ~October 2026); without a policy, each
+transition is decided ad hoc, and outreach can promote a release ("Fedora 45
+is coming" — #1137, #1166) before the product has a tracked plan for it, as
+#1171 flagged.
+
+## Policy
+
+tunaOS tracks Fedora bases on an **N (current stable) + rawhide** model,
+**one base transition at a time**:
+
+1. **N (current stable)** is the GA-track base — e.g. Bonito tracks Fedora 44
+   today. This is the release users are told to expect stability from.
+2. **Rawhide** is tracked in parallel as a preview/early-warning lane (Bonito
+   Rawhide, #637) — it exists to catch breakage before it lands in the next
+   stable, not to ship a second GA product.
+3. When a new Fedora stable ships, it does **not** immediately become a new
+   tunaOS base variant. Planning for the new base (N+1) starts only after
+   the current base (N) reaches GA per [VARIANT-LIFECYCLE.md](VARIANT-LIFECYCLE.md)
+   — i.e. Fedora 45 base planning is sequenced **after** Bonito (Fedora 44)
+   GA (#272), not in parallel with it. Running two incomplete Fedora GA
+   efforts at once is the exact failure mode #1171 and the Q3 mid-quarter
+   review (#1299) both flagged.
+4. Once N+1 GA work starts, the previous stable (N) is retired from active
+   development per the exit criteria in VARIANT-LIFECYCLE.md — tunaOS does
+   not carry more than one GA-track Fedora stable base at a time.
+
+## Fedora 45 sequencing
+
+- **Now (Q3 2026)**: Bonito (Fedora 44) GA is the active goal (#272, Q3
+  milestone). Bonito Rawhide (#637) continues as the preview lane and is the
+  earliest signal for Fedora 45-era breakage, since rawhide already tracks
+  ahead of 44 GA.
+- **Trigger for Fedora 45 base planning**: Bonito (Fedora 44) reaches GA
+  per VARIANT-LIFECYCLE.md exit criteria, or the Q4 checkpoint determines #272
+  is descoped/carried — either way, #1171 is the tracking issue for
+  standing up Fedora 45 base work, and should not open a second parallel
+  GA effort while #272 is still open.
+- **Outreach coordination**: Fedora 45 promotion (#1137 Fedora Magazine
+  pitch, #1166 Q4 promotion calendar) should message Fedora 45 support as
+  planned/upcoming, not shipped, until this policy's trigger condition is
+  met and #1171 reports base readiness.
+
+## Relationship to other bases
+
+This policy covers Fedora only. Other rolling/tracking bases (Sailfin/
+openSUSE Tumbleweed, Marlin/Arch, Flounder/Debian Sid) already follow a
+rolling model by construction and are out of scope here; RHEL-family bases
+(Yellowfin/Albacore/Skipjack/Redfin) follow their own major-version cadence
+and are covered by VARIANT-LIFECYCLE.md's general admission/exit criteria,
+not this document.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,7 +143,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | **Package sourcing policy (system-repos/tideforge-first + allowlist)** | strategist | #1319, #1323 (audit → #1187) |
 | Bonito (Fedora 44) GA carryover | ci-maintainer | #272 |
 | Redfin (RHEL 10) alpha GA | ci-maintainer | #609 |
-| Fedora 45 base readiness | ci-maintainer | #1171 |
+| Fedora 45 base readiness | ci-maintainer | #1171 — [FEDORA-BASE-POLICY.md](./FEDORA-BASE-POLICY.md) drafted 08-13: N+rawhide model, Fedora 45 planning sequenced after Bonito (#272) GA, not parallel |
 | Adoption metrics / usage telemetry | strategist | #1174 |
 | **Adoption evidence (ADOPTERS.md production entries)** | strategist | #1348 — zero public production adopters vs "Mature" claim; first entries at 2026-11-01 snapshot |
 | Variant lifecycle policy (Beta→Stable exit criteria) | strategist | #1175 |


### PR DESCRIPTION
## Summary

#1171 flagged that Fedora 45 base-variant planning was untracked: no roadmap row and no stated base-currency policy (N-1 vs. latest vs. rawhide), while the project currently builds both Fedora 44 (Bonito, #272, still not GA) and rawhide (#637) simultaneously, and outreach is already promoting Fedora 45 (#1137, #1166).

- `FEDORA-BASE-POLICY.md` (new, root-level, same shape as `RFC-PROCESS.md`/`VARIANT-LIFECYCLE.md`): states the policy — track current stable (N) + rawhide as a preview lane, one Fedora GA transition at a time. Fedora 45 base planning is explicitly sequenced to start after Bonito (Fedora 44) reaches GA per `VARIANT-LIFECYCLE.md`, not in parallel with it, and recommends outreach message Fedora 45 as planned/upcoming until then.
- `ROADMAP.md`: the Q4 "Fedora 45 base readiness" row (owner ci-maintainer, #1171 — this row already existed from a prior planning pass) now links the policy doc and states the sequencing decision inline.

## Test plan
- [x] Confirmed #272 (Bonito/Fedora 44 GA) is still open — the trigger condition for Fedora 45 planning has not fired yet
- [x] Confirmed no prior Fedora base-currency policy doc existed (`docs/`, root-level docs, `VARIANT-LIFECYCLE.md`)
- [x] Cross-referenced outreach issues #1137/#1166 for the coordination note

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `c21ac3ca`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->