### PR TITLE
docs: document the pantheon desktop suffix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Image tags are constructed as `<desktop>[-hardware]`:
    * `cosmic`: COSMIC Desktop
    * `niri`: Niri (tiling Wayland compositor)
    * `xfce`: XFCE (Wayland experimental)
+   * `pantheon`: Pantheon desktop (elementary OS) — Gurnard variant, experimental
    * `base`: Plain system image with no desktop environment pre-installed (available for most variants)
 
 2. **Hardware Suffixes** (append to any desktop suffix):


### PR DESCRIPTION
## What changed

Adds `pantheon` to the README's Desktop Suffixes list (Gurnard's `ghcr.io/tuna-os/gurnard:pantheon` image), matching the format of the other suffix entries and noting it's experimental (consistent with Gurnard's current ROADMAP.md status).

## Why

Gurnard shipped Pantheon as a new desktop option but the suffix list never got updated — closes #1350.

## Test plan
- [x] Confirmed `ghcr.io/tuna-os/gurnard:pantheon` is the real image reference (already listed in the Images and variants table above the suffix list)
- [x] Single-file docs change, no build/config files touched, matching the issue's acceptance criteria

Fixes #1350

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `24eeb2d0`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->