### PR TITLE
planning: refresh Q3 checkpoint risk inputs

### DIFF
--- a/Q3_CHECKPOINT-2026-08-22.md
+++ b/Q3_CHECKPOINT-2026-08-22.md
@@ -1,7 +1,7 @@
 # Q3 2026 Checkpoint — Decision Sheet (2026-08-22)
 
 **Milestone**: Q3 2026 "Expand Coverage" (closes 2026-09-30)
-**Tracker**: #1299 | **Prepared**: 2026-08-11 | **Last refreshed**: 2026-08-12 (T-10) | **Decision authority**: maintainer
+**Tracker**: #1299 | **Prepared**: 2026-08-11 | **Last refreshed**: 2026-08-13 (T-9) | **Decision authority**: maintainer
 
 ## Purpose
 
@@ -31,6 +31,13 @@ Make Q3 carryover an explicit decision, not a discovery. For every open Q3 goal,
 | Flavor equality | #1315 / #1316 | Catalog parity gate merged 08-11 (#1322, closes #1281); scheduled cadence parity pending (#1254) | STAFF cadence parity in Q3, or descope to Q4 with owner |
 | Package sourcing | #1319 / #1323 | PACKAGE-SOURCING.md drafted (PR #1330 open); third-party allowlist + per-variant audit outstanding | STAFF — merge policy doc by 08-22; audit due at checkpoint |
 
+### Operational blockers added 2026-08-12–13 (must also be framed)
+
+| Blocker | Issue | Evidence | Decision needed |
+|---------|-------|----------|----------------|
+| NVIDIA flavor family | #1383 | All six NVIDIA releases have shipped zero assets since 07-05/07-12; overlay failures remain red in the 08-13 nightly matrix (#1376/#1379/#1382) | STAFF only if nightly builds are green and `gnome-nvidia` assets are republished by 09-01; otherwise DESCOPE the all-flavors Q3 claim |
+| Publish-path resilience | #1377 / #1187 | `rekor.sigstore.dev` 502s have blocked variant image builds since 08-07, including the 08-13 nightly; downstream Gate/Promote jobs cannot proceed | Carry the resilience requirement into Q4 #1187: retry/backoff plus offline attestation or an alternate transparency log |
+
 ### Supporting items for the checkpoint
 
 - **Contributor retention → capacity**: shimonenator is ACTIVE (8 commits 08-10/11 across tunaOS + xfce-linux; last 08-11 20:26Z). 14-day window closes ~08-24 — 2 days AFTER this checkpoint. Recommend converting retention into capacity: seed GFI-scoped Bonito/Redfin packaging subtasks for the contributor **at** the checkpoint, so #272/#1123 staff tests can borrow external capacity instead of maintainer-only time.
@@ -39,6 +46,7 @@ Make Q3 carryover an explicit decision, not a discovery. For every open Q3 goal,
 - **Release parity**: GNOME releases are now daily (08-09 → 08-11, 3 assets each). kde/xfce/niri/gnome-nvidia still stale 30–37 days (#1254). Browser-catalog parity gate (#1322) fixed the on-demand path; the scheduled GitHub Releases pipeline remains GNOME-only.
 - **New planning debt (mid-cycle)**: wootc ROADMAP merged (wootc#116) but CONTRIBUTING/LICENSE still missing (#1358); gtk-office-suite planning gap open (#1359); tromso stable release untracked (no releases, no milestones — core build tooling; filed as new tracker this cycle).
 - **Enterprise posture**: ADOPTERS.md empty vs Q4 "Mature" claim (#1348); RHEL10/AlmaLinux topics on repo but Redfin alpha dropped (#1123); branch protection unverified (#1167).
+- **Nightly reliability (08-13)**: the rekor outage is now a week-long recurring SPOF (#1377), while GHCR arm64 login failures add a second failure class. GNOME ISO daily releases remain unaffected because they use a separate path.
 
 ## Strategist recommendation (input — decision authority stays with maintainer)
 
@@ -61,6 +69,7 @@ Make Q3 carryover an explicit decision, not a discovery. For every open Q3 goal,
 | #1094 ADR coverage | ⬜ | | | |
 | #1316 Flavor equality | ⬜ | | | |
 | #1323 Package sourcing | ⬜ | | | |
+| #1383 NVIDIA flavor family | ⬜ | | | |
 
 ## Outcome recording
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # tunaOS Roadmap
 
-**Last updated**: 2026-08-12 (NVIDIA flavor row + flavor equality mandate) | **Maintainer**: tuna-os (hanthor)
+**Last updated**: 2026-08-13 (Q3 checkpoint refresh: NVIDIA and publish-path blockers) | **Maintainer**: tuna-os (hanthor)
 
 ---
 
@@ -95,6 +95,8 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 
 **Mid-quarter update 3 (2026-08-11)**: maintainer directive #1319 — **package sourcing policy**: default to system repos / tideforge; no PPAs/COPRs/OBS/AUR; build in-house what the base lacks, with a small trusted third-party allowlist. Second directive in 24h; elevates the Q2 COPR-elimination win (#436) into org-wide supply-chain policy (#1323).
 
+**Mid-quarter update 4 (2026-08-13)**: checkpoint inputs now include the NVIDIA flavor family (#1383) and publish-path resilience (#1377/#1187). NVIDIA nightly failures remain reproducible across the matrix, and recurring `rekor.sigstore.dev` 502s have blocked variant image promotion for a week. The 2026-08-22 checkpoint decision sheet records explicit STAFF/DESCOPE criteria for both alongside the original four goals.
+
 | Goal | Owner | Tracking | Status |
 |------|-------|----------|--------|
 | **Fix ISO downloads** | ci-maintainer | #543, #561 | ✅ Done — downloads verified working (R2, 08-07) |
@@ -116,7 +118,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | **User-proven ISO installs roadmap** | ci-maintainer | #763 | 🟡 In progress (Phase 1 baseline dispatched #761; GUI gate #577) |
 | **Apple Silicon (Asahi Linux) support** | architect / ci-maintainer | #781 | 🟡 In progress (Bonito & Grouper 36/36 verified #776; D0–D4 installer track active) |
 | **Desktop parity floor (non-RPM bases)** | packaging | #133, tunaos-packages#323 | ⬜ Not started — P0 for Q4 (see #1294) |
-| **Q3 checkpoint (08-22): staff or descope #272/#1123/#1093/#1094** | strategist | #1299 | ⬜ Scheduled |
+| **Q3 checkpoint (08-22): staff or descope strategic goals and blockers** | strategist | #1299 | ⬜ Scheduled — decision sheet refreshed 08-13; includes #272/#1123/#1093/#1094 plus #1383 and #1377/#1187 |
 | **Flavor equality mandate (docs wording + cadence parity)** | strategist | #1315, #1254 | 🟡 In progress — catalog parity gate merged 08-11 (#1322, #1281 closed); cadence parity pending (#1316) |
 | **NVIDIA flavor family (6 editions, 0 assets since 07-05)** | ci-maintainer | #1383 | 🔴 Broken — nightly overlay regressed 08-12 (#1382); staff test: nightly green + gnome-nvidia assets republished by 09-01 (#1376/#1379) |
 | **Package sourcing policy (system-repos/tideforge-first + allowlist)** | strategist | #1319, #1323 | 🟡 In progress — PACKAGE-SOURCING.md drafted (planning PR open); third-party allowlist + per-variant audit due at 08-22 checkpoint |


### PR DESCRIPTION
## Summary

- Refresh the #1299 Q3 checkpoint sheet with 2026-08-13 nightly evidence.
- Add explicit STAFF/DESCOPE criteria for the broken NVIDIA flavor family.
- Record the recurring rekor signing-path outage as a Q4 resilience dependency.
- Update ROADMAP.md so the checkpoint scope and refresh date are canonical.

## Why

The four original Q3 strategic goals still need an explicit 2026-08-22 decision, and new operational blockers have emerged since the prior refresh. This keeps carryover and descope decisions visible instead of allowing silent milestone drift.

## Validation

- `git diff --check`

Closes #1299

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789199411&installation_model_id=429180&pr_number=1448&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1448&signature=76f40c642678412cc76017c511135e4b154b43da29a18ba08f3e6c387207c37a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->