### PR TITLE
fix(ci): expand artifact matrix across architectures so arm64 ISOs/QCOW2s are built (#1378)

### DIFF
--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -153,16 +153,20 @@ jobs:
             echo "$FULL_MATRIX" | jq -c --argjson stage "$STAGE" '{
               include: map(
                 select(.stage == $stage and (.build_iso == true or .build_qcow2 == true))
+                | . as $e
+                | ($e.platforms_json | fromjson)[]
+                | select(.platform == "linux/amd64" or .platform == "linux/arm64")
                 | {
-                    variant:       .variant,
-                    image_name:    .image_name,
-                    published_tag: .published_tag,
-                    variant_emoji: .variant_emoji,
-                    flavor:        .flavor,
-                    build_iso:     .build_iso,
-                    build_qcow2:   .build_qcow2,
-                    base_image:    .base_image,
-                    platform:      "linux/amd64"
+                    variant:       $e.variant,
+                    image_name:    $e.image_name,
+                    published_tag: $e.published_tag,
+                    variant_emoji: $e.variant_emoji,
+                    flavor:        $e.flavor,
+                    build_iso:     $e.build_iso,
+                    build_qcow2:   $e.build_qcow2,
+                    base_image:    $e.base_image,
+                    platform:      .platform,
+                    safeplatform:  .safeplatform
                   }
               )
             }'
@@ -318,7 +322,7 @@ jobs:
     with:
       variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
-      image-tag: ${{ matrix.published_tag }}-linux-amd64
+      image-tag: ${{ matrix.published_tag }}-${{ matrix.safeplatform }}
       build-iso: ${{ matrix.build_iso }}
     secrets:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -347,7 +351,7 @@ jobs:
     with:
       variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
-      image-tag: ${{ matrix.published_tag }}-linux-amd64
+      image-tag: ${{ matrix.published_tag }}-${{ matrix.safeplatform }}
       build-iso: ${{ matrix.build_iso }}
     secrets:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -374,7 +378,7 @@ jobs:
     with:
       variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
-      image-tag: ${{ matrix.published_tag }}-linux-amd64
+      image-tag: ${{ matrix.published_tag }}-${{ matrix.safeplatform }}
       build-iso: ${{ matrix.build_iso }}
     secrets:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}


### PR DESCRIPTION
Fixes #1378.

### Summary
- Updated `make_artifact_matrix` in `.github/workflows/build-variant.yml` to iterate across all target architectures declared in `platforms_json` (`linux/amd64` and `linux/arm64`), generating per-platform artifact matrix entries.
- Replaced hardcoded `-linux-amd64` image-tag suffixes with `${{ matrix.safeplatform }}` across stage-2, stage-3, and stage-4 artifact jobs.
- Ensures arm64 live ISOs and QCOW2 images are automatically generated alongside amd64 artifacts for multi-architecture variants.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->