### PR TITLE
Enforce published desktop completeness

### DIFF
--- a/.github/workflows/desktop-contract-sweep.yml
+++ b/.github/workflows/desktop-contract-sweep.yml
@@ -243,6 +243,15 @@ jobs:
             echo "::error::baseline does not reconcile: ${pass}+${fail}+${miss}+${err}+${lost} != ${total}"
             exit 1
           fi
+
+          # A baseline is useful only when every expected cell is healthy.
+          # Keep missing, infrastructure-error, and lost results non-passing:
+          # otherwise a published edition can disappear from the evidence and
+          # still look green to the release process (#1294).
+          if (( fail + miss + err + lost > 0 )); then
+            echo "::error::desktop completeness gate failed: ${fail} failed, ${miss} missing, ${err} errored, ${lost} lost"
+            exit 1
+          fi
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: desktop-contract-baseline

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,7 +115,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | Populate Q3 milestone | strategist | #562 | ✅ Done (2026-08-08, 9 issues) |
 | **User-proven ISO installs roadmap** | ci-maintainer | #763 | 🟡 In progress (Phase 1 baseline dispatched #761; GUI gate #577) |
 | **Apple Silicon (Asahi Linux) support** | architect / ci-maintainer | #781 | 🟡 In progress (Bonito & Grouper 36/36 verified #776; D0–D4 installer track active) |
-| **Desktop parity floor (non-RPM bases)** | packaging | #133, tunaos-packages#323 | ⬜ Not started — P0 for Q4 (see #1294) |
+| **Desktop completeness parity (non-RPM bases)** | ci-maintainer / packaging | #1294, tunaos-packages#132, #133 | 🟡 In progress — published-tag desktop contract is now a gate; remediate sailfin, flounder, and grouper editions below the completeness floor |
 | **Q3 checkpoint (08-22): staff or descope #272/#1123/#1093/#1094** | strategist | #1299 | ⬜ Scheduled |
 | **Flavor equality mandate (docs wording + cadence parity)** | strategist | #1315, #1254 | 🟡 In progress — catalog parity gate merged 08-11 (#1322, #1281 closed); cadence parity pending (#1316) |
 | **NVIDIA flavor family (6 editions, 0 assets since 07-05)** | ci-maintainer | #1383 | 🔴 Broken — nightly overlay regressed 08-12 (#1382); staff test: nightly green + gnome-nvidia assets republished by 09-01 (#1376/#1379) |

--- a/VARIANT-LIFECYCLE.md
+++ b/VARIANT-LIFECYCLE.md
@@ -64,6 +64,28 @@ capacity — before the first build job lands.
 - Desktop contract: at minimum a session starts (#916); `*-nvidia` and ZFS
   flavors additionally pass their flavor-specific smoke checks.
 
+### 2a. Published-edition completeness gate (#1294)
+
+Every declared `variant × desktop` edition must pass the desktop contract
+against the image tag that is actually published. A build-time pass is not
+enough: the scheduled `desktop-contract-sweep.yml` workflow rechecks the
+published tag and treats a failed, missing, errored, or lost result as a gate
+failure.
+
+Package-count and compressed-size deltas are useful audit signals, but they
+are not a portable completeness threshold across Fedora/EL, Debian/Ubuntu,
+openSUSE, Arch, and Gentoo. A small delta therefore requires both:
+
+1. the desktop contract's required session, display-manager, application,
+   portal, and supporting-service checks to pass; and
+2. an explicit ROADMAP-linked waiver naming the owner, affected edition,
+   evidence, remediation, and expiry date.
+
+An edition with no desktop-specific package or runtime evidence cannot be
+promoted or advertised as complete. The non-RPM parity audit and its
+remediation are tracked in ROADMAP under #1294 and
+tuna-os/tunaos-packages#132/#133.
+
 ### 3. Stable — promotion criteria (#1175)
 
 Promotion Beta → Stable requires **all** of:


### PR DESCRIPTION
## What changed

- add a dedicated ROADMAP deliverable for non-RPM desktop completeness parity
- define the published-edition completeness gate in `VARIANT-LIFECYCLE.md`
- make the desktop contract sweep fail when any expected cell fails, is missing, errors, or produces no result

## Why

Issue #1294 identified 24 of 37 published editions whose package/size evidence was too small to contain a usable desktop. The existing sweep recorded those outcomes but did not fail the workflow, allowing a non-green baseline to look successful. This change makes the published image contract authoritative while requiring explicit, time-bounded waivers for legitimate cross-distro size differences.

## Validation

- `git diff --check`
- Reviewed the workflow shell changes; `actionlint` and `yamllint` are not installed locally.

Closes #1294

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789199130&installation_model_id=429180&pr_number=1447&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1447&signature=8bc6b65541e40eb3c6e555a1aa0ef672e00748f7cac332a5c9c69d033d12b177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->