### PR TITLE
security: prevent credentials in workflow URLs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,6 +51,9 @@ and the signature is recorded in Sigstore's transparency infrastructure. See
 - Release promotion requires successful keyless signature and SBOM-attestation
   verification against the expected repository workflow and protected ref
 - Build secrets use BuildKit secret mounts, never environment variables
+- Workflow credentials must not be embedded in URLs; use header-based Git
+  authentication (for example, `http.extraheader`) when a private checkout
+  is required
 - RPM packages from official AlmaLinux/CentOS/Fedora repositories and verified COPRs
 
 ## Disclosure Policy

--- a/tests/bats/test_secret_transport.bats
+++ b/tests/bats/test_secret_transport.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+# Credentials interpolated into URLs are persisted in git remotes and can
+# leak through diagnostics, process listings, or error output. Keep workflow
+# authentication transport-safe even when a future private checkout is added.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+WORKFLOWS="${REPO_ROOT}/.github/workflows"
+
+@test "active workflows do not interpolate repository secrets into URLs" {
+  run grep -R -E \
+    'https?://[^[:space:]]*\$\{\{[[:space:]]*secrets\.' \
+    "$WORKFLOWS" --exclude-dir=archive
+  [ "$status" -ne 0 ]
+}
+
+@test "active workflows do not interpolate token variables into URLs" {
+  run grep -R -E \
+    'https?://[^[:space:]]*\$\{[A-Za-z_][A-Za-z0-9_]*TOKEN\}' \
+    "$WORKFLOWS" --exclude-dir=archive
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

- document the rule that workflow credentials must not be embedded in URLs
- add regression tests covering both GitHub Actions secret interpolation and token environment variables in active workflows

## Context

Issue #1257 identified `FLATPAK_INDEX_TOKEN` embedded in clone URLs across eight additional active repositories. Those repository-specific fixes are tracked by their own PRs; TunaOS itself has no such active workflow reference. This change adds a local guard so the unsafe transport pattern cannot be reintroduced here.

## Validation

- equivalent grep checks passed locally
- `git diff --check` passed
- Bats was unavailable in the local environment, so the test file was not run through the Bats harness

Closes #1257

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789198458&installation_model_id=429180&pr_number=1443&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1443&signature=6897d8a47f9862cf830731d51135883ddc8bafc94ceb831130954c5e9aaa888d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->