### PR TITLE
docs: fold Reddit/Lemmy release-gate + community table into the existing playbook

### DIFF
--- a/ADOPTION-METRICS.md
+++ b/ADOPTION-METRICS.md
@@ -32,6 +32,7 @@ publish, and *how* the snapshot feeds roadmap decisions.
 | Community | Open PRs from external contributors | GitHub API | 0 external contributors | ≥2 external contributor PRs merged |
 | Community | Discussion posts, `good first issue` pickups | GitHub API | 0 starter issues (dead label, #1308) | ≥5 starter issues picked up |
 | Community | Public adopters (production or evaluation), [ADOPTERS.md](./ADOPTERS.md) | Manual — PR from the adopting org, or outreach asking permission to list | 0 production entries (#1348) | ≥2–3 public evaluator/production entries |
+| Community | Reddit/Lemmy release-announcement posts | Post records + GitHub API / release assets | **not measured** | Record each post and its 7/30-day star/download deltas; max ~1 post/mo |
 
 **Instrumentation order** (cheapest first):
 
@@ -51,8 +52,9 @@ publish, and *how* the snapshot feeds roadmap decisions.
   **2026-11-01**, covering October — aligns with Q4 "Mature" opening).
 - Snapshot format: downloads by variant × desktop (top 10), stars/forks,
   external-contributor PRs, release-asset presence per flavor,
-  [ADOPTERS.md](./ADOPTERS.md) production/evaluation entry count, and a
-  one-line "variant ranking" that flags under-/over-performing editions.
+  [ADOPTERS.md](./ADOPTERS.md) production/evaluation entry count, Reddit/Lemmy
+  post URLs and 7/30-day results, and a one-line "variant ranking" that flags
+  under-/over-performing editions.
 - Ownership: **strategist** compiles; **ci-maintainer** supplies R2/Releases
   exports; **guide** publishes on tunaos.org/blog.
 

--- a/docs/REDDIT-LEMMY-PLAYBOOK.md
+++ b/docs/REDDIT-LEMMY-PLAYBOOK.md
@@ -25,6 +25,19 @@ release announcements a repeatable, low-effort process.
 - **Engage honestly in comments** — answer questions, accept criticism,
   update the post with fixes
 
+## Target communities
+
+| Community | Purpose | Posting approach |
+|---|---|---|
+| [r/linux](https://www.reddit.com/r/linux/) | Broad Linux audience for a substantial release or project milestone | One original, discussion-oriented post when the release has broad interest; answer questions in the same thread |
+| [r/immutables](https://www.reddit.com/r/immutables/) | People specifically interested in image-based/atomic desktops | Use for variant, bootc, rollback, or image-update details; cross-post only when the content is relevant |
+| [programming.dev/c/linux](https://programming.dev/c/linux) | Lemmy Linux audience | Publish the same announcement as a native post, adapting links and tone to the community |
+| [lemmy.world/c/linux](https://lemmy.world/c/linux) | Additional Lemmy Linux audience | Cross-post only after checking local rules and whether the post adds value there |
+
+Keep this list small and check relevance/local moderation rules before
+expanding it — a post that fits r/linux does not automatically fit every
+Lemmy Linux community.
+
 ## When to post (candidate hooks)
 
 | Hook | Date | Post angle |
@@ -47,14 +60,35 @@ release announcements a repeatable, low-effort process.
 5. Known limitations / status (honest)
 6. Link: tunaos.org/blog post + GitHub
 
+## Release gate
+
+Before drafting a post, confirm:
+
+- the release or variant is published and the download page works;
+- the release notes identify what changed, known limitations, and a
+  support path;
+- checksums/signatures and source links are available where applicable;
+- the named variant and desktop are spelled consistently with the catalog;
+- screenshots or other media are free to redistribute and have useful alt
+  text;
+- the post has one clear action for readers (try it, read the notes, or
+  give feedback), not a list of unrelated asks.
+
+If the download, release notes, or signing state is not ready, wait — a
+broken announcement link is worse than a late announcement.
+
 ## Process
 
 1. Draft post as a **GitHub Discussion** first (public review, gets the
    community's eyes on it before it goes out)
-2. Maintainer posts to r/linux + Lemmy (one human account)
-3. Track star/download deltas per post in the monthly
-   ADOPTION-METRICS.md snapshot (#1311)
-4. Retro after 3 posts: what worked, what to cut
+2. Re-check the target community's current rules immediately before
+   posting — promotion limits, flair, and account-age requirements can
+   change between drafting and publishing
+3. Maintainer posts to r/linux + Lemmy (one human account)
+4. Track star/download deltas per post in the monthly
+   ADOPTION-METRICS.md snapshot (#1311); label unavailable values
+   `not available` rather than estimating them
+5. Retro after 3 posts: what worked, what to cut
 
 ## Ready-to-post drafts (August 2026 launch trio)
 


### PR DESCRIPTION
Addresses #1346's proposed action (Reddit/Lemmy release-announcement playbook).

## What changed since this PR was opened

This PR originally added a new `docs/REDDIT-LEMMY-RELEASE-PLAYBOOK.md`. Rebasing onto current `main` surfaced that `docs/REDDIT-LEMMY-PLAYBOOK.md` — same topic, same tracking issue (#1346) — had since been merged separately, with real overlapping content (rules of engagement, a "when to post" hook table, a post template, and ready-to-post drafts for the August launch trio).

Two similarly-named docs on the same subject would be worse than one, so I rewrote this to **fold the genuinely new material into the already-merged file** instead of shipping a duplicate:

- **"Target communities" table** — r/immutables and the two specific Lemmy instances (programming.dev, lemmy.world), more detailed than the existing subreddit list.
- **"Release gate" pre-flight checklist** — download/checksum/release-note readiness checks that weren't in the merged file.
- **Process refinement** — re-check community rules immediately before posting (they can change between drafting and publishing), and label unavailable tracking values `not available` rather than estimate them.

Dropped:
- The redundant new file and its `docs/README.md` index entry.
- Its "First planned hooks" section — Gurnard already launched 2026-08-12 (per the merged file's own ready-to-post drafts), so that hook is now stale, not upcoming.

Kept:
- The `ADOPTION-METRICS.md` wiring — a "Reddit/Lemmy release-announcement posts" funnel row and a snapshot-format update. The already-merged file never added this tracking hook, so it's the one piece of the original proposal that was genuinely still missing.

## Verification

- Diff against current `main`: only `ADOPTION-METRICS.md` and `docs/REDDIT-LEMMY-PLAYBOOK.md` change — no new file, no duplicate README index entry.
- `mergeable: MERGEABLE`, confirmed after the rebase.
