### PR TITLE
ci: make upstream snapshot refreshes rerunnable

### DIFF
--- a/.github/workflows/snapshot-upstreams.yml
+++ b/.github/workflows/snapshot-upstreams.yml
@@ -90,8 +90,18 @@ jobs:
           DATE=$(date -u +%Y-%m-%d)
           NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           BRANCH="upstream-snapshots/${DATE}"
-          # Stable branch per-week so re-runs the same week reuse it.
-          git checkout -b "$BRANCH" 2>/dev/null || git checkout "$BRANCH"
+          # Stable branch per-week so re-runs the same week reuse it. The
+          # checkout action starts from the default branch and does not fetch
+          # arbitrary remote branches, so fetch the existing branch before
+          # using force-with-lease below. Without this, a same-week rerun can
+          # fail even though the branch and PR are both still valid (#1194).
+          if git ls-remote --exit-code origin "refs/heads/${BRANCH}" >/dev/null 2>&1; then
+            git fetch --no-tags origin \
+              "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+          else
+            git checkout -b "$BRANCH"
+          fi
           git add _upstream-snapshots/
           if git diff --cached --quiet; then
             echo "Nothing staged after add — skip"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -127,14 +127,14 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 
 **Theme**: Enterprise readiness, community governance, ecosystem integration.
 
-**Planning started (2026-08-08)**: Q4 milestone #3 created; tracking issue #1159 open. **All 9 Q4 goals now tracked** (#1167 branch protection, #1168 governance, #1186 release automation, #1187 package signing/SBOM). Stale dependency refs (#306/#307/#212/#301 closed) still flagged in #1159 — new trackers needed for Tacklebox decoupling and Upstream snapshot automation. Extended 08-08 evening: adoption metrics (#1174) and variant lifecycle policy (#1175) added as strategist-owned goals.
+**Planning started (2026-08-08)**: Q4 milestone #3 created; tracking issue #1159 open. **All 9 Q4 goals now tracked** (#1167 branch protection, #1168 governance, #1186 release automation, #1187 package signing/SBOM, #1194 upstream snapshot automation). Stale dependency refs (#306/#307/#212/#301 closed) still need replacement trackers for Tacklebox decoupling and supply-chain hardening. Extended 08-08 evening: adoption metrics (#1174) and variant lifecycle policy (#1175) added as strategist-owned goals.
 
 **Progress note (2026-08-11)**: keyless Cosign signing + signed SBOM attestations **landed 08-10** for published ISOs and container images (#1303, #1305) — first Q4 supply-chain deliverable. Remaining scope for #1187: signed SBOMs for **every** release artifact across all flavors (blocked on Releases cadence parity #1254) and tunaos-packages artifacts. Package sourcing policy (#1319/#1323) drafted as [PACKAGE-SOURCING.md](./PACKAGE-SOURCING.md) — source inventory feeds the #1187 attestation graph in Q4.
 
 | Goal | Owner | Dependencies |
 |------|-------|--------------|
 | Tacklebox decoupling | architect | #306 (closed — needs new tracker) |
-| Upstream snapshot automation | ci-maintainer | #307 (closed — needs new tracker) |
+| Upstream snapshot automation | ci-maintainer | [#1194](https://github.com/tuna-os/tunaos/issues/1194); [scheduled snapshot workflow](.github/workflows/snapshot-upstreams.yml) |
 | Branch protection + required CI | strategist | CI health, #1167 |
 | Supply chain hardening | sec-check | #212, #301 (closed — needs new tracker) |
 | Release automation | ci-maintainer | CI health, VERSIONING.md, #1186 |


### PR DESCRIPTION
## Summary

- update the Q4 roadmap to use #1194 as the upstream snapshot tracker
- link the live scheduled snapshot workflow from the roadmap
- fetch and check out an existing dated snapshot branch before force-with-lease

## Why

The snapshot workflow reuses a stable branch for same-week reruns, but the default checkout does not fetch that branch. A rerun could therefore fail at `git push --force-with-lease` even when the branch and PR were valid. This change makes the scheduled automation reliably update its existing review PR.

## Validation

- `git diff --check`
- `bash -n scripts/sync-upstream-snapshots.sh`
- `bats` and `actionlint` were unavailable in the environment

Closes #1194

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789197388&installation_model_id=429180&pr_number=1437&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1437&signature=395fb8ef6529ebe466b7b312856d157218bd1825dcca4e3a48a1c3118fe14618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->