### PR TITLE
ci: verify release assets and cadence criteria

### DIFF
--- a/.github/workflows/generate-changelog-release.yml
+++ b/.github/workflows/generate-changelog-release.yml
@@ -296,6 +296,37 @@ jobs:
           handwritten:  ${{ inputs.handwritten || '' }}
           github-token: ${{ github.token }}
 
+      # A successful action invocation is not proof that GitHub received the
+      # release payload. Keep an empty release from looking healthy (#1186).
+      - name: Verify release assets
+        if: >-
+          !cancelled() &&
+          steps.check.outputs.skip == 'false' &&
+          inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO:     ${{ github.repository }}
+          TAG:      ${{ steps.vars.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          ASSETS=$(gh api --paginate \
+            "repos/${REPO}/releases/tags/${TAG}" \
+            --jq '.assets[]?.name' 2>/dev/null || true)
+          ASSET_COUNT=$(printf '%s\n' "${ASSETS}" | sed '/^$/d' | wc -l)
+
+          if [[ "${ASSET_COUNT}" -eq 0 ]]; then
+            echo "::error::release ${TAG} exists but has no uploaded assets"
+            exit 1
+          fi
+
+          if ! grep -q '\.spdx\.json$' <<< "${ASSETS}"; then
+            echo "::error::release ${TAG} has no SPDX SBOM asset"
+            exit 1
+          fi
+
+          echo "Verified ${ASSET_COUNT} uploaded asset(s), including an SPDX SBOM, for ${TAG}"
+
       # ── Release cadence health gate (#1147) ───────────────────────────────
       # Before this existed, "we shipped nothing" and "we shipped" were the
       # same colour. 27 scheduled runs exited 0 having published nothing and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -137,7 +137,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | Upstream snapshot automation | ci-maintainer | #307 (closed — needs new tracker) |
 | Branch protection + required CI | strategist | CI health, #1167 |
 | Supply chain hardening | sec-check | #212, #301 (closed — needs new tracker) |
-| Release automation | ci-maintainer | CI health, VERSIONING.md, #1186 |
+| Release automation | ci-maintainer | CI health, VERSIONING.md, [#1186](https://github.com/tuna-os/tunaos/issues/1186), [definition of done](docs/RELEASE-AUTOMATION.md) |
 | Community governance model | strategist | #1168 |
 | Package signing / SBOM | sec-check | Supply chain, #1187 |
 | **Package sourcing policy (system-repos/tideforge-first + allowlist)** | strategist | #1319, #1323 (audit → #1187) |

--- a/docs/RELEASE-AUTOMATION.md
+++ b/docs/RELEASE-AUTOMATION.md
@@ -1,0 +1,31 @@
+# Release Automation — Q4 2026
+
+**Tracker**: [tunaOS#1186](https://github.com/tuna-os/tunaos/issues/1186)<br>
+**Milestone**: Q4 2026 — Mature<br>
+**Owner**: ci-maintainer
+
+This is the definition of done for the Q4 release-automation goal. It turns
+the date-based tags in [VERSIONING.md](../VERSIONING.md) into a release process
+whose omissions are visible to CI and whose published output is verifiable.
+
+## Acceptance criteria
+
+- **Cadence**: the scheduled release workflow attempts the daily date-based
+  release for each admitted stream. A legitimate no-build day may remain
+  green, but the Releases page must fail the workflow after the configured
+  eight-day freshness window (`MAX_RELEASE_AGE_DAYS`).
+- **Asset completeness**: every non-dry-run release must contain at least one
+  uploaded asset and an SPDX SBOM asset. The workflow verifies the published
+  GitHub Release through the API after creation, so a successful action call
+  cannot hide an empty release.
+- **Fail-on-drop**: when a build ran but no usable SBOM can be found, the
+  release job fails (`reason=no-sbom`). This distinguishes a dropped release
+  from a legitimate no-build day and keeps the signal required by #1147.
+- **Traceability**: the release tag follows
+  `<stream>-<YYYYMMDD>`, and the release summary records the stream, tag,
+  source build run, and SBOM package count.
+
+The implementation lives in
+`.github/workflows/generate-changelog-release.yml`. Stream coverage and
+release cadence parity remain tracked separately where a stream is not yet
+admitted to the scheduled matrix.


### PR DESCRIPTION
## Summary

- verify every non-dry-run release has uploaded assets and an SPDX SBOM
- document the Q4 #1186 release-automation definition of done
- link the definition from the Q4 roadmap row

## Why

The cadence gate detects dropped releases, but a successful release action could still leave an empty GitHub Release. The post-release API check makes asset loss fail visibly and preserves the fail-on-drop signal.

## Validation

- `git diff --check`
- extracted workflow shell blocks pass `bash -n`
- `just check` could not run because `just` is not installed

Closes #1186

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789197248&installation_model_id=429180&pr_number=1436&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1436&signature=7a33b9c265cf9a77d76f1ffffcbe2cd3e6e8f6cfdd479a8e5ed5c04d8d61f964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->