### PR TITLE
planning: re-track Supply chain hardening Q4 goal under #1193

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -127,7 +127,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 
 **Theme**: Enterprise readiness, community governance, ecosystem integration.
 
-**Planning started (2026-08-08)**: Q4 milestone #3 created; tracking issue #1159 open. **All 9 Q4 goals now tracked** (#1167 branch protection, #1168 governance, #1186 release automation, #1187 package signing/SBOM). Stale dependency refs (#306/#307/#212/#301 closed) still flagged in #1159 — new trackers needed for Tacklebox decoupling and Upstream snapshot automation. Extended 08-08 evening: adoption metrics (#1174) and variant lifecycle policy (#1175) added as strategist-owned goals.
+**Planning started (2026-08-08)**: Q4 milestone #3 created; tracking issue #1159 open. **All 9 Q4 goals now tracked** (#1167 branch protection, #1168 governance, #1186 release automation, #1187 package signing/SBOM). Stale dependency refs (#306/#307/#212/#301 closed) still flagged in #1159. Extended 08-08 evening: adoption metrics (#1174) and variant lifecycle policy (#1175) added as strategist-owned goals. **Update 08-13**: Supply chain hardening re-tracked under #1193 (was #212/#301, both closed) — the last of the 3 untracked Q4 goals fixed; Tacklebox decoupling and Upstream snapshot automation (#306/#307 closed) still need new trackers.
 
 **Progress note (2026-08-11)**: keyless Cosign signing + signed SBOM attestations **landed 08-10** for published ISOs and container images (#1303, #1305) — first Q4 supply-chain deliverable. Remaining scope for #1187: signed SBOMs for **every** release artifact across all flavors (blocked on Releases cadence parity #1254) and tunaos-packages artifacts. Package sourcing policy (#1319/#1323) drafted as [PACKAGE-SOURCING.md](./PACKAGE-SOURCING.md) — source inventory feeds the #1187 attestation graph in Q4.
 
@@ -136,7 +136,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | Tacklebox decoupling | architect | #306 (closed — needs new tracker) |
 | Upstream snapshot automation | ci-maintainer | #307 (closed — needs new tracker) |
 | Branch protection + required CI | strategist | CI health, #1167 |
-| Supply chain hardening | sec-check | #212, #301 (closed — needs new tracker) |
+| Supply chain hardening | sec-check | #1193 (tracker; #212/#301 closed) — coordinates with #1187 (package signing/SBOM is the largest hardening item, tracked there in detail) |
 | Release automation | ci-maintainer | CI health, VERSIONING.md, #1186 |
 | Community governance model | strategist | #1168 |
 | Package signing / SBOM | sec-check | Supply chain, #1187 |


### PR DESCRIPTION
## Summary

#1193 found the Q4 "Supply chain hardening" goal pointing at closed dependency refs (#212, #301) with no replacement tracker — the last of the 3 untracked Q4 goals (alongside Tacklebox decoupling and Upstream snapshot automation).

- `ROADMAP.md`'s Q4 goals table: the "Supply chain hardening" row now points at #1193 instead of the closed #212/#301, with an explicit coordination note pointing at #1187 (package signing/SBOM is the largest hardening item and is already tracked in detail there — avoids the two issues duplicating scope, per #1193's own "coordinate with #1187" instruction).
- The Q4 planning summary paragraph now records this fix and clarifies only Tacklebox decoupling and Upstream snapshot automation remain untracked (both still point at closed issues #306/#307).

#1193 is already milestone-assigned to Q4 2026 - Mature, so no milestone change was needed.

## Test plan
- [x] Confirmed #212 and #301 are closed (per the issue's own finding)
- [x] Confirmed #1193 carries the Q4 2026 - Mature milestone already
- [x] Checked #1187 for scope overlap — it covers package signing/SBOM specifically; #1193 is the broader supply-chain tracker, so the coordination note avoids ambiguity without merging the two

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `8942c9f7`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->