### PR TITLE
docs: add 'Verifying downloads' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,42 @@ If you're already running a compatible bootc system:
 sudo bootc switch ghcr.io/tuna-os/yellowfin:gnome
 ```
 
+### Verifying downloads
+
+TunaOS images and ISOs are keylessly signed (Sigstore Cosign, GitHub Actions
+OIDC identity — no project key or password) and published with SBOMs, so you
+can verify what you're running instead of trusting the download blindly.
+
+**ISOs** ship with a `.iso.sha256` checksum and a `.iso.sigstore.json`
+verification bundle alongside the image:
+
+```bash
+sha256sum --check --strict tunaos-example.iso.sha256
+
+cosign verify-blob tunaos-example.iso \
+  --bundle tunaos-example.iso.sigstore.json \
+  --certificate-identity \
+    "https://github.com/tuna-os/tunaOS/.github/workflows/reusable-build-artifacts.yml@refs/heads/main" \
+  --certificate-oidc-issuer \
+    "https://token.actions.githubusercontent.com"
+```
+
+**Container images** are signed by digest, with a signed SPDX SBOM
+attestation attached to each platform image:
+
+```bash
+digest=$(skopeo inspect docker://ghcr.io/tuna-os/yellowfin:gnome | jq -r .Digest)
+cosign verify "ghcr.io/tuna-os/yellowfin@${digest}" \
+  --certificate-identity \
+    "https://github.com/tuna-os/tunaOS/.github/workflows/reusable-build-image.yml@refs/heads/main" \
+  --certificate-oidc-issuer \
+    "https://token.actions.githubusercontent.com"
+```
+
+Full commands, the SBOM-attestation example, and the exact trust boundary
+(which identities/issuers are accepted and why) are in
+[docs/VERIFY-ARTIFACTS.md](docs/VERIFY-ARTIFACTS.md).
+
 ## Container registry authentication
 
 Images are published on GitHub Container Registry (GHCR). To pull images with `bootc` or `podman`:


### PR DESCRIPTION
## What changed

Adds a `### Verifying downloads` section under Installation, covering:
1. ISO checksum + Cosign bundle verification (`sha256sum -c` + `cosign verify-blob`)
2. Container image signature verification by digest (`cosign verify`)
3. A link to `docs/VERIFY-ARTIFACTS.md` for the full commands, SBOM-attestation example, and trust boundary

## Why

Closes #1366. TunaOS publishes signed images and SBOMs but README never told users how to check them — this gives first-time visitors a way to verify what they're running, and doubles as a small first-timer docs task.

## Test plan
- [x] Cross-checked both commands against `docs/VERIFY-ARTIFACTS.md`'s existing examples — same identity/issuer values, no new claims invented
- [x] Kept the section under 40 lines per the issue's guidance
- [x] Placed between "Switch an existing system" and "Container registry authentication", matching README's existing Installation flow

Fixes #1366

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `605cd135`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->