### PR TITLE
planning: record good-first-issue/help-wanted label pool now non-empty

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -109,7 +109,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | Migration guide (Silverblue/Kinoite/UB) | guide | #273 | ✅ Done (MIGRATION.md) |
 | mdBook → tunaos.org centralized | guide | — | ✅ Done |
 | Versioning policy documented | strategist | #274 | ✅ Done (VERSIONING.md, date-based + tiers) |
-| **External contributor onboarding / Hacktoberfest 2026** | guide / strategist | #1331, #1347 | 🟡 In progress — GFI pool 0→5 (08-13, #1277: `good first issue` and `help wanted` both non-empty for the first time — #1308/#1350/#1351/#1366/#1385); hard deadline: 10-15 curated issues by 09-15, registration ~09-01 |
+| **External contributor onboarding / Hacktoberfest 2026** | guide / strategist | #1331, #1347, #1362 | 🟡 In progress — org-wide GFI pool 0→9 (08-13): tunaos 5 (#1277), docs 3, protota 1 (#193, newly tagged). #1362's real target is **20+ across 8 repos by 09-15**; `bootc-installer` has issues **disabled entirely** (structural blocker, needs re-enabling or dropping from the target list) and `letters` is archived (its 1 tag doesn't count) |
 | Weekly boot report as build gate | ci-maintainer | #989 | 🟡 In progress |
 | Outreach sequencing | strategist | #563 | ✅ Done (gate lifted) |
 | Populate Q3 milestone | strategist | #562 | ✅ Done (2026-08-08, 9 issues) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -109,7 +109,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | Migration guide (Silverblue/Kinoite/UB) | guide | #273 | ✅ Done (MIGRATION.md) |
 | mdBook → tunaos.org centralized | guide | — | ✅ Done |
 | Versioning policy documented | strategist | #274 | ✅ Done (VERSIONING.md, date-based + tiers) |
-| **External contributor onboarding / Hacktoberfest 2026** | guide / strategist | #1331, #1347 | 🟡 In progress — GFI pool seeded 0→3 (08-11); hard deadline: 10-15 curated issues by 09-15, registration ~09-01 |
+| **External contributor onboarding / Hacktoberfest 2026** | guide / strategist | #1331, #1347 | 🟡 In progress — GFI pool 0→5 (08-13, #1277: `good first issue` and `help wanted` both non-empty for the first time — #1308/#1350/#1351/#1366/#1385); hard deadline: 10-15 curated issues by 09-15, registration ~09-01 |
 | Weekly boot report as build gate | ci-maintainer | #989 | 🟡 In progress |
 | Outreach sequencing | strategist | #563 | ✅ Done (gate lifted) |
 | Populate Q3 milestone | strategist | #562 | ✅ Done (2026-08-08, 9 issues) |


### PR DESCRIPTION
## Summary

#1277 found the onboarding loop broken at the label level: CONTRIBUTING.md advertised `good first issue` and `help wanted` labels, but `is:open label:"good first issue"` returned zero results (verified 2026-08-10) — the doc pointed at an empty query.

Fixed the actual gap directly via the Issues API (not a file change, so no diff for it): applied `help wanted` alongside the existing `good first issue` label to the 5 starter issues already curated for this purpose (#1308, #1350, #1351, #1366, #1385 — all open, docs-only, independent of the build pipeline). Verified via `gh issue view --json labels` on all 5 after tagging. Both label queries are now non-empty for the first time.

This PR is just the ROADMAP.md bookkeeping: updates the "External contributor onboarding" Q3 row from the stale "GFI pool 0→3 (08-11)" note to the current, verified 0→5 count and cites #1277 as the issue that got it there.

Note: the CONTRIBUTING.md doc-side improvement this issue's recommendation also touches (fork→PR loop instructions, explicit starter-issue list, a weekly-triage habit — which directly implements #1277's recommendation #2) is already covered by my earlier open PR #1427, which is unmerged but rebases cleanly onto current main. Not duplicating that content here.

## Test plan
- [x] `gh issue view <n> --json labels` on all 5 issues — confirmed both `good first issue` and `help wanted` present
- [x] Confirmed `help wanted` label already existed org-wide (`gh label list --search "help wanted"`) — no label creation needed
- [x] Checked PR #1427 still applies cleanly to current upstream/main (`git merge-base --is-ancestor` — yes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `e7ad97fc`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->