### PR TITLE
planning: correct Redfin ROADMAP status, explain deliberate build-config exclusion

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,7 +99,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 |------|-------|----------|--------|
 | **Fix ISO downloads** | ci-maintainer | #543, #561 | ✅ Done — downloads verified working (R2, 08-07) |
 | Bonito (Fedora 44) GA | ci-maintainer | #272 | 🟡 In progress (Q3 milestone) |
-| Redfin (RHEL 10) alpha | ci-maintainer | #609, #1123 | 🔴 DROPPED — restored to roadmap 2026-08-08 |
+| Redfin (RHEL 10) alpha | ci-maintainer | #609 (closed, shipped 08-09), #1123 | 🟡 Local-build alpha shipped (systemd auto-update timer units, #609/#1182/#1219) — intentionally **not** in `.github/build-config.yml`'s CI matrix (RHEL EULA forbids redistribution + no RHSM creds on CI runners, see `scripts/get-base-image.sh`); build via `just build redfin <desktop>` or `scripts/corral-build.sh`, see [docs/rhel-setup.md](docs/rhel-setup.md). Remaining: no automated build/publish path is possible by design, so "alpha" here means local-build-verified, not downloadable |
 | Ship KDE, COSMIC, Niri, XFCE variants | ci-maintainer | #285 | 🟡 Published but **desktop-completeness unverified** — 24/37 editions undersized per #133/#1294 |
 | GitHub Releases page carries ISO assets | ci-maintainer | #1106 | ✅ Verified 08-09 — `gnome-20260809` published with assets; cadence resumed |
 | Release-cadence health gate (no silent skip) | ci-maintainer | #1147 | 🟡 Root cause fixed 08-08 (`a4b147f8` fails on dropped release) — verify no silent skip 08-09 |


### PR DESCRIPTION
## Summary

#1123's three proposed next steps are mostly already done, and the ROADMAP row didn't reflect it:

1. **"Add redfin to build-config.yml"** — checked why it's absent: `scripts/get-base-image.sh` has an explicit comment that redfin is "not part of the public build matrix" because RHEL's EULA forbids redistribution and CI runners have no RHSM subscription. This is a deliberate design constraint, not an oversight — adding it to `build-config.yml` would break the CI matrix. Not actioned; documented instead.
2. **"Assign #609 to Q3 milestone"** — already done, and #609 itself is now **closed** (shipped 2026-08-09): the local image-factory auto-update systemd timer units landed via #1182/#1219.
3. **"Publish a docs page"** — already covered by the existing `docs/rhel-setup.md` (252 lines, linked from README), just under a different name than the issue guessed.

The ROADMAP.md row still said "🔴 DROPPED — restored to roadmap 2026-08-08", which undersells what actually shipped and doesn't explain why there's no CI build entry. Updated it to state the real status (local-build alpha shipped) and the deliberate reason the automated build matrix doesn't include it, so a future reader doesn't re-file "why isn't redfin in build-config.yml" as a bug.

## Test plan
- [x] `gh issue view 609` — confirmed closed 2026-08-09, milestone Q3 2026 - Expand Coverage
- [x] `git log --grep="609"` — confirmed real shipped commits (#1182, #1219)
- [x] Read `scripts/get-base-image.sh`'s own comment explaining the build-config exclusion, rather than assuming it was an oversight
- [x] Confirmed `docs/rhel-setup.md` exists and is linked from README's Redfin note

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `123b9c61`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->