### PR TITLE
docs: seed good-first-issue audit brief

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ just fix && just check
 
 ## Good First Issues
 
-New here? Start with issues tagged **[good first issue](https://github.com/tuna-os/tunaOS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)** — a curated, maintainer-sized set of starter tasks covering documentation parity, small script fixes, and test coverage. They are deliberately small, well-scoped, and safe to attempt without deep image-factory knowledge.
+New here? Start with issues tagged **[good first issue](https://github.com/issues?q=is%3Aissue+is%3Aopen+org%3Atuna-os+label%3A%22good+first+issue%22)** — a curated, maintainer-sized set of starter tasks covering documentation parity, small script fixes, and test coverage. If the queue is empty, use the [documentation-parity audit brief](docs/GOOD-FIRST-ISSUES.md) to make a small, self-contained contribution and report the result in [#1308](https://github.com/tuna-os/tunaOS/issues/1308).
 
 Ways to contribute without touching the build pipeline:
 

--- a/docs/GOOD-FIRST-ISSUES.md
+++ b/docs/GOOD-FIRST-ISSUES.md
@@ -1,0 +1,60 @@
+# Good-first-issue starter brief
+
+This page is a fallback when the [organization-wide good-first-issue
+queue](https://github.com/issues?q=is%3Aissue+is%3Aopen+org%3Atuna-os+label%3A%22good+first+issue%22)
+has no usable tasks. It is intentionally documentation-only: no image build,
+registry login, or privileged access is needed.
+
+## Starter task: documentation and download parity
+
+Audit the published editions listed in the [tunaOS download
+catalog](https://tunaos.org/download), using the 37-edition scope from
+[tunaos-packages#133](https://github.com/tuna-os/tunaos-packages/issues/133).
+For each edition, verify both:
+
+1. The edition has a discoverable variant page or catalog entry.
+2. Its download link resolves successfully and points to the intended artifact.
+
+Do not infer a missing desktop from image size alone. The earlier audit found
+that size is only a triage signal; a package/session check or a catalog fact is
+needed before calling an edition broken.
+
+| Variant family | Historical editions to check | Result | Evidence |
+|---|---|---|---|
+| yellowfin | base, gnome, kde, cosmic, niri, xfce | ⬜ | |
+| bonito | base, gnome, kde, cosmic, niri, xfce | ⬜ | |
+| sailfin | gnome, kde, niri, xfce | ⬜ | |
+| flounder | base, gnome, kde, cosmic, niri, xfce | ⬜ | |
+| grouper | gnome, kde, niri, xfce | ⬜ | |
+| marlin | base, gnome, kde, cosmic, niri, xfce | ⬜ | |
+| skipjack | base, gnome, kde, cosmic, niri, xfce | ⬜ | |
+| albacore | base, gnome, kde, cosmic, niri, xfce | ⬜ | |
+| guppy | gnome, kde | ⬜ | |
+
+The table is the historical family checklist used to reproduce the #133
+audit; the catalog is authoritative if the current published set differs from
+it. Note any additions or removals in the result rather than silently changing
+the checklist. The reported 37-edition scope is therefore a baseline to
+reconcile, not a claim that every row above is still published today.
+
+## Acceptance criteria
+
+- Record the date checked, edition, catalog or variant-page URL, download URL,
+  and HTTP/result status.
+- Report missing pages and broken links in a follow-up issue or comment on
+  [#1308](https://github.com/tuna-os/tunaOS/issues/1308), linking the evidence.
+- If all links work, say so explicitly and include the checked-edition count.
+- Keep the change documentation-only; do not “fix” a broken artifact by
+  changing build configuration as part of this starter task.
+
+## Other safe starter areas
+
+Maintainers can turn the following into similarly scoped issues:
+
+- Add a focused shell-test case for an existing script edge case.
+- Improve one troubleshooting page with a reproduced command and output.
+- Add a missing acceptance check to an existing documentation or lifecycle
+  checklist.
+
+When claiming a starter issue, comment on it first and keep the pull request
+focused on its acceptance criteria.


### PR DESCRIPTION
## Summary

- Add a documentation-only starter brief for the 37-edition parity audit from tunaos-packages#133.
- Define evidence and acceptance criteria for checking variant pages and download links.
- Update CONTRIBUTING.md to use an organization-wide good-first-issue search and link the fallback brief.

## Why

The advertised starter-issue label can be empty, leaving new contributors without a bounded task. This brief gives them a safe, self-contained documentation audit and a clear place to report findings, while avoiding unsupported conclusions from image size alone.

## Validation

- `git diff --check`
- Confirmed the branch is based on `upstream/main` and the working tree is clean.

Closes #1308

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789199648&installation_model_id=429180&pr_number=1450&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1450&signature=fbe79e0975cdb9688c107544d85b8a951f431e689aa675e2d73291ed37b883e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->