### PR TITLE
Enforce variant admission metadata in PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- Describe what this pull request changes and why. -->
+
+## Portfolio admission
+
+<!-- Complete this section for any new or removed base variant, desktop flavor,
+hardware/kernel profile (including T2, Asahi, or HWE), or output architecture. -->
+
+- [ ] This PR does not change the TunaOS portfolio.
+- [ ] This is a portfolio change, and the admission gate is complete:
+  - [ ] The ROADMAP row is linked: <!-- e.g. ROADMAP.md#... -->
+  - [ ] The row names an owner and acceptance criteria.
+  - [ ] Capacity confirmation is documented, or the change is explicitly deferred by the current capacity gate.
+  - [ ] Upstream base availability is confirmed.
+  - [ ] The tracking issue is linked and has the `roadmap` label.
+
+Portfolio changes cannot merge until the admission checklist is complete. See
+[VARIANT-LIFECYCLE.md](../VARIANT-LIFECYCLE.md#1-proposal--admission-gate-1196)
+for the full policy.
+
+## Validation
+
+<!-- List tests, checks, or hardware validation performed. -->

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,6 +115,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | Populate Q3 milestone | strategist | #562 | ✅ Done (2026-08-08, 9 issues) |
 | **User-proven ISO installs roadmap** | ci-maintainer | #763 | 🟡 In progress (Phase 1 baseline dispatched #761; GUI gate #577) |
 | **Apple Silicon (Asahi Linux) support** | architect / ci-maintainer | #781 | 🟡 In progress (Bonito & Grouper 36/36 verified #776; D0–D4 installer track active) |
+| **Bonito `gnome-t2` hardware profile** | ci-maintainer | #1270, #1256 | 🔴 Deferred — admission row for the T2 profile; acceptance requires capacity confirmation, T2 build/boot evidence, and maintainer approval after the no-new-flavors gate (2026-09-30) |
 | **Desktop parity floor (non-RPM bases)** | packaging | #133, tunaos-packages#323 | ⬜ Not started — P0 for Q4 (see #1294) |
 | **Q3 checkpoint (08-22): staff or descope #272/#1123/#1093/#1094** | strategist | #1299 | ⬜ Scheduled |
 | **Flavor equality mandate (docs wording + cadence parity)** | strategist | #1315, #1254 | 🟡 In progress — catalog parity gate merged 08-11 (#1322, #1281 closed); cadence parity pending (#1316) |


### PR DESCRIPTION
## What changed

- add the missing ROADMAP admission row for the `bonito:gnome-t2` hardware profile
- add a pull-request template checklist for portfolio admission requirements

## Why

Issue #1270 identified that the variant lifecycle gate was documented but did not give contributors a structural PR-time reminder. The T2 profile is recorded as deferred under the interim no-new-flavors gate, with an owner, tracking references, and acceptance criteria.

## Validation

- `git diff --check`

Closes #1270

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789198658&installation_model_id=429180&pr_number=1444&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1444&signature=7aca9019852745caff7f303ec2b1a38647f880a268691950e3f68c4b9967fc4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->