### PR TITLE
docs: clarify GNOME/bootc-installer is out of scope for the fisherman recipe contract

### DIFF
--- a/docs/INSTALLER-FRONTENDS.md
+++ b/docs/INSTALLER-FRONTENDS.md
@@ -10,8 +10,11 @@ TunaOS ships **five independently-forked installer frontends**, one per desktop:
 | XFCE | `org.tunaos.InstallerXfce` | fork of bootc-installer |
 | GNOME | `org.bootcinstaller.Installer` | upstream, unmodified |
 
-They all drive the same backend (**fisherman**, via `recipe.json`), but the UIs
-are separate codebases. **Feature drift is therefore the default failure mode**:
+The four TunaOS-forked frontends (KDE, COSMIC, Niri, XFCE) all drive the same
+backend (**fisherman**, via `recipe.json`); GNOME is unmodified upstream
+bootc-installer with its own disk backend (see §3–§5 below). The UIs are
+separate codebases regardless. **Feature drift is therefore the default
+failure mode**:
 a screen or recipe field wired up in one fork silently never lands in the others.
 Nothing about "it built" or "it launched" catches that — this page does.
 
@@ -124,9 +127,11 @@ drift is *visible* before we promote them to required.
 ## Behavior contract
 
 The screen contract above only covers *what renders*. Five more behaviors are
-reimplemented by **each** frontend in its own language (Rust, C++, Go, Python,
-plus upstream bootc-installer) because the frontends share no code. These are
-the contracts those implementations must agree on — they are what a parity
+reimplemented — three of them (§3–§5) across the four TunaOS-forked frontends
+only (Rust, C++, Go, Python — GNOME/bootc-installer does not participate, see
+§3's note), two of them (§1–§2) across all five including upstream
+bootc-installer — because the frontends share no code. These are the
+contracts those implementations must agree on — they are what a parity
 check (and a sixth frontend) should be written against. Filed as
 [#1197](https://github.com/tuna-os/tunaOS/issues/1197).
 
@@ -176,6 +181,15 @@ describes the *runtime*, not the live ISO):
 
 Resolved once and cached: the value cannot change while the installer runs.
 A harness override may exist for screenshot capture, but must be explicit.
+
+§3–§5 below describe the four TunaOS-forked frontends (KDE, COSMIC, Niri,
+XFCE) — the ones that drive fisherman via `recipe.json`. GNOME
+(`org.bootcinstaller.Installer`) is upstream bootc-installer, unmodified: a
+repo search turns up zero references to `fisherman` or `recipe.json` anywhere
+in its source. It owns its own disk-partitioning and encryption logic and is
+out of scope for §3–§5's contracts; only §1 (readiness stamp) and §2
+(product-name resolution) apply to it, and both already list it in their
+tables above.
 
 ### §3 Privilege escalation
 


### PR DESCRIPTION
## Summary

#1197's core recommendation #2 ("document the five behaviors in INSTALLER-FRONTENDS.md as a machine-checkable contract") turned out to already be done — `docs/INSTALLER-FRONTENDS.md` already has a full "Behavior contract" section (§1–§5) citing #1197 directly.

While verifying that section against the actual frontend repos before deciding what else to do, I found one inaccuracy: the doc's intro claims all five frontends "drive the same backend (fisherman, via recipe.json)". A repo-wide code search on `tuna-os/bootc-installer` (the GNOME frontend, "upstream, unmodified") turns up **zero** references to `fisherman` or `recipe.json` anywhere in its source — it owns its own disk-partitioning/encryption logic (e.g. `bootc_installer/views/recovery_key.py`), unrelated to fisherman's recipe format.

This matters because §3 (privilege escalation via fisherman), §4 (offline detection via `TUNA_OFFLINE_STORES`/recipe), and §5 (fisherman's four encryption ids) don't apply to GNOME — only §1 (readiness stamp) and §2 (product-name resolution) do, and both already correctly list it in their tables. Left uncorrected, the doc reads as if a future parity check (recommendation #3) should verify GNOME against §3–§5, which it structurally cannot.

Changes:
- Intro table's summary sentence now distinguishes the four fisherman-driven forks from GNOME's separate backend.
- "Behavior contract" section intro now states which behaviors apply to all five vs. the four forks only.
- New note at the top of §3 making the scope explicit, with the negative-search evidence.

Recommendation #1 (extend fisherman with backend-owned queries) and #3 (a parity check diffing the five implementations' emitted answers) are both larger, cross-repo follow-ups — #1 is new backend surface in the `fisherman` repo, and #3 needs each frontend to emit machine-readable answers for §3–§5 that mostly don't exist yet (only §1's readiness stamp does today, per the doc's own parity matrix). Left for separate work.

## Test plan
- [x] `gh api search/code -f q="fisherman repo:tuna-os/bootc-installer"` and `q="recipe.json repo:tuna-os/bootc-installer"` — both zero results
- [x] Confirmed `bootc_installer/views/recovery_key.py` exists (GNOME has its own encryption UX, just not the fisherman recipe-id contract)
- [x] Cross-checked §1/§2's existing tables already list GNOME/bootc-installer correctly — only §3–§5 needed the scoping note

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `c073428f`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->