### PR TITLE
[outreach] add elementary cross-post handoff tracking

### DIFF
--- a/ADOPTION-METRICS.md
+++ b/ADOPTION-METRICS.md
@@ -31,6 +31,7 @@ publish, and *how* the snapshot feeds roadmap decisions.
 | Community | Open PRs from external contributors | GitHub API | 0 external contributors | ≥2 external contributor PRs merged |
 | Community | Discussion posts, `good first issue` pickups | GitHub API | 0 starter issues (dead label, #1308) | ≥5 starter issues picked up |
 | Community | Public adopters (production or evaluation), [ADOPTERS.md](./ADOPTERS.md) | Manual — PR from the adopting org, or outreach asking permission to list | 0 production entries (#1348) | ≥2–3 public evaluator/production entries |
+| Discovery | Elementary OS cross-post pickup / referrals | Maintainer submission record + tunaos.org analytics | **not measured** | Record submission outcome and referral signal for the Gurnard/Pantheon pitch (#1368) |
 
 **Instrumentation order** (cheapest first):
 
@@ -50,8 +51,9 @@ publish, and *how* the snapshot feeds roadmap decisions.
   **2026-11-01**, covering October — aligns with Q4 "Mature" opening).
 - Snapshot format: downloads by variant × desktop (top 10), stars/forks,
   external-contributor PRs, release-asset presence per flavor,
-  [ADOPTERS.md](./ADOPTERS.md) production/evaluation entry count, and a
-  one-line "variant ranking" that flags under-/over-performing editions.
+  [ADOPTERS.md](./ADOPTERS.md) production/evaluation entry count, elementary
+  cross-post outcome/referrals, and a one-line "variant ranking" that flags
+  under-/over-performing editions.
 - Ownership: **strategist** compiles; **ci-maintainer** supplies R2/Releases
   exports; **guide** publishes on tunaos.org/blog.
 

--- a/docs/ELEMENTARY-CROSSPOST.md
+++ b/docs/ELEMENTARY-CROSSPOST.md
@@ -6,14 +6,14 @@
 
 ## Cross-post summary (3–4 paragraphs, submission-ready)
 
-**Title (working): Pantheon, anywhere: Gurnard brings the elementary desktop to Ubuntu 24.04 LTS**
+**Title (working): Pantheon beyond elementary OS: Gurnard brings the desktop to Ubuntu 24.04 LTS**
 
-If you love the Pantheon desktop — the calm, minimal environment at the heart
-of elementary OS — you mostly had to run elementary OS itself to get it. A new
-project called [TunaOS](https://tunaos.org) just made that choice bigger:
-**Gurnard** pairs Ubuntu 24.04 LTS with Pantheon, wrapped in an atomic,
-container-native core. It's the first widely-buildable way to get the
-elementary desktop on a standard Ubuntu LTS base.
+If you love the Pantheon desktop — the calm, minimal environment associated
+with elementary OS — you may also want to try it on another base. A community
+project called [TunaOS](https://tunaos.org) has built **Gurnard**, an
+experimental image that pairs Ubuntu 24.04 LTS with Pantheon and a
+container-native core. This is a TunaOS community project, not an elementary
+OS release or endorsement.
 
 Gurnard keeps what makes Pantheon special — the elegant shell, the
 application-centric workflow, the clean out-of-the-box feel — while the base
@@ -22,13 +22,13 @@ updates, rollback on failure, verified upgrades. Flathub and Homebrew come
 pre-enabled, so apps and tools are a click away. The images ship for both
 x86_64 and arm64.
 
-Why does this matter for the elementary community? Because Pantheon is
-packaging surface that deserves to live beyond one distribution. Gurnard is
-experimental today (`ghcr.io/tuna-os/gurnard:base` and `:pantheon`) — the
-right time to try it is now, while bug reports are cheap to fix and can shape
-the packaging before the surface settles. Think of it as a second home for
-Pantheon: same desktop, new foundation, and a project that explicitly lists
-elementary OS in its ecosystem table.
+Why does this matter for the elementary community? Because it gives Pantheon
+users another place to test the desktop and gives packagers concrete feedback
+about a non-elementary base. Gurnard is experimental today
+(`ghcr.io/tuna-os/gurnard:base` and `:pantheon`) — the right time to try it is
+now, while bug reports are cheap to fix and can shape the packaging before the
+surface settles. TunaOS lists elementary OS in its ecosystem table as a
+desktop relationship; that listing is not a claim of endorsement or use.
 
 If you're curious: [announcement post](https://tunaos.org/blog/2026/08/12/announcing-gurnard-ubuntu-pantheon),
 [download](https://tunaos.org/download), or join the conversation on
@@ -42,8 +42,9 @@ elementary users about what a Pantheon-on-Ubuntu should feel like.
 >
 > TunaOS just shipped Gurnard — Ubuntu 24.04 LTS with the Pantheon desktop as
 > an atomic bootc image. We'd love to feature a short cross-post on the
-> elementary blog/planet or community forum, framed around "Pantheon on a
-> non-elementary base" and what that means for the desktop's reach.
+> elementary blog/planet or community forum, framed around “Pantheon on a
+> non-elementary base” and what that means for the desktop's reach. This is a
+> TunaOS community proposal, not a request to imply elementary OS endorsement.
 >
 > Happy to adapt tone/length to your editorial style. Full announcement:
 > https://tunaos.org/blog/2026/08/12/announcing-gurnard-ubuntu-pantheon
@@ -69,8 +70,13 @@ Before sending, the maintainer should confirm:
 
 - [ ] Gurnard's experimental status, Ubuntu 24.04 base, tested architectures,
       and current download URL are accurate.
+- [ ] The `base` and `pantheon` image references resolve to the currently
+      published Gurnard artifacts, or the pitch uses the current release URL
+      instead of stale tags.
 - [ ] The pitch does not imply elementary OS endorses, supports, or uses
       TunaOS; it describes a TunaOS community proposal.
+- [ ] The destination accepts this kind of community submission and the final
+      copy follows its current length, attribution, and link rules.
 - [ ] The [Pantheon feedback tracker](https://github.com/tuna-os/tunaos/issues/1469)
       is linked for technical reports.
 - [ ] The destination and date are recorded in the monthly adoption snapshot.

--- a/docs/ELEMENTARY-CROSSPOST.md
+++ b/docs/ELEMENTARY-CROSSPOST.md
@@ -54,6 +54,29 @@ elementary users about what a Pantheon-on-Ubuntu should feel like.
 
 - **No external contact without maintainer approval** (outreach policy Rule 10)
 - On approval, route the pitch through the maintainer (hanthor)
-- Track pickup in ADOPTION-METRICS.md funnel tier 1 (#1311)
-- elementary OS is a warm partner (ADOPTERS.md row added in #1356) — this is
+- Check the destination's current submission rules, attribution requirements,
+  and link policy immediately before sending; the maintainer owns the final
+  submission and any follow-up
+- Track pickup, referral traffic, and the Gurnard/Pantheon feedback response in
+  ADOPTION-METRICS.md funnel tier 1 (#1311)
+- elementary OS is listed in ADOPTERS.md's **Ecosystem & Downstream Projects**
+  table as a desktop relationship, not as a production adopter; this is warm
   ecosystem engagement, not cold outreach
+
+## Approval and outcome record
+
+Before sending, the maintainer should confirm:
+
+- [ ] Gurnard's experimental status, Ubuntu 24.04 base, tested architectures,
+      and current download URL are accurate.
+- [ ] The pitch does not imply elementary OS endorses, supports, or uses
+      TunaOS; it describes a TunaOS community proposal.
+- [ ] The [Pantheon feedback tracker](https://github.com/tuna-os/tunaos/issues/1469)
+      is linked for technical reports.
+- [ ] The destination and date are recorded in the monthly adoption snapshot.
+
+After sending, record the submission URL, publication date, referral or page
+views when available, and any pickup or moderator response. Treat referral
+traffic as directional: it does not prove installations or elementary OS
+endorsement. If the pitch is declined or receives no response, record that
+without escalating or repeatedly contacting the destination.


### PR DESCRIPTION
Relates to #1368

PR #1415 already landed the elementary OS cross-post draft. This follow-up completes the operational handoff:

- add maintainer approval and destination-rule checklist
- clarify that the ADOPTERS.md ecosystem row does not imply elementary endorsement or production use
- link the Pantheon feedback tracker for technical reports
- define submission outcome, referral, and pickup tracking
- add the elementary cross-post metric to ADOPTION-METRICS.md

## Validation

- `git diff --check`
- documentation-only change; no code or workflow tests required

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789206086&installation_model_id=429180&pr_number=1473&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1473&signature=2ac770a0abb92901516f835751bee706ae6667476b3d2fbdb83ad691a9b6a9c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->