### PR TITLE
docs: document supported ARM laptop hardware in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ Image tags are constructed as `<desktop>[-hardware]`:
 | **RAM** | 4 GB | 8 GB+ |
 | **Storage** | 20 GB | 50 GB+ |
 
+### Supported hardware (ARM laptops)
+
+| Hardware | Status | Docs |
+|----------|--------|------|
+| Snapdragon X Elite (e.g. Lenovo ThinkPad X13s) | Supported | [docs.tunaos.org/bonito-x13s](https://github.com/tuna-os/docs/tree/main/docs/bonito-x13s), [docs.tunaos.org/dakota-x13s](https://github.com/tuna-os/docs/tree/main/docs/dakota-x13s) |
+| Apple Silicon (M1, M2) | Supported via [Asahi Linux](https://asahilinux.org/) | [bootc-installer-asahi](https://github.com/tuna-os/bootc-installer-asahi) |
+| Apple Silicon (M3 and newer) | Not yet supported | — |
+
 ---
 
 ## Installation


### PR DESCRIPTION
## What changed

Adds a `### Supported hardware (ARM laptops)` subsection under System Requirements, additive to the existing generic CPU/RAM/Storage table:
1. Snapdragon X Elite (ThinkPad X13s) — links docs/bonito-x13s and docs/dakota-x13s
2. Apple Silicon M1/M2 via Asahi Linux — links bootc-installer-asahi
3. Apple Silicon M3+ explicitly marked not yet supported

## Why

Closes #1385. Prospective ARM laptop users land on README first with no signal that this hardware is supported; the docs already exist, just not surfaced here.

## Test plan
- [x] Confirmed `docs/bonito-x13s` and `docs/dakota-x13s` exist in the docs repo via the GitHub API
- [x] Confirmed `bootc-installer-asahi` repo exists and its description matches ("Asahi Linux installer path")
- [x] Checked `docs/ASAHI-HARDWARE-TIERS.md` in this repo (real M1/M2 hardware CI tiers) before writing the M1/M2-only, not-M3+ claim, rather than overstating support
- [x] Additive only — did not modify the existing generic table

Fixes #1385

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `f5ca113f`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->