### PR TITLE
docs: refresh DistroWatch submission metadata

### DIFF
--- a/ADOPTION-METRICS.md
+++ b/ADOPTION-METRICS.md
@@ -26,6 +26,7 @@ publish, and *how* the snapshot feeds roadmap decisions.
 | Discovery | GitHub stars / forks | GitHub API | 56 / 3 | ≥100 stars |
 | Discovery | Docs site visits, top variant pages | Cloudflare analytics on tunaos.org | not measured | ≥1k visits/mo, variant-page ranking |
 | Download | ISO downloads by variant+desktop | R2 access logs (tunaos.org/download) | **not measured** | ≥1k ISO downloads/mo; variant ranking |
+| Outreach | DistroWatch referral visits and ISO clicks | Cloudflare/R2 logs for `utm_campaign=distrowatch-2026` | not submitted | establish baseline in first 30 days |
 | Download | GitHub Release asset downloads | Releases API (resumed 08-09, #1106) | 0 (assets were empty shells) | assets present on all flavors; downloads counted |
 | Install | Installs / successful boots | opt-in telemetry or boot-report gating | **not measured** | Q4 design decision (#577 GUI gate, #763) |
 | Community | Open PRs from external contributors | GitHub API | 0 external contributors | ≥2 external contributor PRs merged |
@@ -37,6 +38,8 @@ publish, and *how* the snapshot feeds roadmap decisions.
    flavors to publish assets too (#1254 parity gap).
 2. **R2/Cloudflare access-log analytics** on tunaos.org/download — R2 already
    serves the ISOs; enable access logs + a dashboard (owner: ci-maintainer).
+   External campaigns should use a stable UTM campaign name so referral
+   traffic can be separated from direct visits without adding OS telemetry.
 3. **Docs analytics** — Cloudflare Web Analytics on the Docusaurus site
    (one script tag; owner: guide).
 4. **Install telemetry** — deferred to Q4 design decision; do not block 1–3.

--- a/docs/DISTROWATCH-SUBMISSION.md
+++ b/docs/DISTROWATCH-SUBMISSION.md
@@ -14,17 +14,16 @@ that runs the datacenter — and applies them atomically with bootc. Updates
 are transactional: one image, one rollback, verified upgrades, and the
 desktop can never be left half-upgraded.
 
-Variants cover the desktop spectrum on a common base: GNOME with backports
-onto Enterprise Linux lifecycles (AlmaLinux 10 and CentOS Stream 10),
-KDE Plasma 6, the Rust-built COSMIC, the scrollable-tiling Niri compositor,
-XFCE 4.20, plus Ubuntu-, Debian-, Gentoo-, Arch-, and Fedora-based flavors.
-All published images are multi-arch (x86_64 and aarch64), with Apple Silicon
-(M1/M2) support via an Asahi-based installer and Snapdragon X Elite laptop
-support documented per variant.
+Variants cover the desktop spectrum on Enterprise Linux bases (AlmaLinux 10
+and CentOS Stream 10): GNOME, KDE Plasma, the Rust-built COSMIC, the
+scrollable-tiling Niri compositor, and XFCE. Additional published variants
+track Fedora, openSUSE, Ubuntu, Debian, Gentoo, and Arch. Platform support is
+variant-specific: the catalog currently includes x86_64 and selected arm64
+images, while Apple Silicon (M1/M2) follows the Asahi installer path.
 
 Under the hood, TunaOS is manifest-driven: a YAML file defines a variant,
-the pipeline turns it into a published, signed, multi-arch image, and CI
-verifies every release. For teams already running Kubernetes, the Corral
+the pipeline turns it into a published, signed image for each supported
+architecture, and CI verifies every release. For teams already running Kubernetes, the Corral
 project manages desktop and service VMs as declarative resources on the
 same cluster estate, with snapshots and GPU passthrough as code.
 
@@ -42,40 +41,66 @@ release cadence, verified boot reports, and an active community on Matrix.
 | **Image registry** | https://github.com/orgs/tuna-os/packages (GHCR) |
 | **Status** | Active (weekly releases) |
 | **Origin** | USA / global maintainer community |
-| **Desktop environments** | GNOME, KDE Plasma, COSMIC, Niri, XFCE, Pantheon |
+| **Desktop environments** | GNOME, KDE Plasma, COSMIC, Niri, XFCE, Pantheon (variant-dependent) |
 | **Package management** | bootc image-based (rpm-ostree-style), atomic |
-| **Architectures** | x86_64, aarch64 |
+| **Architectures** | x86_64; arm64 for selected variants |
 | **License** | Apache-2.0 |
 | **First release** | 2026 |
-| **Based on** | AlmaLinux 10, CentOS Stream 10, Fedora, Ubuntu, Debian, Gentoo, Arch |
+| **Based on** | AlmaLinux Kitten 10, AlmaLinux 10, CentOS Stream 10, Fedora, openSUSE Tumbleweed, Ubuntu, Debian, Gentoo, Arch |
 | **Related projects** | bootc (CNCF Sandbox), Bluefin/Universal Blue, Corral |
 
 ## Variant matrix (for the listing)
 
-| Variant | Base | Desktop | Status |
+| Variant | Base | Desktop(s) | Status |
 |---|---|---|---|
-| Yellowfin | AlmaLinux 10 | GNOME | Stable |
-| Albacore | AlmaLinux 10 | GNOME | Stable |
-| Bonito | Fedora | GNOME | Beta |
-| Skipjack | CentOS Stream 10 | KDE Plasma | Stable |
-| Tromsø | BuildStream-based | KDE Plasma 6 | Stable |
-| XFCE Linux | BuildStream-based | XFCE 4.20 | Stable |
-| COSMIC | EL10 cell (Tideforge-built) | COSMIC | Beta |
-| Niri | Fedora | Niri | Beta |
-| Gurnard | Ubuntu 24.04 LTS | Pantheon | New (08-2026) |
-| Marlin | Arch | GNOME | Alpha |
+| Yellowfin | AlmaLinux Kitten 10 | GNOME, KDE, COSMIC, Niri, XFCE | Published |
+| Albacore | AlmaLinux 10 | GNOME, KDE, COSMIC, Niri, XFCE | Published |
+| Skipjack | CentOS Stream 10 | GNOME, KDE, COSMIC, Niri, XFCE | Published |
+| Bonito | Fedora 44 | GNOME, KDE, COSMIC, Niri, XFCE | Published |
+| Bonito Rawhide | Fedora Rawhide | GNOME, KDE, COSMIC, Niri, XFCE | Rolling |
+| Hummingbird | Fedora Hummingbird | Base, GNOME | Experimental |
+| Sailfin | openSUSE Tumbleweed | GNOME, KDE, Niri, XFCE | Published |
+| Guppy | Gentoo | GNOME, KDE | Published |
+| Gurnard | Ubuntu 24.04 LTS | Base, Pantheon | Experimental |
+| Grouper | Ubuntu 26.04 | GNOME, KDE, Niri, XFCE | Experimental |
+| Marlin | Arch Linux | GNOME, KDE, COSMIC, Niri, XFCE | Experimental |
+| Flounder | Debian 13 | GNOME, KDE, COSMIC, Niri, XFCE | Experimental |
+| Flounder Sid | Debian Sid | GNOME, KDE, COSMIC, Niri, XFCE | Rolling |
+
+The matrix intentionally lists only variants in `.github/build-config.yml`
+with a published registry path. Redfin (RHEL 10) is local-build-only and is
+not a DistroWatch download target. Hardware-specific suffixes (such as
+`-nvidia` and `-hwe`) are image flavors, not separate distributions.
 
 ## Suggested pitch to DistroWatch Weekly editors
 
 > "TunaOS brings the bootable-container model to the enterprise desktop:
 > GNOME and KDE on 10-year Enterprise Linux lifecycles, updated atomically
 > like a container fleet. New this quarter: an Ubuntu 24.04 + Pantheon
-> variant (Gurnard) and Apple Silicon installer support."
+> variant (Gurnard) and an Apple Silicon installer path."
 
 ## Submission checklist
 
 - [ ] Maintainer review of description and variant matrix
-- [ ] Confirm current download URLs + image tags before submission
+- [ ] Confirm current download URLs + image tags before submission (the
+      catalog and published release assets may change before Fedora 45)
 - [ ] Submit via DistroWatch project submission form
 - [ ] Add tunaos.org/download link to any public project listings
-- [ ] Record submission date + referral traffic in ADOPTION-METRICS.md (funnel tier 1, #1311)
+- [ ] Use `https://tunaos.org/download?utm_source=distrowatch&utm_medium=referral&utm_campaign=distrowatch-2026`
+      as the download link where query parameters are accepted
+- [ ] Record submission date, landing URL, and referral traffic in
+      `ADOPTION-METRICS.md` (funnel tier 1, #1311)
+
+### Maintainer verification before submission
+
+Run these checks immediately before filing the external listing so the
+submission does not promise an unavailable ISO:
+
+```sh
+grep -E '^  - id:|^    description:|^    platforms:' .github/build-config.yml
+gh release list --repo tuna-os/tunaos --limit 1
+```
+
+Then confirm that the download page resolves and that each advertised
+variant has a current release asset. Update the matrix above if either the
+catalog or release policy has changed.


### PR DESCRIPTION
Closes #1333

## What changed

- Refresh the DistroWatch submission draft from the current `.github/build-config.yml` catalog.
- Remove non-catalog entries and local-only Redfin from the external listing matrix.
- Correct architecture and variant-status claims, and document flavor suffixes.
- Add a stable DistroWatch UTM campaign URL and adoption-metrics tracking guidance.
- Add maintainer checks for the catalog, release availability, and download page before filing externally.

## Why

The original draft merged in #1375 was useful but had stale or unsupported variant names and overstated multi-architecture coverage. This follow-up makes the submission safe to copy into DistroWatch and gives maintainers a measurable referral path.

## Validation

- `git diff --check`
- `GH_TOKEN="$GH_TOKEN" gh release list --repo tuna-os/tunaos --limit 3`
- `curl -ILsS https://tunaos.org/ https://tunaos.org/download` (both HTTP 200)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789201157&installation_model_id=429180&pr_number=1458&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1458&signature=c3f67e24664a27f7e3ec2101bdea8c45fdbe2960043744825083f11b719a82b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->