### PR TITLE
docs: add ADOPTERS.md entry count as a tracked adoption-metrics KPI

### DIFF
--- a/ADOPTION-METRICS.md
+++ b/ADOPTION-METRICS.md
@@ -30,6 +30,7 @@ publish, and *how* the snapshot feeds roadmap decisions.
 | Install | Installs / successful boots | opt-in telemetry or boot-report gating | **not measured** | Q4 design decision (#577 GUI gate, #763) |
 | Community | Open PRs from external contributors | GitHub API | 0 external contributors | ≥2 external contributor PRs merged |
 | Community | Discussion posts, `good first issue` pickups | GitHub API | 0 starter issues (dead label, #1308) | ≥5 starter issues picked up |
+| Community | Public adopters (production or evaluation), [ADOPTERS.md](./ADOPTERS.md) | Manual — PR from the adopting org, or outreach asking permission to list | 0 production entries (#1348) | ≥2–3 public evaluator/production entries |
 
 **Instrumentation order** (cheapest first):
 
@@ -48,8 +49,9 @@ publish, and *how* the snapshot feeds roadmap decisions.
 - **Monthly snapshot**, published in the ROADMAP **Community** section (first:
   **2026-11-01**, covering October — aligns with Q4 "Mature" opening).
 - Snapshot format: downloads by variant × desktop (top 10), stars/forks,
-  external-contributor PRs, release-asset presence per flavor, and a one-line
-  "variant ranking" that flags under-/over-performing editions.
+  external-contributor PRs, release-asset presence per flavor,
+  [ADOPTERS.md](./ADOPTERS.md) production/evaluation entry count, and a
+  one-line "variant ranking" that flags under-/over-performing editions.
 - Ownership: **strategist** compiles; **ci-maintainer** supplies R2/Releases
   exports; **guide** publishes on tunaos.org/blog.
 


### PR DESCRIPTION
## Summary

#1348 found `ADOPTERS.md` still lists zero production users while Q4 is themed "Mature" — a credibility gap for DistroWatch (#1333) and CNCF (#1340) outreach that cite adoption evidence.

Two of the issue's three proposed actions are things I can actually do as a docs PR; the third (reach out to known evaluators to request permission to list) is a live outreach action requiring a real human conversation, not something to fabricate or originate as a hive agent.

This PR implements:

- **Recommendation #1**: added a "Public adopters (production or evaluation)" row to `ADOPTION-METRICS.md`'s metric tiers table — baseline 0 (verified live against `ADOPTERS.md`), target ≥2–3 public evaluator/production entries, sourced from PRs/outreach rather than an API (it's a qualitative, permission-gated metric, not scraped telemetry — noted explicitly to distinguish it from the quantitative rows around it).
- **Recommendation #3**: added the ADOPTERS.md entry count to the monthly snapshot format so it's tracked as a KPI going forward, not just observed once.

Recommendation #2 (outreach to known evaluators) isn't actioned here — it needs someone with actual Matrix/community visibility to identify real candidates and ask permission, which is outside what a repo PR can manufacture.

## Test plan
- [x] Confirmed `ADOPTERS.md`'s Production Users section currently reads "_(None listed yet — be the first!)_" — baseline is genuinely 0, not stale
- [x] Checked `ADOPTERS.md`'s "Adding Your Organization" section is already a clear, low-friction self-serve process — no changes needed there, the gap is evidence collection as the issue itself says, not process clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `44890e06`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->