### PR TITLE
ci: publish all stable desktop release streams

### DIFF
--- a/.github/workflows/generate-changelog-release.yml
+++ b/.github/workflows/generate-changelog-release.yml
@@ -53,7 +53,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stream: ${{ github.event_name == 'workflow_dispatch' && fromJson(format('[\"{0}\"]', inputs.stream)) || fromJson('["gnome"]') }}
+        # Keep the scheduled Releases surface in parity with the stable
+        # desktop streams built nightly. Manual dispatch remains scoped to
+        # the requested stream so it can be used for targeted catch-up runs.
+        stream: ${{ github.event_name == 'workflow_dispatch' && fromJson(format('[\"{0}\"]', inputs.stream)) || fromJson('["gnome", "kde", "xfce", "cosmic", "niri"]') }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- publish scheduled GitHub Releases for all stable desktop streams: gnome, kde, xfce, cosmic, and niri
- keep workflow dispatch targeted to the requested stream for catch-up runs

## Why

The scheduled matrix was hard-coded to `gnome`, even though the nightly image builds produce the other stable desktop streams. As a result, their GitHub Release assets became stale despite current builds being available.

## Validation

- `git diff --check`

Closes #1254

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789198234&installation_model_id=429180&pr_number=1441&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1441&signature=661ab468c386dfa903b49fe1699beed358363d8f82ec5f30314f0bfa4e632588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->