### PR TITLE
ci: enforce immutable GitHub Actions refs

### DIFF
--- a/.github/scripts/check-action-pins.py
+++ b/.github/scripts/check-action-pins.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Reject mutable third-party GitHub Actions references."""
+
+from pathlib import Path
+import re
+import sys
+
+
+USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*(\S+)")
+SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def main() -> int:
+    errors: list[str] = []
+    for path in sorted(Path(".github").rglob("*.yml")) + sorted(
+        Path(".github").rglob("*.yaml")
+    ):
+        for line_number, line in enumerate(path.read_text().splitlines(), 1):
+            match = USES_RE.match(line)
+            if not match:
+                continue
+
+            reference = match.group(1)
+            # Local composite actions are versioned with this repository.
+            if reference.startswith("./") or reference.startswith("docker://"):
+                continue
+
+            if "@" not in reference:
+                errors.append(f"{path}:{line_number}: missing immutable SHA: {reference}")
+                continue
+
+            _, ref = reference.rsplit("@", 1)
+            if not SHA_RE.fullmatch(ref):
+                errors.append(f"{path}:{line_number}: mutable action ref: {reference}")
+
+    if errors:
+        print("GitHub Actions must use full commit SHAs:", file=sys.stderr)
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+
+    print("All third-party GitHub Actions are pinned to full commit SHAs.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,6 +43,7 @@ jobs:
           - yamllint
           - json-validate
           - actionlint
+          - action-pins
           - justfmt
     steps:
       - name: Checkout
@@ -111,6 +112,10 @@ jobs:
             -ignore "save-always" \
             -ignore "cannot be filtered" \
             .github/workflows/*.yml .github/workflows/*.yaml
+
+      - name: Check action pins
+        if: matrix.check == 'action-pins'
+        run: python3 .github/scripts/check-action-pins.py
 
       - name: Check Justfile formatting
         if: matrix.check == 'justfmt'


### PR DESCRIPTION
## Summary

- add a CI check that requires third-party GitHub Actions to use full commit SHAs
- run the check in the existing lint matrix
- confirm the current 139 action references in tunaos are already SHA-pinned

## Why

Issue #1328 identifies mutable action tags and branches as a supply-chain risk. This repository has already pinned its current action references; the new guard prevents future workflow or composite-action changes from reintroducing mutable refs.

## Validation

- `python3 .github/scripts/check-action-pins.py`
- `python3 -m py_compile .github/scripts/check-action-pins.py`
- `git diff --check`

Closes #1328

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->