### PR TITLE
docs: make flavor equality policy explicit

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -23,9 +23,10 @@ iso_groups:
   # Additional desktop ISO group (KDE/COSMIC/Niri/XFCE). NOT published as a
   # single grouped ISO — the browser ISO Builder (https://iso.tunaos.org) covers these on
   # demand from the published images, so we don't carry the cost of a
-  # 5-flavor offline-store ISO for the long tail. The images still build
-  # and publish to GHCR; only the grouped ISO is skipped.
-  # (Manually publishable via workflow_dispatch group=community if needed.)
+  # 5-flavor offline-store ISO for the remaining desktop set. The images still
+  # build and publish to GHCR; only the grouped ISO is skipped.
+  # (Manually publishable via workflow_dispatch group=community if needed; the
+  # suffix is retained for workflow compatibility, not as a support tier.)
   - suffix: community
     publish: false
     flavors: [kde-nvidia, cosmic-nvidia, niri-nvidia, xfce-nvidia]
@@ -575,7 +576,7 @@ variants:
     # Note: linux/amd64/v2 intentionally omitted — verify builder support before adding.
     platforms: ["linux/amd64", "linux/arm64"]
     # Flavor strategy: Fedora ships the latest kernel and GNOME by default,
-    # so HWE layers are only provided for gnome (the primary desktop).
+    # so HWE layers are only provided for gnome (the default desktop image).
     # GNOME 50 is EL10-specific and not needed on Fedora.
     # gnome-nvidia-hwe (stage 4) omitted for now — kernel compatibility TBD.
     flavors:

--- a/.github/workflows/publish-iso-groups.yml
+++ b/.github/workflows/publish-iso-groups.yml
@@ -24,7 +24,7 @@ on:
           - bonito
           - grouper
       group:
-        description: 'ISO group (all = flagship + community + nvidia)'
+        description: 'ISO group (all = default desktop + additional desktop + nvidia)'
         required: false
         default: 'all'
         type: choice
@@ -66,7 +66,7 @@ jobs:
         run: |
           # Emit one matrix entry per (variant, group) whose intersection of
           # group flavors with the variant's build_image flavors is non-empty.
-          # "default"/'' is the flagship group; its ISO has no suffix.
+          # "default"/'' is the default desktop group; its ISO has no suffix.
           MATRIX=$(yq -o=json .github/build-config.yml | jq -c \
             --arg wv "$WANT_VARIANT" --arg wg "$WANT_GROUP" '
             [ .variants[] as $var
@@ -79,7 +79,7 @@ jobs:
               | select($wg == "all"
                        or ($wg == "default" and $suffix == "")
                        or $wg == $suffix)
-              # Skip publish:false groups (builder-only, e.g. community)
+              # Skip publish:false groups (builder-only, e.g. additional desktop)
               # UNLESS the dispatch names that exact suffix.
               | select(($g.publish != false) or ($wg == $suffix))
               | {
@@ -89,11 +89,11 @@ jobs:
                   basename: (if $suffix == "" then $var.id else "\($var.id)-\($suffix)" end)
                 }
             ] | { include: . }')
-          # Probe the registry: a variant whose flagship image was never
+          # Probe the registry: a variant whose default desktop image was never
           # published (e.g. rawhide while its image gates are red) is
           # SKIPPED with a warning instead of hard-failing the matrix —
           # the publish pipeline ships what exists. A variant with a
-          # published flagship keeps failing loudly if other flavors of
+          # published default desktop keeps failing loudly if other flavors of
           # its group are missing (that is a real regression signal).
           PRUNED='[]'
           for row in $(echo "$MATRIX" | jq -cr '.include[] | @base64'); do

--- a/Justfile
+++ b/Justfile
@@ -202,7 +202,7 @@ iso variant='skipjack' flavor='gnome' repo='local' tag='' dev='0':
     sudo -E bash ./scripts/build-iso-tacklebox.sh "{{ variant }}" "{{ flavor }}" "$_repo" "$_tag" "{{ dev }}"
 
 # Build ONE combined dedup ISO containing every desktop in an iso_group (#455).
-# group: '' / default (flagship gnome+hwe), community (kde/cosmic/niri), nvidia.
+# group: '' / default (gnome+hwe), community (kde/cosmic/niri), nvidia.
 iso-group variant='yellowfin' group='default' repo='ghcr':
     # --preserve-env: the inner sudo must not strip the CI-pinned tacklebox
     # source build vars (a plain sudo here silently fell back to the stale

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Image tags are constructed as `<desktop>[-hardware]`:
    * `kde`: KDE Plasma
    * `cosmic`: COSMIC Desktop
    * `niri`: Niri (tiling Wayland compositor)
-   * `xfce`: XFCE (Wayland experimental)
+   * `xfce`: XFCE (Wayland session)
    * `base`: Plain system image with no desktop environment pre-installed (available for most variants)
 
 2. **Hardware Suffixes** (append to any desktop suffix):

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # tunaOS Roadmap
 
-**Last updated**: 2026-08-12 (NVIDIA flavor row + flavor equality mandate) | **Maintainer**: tuna-os (hanthor)
+**Last updated**: 2026-08-13 (flavor equality acceptance criteria + cadence parity sequencing) | **Maintainer**: tuna-os (hanthor)
 
 ---
 
@@ -117,7 +117,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | **Apple Silicon (Asahi Linux) support** | architect / ci-maintainer | #781 | 🟡 In progress (Bonito & Grouper 36/36 verified #776; D0–D4 installer track active) |
 | **Desktop parity floor (non-RPM bases)** | packaging | #133, tunaos-packages#323 | ⬜ Not started — P0 for Q4 (see #1294) |
 | **Q3 checkpoint (08-22): staff or descope #272/#1123/#1093/#1094** | strategist | #1299 | ⬜ Scheduled |
-| **Flavor equality mandate (docs wording + cadence parity)** | strategist | #1315, #1254 | 🟡 In progress — catalog parity gate merged 08-11 (#1322, #1281 closed); cadence parity pending (#1316) |
+| **Flavor equality mandate (docs wording + cadence parity)** | strategist / ci-maintainer | #1315, #1316, #1254 | 🟡 In progress — tier language retired in docs and lifecycle policy; cadence parity is the first deliverable: schedule KDE/COSMIC/Niri/XFCE releases or record an explicit tunaos.org-only cadence per flavor |
 | **NVIDIA flavor family (6 editions, 0 assets since 07-05)** | ci-maintainer | #1383 | 🔴 Broken — nightly overlay regressed 08-12 (#1382); staff test: nightly green + gnome-nvidia assets republished by 09-01 (#1376/#1379) |
 | **Package sourcing policy (system-repos/tideforge-first + allowlist)** | strategist | #1319, #1323 | 🟡 In progress — PACKAGE-SOURCING.md drafted (planning PR open); third-party allowlist + per-variant audit due at 08-22 checkpoint |
 

--- a/VARIANT-LIFECYCLE.md
+++ b/VARIANT-LIFECYCLE.md
@@ -12,6 +12,15 @@ grows without a capacity plan and no variant ever reaches GA — the treadmill
 risk flagged in #1175, now observable on the **entry** side (#1185 ZFS root,
 #1191 `*-nvidia`, opened the same day #1196 was filed).
 
+### Flavor equality (#1315/#1316)
+
+Every supported desktop, hardware, and filesystem flavor is a first-class
+portfolio entry. The lifecycle stage describes readiness and maintenance
+state, not product rank: GNOME is not a default support tier, and the
+`community` ISO-group suffix is a packaging identifier rather than a claim
+that its desktops are secondary. Release-currency and admission rules below
+therefore apply equally to every published flavor.
+
 ## Scope
 
 Applies to every row and dimension in the ROADMAP variant table: base variants
@@ -106,7 +115,8 @@ GitHub Releases channel must carry a **current release asset**:
 
 Until the pipeline is extended, the gap observed on 2026-08-10 (kde/xfce/
 cosmic/niri releases 36 days stale vs gnome-20260809 current) is a known
-violation tracked in #1254.
+violation tracked in #1254. Closing that gap is the first concrete deliverable
+of the flavor-equality mandate, not a request to make only GNOME the default.
 
 ## Matrix economics
 

--- a/docs/ci-troubleshooting.md
+++ b/docs/ci-troubleshooting.md
@@ -103,13 +103,13 @@ so neither runs if the system stays at multi-user.target.
 individual gated checks with diagnostic `TUNAOS_DESKTOP_CONTRACT_FAIL` markers
 instead of `set -e` killing the script silently. Commit `ebdb0cd`.
 
-**Caveat for NVIDIA images:** The grouped ISO flagship group boots
+**Caveat for NVIDIA images:** The grouped ISO default desktop group boots
 `gnome-nvidia` by default. In QEMU with virtio-gpu (no NVIDIA hardware),
 the NVIDIA kernel modules may interfere with DRM initialisation. This produces
 a blank framebuffer even if graphical.target is reached. Two mitigations:
 1. The `graphical.target` fix should at least let the contract service run
    (marker appears on serial even if screen is blank).
-2. Consider changing the flagship group's default boot entry from
+2. Consider changing the default desktop group's default boot entry from
    `gnome-nvidia` to `gnome` for CI boot gates, or adding a
    `--boot-entry <name>` option to `iso-e2e.sh`.
 
@@ -141,7 +141,7 @@ at the build step (they fell through to the boot gate).
   in a way that breaks the matrix generation (`generate-matrix` step).
 
 **Status:** Not yet root-caused. The schedule failures have stopped since the
-config was simplified to two groups (flagship + community). Monitor the next
+config was simplified to two groups (default desktop + additional desktop). Monitor the next
 Sunday run (2026-07-20).
 
 ---
@@ -608,7 +608,7 @@ All failing gates share the same root cause — images built before the
 |----------|---------------|------|-------|
 | Build Yellowfin | yellowfin:gnome | disk | `TUNAOS_DESKTOP_CONTRACT_OK` not emitted |
 | Build Grouper | grouper:niri | disk | `TUNAOS_DESKTOP_CONTRACT_OK` not emitted |
-| Publish Grouped ISOs | yellowfin (flagship) | ISO ready | `TUNAOS_LIVE_READY` not emitted + blank screen |
+| Publish Grouped ISOs | yellowfin (default desktop) | ISO ready | `TUNAOS_LIVE_READY` not emitted + blank screen |
 | LUKS E2E | yellowfin:kde | ISO → install | `flatpak: command not found` (separate root cause, see §1) |
 
 Once new images are published with the `graphical.target` fix, all three boot-gate

--- a/scripts/build-iso-group.sh
+++ b/scripts/build-iso-group.sh
@@ -16,7 +16,7 @@
 # Usage:
 #   sudo ./scripts/build-iso-group.sh <variant> <group> [<repo>]
 #     variant   yellowfin | albacore | skipjack | bonito
-#     group     ""|default (flagship), community, nvidia, … (a suffix in iso_groups)
+#     group     ""|default (default desktop), community, nvidia, … (a suffix in iso_groups)
 #     repo      local | ghcr   (default: ghcr)
 #
 # Outputs to project root as <variant>[-<group>]-<version>-<arch>.iso
@@ -28,7 +28,7 @@ set -euo pipefail
 . "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
 
 VARIANT="${1:?usage: $0 <variant> <group> [repo]}"
-# "default"/"flagship"/"" all select the empty-suffix flagship group.
+# "default"/"flagship"/"" all select the empty-suffix default desktop group.
 GROUP_RAW="${2-default}"
 REPO="${3:-ghcr}"
 
@@ -54,7 +54,7 @@ done
 
 REPO_ROOT="$(pwd)"
 
-# Normalise the group selector to its config suffix ("" for the flagship).
+# Normalise the group selector to its config suffix ("" for the default group).
 case "$GROUP_RAW" in
 default | flagship | "") GROUP_SUFFIX="" ;;
 *) GROUP_SUFFIX="$GROUP_RAW" ;;
@@ -115,7 +115,7 @@ for f in "${OFFLINE_FLAVORS[@]}"; do
 done
 
 if ((${#SELECTED[@]} == 0)); then
-	echo "==> No flavors from group '${GROUP_SUFFIX:-flagship}' are built for ${VARIANT}; nothing to do." >&2
+	echo "==> No flavors from group '${GROUP_SUFFIX:-default}' are built for ${VARIANT}; nothing to do." >&2
 	exit 0
 fi
 
@@ -134,7 +134,7 @@ echo "    offline payloads: ${SELECTED_OFFLINE[*]}"
 
 # ── Build the recipe ────────────────────────────────────────────────────────
 # Build scratch: GitHub runners keep ~14 GB on / but ~60 GB on /mnt —
-# community groups (5+ flavors of images + embedded store + squash +
+# Additional desktop groups (5+ flavors of images + embedded store + squash +
 # ISO) exhaust the root disk (run 29630690744: ENOSPC mid image-copy).
 OUT_BASE="${TUNAOS_ISO_OUT_BASE:-.build/iso-group}"
 if [[ -z "${TUNAOS_ISO_OUT_BASE:-}" && -d /mnt && -w /mnt ]]; then


### PR DESCRIPTION
## Summary

- Make #1315/#1316 flavor equality explicit in the lifecycle policy and roadmap acceptance criteria.
- Reframe grouped ISO and troubleshooting terminology from flagship/community tiers to default/additional desktop packaging.
- Remove the remaining GNOME-primary wording from build comments and README flavor descriptions.
- State release cadence parity (#1254) as the first concrete deliverable and require an explicit cadence decision per flavor.

## Why

The mandate applies to product positioning and operational policy, not only prose. Stale “flagship” and “community” labels made the grouped ISO implementation look like a support hierarchy, while the roadmap did not state what completion means.

## Validation

- `git diff --check`
- `bash -n scripts/build-iso-group.sh`
- Confirmed compatibility aliases and the `community` ISO suffix remain unchanged.

Closes #1316

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789199881&installation_model_id=429180&pr_number=1452&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1452&signature=df45bb4b0fc0578be8998119af8616f76a2a1a7161397a76fe45db370ca3907f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->