### PR TITLE
docs: tie CNCF bootc ecosystem angle into FOSDEM CFP draft

### DIFF
--- a/docs/CFP-FOSDEM-2027.md
+++ b/docs/CFP-FOSDEM-2027.md
@@ -55,6 +55,25 @@ this is an open-source project's architecture talk with live demos.
 - Speaker: maintainer or maintainer-designate (travel: FOSDEM is free to attend; Brussels transit from most of Europe)
 - Materials: laptop + demo VMs pre-built (bootc images exist in GHCR; Corral runs anywhere with KubeVirt)
 
+## bootc / CNCF ecosystem angle (#1340)
+
+bootc is a CNCF Sandbox project, and TunaOS is one of the more complete
+production bootc *desktop* deployments (37 published editions, daily GNOME
+releases, keyless-signed artifacts) — a concrete adoption story for a
+sandbox project working toward incubation. This isn't cold outreach: Jorge
+Castro (castrojo), CNCF Developer Relations and a Universal Blue founder, is
+already a 201-commit contributor and CODEOWNERS entry on this repo
+(verified via the GitHub API and `.github/CODEOWNERS`, 2026-08-13).
+
+This makes the FOSDEM talk (Containers devroom) a natural fit for a
+CNCF-adjacent bootc ecosystem showcase, not just a standalone project talk.
+**A pitch to bootc-dev / CNCF channels has not been sent** — that's a
+maintainer decision (it's an external, public action on the org's behalf),
+not something to originate from this doc. If a maintainer wants to make
+that pitch, this CFP abstract and the ADOPTERS.md ecosystem table (which
+already lists bootc-dev/bootc as an upstream dependency) are the supporting
+material to point to.
+
 ## Submission checklist
 
 - [ ] CFP portal opens (~Oct 2026) — confirm exact date
@@ -62,6 +81,7 @@ this is an open-source project's architecture talk with live demos.
 - [ ] Record demo video (3–5 min) — needs a spare laptop/VM
 - [ ] Ask 1–2 community members to proof the abstract (FOSDEM reviewers like demos + no-vendor-pitch)
 - [ ] Submit to Containers devroom first; fall back to Desktops if categories allow
+- [ ] (Optional, maintainer call) Pitch a bootc-ecosystem case-study feature to bootc-dev/CNCF channels — see #1340
 
 ## Supporting material (for reviewers / talk page)
 


### PR DESCRIPTION
## Summary

#1340 proposes positioning TunaOS as a bootc/CNCF ecosystem case study, citing Jorge Castro (castrojo) — CNCF Developer Relations, Universal Blue founder — as an existing 201-commit contributor. Verified both facts before acting: `gh api repos/tuna-os/tunaos/contributors` confirms 201 contributions from castrojo, and `.github/CODEOWNERS` lists `@castrojo`.

Scoped what I actually did carefully. Two of the issue's three proposed actions are **external, public actions on the org's behalf** — pitching to bootc-dev/CNCF channels, and submitting a CFP — that a hive agent shouldn't originate unilaterally; those are maintainer calls. The third (drafting case-study content) is explicitly gated in the issue's own text ("once the pitch clears") — premature to write now.

What's left, and what this PR does: strengthens the existing FOSDEM 2027 CFP draft (`docs/CFP-FOSDEM-2027.md`, already tracked under #1135) with a new section making the CNCF/bootc ecosystem angle explicit — the verified castrojo/CODEOWNERS fact, why it makes the Containers-devroom pitch stronger, and an explicit note that **no pitch has been sent** (so this doc doesn't get read later as claiming outreach happened that didn't). Added a checklist item flagging the optional CNCF pitch as a maintainer decision, linked to #1340.

## Test plan
- [x] `gh api repos/tuna-os/tunaos/contributors` — confirmed castrojo shows exactly 201 contributions
- [x] Confirmed `@castrojo` in `.github/CODEOWNERS`
- [x] Confirmed no existing pitch/outreach record to bootc-dev or CNCF anywhere in the repo before writing the "not yet sent" note

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `4297a16e`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->