### PR TITLE
docs: audit third-party package sources against the #1319 sourcing policy

### DIFF
--- a/PACKAGE-SOURCING.md
+++ b/PACKAGE-SOURCING.md
@@ -71,7 +71,33 @@ A repo enters the allowlist only when all of the following hold:
 
 | Repo | Gap covered | Consuming variants | Added | Next review | Justification |
 |------|-------------|--------------------|-------|-------------|---------------|
-| *(pending audit)* | — | — | — | — | Audit per variant lands before entries are added; maintainer-cited codec/Nvidia repos are the starting candidates |
+| *(pending maintainer sign-off)* | — | — | — | — | Candidates below come from a code audit (2026-08-13); none are formally admitted yet — that decision stays with the maintainer/sec-check per the admission criteria above |
+
+## Audit findings (2026-08-13, ahead of the 08-22 checkpoint)
+
+`grep`-based inventory of every `build_scripts/`/`manifests/` reference to a
+COPR, PPA, OBS project, or other external repo, as it exists on `main` today.
+Classified against the sourcing tiers above — **classification only, no
+migration performed by this audit**.
+
+| Source | What it provides | Where used | Classification | Notes |
+|---|---|---|---|---|
+| `rpmfusion` (free + nonfree) | Standard Fedora multimedia/codec/driver packages absent from Fedora's own repos | `build_scripts/10-base-packages.sh` (Bonito) | Tier-3 candidate | Fedora-ecosystem-standard third-party repo; large install base, actively maintained — the kind of repo the allowlist process exists to formalize, not eliminate |
+| `negativo17` (`epel-multimedia`, `fedora-nvidia`/`epel-nvidia`) | Multimedia codecs, Nvidia drivers | `build_scripts/10-base-packages.sh`, `build_scripts/overlay/overrides/nvidia/20-nvidia.sh` | Tier-3 candidate | **This is the exact repo #1319 cited by name as acceptable** — highest-priority formal allowlist entry |
+| `pkgs.tailscale.com` (vendor repo) | Tailscale VPN mesh client | `build_scripts/20-packages.sh` | Needs clarification | Repo file is written then immediately `enabled=0`'d — unclear if this definition is load-bearing or dead code; flag for the script owner, not necessarily a sourcing violation |
+| COPR `trixieua/morewaita-icon-theme` | `morewaita-icon-theme` (GNOME icon theme) | `build_scripts/20-packages.sh` (gnome flavors) | **Violation** | Single-maintainer personal COPR with no allowlist entry — exactly what #1319 prohibits. Smallest migration candidate: one package, one desktop |
+| COPR `ublue-os/packages` | `krunner-bazaar` | `build_scripts/desktop/kcm-ublue.sh` | **Violation** — and a regression | ROADMAP.md's Q2 goal "ublue-os/packages COPR eliminated" (#436) is not fully true: this one package still pulls from it on Fedora. EL10 already builds from source in the same script — same pattern could retire the Fedora COPR path |
+| COPR `zirconium/packages`, `yalter/niri-git`, `avengemedia/danklinux`, `avengemedia/dms-git`, `yselkowitz/wlroots-epel`, `ligenix/enterprise-cosmic` | niri itself, DankMaterialShell suite, wlroots-epel, COSMIC-on-EL10 backport | `build_scripts/desktop/niri.sh` (Fedora/EL10 niri build) | **Violation — largest gap found** | The niri desktop's core WM binary ships from an individual's git-build COPR (`yalter/niri-git`), not Fedora's own `niri` package. Six distinct COPRs feed one desktop flavor. Migrating this is a real Tideforge packaging project, not a quick fix — flagging scope honestly rather than understating it |
+| COPR `@asahi/fedora-remix-branding`, `@asahi/u-boot`; CentOS Hyperscale SIG repos; OBS `home:mrkcee` | Apple Silicon (Asahi) hardware enablement: branding, u-boot, kernel | `build_scripts/overlay/asahi.sh` | Tier-3 candidate, scoped exception | Upstream Asahi Linux project's own infrastructure for hardware this org doesn't control the kernel for — narrow, hardware-gated (only applies to `*-asahi` builds), well-precedented pattern for this class of variant |
+| `ppa:elementary-os/stable` | Pantheon desktop environment | `build_scripts/desktop/install-desktop.sh` (Gurnard/Pantheon) | Tier-3 candidate, scoped exception | Official upstream elementary OS PPA — the canonical source for Pantheon on Ubuntu, not a third-party mirror |
+| Manifest-driven `packages.<os>.copr[]` block (`install-desktop.sh`) | General per-desktop COPR mechanism | Any desktop manifest that declares a `copr:` block | Mechanism, not a violation itself | This is *how* a desktop opts into a COPR — the entries above are what actually uses it. Worth a lint step (see §Enforcement) so new `copr:` blocks require a matching allowlist entry, not just code review |
+
+**Not yet audited**: apt/AUR/OBS usage outside the entries found above (Debian/
+Arch/openSUSE/Gentoo bases largely use their own package managers' extra
+repos differently than DNF's COPR model) — this pass focused on the DNF/COPR
+ecosystem where the volume was highest. A follow-up pass should cover
+`marlin` (Arch/AUR), `flounder`/`flounder-sid` (Debian), `sailfin` (openSUSE
+OBS), and `guppy` (Gentoo overlays) before the audit is called complete.
 
 ## Audit & transition plan
 

--- a/Q3_CHECKPOINT-2026-08-22.md
+++ b/Q3_CHECKPOINT-2026-08-22.md
@@ -29,7 +29,7 @@ Make Q3 carryover an explicit decision, not a discovery. For every open Q3 goal,
 | Directive | Issue | Status | Decision needed |
 |-----------|-------|--------|-----------------|
 | Flavor equality | #1315 / #1316 | Catalog parity gate merged 08-11 (#1322, closes #1281); scheduled cadence parity pending (#1254) | STAFF cadence parity in Q3, or descope to Q4 with owner |
-| Package sourcing | #1319 / #1323 | PACKAGE-SOURCING.md drafted (PR #1330 open); third-party allowlist + per-variant audit outstanding | STAFF — merge policy doc by 08-22; audit due at checkpoint |
+| Package sourcing | #1319 / #1323 | PACKAGE-SOURCING.md merged (#1330); DNF/COPR audit landed 08-13 — found the niri desktop depends on 6 distinct unsanctioned COPRs (largest single gap: `yalter/niri-git` ships niri itself), plus a Q2 "COPR eliminated" regression (`ublue-os/packages` still feeds krunner-bazaar). apt/AUR/OBS bases (marlin/flounder/sailfin/guppy) not yet audited | STAFF — allowlist sign-off + migration plan for the niri COPR cluster at the 08-22 checkpoint |
 
 ### Supporting items for the checkpoint
 


### PR DESCRIPTION
## Summary

#1323's remaining proposed next step (the policy skeleton itself already merged via #1330) was: "Audit current third-party repo usage per variant and link to Q4 supply-chain trackers." `PACKAGE-SOURCING.md` already scheduled this audit for the 2026-08-22 checkpoint — this PR does it now, ahead of that date, so the checkpoint has real data instead of a blank table.

Method: `grep` across `build_scripts/` and `manifests/` for every COPR/PPA/OBS/vendor-repo reference on `main`, classified against the policy's sourcing tiers. **Classification only — no migration performed here.**

Findings (full table in the PR diff):

- **`negativo17`** (codecs/Nvidia) and **`rpmfusion`** — exactly the kind of well-known, widely-used third-party repo #1319 says is fine with an allowlist entry. `negativo17` is literally the repo the maintainer directive named by example.
- **Two real violations**: COPR `trixieua/morewaita-icon-theme` (single-maintainer personal COPR, one package) and COPR `ublue-os/packages` for `krunner-bazaar` — the latter is a **regression** against ROADMAP.md's own claim that Q2 goal #436 "eliminated" the ublue-os/packages COPR; it didn't, fully.
- **The largest gap**: the niri desktop pulls from **6 distinct unsanctioned COPRs** (`zirconium/packages`, `yalter/niri-git`, `avengemedia/danklinux`, `avengemedia/dms-git`, `yselkowitz/wlroots-epel`, `ligenix/enterprise-cosmic`) — niri's own WM binary ships from an individual's git-build COPR, not Fedora's package. Flagging this honestly as a real Tideforge packaging project, not understating the scope.
- Asahi hardware-enablement repos and the elementary OS Pantheon PPA are both narrow, upstream-canonical, hardware/desktop-gated — reasonable allowlist candidates, not violations.
- Explicitly scoped what this audit did **not** cover: apt/AUR/OBS usage on the non-DNF bases (marlin/Arch, flounder/Debian, sailfin/openSUSE, guppy/Gentoo) — flagged as a follow-up rather than claimed as covered.

Also updated `Q3_CHECKPOINT-2026-08-22.md`'s "Package sourcing" row with this real data instead of the "audit outstanding" placeholder.

## Test plan
- [x] `grep -rln` across `build_scripts/`/`manifests/` for `copr`, `add-apt-repository`, `ppa:`, `.repo`, `baseurl`, and known third-party repo hostnames — every hit traced to its source file and classified
- [x] Verified the `ublue-os/packages` finding against ROADMAP.md's Q2 "COPR eliminated" claim (#436) — confirmed still present in `build_scripts/desktop/kcm-ublue.sh`
- [x] Confirmed each classification against `PACKAGE-SOURCING.md`'s existing tier definitions and admission criteria — no new policy invented, just applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `5e3f850e`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->