### PR TITLE
security: remove unpinned just.systems install.sh fallback

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -149,12 +149,18 @@ jobs:
               && break || sleep $((i * 2))
           done
 
-          curl -fsSL \
-            "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz" \
-            -o /tmp/just.tgz 2>/dev/null \
-            || curl -fsSL https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
+          # Pinned GitHub release only — no unpinned just.systems/install.sh
+          # fallback (that pipes an unauthenticated remote script into
+          # `sudo bash`, tunaos#1357). Retry the pinned download instead,
+          # same as the yq retry loop above.
+          for i in 1 2 3; do
+            curl -fsSL \
+              "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz" \
+              -o /tmp/just.tgz \
+              && break || sleep $((i * 2))
+          done
 
-          if [ -f /tmp/just.tgz ]; then sudo tar -xzf /tmp/just.tgz -C /usr/local/bin just; fi
+          sudo tar -xzf /tmp/just.tgz -C /usr/local/bin just
           sudo chmod +x /usr/bin/yq /usr/local/bin/just 2>/dev/null || true
           just --version && yq --version
 


### PR DESCRIPTION
## Summary

A prior fix for #1357 was prepared but never landed — blocked on \`workflows\` push permission for the agent that filed it (per the issue comment). Redid it via the normal fork+PR flow.

\`.github/workflows/reusable-build-image.yml\`'s "Install just and yq" step fell back to \`curl -fsSL https://just.systems/install.sh | sudo bash\` whenever the pinned GitHub release download failed — an unpinned remote script executed as root on every image build if it ever fires. Replaced the fallback with a 3-attempt retry loop against the same pinned release URL, matching the pattern already used for \`yq\` two lines above in the same step. If the pinned download still fails after 3 attempts, the step now fails closed (the \`tar\` call errors on a missing file) instead of silently degrading to an unpinned installer — this matches the fix the issue itself recommended.

## Test plan
- [x] \`yaml.safe_load\` — parses cleanly
- [x] Extracted and \`bash -n\`-checked the modified step — no syntax errors
- [x] Confirmed \`just.systems/install.sh\` doesn't appear anywhere else in the repo's workflows (single occurrence, now removed)
- [x] Confirmed the retry-loop pattern mirrors the existing \`yq\` retry loop immediately above it in the same step, so the change is consistent with existing style rather than introducing a new pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `35082e7b`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->