### PR TITLE
supply-chain: attest provenance alongside SBOM for signed images

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -819,6 +819,8 @@ jobs:
       IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}
       DEFAULT_TAG: ${{ inputs.default-tag }}
       INDEX_DIGEST: ${{ needs.manifest.outputs.digest }}
+      IMAGE_VARIANT: ${{ inputs.image-variant }}
+      FLAVOR: ${{ inputs.flavor }}
       COSIGN_YES: "true"
     steps:
       - name: Install Cosign
@@ -846,7 +848,7 @@ jobs:
           merge-multiple: true
           path: supply-chain/sboms
 
-      - name: Sign images and attest SBOMs
+      - name: Sign images and attest SBOMs + provenance
         env:
           REQUIRE_SBOM: ${{ inputs.sbom }}
         run: |
@@ -854,6 +856,14 @@ jobs:
           identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/reusable-build-image.yml@${GITHUB_REF}"
           issuer="https://token.actions.githubusercontent.com"
           index_ref="${IMAGE_REGISTRY}/${IMAGE_NAME}@${INDEX_DIGEST}"
+          # https://tunaos.org/provenance/v1 fields: source commit, workflow/run,
+          # variant, flavor, platform, build-config revision (tunaos/tunaos#1187).
+          # Base-image digest is deliberately omitted: get-base-image.sh resolves
+          # a tag, not a digest, in the per-platform build job, and pinning it
+          # would mean adding a `skopeo inspect` call to that live 180-minute
+          # build matrix — not something to do blind in this change.
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          provenance_dir="$(mktemp -d)"
 
           cosign sign "$index_ref"
           cosign verify "$index_ref" \
@@ -887,6 +897,25 @@ jobs:
               echo "::error::missing SPDX SBOM for ${safeplatform}"
               exit 1
             fi
+
+            provenance="${provenance_dir}/provenance-${safeplatform}.json"
+            jq -n \
+              --arg sourceCommit "$GITHUB_SHA" \
+              --arg sourceRepository "https://github.com/${GITHUB_REPOSITORY}" \
+              --arg workflow ".github/workflows/reusable-build-image.yml" \
+              --arg runId "$GITHUB_RUN_ID" \
+              --arg runUrl "$run_url" \
+              --arg variant "$IMAGE_VARIANT" \
+              --arg flavor "$FLAVOR" \
+              --arg platform "$safeplatform" \
+              --arg buildConfigRevision "$GITHUB_SHA" \
+              '{sourceCommit: $sourceCommit, sourceRepository: $sourceRepository, workflow: $workflow, runId: $runId, runUrl: $runUrl, variant: $variant, flavor: $flavor, platform: $platform, buildConfigRevision: $buildConfigRevision}' \
+              > "$provenance"
+            cosign attest --type https://tunaos.org/provenance/v1 --predicate "$provenance" "$ref"
+            cosign verify-attestation "$ref" \
+              --type https://tunaos.org/provenance/v1 \
+              --certificate-identity "$identity" \
+              --certificate-oidc-issuer "$issuer" >/dev/null
           done
 
           [[ "$signed" -gt 0 ]] || { echo "::error::no platform digests found"; exit 1; }
@@ -894,7 +923,7 @@ jobs:
             echo "::error::attested ${attested}/${signed} platform SBOMs"
             exit 1
           fi
-          echo "Signed index plus ${signed} platform image(s); attested ${attested} SPDX SBOM(s)." >> "$GITHUB_STEP_SUMMARY"
+          echo "Signed index plus ${signed} platform image(s); attested ${attested} SPDX SBOM(s) and ${signed} provenance statement(s)." >> "$GITHUB_STEP_SUMMARY"
 
   # ── Boot gate ───────────────────────────────────────────────────────────────
   # Pull the just-pushed :<tag>-testing manifest, install it to a qcow2 with

--- a/docs/VERIFY-ARTIFACTS.md
+++ b/docs/VERIFY-ARTIFACTS.md
@@ -47,6 +47,26 @@ Cosign prints the verified in-toto statement. Its `subject[].digest.sha256`
 must match the digest in `ref`. The predicate contains the SPDX document for
 that platform image.
 
+## Verify the provenance attestation
+
+Each published platform image also has a signed provenance attestation
+recording the source commit, workflow/run, variant, flavor, platform, and
+build-config revision it was produced from:
+
+```bash
+cosign verify-attestation "${ref}" \
+  --type https://tunaos.org/provenance/v1 \
+  --certificate-identity \
+    "https://github.com/tuna-os/tunaOS/.github/workflows/reusable-build-image.yml@refs/heads/main" \
+  --certificate-oidc-issuer \
+    "https://token.actions.githubusercontent.com"
+```
+
+The predicate's `sourceCommit` and `buildConfigRevision` should match the
+commit you expect this image to have been built from. This attestation does
+not currently pin the resolved base-image digest — see tunaos#1187 for that
+remaining gap.
+
 ## Trust boundary
 
 The accepted identity is intentionally narrow:


### PR DESCRIPTION
## Summary

#1187 is a large checklist; most of it is already implemented (verified by reading the live workflows before starting):

- Keyless Cosign OIDC signing of every platform manifest + multi-arch index by digest, verified immediately (`reusable-build-image.yml`'s `sign` job)
- SPDX SBOM generation + signed attestation per platform image
- ISO checksum manifests + Cosign v3 `sign-blob`/bundle, uploaded alongside the ISO to R2 (`publish-iso-groups.yml`)
- `docs/VERIFY-ARTIFACTS.md` with copy/paste verify commands and a documented trust boundary (narrow identity + issuer, no permissive regex)
- Signing/attestation jobs gated on `github.event_name != 'pull_request'`, so fork/PR events structurally cannot reach them

One concrete, named checklist item was still missing: **"Attach provenance for the source commit, workflow/run, variant, flavor, platform, base-image digest, and build configuration revision"** — only the SBOM attestation existed, no separate provenance attestation.

This PR adds it, in the same `sign` job, right next to the existing SBOM attestation, using the identical identity/issuer/verify pattern that's already proven to work:

- A `https://tunaos.org/provenance/v1` in-toto predicate per platform image, with `sourceCommit`, `sourceRepository`, `workflow`, `runId`, `runUrl`, `variant`, `flavor`, `platform`, `buildConfigRevision`.
- `cosign attest` + immediate `cosign verify-attestation`, same as the SBOM path.
- `docs/VERIFY-ARTIFACTS.md` gets a matching "Verify the provenance attestation" section.

**Deliberately not included**: the base-image digest. `get-base-image.sh` resolves a *tag*, not a pinned digest, inside the per-platform `build_push` matrix job (a live, 180-minute-timeout build path I can't test). Pinning it would mean adding a `skopeo inspect` call to every build cell across every variant/platform — a change to the hot build path I'm not willing to make blind. Left as a documented, explicit gap in both the code comment and the docs, for a follow-up that can actually be tested against a real build.

Remaining #1187 scope not touched here: the negative test (unapproved workflow/ref rejected) and the fork/PR test are process items around already-existing `if:` gates, and #1278 lifecycle-ledger reporting — all separate, larger follow-ups.

## Test plan
- [x] `yaml.safe_load` on the modified workflow — parses cleanly
- [x] Extracted and `bash -n`-checked the modified shell script — no syntax errors
- [x] Ran the `jq -n` predicate-construction command standalone with representative values — produces valid, correctly-shaped JSON
- [x] Confirmed the new step reuses the exact same `identity`/`issuer` variables already used (and working) for image signing and SBOM attestation — no new trust-boundary logic introduced
- [x] Grepped for other references to the renamed step name — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `7c3ef7cb`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->