### PR TITLE
[outreach] add warm-channel adoption call

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -3,11 +3,12 @@
 > A list of organizations and projects that use TunaOS in production, development, or evaluation.
 >
 > If you or your organization is using TunaOS, we'd love to add you to this list!
-> Please submit a PR adding your name or open an issue.
+> See the [adoption call](docs/ADOPTION-CALL.md) to self-identify in the public
+> Show-and-tell Discussion, or submit a PR with the same consent details.
 
 ## Production Users
 
-_(None listed yet — be the first!)_
+_(None listed yet — see the [adoption call](docs/ADOPTION-CALL.md) and be the first!)_
 
 ## Development & Evaluation
 

--- a/ADOPTION-METRICS.md
+++ b/ADOPTION-METRICS.md
@@ -31,6 +31,7 @@ publish, and *how* the snapshot feeds roadmap decisions.
 | Community | Open PRs from external contributors | GitHub API | 0 external contributors | ≥2 external contributor PRs merged |
 | Community | Discussion posts, `good first issue` pickups | GitHub API | 0 starter issues (dead label, #1308) | ≥5 starter issues picked up |
 | Community | Public adopters (production or evaluation), [ADOPTERS.md](./ADOPTERS.md) | Manual — PR from the adopting org, or outreach asking permission to list | 0 production entries (#1348) | ≥2–3 public evaluator/production entries |
+| Community | Adoption-call conversion | GitHub Discussion + follow-up PRs | **not measured** | Record responses, consent-confirmed named entries, anonymous reports, and ADOPTERS.md PRs |
 
 **Instrumentation order** (cheapest first):
 
@@ -50,8 +51,9 @@ publish, and *how* the snapshot feeds roadmap decisions.
   **2026-11-01**, covering October — aligns with Q4 "Mature" opening).
 - Snapshot format: downloads by variant × desktop (top 10), stars/forks,
   external-contributor PRs, release-asset presence per flavor,
-  [ADOPTERS.md](./ADOPTERS.md) production/evaluation entry count, and a
-  one-line "variant ranking" that flags under-/over-performing editions.
+  [ADOPTERS.md](./ADOPTERS.md) production/evaluation entry count, adoption-call
+  responses/conversion, and a one-line "variant ranking" that flags
+  under-/over-performing editions.
 - Ownership: **strategist** compiles; **ci-maintainer** supplies R2/Releases
   exports; **guide** publishes on tunaos.org/blog.
 

--- a/Q3_CHECKPOINT-2026-08-22.md
+++ b/Q3_CHECKPOINT-2026-08-22.md
@@ -41,6 +41,11 @@ Make Q3 carryover an explicit decision, not a discovery. For every open Q3 goal,
 
 ### Supporting items for the checkpoint
 
+- **Adoption call (#1367)**: before using Q4 “Mature” language, publish the
+  [warm-channel adoption call](docs/ADOPTION-CALL.md) in a Show-and-tell
+  Discussion and record the link here. Count only consent-confirmed named
+  entries as public adoption evidence; downloads, stars, pulls, CI, and
+  anonymous reports do not populate `ADOPTERS.md` Production Users.
 - **Contributor retention → capacity**: shimonenator is ACTIVE (8 commits 08-10/11 across tunaOS + xfce-linux; last 08-11 20:26Z). 14-day window closes ~08-24 — 2 days AFTER this checkpoint. Recommend converting retention into capacity: seed GFI-scoped Bonito/Redfin packaging subtasks for the contributor **at** the checkpoint, so #272/#1123 staff tests can borrow external capacity instead of maintainer-only time.
 - **GFI pool is ZERO usable (#1362)**: the #1308 seeds never landed (letters#8 is on an archived repo); CONTRIBUTING's good-first-issue link is dead. No seeds → no external capacity → the retention-window opportunity above is moot. Seed 20+ GFIs by 09-15 (#1362; outreach #1354 tracks 3→8).
 - **Q4 dependency risk**: Q4 is 0/13 items closed (was 0/9); Bonito GA and Redfin GA already appear as Q4 rows — every Q3 descope adds Q4 load before Q4 starts. #1159/#1307 track Q4 goal fidelity.
@@ -73,6 +78,16 @@ Make Q3 carryover an explicit decision, not a discovery. For every open Q3 goal,
 ## Outcome recording
 
 After the checkpoint, update the ROADMAP.md Q3 status table (per #1299 step 3) so carryover is a decision, not a discovery.
+
+### Adoption-call record
+
+| Discussion URL | Responses | Confirmed named entries | Anonymous reports | ADOPTERS.md PRs |
+|---|---:|---:|---:|---:|
+| `[DISCUSSION_URL]` | [N] | [N] | [N] | [#PRs] |
+
+Replace the placeholder only after the maintainer publishes the Discussion.
+Keep the counts separate and do not promote the Q4 “Mature” claim from this
+call unless the evidence target is met.
 
 ---
 *Prepared by strategist agent (ACMM L6 — full mode). Signed-off-by: hanthor-hive-agent[bot] <290068839+hanthor-hive-agent[bot]@users.noreply.github.com>*

--- a/docs/ADOPTION-CALL.md
+++ b/docs/ADOPTION-CALL.md
@@ -1,0 +1,103 @@
+# Adoption call: who is running TunaOS?
+
+**Status**: ready for maintainer publication
+**Tracking**: [tunaOS#1367](https://github.com/tuna-os/tunaos/issues/1367)
+
+This is a warm-channel call for organizations and teams already running or
+evaluating TunaOS. It supports the Q4 “Mature” evidence review without
+inventing adopters or treating a download as proof of production use.
+
+## Where and when to publish
+
+Publish as a GitHub Discussion in the **Show-and-tell** category, then share
+the Discussion link in the TunaOS Matrix room and the next community or
+release post. Use existing community relationships and public channels only;
+do not cold-DM people or claim that a named organization uses TunaOS without
+their permission.
+
+The call should run for at least two weeks before the Q4 checkpoint. Keep it
+open afterward so new adopters have a stable path to self-identify. The
+Discussion is the source of truth for responses; comments and Matrix replies
+should link back to it.
+
+## Discussion title and body
+
+Use this copy, replacing the date and links before publishing:
+
+```markdown
+# Who's running TunaOS? Add yourself to ADOPTERS.md
+
+Are you or your organization running TunaOS in production, development, or
+evaluation? We are collecting voluntary, public adopter reports before the Q4
+“Mature” checkpoint.
+
+If you would like to be listed, reply with this template:
+
+Organization or public name:
+Use case (production, development, or evaluation):
+Variant(s) and desktop(s):
+Since (YYYY-MM):
+Public link (optional):
+What is working well or what should we improve? (optional):
+
+Please share only information you are authorized to publish. A maintainer will
+confirm the wording with you before opening a small follow-up PR to
+[ADOPTERS.md](https://github.com/tuna-os/tunaos/blob/main/ADOPTERS.md). You can
+also open that PR yourself. We will not add a person or organization from a
+private message, telemetry, registry pull, or an unverified claim.
+
+If you prefer not to be named, a maintainer can record an anonymous count in
+the monthly adoption snapshot; anonymous use will not be presented as a named
+Production User.
+```
+
+## Matrix and release-note CTA
+
+Use a short pointer in Matrix `#tunaos:reilly.asia` or a release/community
+post:
+
+> Are you already running or evaluating TunaOS? Tell us what you use and
+> whether we may list it publicly in [the “Who’s running TunaOS?” Discussion]
+> ([DISCUSSION_URL]). We will confirm the wording with you before updating
+> [ADOPTERS.md](https://github.com/tuna-os/tunaos/blob/main/ADOPTERS.md).
+
+The Q3 checkpoint recap or release notes should use the same CTA and link to
+the Discussion. Do not duplicate a response template in several posts, since
+that fragments the record.
+
+## Consent and verification rules
+
+1. A maintainer acknowledges each response and asks the respondent to confirm
+   the exact public name, category, variants, and start month.
+2. A named Production User requires explicit confirmation from an authorized
+   representative. A GitHub username alone is not evidence of organizational
+   production use.
+3. Development and evaluation reports are welcome and should stay in those
+   sections unless the respondent later confirms production use.
+4. Never infer an adopter from downloads, stars, container pulls, CI jobs, or
+   an organization appearing in the ecosystem table.
+5. If a respondent withdraws consent, remove or amend the entry in a follow-up
+   PR and note the change in the next snapshot without retaining private
+   details.
+
+## Follow-up workflow
+
+- [ ] Create the Discussion in **Show-and-tell** and record its URL in issue
+      #1367.
+- [ ] Share the URL in Matrix and the next community/release post.
+- [ ] Acknowledge responses and request confirmation of the proposed wording.
+- [ ] Open one small PR per confirmed adopter, linking the Discussion comment
+      and issue #1367; do not bundle unconfirmed entries.
+- [ ] Record response count, confirmed named entries, anonymous responses, and
+      conversion to ADOPTERS.md in the next monthly adoption snapshot.
+- [ ] Refresh the Q4 “Mature” claim only after comparing the evidence against
+      the documented target; otherwise state the gap and re-baseline it.
+
+## Tracking record
+
+| Date | Channel / Discussion URL | Responses | Confirmed named entries | Anonymous reports | ADOPTERS.md PRs | Notes |
+|---|---|---:|---:|---:|---:|---|
+| [YYYY-MM-DD] | [URL] | [N] | [N] | [N] | [#PRs] | [follow-up] |
+
+The count measures participation in the call, not adoption itself. Keep named
+entries and anonymous responses separate in every report.

--- a/docs/MATRIX-WEEKLY-DIGEST.md
+++ b/docs/MATRIX-WEEKLY-DIGEST.md
@@ -29,6 +29,9 @@
 - New good-first-issue tasks: [#NNNN](https://github.com/tuna-os/tunaOS/issues/NNNN) — _one-line scope_
 - Discussion thread worth reading: [title](link) — _one-line why_
 - New contributor shout-out (if any): @handle merged _x_ PR(s)
+- Adoption call (once published): [Who's running TunaOS?](DISCUSSION_URL) —
+  _voluntary, consent-confirmed reports for ADOPTERS.md; do not infer use from
+  downloads or image pulls_
 
 ### 🔗 Links
 
@@ -46,7 +49,8 @@
 - **Ad hoc** only for: variant launches, conference talks, Hacktoberfest
   start, release-week events (e.g., GNOME 51, Fedora 45)
 - Always end with one **call to action** (try the ISO, pick up a GFI,
-  join office hours) — a digest without an ask does not grow the room
+  join office hours, or self-identify through the [adoption call](ADOPTION-CALL.md))
+  — a digest without an ask does not grow the room
 
 ## First post candidates
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ user-facing site:
 | [IMAGE-FACTORY-LIFECYCLE-GATE.md](IMAGE-FACTORY-LIFECYCLE-GATE.md) | Image factory lifecycle coverage & required gate (#1278) |
 | [CFP-FOSDEM-2027.md](CFP-FOSDEM-2027.md) | FOSDEM 2027 CFP draft |
 | [DISTROWATCH-SUBMISSION.md](DISTROWATCH-SUBMISSION.md) | DistroWatch project submission draft |
+| [ADOPTION-CALL.md](ADOPTION-CALL.md) | Warm-channel call and consent workflow for public TunaOS adopter reports |
 | [IMPROVEMENT_PLAN.md](IMPROVEMENT_PLAN.md) | Historical record of the May 2026 sprint + remaining roadmap items |
 | [agents/](agents/) | Hive agent guides (issue-tracker, triage-labels, domain) |
 | [adr/](adr/) | Architecture Decision Records |


### PR DESCRIPTION
Closes #1367

## What changed

- add a reusable GitHub Discussion / Matrix adoption-call template for existing TunaOS users and organizations
- document consent, verification, public-naming, and anonymous-response rules so no adopter is fabricated
- define the follow-up PR workflow and monthly conversion record before the Q4 Mature checkpoint
- link the call from ADOPTERS.md and the maintainer docs index
- track adoption-call response/conversion in ADOPTION-METRICS.md

## Validation

- `git diff --check`
- documentation-only change; no code or workflow tests required

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789205895&installation_model_id=429180&pr_number=1472&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1472&signature=e04acfdb5f8e87dc189bf202195fa49d70c48b27df15d47c15250d6bf01a7482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->