### PR TITLE
docs: converge README with ROADMAP/build-config for hummingbird/gurnard

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ _Generated from the latest completed main-branch build for each variant. A cell 
 | 🐟 **Albacore** | AlmaLinux 10 (RHEL 10) | `ghcr.io/tuna-os/albacore` | GNOME, KDE, COSMIC, Niri | x86_64, x86_64/v2, arm64 |
 | 🍣 **Skipjack** | CentOS Stream 10 | `ghcr.io/tuna-os/skipjack` | GNOME, KDE, COSMIC, Niri | x86_64, arm64 |
 | 🎣 **Bonito** | Fedora 44 | `ghcr.io/tuna-os/bonito` | GNOME, KDE, COSMIC, Niri | x86_64, arm64 |
-| 🐦 **Hummingbird** | Fedora Hummingbird (experimental) | `ghcr.io/tuna-os/hummingbird` | Base only | x86_64, arm64 |
+| 🐦 **Hummingbird** | Fedora Hummingbird (experimental) | `ghcr.io/tuna-os/hummingbird` | Base, GNOME, KDE, COSMIC, Niri | x86_64, arm64 |
 | 🔒 **Redfin** | Red Hat Enterprise Linux 10 | *Local-Build Only* | GNOME, KDE, COSMIC, Niri, XFCE | x86_64, arm64 |
 | 🐟 **Grouper** | Ubuntu 26.04 | `ghcr.io/tuna-os/grouper` | GNOME, KDE, Niri, XFCE | x86_64 |
-| 🐟 **Gurnard** | Ubuntu 24.04 (Noble Numbat) | `ghcr.io/tuna-os/gurnard` | Base, Pantheon | x86_64, arm64 |
+| 🐟 **Gurnard** | Ubuntu 24.04 (Noble Numbat, experimental) | `ghcr.io/tuna-os/gurnard` | Base, Pantheon | x86_64, arm64 |
 | 🚀 **Marlin** | Arch Linux (Rolling) | `ghcr.io/tuna-os/marlin` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
 | 🐡 **Flounder** | Debian 13 (Trixie) | `ghcr.io/tuna-os/flounder` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
 | ☢️ **Flounder Sid** | Debian Sid (Unstable) | `ghcr.io/tuna-os/flounder:*-sid` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |


### PR DESCRIPTION
## Summary

#1341's recommendations #1 and #2 (ROADMAP rows with Experimental status, admission-gate backfill deferred to the Q3 checkpoint) were already done in a prior pass — `ROADMAP.md`'s Active Variants table already has both rows and an explanatory note citing this issue and #1299.

Verifying recommendation #3 ("cross-reference #1298 so all three surfaces — ROADMAP, README, build-config — converge") found #1298 closed but the convergence incomplete:

- README's Hummingbird row said "Base only" for desktops; `.github/build-config.yml` actually defines `base, gnome, kde, niri, cosmic` for hummingbird (matching what ROADMAP.md already correctly states) — README understated the real, currently-building flavor set.
- README's Gurnard row had no "(experimental)" marker, while Hummingbird's did and ROADMAP.md marks both Experimental — inconsistent framing between the two variants that are supposed to carry the same status per the maintainer's #1315 directive.

Fixed both so README actually matches ROADMAP.md and build-config.yml.

## Test plan
- [x] `python3 -c "import yaml; ..."` against `.github/build-config.yml` — confirmed hummingbird's flavor list is `base, gnome, kde, niri, cosmic`, matching the corrected README row
- [x] Confirmed `#1298` (the tracked README-convergence issue) is closed, then verified the actual current README content rather than trusting the closed status
- [x] Confirmed `docs/MATRIX-STATUS.md` (auto-generated, not hand-edited here) still shows the missing ISO cells this issue cites — no change needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `34dfeb01`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->