### PR TITLE
planning: record Q4 milestone attachment fix, add fidelity rule

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -148,6 +148,14 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | **Adoption evidence (ADOPTERS.md production entries)** | strategist | #1348 — zero public production adopters vs "Mature" claim; first entries at 2026-11-01 snapshot |
 | Variant lifecycle policy (Beta→Stable exit criteria) | strategist | #1175 |
 
+**Milestone fidelity (#1307, 2026-08-12)**: 7 of the 9 goal trackers above were
+filed without being attached to the Q4 milestone (#3), so the milestone
+undercounted real progress (e.g. keyless signing landing 08-10 for #1187
+while the milestone still showed 0 closed). All 7 (#1174/#1175/#1186/#1187/
+#1192/#1193/#1194) are now attached. Going forward: **every goal tracker must
+set its milestone at creation**, not as a follow-up sweep — a tracker without
+a milestone is invisible to milestone-based reporting by construction.
+
 ---
 
 ## Technical Debt Backlog


### PR DESCRIPTION
## Summary

#1307's two substantive asks were already done before I picked this up:

- **Milestone attachment**: verified via API that all 7 previously-unattached Q4 goal trackers (#1174, #1175, #1186, #1187, #1192, #1193, #1194) are now attached to milestone #3 (Q4 2026 - Mature) — confirmed by a prior comment on the issue and by `gh issue view --json milestone` on each of the 7. Milestone open-issue count is 11 (4 original + 7 attached).
- **ROADMAP Q4 table refresh**: already has an open, comprehensive PR (#1403) rewriting the whole table with a Status column and current tracker refs. Didn't duplicate that — a second PR touching the same table rows would just conflict with it.

What was still missing: recommendation #3, "add a milestone-fidelity check to the quarterly planning ritual." This PR adds that as a short note in ROADMAP.md's Q4 section (placed after the goals table, not inside it, specifically to avoid conflicting with #1403's in-flight table rewrite) — records what happened and states the going-forward rule: every goal tracker must set its milestone at creation, not get swept up later.

## Test plan
- [x] `gh issue view <n> --json milestone` on all 7 previously-unattached trackers — all show `Q4 2026 - Mature`
- [x] `gh api repos/tuna-os/tunaos/milestones/3` — 11 open issues, confirming the attach landed
- [x] Checked PR #1403 for the roadmap-table portion of this issue's recommendation — already open and covers it; deliberately inserted this note outside the table block it rewrites to minimize merge-conflict surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `82345b5e`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->