### PR TITLE
docs: draft Q3 community checkpoint recap

### DIFF
--- a/docs/Q3-COMMUNITY-RECAP-2026-08-22.md
+++ b/docs/Q3-COMMUNITY-RECAP-2026-08-22.md
@@ -1,0 +1,104 @@
+# Q3 community recap — draft for 2026-08-22
+
+> **Editorial status:** draft for maintainer and strategist review. Publish on
+> tunaos.org only after the 2026-08-22 checkpoint decisions are recorded.
+>
+> Tracking: [tunaos#1345](https://github.com/tuna-os/tunaos/issues/1345)
+
+## Suggested title
+
+**TunaOS Q3 checkpoint: expanding the project with users and contributors**
+
+## Draft post
+
+Q3 has been about expanding TunaOS beyond a working build pipeline: making
+more variants discoverable, making releases easier to trust, and making room
+for more people to contribute. As we reach the 2026-08-22 checkpoint, here is
+what changed and where we are going next.
+
+### A healthier path from image to download
+
+The download path is working again: tunaos.org serves the current ISO set,
+and the project has verified a catalog of 179 downloadable images. GitHub
+Release publishing also resumed with release assets and SBOM material. A new
+browser-catalog parity gate now fails when an on-demand flavor has no
+published catalog facts, so a missing entry is caught during CI instead of by
+someone finding a broken download link later.
+
+The work is not finished. Release cadence is still uneven across desktop
+flavors, and desktop completeness on several non-RPM bases needs more
+verification. These are visible follow-up items, not claims that every
+variant has reached the same support tier.
+
+### More ways to build a TunaOS desktop
+
+Hummingbird and Gurnard/Pantheon are now represented in the build catalog and
+are building as experimental variants. They are being brought through the
+same admission and acceptance process as the rest of the portfolio; the
+checkpoint will decide whether their next work stays in Q3 or moves to Q4
+with an owner.
+
+The maintainer team also adopted a flavor-equality direction: GNOME is no
+longer the product definition for the project. KDE, COSMIC, Niri, XFCE, and
+other supported flavors need the same catalog, release, and verification
+standards. This is a change in operating discipline, not just a change to a
+table in the README.
+
+### A first external contributor is now part of the story
+
+In August, shimonenator became TunaOS's first recurring external human
+contributor, with work spanning EL10/OBS design, the image-factory completion
+gate, flavor-equality documentation, and related repository fixes. Thank you
+for turning an initial contribution into an ongoing collaboration.
+
+The next step is to make that path easier for the next person. We are
+curating good-first issues, improving the contributor documentation, and
+tracking whether new contributors can find a useful second task. If you want
+to help, start with an issue labeled `good first issue` or `help wanted`, or
+join the [TunaOS Matrix room](https://matrix.to/#/%23tunaos:reilly.asia) and
+tell us which variant, desktop, or documentation area you use.
+
+### What the checkpoint decides
+
+The checkpoint is an explicit decision point for Q3 carryover. For each open
+goal, maintainers will either staff it with an owner and a concrete first PR,
+descope it to Q4 with a named owner, or drop it. The community-facing result
+will be recorded here before publication:
+
+| Area | Decision after 08-22 | Next step / owner |
+|---|---|---|
+| Bonito Fedora GA | **[STAFF / DESCOPE / DROP]** | **[fill after checkpoint]** |
+| Redfin RHEL 10 alpha | **[STAFF / DESCOPE / DROP]** | **[fill after checkpoint]** |
+| RFC governance | **[STAFF / DESCOPE / DROP]** | **[fill after checkpoint]** |
+| ADR coverage | **[STAFF / DESCOPE / DROP]** | **[fill after checkpoint]** |
+| Flavor release parity | **[STAFF / DESCOPE / DROP]** | **[fill after checkpoint]** |
+| Package sourcing policy | **[STAFF / DESCOPE / DROP]** | **[fill after checkpoint]** |
+
+This makes the roadmap legible: a goal that moves to Q4 is not silently
+forgotten, and a goal that stays in Q3 has a person and a next action behind
+it.
+
+### Join the next phase
+
+You do not need to know the whole build system to participate. Try an image,
+report an install or desktop issue, improve a guide, or take a small labeled
+issue. The project is especially interested in testing the non-GNOME flavors,
+checking downloads on real hardware, and helping turn the new variant catalog
+into reliable releases.
+
+Thanks to everyone testing images, reviewing changes, filing issues, and
+contributing code and documentation. Q3 is not a claim that every goal is
+complete; it is the point where we make the next set of commitments visible.
+
+## Publication checklist
+
+- [ ] Fill the decision table from `Q3_CHECKPOINT-2026-08-22.md` after the
+      checkpoint; do not publish placeholders.
+- [ ] Confirm the contributor acknowledgment and retention status with the
+      contributor before naming them publicly.
+- [ ] Refresh the download count, release-asset status, and variant wording
+      against the current README and build catalog.
+- [ ] Replace the `good first issue` sentence with the current curated issue
+      list once #1362 has landed.
+- [ ] Publish on tunaos.org/blog and cross-post the link to Matrix #tunaos.
+- [ ] Link the final post from issue #1345 and record the publication date.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ user-facing site:
 | [CI_SPEC.md](CI_SPEC.md) | CI behavior specification |
 | [TESTING.md](TESTING.md) | ISO end-to-end test harness |
 | [MATRIX-STATUS.md](MATRIX-STATUS.md) | Which variant×desktop combinations are actually verified — and which have never been tested |
+| [Q3-COMMUNITY-RECAP-2026-08-22.md](Q3-COMMUNITY-RECAP-2026-08-22.md) | Draft community-facing recap for the 2026-08-22 Q3 checkpoint |
 | [ASAHI-HARDWARE-TIERS.md](ASAHI-HARDWARE-TIERS.md) | Real Apple Silicon hardware CI: rented Scaleway rental + personal-machine tiers, and the m1n1/boot.bin safety rule both must follow |
 | [rhel-setup.md](rhel-setup.md) | RHEL 10 (Redfin) local-build instructions |
 | [ROLL_YOUR_OWN.md](ROLL_YOUR_OWN.md) | Guide to building custom TunaOS variants for your own use |


### PR DESCRIPTION
Closes #1345

## What changed

- Add a maintainer-ready draft for the 2026-08-22 Q3 community recap.
- Summarize verified download/catalog progress, experimental Hummingbird and Gurnard status, flavor equality, and external contributor momentum.
- Include a post-checkpoint decision table with STAFF/DESCOPE/DROP placeholders so no decision is pre-announced.
- Add contributor onboarding guidance and a publication checklist for the tunaos.org blog and Matrix.
- Index the draft in `docs/README.md`.

## Why

The internal checkpoint sheet is decision-focused, while issue #1345 calls for a companion public recap that turns the milestone into a retention and recruitment touchpoint. This draft keeps current facts separate from decisions that must be filled after the checkpoint and flags the items requiring a final editorial refresh.

## Validation

- `git diff --check`
- `git diff --cached --check`
- Verified referenced repository files exist.
- Confirmed the branch is based on current `upstream/main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789201804&installation_model_id=429180&pr_number=1461&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1461&signature=b4a63ed7d6b045de877436cb80c501924155c112c58c9cfaff5d3a46c58ffc04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->