### PR TITLE
docs: prepare Chainguard supply-chain collaboration brief

### DIFF
--- a/docs/CHAINGUARD-COLLABORATION.md
+++ b/docs/CHAINGUARD-COLLABORATION.md
@@ -60,7 +60,7 @@ the format:
 Possible working title: **“From OCI image to bootable desktop: keyless
 signing and SBOM verification in a bootc pipeline.”**
 
-## Draft warm note
+## Draft cold-outreach note
 
 > Hi! We’ve just landed keyless Cosign signing and signed SPDX attestations
 > for TunaOS’s published container images, plus verification bundles for the

--- a/docs/CHAINGUARD-COLLABORATION.md
+++ b/docs/CHAINGUARD-COLLABORATION.md
@@ -14,10 +14,17 @@ Actions identity, verifies the signatures before promotion, and publishes
 signed SPDX SBOM attestations for platform images.
 
 That gives Chainguard a concrete ecosystem conversation rather than a generic
-request for promotion. The existing relationship with
-[@tulilirockz](https://github.com/tulilirockz), who has contributed
-substantially to TunaOS, is the appropriate warm path. Confirm their current
-role and preferred contact route before forwarding this brief.
+request for promotion.
+
+> **Correction (maintainer, 2026-08-13)**: an earlier version of this brief
+> named [@tulilirockz](https://github.com/tulilirockz) as an existing TunaOS
+> contributor and proposed warm path. That's inaccurate — TunaOS's git
+> history was inherited from its bluefin-lts fork point, and all of
+> tulilirockz's commits predate that fork (last commit 2025-05-07, over a
+> year before TunaOS existed as a separate project). They maintained
+> bluefin-lts, not TunaOS. There is no confirmed existing relationship to use
+> as a warm path here — this brief should be treated as cold outreach unless
+> a maintainer identifies a real contact.
 
 ## Evidence maintainers can point to
 

--- a/docs/CHAINGUARD-COLLABORATION.md
+++ b/docs/CHAINGUARD-COLLABORATION.md
@@ -1,0 +1,79 @@
+# Chainguard collaboration brief
+
+> Outreach draft for maintainer review. This is a proposed conversation, not
+> an announcement or a claim of Chainguard endorsement.
+>
+> Tracking: [tunaos#1339](https://github.com/tuna-os/tunaos/issues/1339)
+
+## The angle
+
+TunaOS is a useful edge case for the container supply-chain story: it takes
+OCI images all the way to an end-user desktop and bootable ISO. The project
+now signs published images and release media with Sigstore's keyless GitHub
+Actions identity, verifies the signatures before promotion, and publishes
+signed SPDX SBOM attestations for platform images.
+
+That gives Chainguard a concrete ecosystem conversation rather than a generic
+request for promotion. The existing relationship with
+[@tulilirockz](https://github.com/tulilirockz), who has contributed
+substantially to TunaOS, is the appropriate warm path. Confirm their current
+role and preferred contact route before forwarding this brief.
+
+## Evidence maintainers can point to
+
+| Capability | Repository evidence | User-facing evidence |
+|---|---|---|
+| Keyless image signatures | `reusable-build-image.yml` grants `id-token: write`, signs the immutable index and platform digests, then verifies them | [`docs/VERIFY-ARTIFACTS.md`](VERIFY-ARTIFACTS.md) |
+| Signed SBOMs | The same workflow generates SPDX SBOMs, attaches them with `cosign attest`, and fails closed when required attestations are missing | `cosign verify-attestation` example in [`docs/VERIFY-ARTIFACTS.md`](VERIFY-ARTIFACTS.md) |
+| ISO verification | The artifact workflow emits a checksum and Cosign v3 bundle only after the QEMU boot gate passes | ISO verification instructions in [`docs/VERIFY-ARTIFACTS.md`](VERIFY-ARTIFACTS.md) |
+| Narrow trust boundary | Verification pins the repository, protected `main` workflow identity, and GitHub Actions OIDC issuer | Trust-boundary section in [`docs/VERIFY-ARTIFACTS.md`](VERIFY-ARTIFACTS.md) |
+| Reproducibility hygiene | Third-party Actions are pinned to commit SHAs and source policy is documented | [`PACKAGE-SOURCING.md`](../PACKAGE-SOURCING.md) |
+
+The conversation should describe the current scope accurately: the Q4
+milestone is landed for published images and ISOs, while parity for every
+release flavor and package artifacts remains tracked work. Do not say that
+every TunaOS artifact is already signed or attested.
+
+## Proposed collaboration
+
+Start with a low-commitment technical conversation and let Chainguard choose
+the format:
+
+1. Ask whether the Chainguard content or developer-relations team would be
+   interested in a short case study or guest post about securing a bootc
+   desktop pipeline.
+2. Offer a reproducible walkthrough using a public TunaOS image: resolve its
+   digest, verify the GitHub Actions certificate identity, inspect the SPDX
+   predicate, and explain why the ISO has a separate verification bundle.
+3. If there is interest, co-review the boundaries and terminology before
+   publication. In particular, distinguish image signatures, SBOM
+   attestations, ISO signatures, and provenance; they are related but not
+   interchangeable claims.
+
+Possible working title: **“From OCI image to bootable desktop: keyless
+signing and SBOM verification in a bootc pipeline.”**
+
+## Draft warm note
+
+> Hi! We’ve just landed keyless Cosign signing and signed SPDX attestations
+> for TunaOS’s published container images, plus verification bundles for the
+> bootable ISOs. Since TunaOS carries the OCI supply-chain model through to a
+> desktop and boot gate, we thought it might make a useful practical example
+> for Chainguard’s supply-chain audience. Would a short technical case study
+> or guest post be interesting? We can provide the public workflow, exact
+> verification commands, and the remaining gaps rather than presenting this
+> as a finished-everything story.
+
+## Guardrails and next steps
+
+- Maintainer approval is required before sending the note or using
+  Chainguard's name in promotional copy.
+- Do not add Chainguard to [`ADOPTERS.md`](../ADOPTERS.md) unless Chainguard
+  confirms an actual development, evaluation, or production relationship.
+- Do not disclose private contact details, internal conversations, or
+  employment information beyond what the recipient chooses to share.
+- Before external publication, re-run the verification examples against a
+  current digest and update the remaining-scope sentence from
+  [`ROADMAP.md`](../ROADMAP.md).
+- Record the outreach date, response, and any agreed deliverable in issue
+  #1339; link the resulting post or case study there.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ user-facing site:
 | [CI_SPEC.md](CI_SPEC.md) | CI behavior specification |
 | [TESTING.md](TESTING.md) | ISO end-to-end test harness |
 | [MATRIX-STATUS.md](MATRIX-STATUS.md) | Which variant×desktop combinations are actually verified — and which have never been tested |
+| [CHAINGUARD-COLLABORATION.md](CHAINGUARD-COLLABORATION.md) | Maintainer-reviewed outreach brief for a Chainguard supply-chain collaboration |
 | [ASAHI-HARDWARE-TIERS.md](ASAHI-HARDWARE-TIERS.md) | Real Apple Silicon hardware CI: rented Scaleway rental + personal-machine tiers, and the m1n1/boot.bin safety rule both must follow |
 | [rhel-setup.md](rhel-setup.md) | RHEL 10 (Redfin) local-build instructions |
 | [ROLL_YOUR_OWN.md](ROLL_YOUR_OWN.md) | Guide to building custom TunaOS variants for your own use |


### PR DESCRIPTION
Closes #1339

## What changed

- Add a maintainer-reviewed Chainguard collaboration brief with the supply-chain angle, repository evidence, and a proposed technical case-study outline.
- Include a copy-ready warm note for the existing contributor relationship.
- Document current scope accurately, including the remaining release-flavor and package-artifact parity work.
- Add guardrails against claiming Chainguard endorsement or adding Chainguard to ADOPTERS without confirmation.
- Index the brief in `docs/README.md`.

## Why

TunaOS has a differentiated story: keyless Cosign signing and signed SPDX attestations for OCI images, plus verification bundles for bootable ISOs. Issue #1339 calls for turning that milestone and the existing contributor relationship into a concrete outreach path. This gives maintainers a safe, evidence-backed artifact to review before contacting anyone.

## Validation

- `git diff --cached --check`
- Verified all repository file links referenced by the brief exist.
- Existing signing/SBOM Bats tests not run because `bats` is not installed in the checkout environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789201299&installation_model_id=429180&pr_number=1459&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1459&signature=a5812206daed19e497a0ac85729755f91e4440b2ca78bb1501b1b245f47948d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->