### PR TITLE
docs: correct COPR/R2 framing in ADOPTERS.md ecosystem list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -39,7 +39,8 @@ _(None listed yet — be the first!)_
 | [Ubuntu](https://ubuntu.com) | Base OS — Ubuntu variant image | [ubuntu.com](https://ubuntu.com) |
 | [Niri](https://github.com/YaLTeR/niri) | Desktop environment — scrollable-tiling Wayland compositor (Bonito variant) | [github.com/YaLTeR/niri](https://github.com/YaLTeR/niri) |
 | [elementary OS](https://elementary.io) | Desktop environment — Pantheon desktop for the Gurnard (Ubuntu 24.04 LTS) variant | [elementary.io](https://elementary.io) |
-| [Fedora COPR](https://copr.fedorainfracloud.org) | Package distribution — GNOME 49/50 backports for CentOS Stream 10 / Fedora bases | [copr.fedorainfracloud.org](https://copr.fedorainfracloud.org) |
+| [Fedora COPR](https://copr.fedorainfracloud.org) | Package distribution (legacy/compatibility) — GNOME 49/50 backports for CentOS Stream 10 / Fedora bases; being retired in favor of the native RPM + Cloudflare R2 pipeline below | [copr.fedorainfracloud.org](https://copr.fedorainfracloud.org) |
+| [Cloudflare R2](https://www.cloudflare.com/developer-platform/products/r2/) | Package/artifact distribution — native EL10 RPM repository (GNOME 51 onward), ISOs, and boot screenshots | [cloudflare.com/r2](https://www.cloudflare.com/developer-platform/products/r2/) |
 | [Tideforge](https://tideforge.org) | Build service — COSMIC packages built from source for the EL10 desktop cells | [tideforge.org](https://tideforge.org) |
 | [GHCR](https://ghcr.io) | Image registry — all published TunaOS image flavors | [github.com/orgs/tuna-os/packages](https://github.com/orgs/tuna-os/packages) |
 


### PR DESCRIPTION
## Summary

#1334's proposed action #4 was "add a GNOME 51 on TunaOS line to ADOPTERS/COPR ecosystem rows if the packaging lands." The packaging did land (tunaos-packages#320, merged 08-10, GNOME 51 tier currently green in CI) — but adding a new "GNOME 51 via COPR" row would have been factually wrong: `tunaos-packages/README.md` states COPR is legacy/compatibility infrastructure being retired, and the GNOME 51 build workflow actually publishes to Cloudflare R2, not a COPR project.

Instead of adding an inaccurate row, corrected the existing one:

- `Fedora COPR` row now scoped to what it actually still covers (GNOME 49/50 legacy backports) and notes it's being retired.
- Added a `Cloudflare R2` row — the actual distribution mechanism for the native EL10 RPM repo (GNOME 51 onward), plus the ISOs and boot screenshots R2 already serves, none of which were previously acknowledged in this ecosystem list.

Companion PR fixing the same stale COPR framing in the scheduled GNOME 51 blog post: tuna-os/docs#202.

## Test plan
- [x] Confirmed via `tunaos-packages/README.md` and `build-gnome51-distributed.yml` that GNOME 51 publishes via R2, not COPR (same verification as the docs PR)
- [x] Confirmed Cloudflare R2 wasn't previously listed anywhere in `ADOPTERS.md` despite being core ISO/screenshot/package infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `702efbf2`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->