### PR TITLE
[outreach] add Pantheon packaging feedback loop

### DIFF
--- a/ADOPTION-METRICS.md
+++ b/ADOPTION-METRICS.md
@@ -30,6 +30,7 @@ publish, and *how* the snapshot feeds roadmap decisions.
 | Install | Installs / successful boots | opt-in telemetry or boot-report gating | **not measured** | Q4 design decision (#577 GUI gate, #763) |
 | Community | Open PRs from external contributors | GitHub API | 0 external contributors | ≥2 external contributor PRs merged |
 | Community | Discussion posts, `good first issue` pickups | GitHub API | 0 starter issues (dead label, #1308) | ≥5 starter issues picked up |
+| Community | Pantheon feedback reports | Public tracker #1469 + GitHub API | **not measured** | Classify reports and compare Gurnard downloads/docs visits in monthly snapshots |
 | Community | Public adopters (production or evaluation), [ADOPTERS.md](./ADOPTERS.md) | Manual — PR from the adopting org, or outreach asking permission to list | 0 production entries (#1348) | ≥2–3 public evaluator/production entries |
 
 **Instrumentation order** (cheapest first):
@@ -49,9 +50,10 @@ publish, and *how* the snapshot feeds roadmap decisions.
 - **Monthly snapshot**, published in the ROADMAP **Community** section (first:
   **2026-11-01**, covering October — aligns with Q4 "Mature" opening).
 - Snapshot format: downloads by variant × desktop (top 10), stars/forks,
-  external-contributor PRs, release-asset presence per flavor,
-  [ADOPTERS.md](./ADOPTERS.md) production/evaluation entry count, and a
-  one-line "variant ranking" that flags under-/over-performing editions.
+  external-contributor PRs, release-asset presence per flavor, Pantheon
+  feedback counts/classifications, [ADOPTERS.md](./ADOPTERS.md)
+  production/evaluation entry count, and a one-line "variant ranking" that
+  flags under-/over-performing editions.
 - Ownership: **strategist** compiles; **ci-maintainer** supplies R2/Releases
   exports; **guide** publishes on tunaos.org/blog.
 

--- a/docs/PANTHEON-FEEDBACK-LOOP.md
+++ b/docs/PANTHEON-FEEDBACK-LOOP.md
@@ -1,0 +1,96 @@
+# Pantheon packaging feedback loop
+
+**Status**: maintainer-ready
+**Tracking**: [tunaOS#1353](https://github.com/tuna-os/tunaos/issues/1353)
+and the canonical [Pantheon packaging/bug triage tracker](https://github.com/tuna-os/tunaos/issues/1469)
+
+Gurnard is TunaOS's Ubuntu 24.04/Noble variant with the Pantheon desktop. It
+is a new packaging surface: upstream elementary targets elementary OS, while
+Gurnard combines the Pantheon packages with an immutable bootc image. This
+document defines how to invite useful public feedback and turn it into
+actionable triage without presenting TunaOS as an elementary OS channel.
+
+## Public invitation
+
+Publish this invitation only after the Gurnard launch post and download link
+are live. Use a public blog comment or reply and the TunaOS Matrix room
+(`#tunaos:reilly.asia`); do not cold-DM users or elementary maintainers.
+
+```markdown
+Gurnard is TunaOS's experimental Ubuntu 24.04 + Pantheon image. We are
+looking for people familiar with Pantheon or elementary OS to try the desktop
+and report packaging or integration issues.
+
+Please report one reproducible symptom per issue in the public Pantheon
+triage tracker: https://github.com/tuna-os/tunaos/issues/1469
+
+Include the Gurnard image/ISO version, hardware and architecture, whether the
+problem occurs in the live ISO or installed system, reproduction steps, and
+relevant logs or screenshots. Please do not send private logs or secrets.
+
+This is feedback for TunaOS's packaging surface, not a request for upstream
+elementary support. If a behavior also occurs on elementary OS, mention that
+so we can separate upstream behavior from TunaOS integration work.
+```
+
+Adapt the wording to the channel and follow its moderation rules. The launch
+post is the canonical announcement; the invitation should link to it and to
+the tracker rather than repeating a full release pitch.
+
+## Triage contract
+
+Every report should receive an acknowledgement or a classification. Keep the
+discussion public unless a reporter has accidentally disclosed sensitive data.
+
+| Classification | Meaning | Next action |
+|---|---|---|
+| `upstream` | Reproduces in the upstream Pantheon/elementary stack | Link the upstream report or documentation; do not promise a TunaOS fix |
+| `packaging` | Missing, conflicting, or incorrectly configured Debian/PPA package or file | Identify the manifest/package change and add a focused follow-up |
+| `image` | Bootc image, filesystem, service, update, or rollback integration | Capture the image tag and relevant service/log output; file a code issue |
+| `installer` | Live ISO, first boot, or installation-specific behavior | Record ISO version and hardware; link installer evidence |
+| `documentation` | Missing or unclear Gurnard/Pantheon instruction | File a small documentation task and link the corrected guide |
+| `needs-info` | Reproduction or version details are missing | Ask one concise public follow-up; do not guess the cause |
+
+Do not label a report `upstream` merely because it involves Pantheon. First
+check whether the package set, display manager, image configuration, or
+immutable update path changes the behavior. Conversely, do not promise to
+patch upstream behavior in the Gurnard image without maintainer agreement.
+
+## Maintainer checklist
+
+Before inviting feedback:
+
+- [ ] Gurnard/Pantheon is downloadable and the URL resolves to the current
+      release or catalog entry.
+- [ ] The post says `experimental` and names the tested architecture and
+      hardware scope.
+- [ ] The public tracker [#1469](https://github.com/tuna-os/tunaos/issues/1469)
+      has the `bug`, `community`, and `outreach` labels.
+- [ ] The invitation links to the tracker and does not ask for cold DMs.
+- [ ] The maintainer or triager is available to acknowledge reports.
+
+For each new report:
+
+1. Confirm the Gurnard/Pantheon version, architecture, and reproduction path.
+2. Add one classification label and link the relevant manifest, check, or
+   upstream issue.
+3. Separate packaging defects from upstream behavior in the issue summary.
+4. Mark the first one or two small, reproducible follow-ups `good first issue`
+   only after a maintainer has written acceptance criteria and confirmed that
+   the task does not require elementary upstream access.
+5. Record the outcome in the next adoption snapshot, including unresolved
+   reports and any change to the download or docs funnel.
+
+## Monthly feedback record
+
+The adoption-metrics owner should add a row or short note for each snapshot.
+Do not treat issue volume as a measure of quality by itself: a successful
+invitation may initially increase reports because more users can find the
+project.
+
+| Snapshot | Invitation URL/channel | New Pantheon reports | Classified | Fixed/closed | Needs upstream | Gurnard downloads/docs signal | Notes |
+|---|---|---:|---:|---:|---|---|---|
+| [YYYY-MM] | [URL and blog/Matrix] | [N] | [N] | [N] | [N] | [value or not measured] | [context] |
+
+The public tracker is the source of truth for individual reports. This table
+is only a monthly summary and must not duplicate private reporter data.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ user-facing site:
 | [CI_SPEC.md](CI_SPEC.md) | CI behavior specification |
 | [TESTING.md](TESTING.md) | ISO end-to-end test harness |
 | [MATRIX-STATUS.md](MATRIX-STATUS.md) | Which variant×desktop combinations are actually verified — and which have never been tested |
+| [PANTHEON-FEEDBACK-LOOP.md](PANTHEON-FEEDBACK-LOOP.md) | Public invitation and triage contract for Gurnard/Pantheon packaging feedback |
 | [ASAHI-HARDWARE-TIERS.md](ASAHI-HARDWARE-TIERS.md) | Real Apple Silicon hardware CI: rented Scaleway rental + personal-machine tiers, and the m1n1/boot.bin safety rule both must follow |
 | [ASAHI-EL10-OBS-PROJECT.md](ASAHI-EL10-OBS-PROJECT.md) | Open Build Service project for EL10 Asahi packages (#777) |
 | [rhel-setup.md](rhel-setup.md) | RHEL 10 (Redfin) local-build instructions |


### PR DESCRIPTION
Closes #1353

## What changed

- created canonical tracker #1469 for Pantheon-on-Gurnard packaging and desktop-surface reports
- added a public invitation template and triage contract distinguishing upstream, packaging, image, installer, documentation, and missing-information reports
- added maintainer launch/triage checklists and a monthly feedback record
- wired Pantheon feedback classifications into the adoption metrics plan and documentation index

## Validation

- `git diff --check`
- documentation-only change; no code or workflow tests required

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789205726&installation_model_id=429180&pr_number=1470&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1470&signature=5473a2ff915130d341c2792f27b9b181175179b9a311841b32512ed4ae61edf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->