### PR TITLE
security: remove unnecessary privileged manifest job

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -550,7 +550,10 @@ jobs:
       - build_push
     container:
       image: cgr.dev/chainguard/wolfi-base@sha256:82d4510534784020cb991dda82a7a1be75d4cd00ceae6e81590cc1ebf7a58ab5  # :latest linux/amd64 as of 2026-06-13
-      options: --privileged --security-opt seccomp=unconfined
+      # This job only performs registry/API operations (podman login and
+      # manifest create/add/annotate/push). It does not run or build a
+      # container, mount a host filesystem, or need kernel capabilities.
+      # Keep the job at the runner's default container confinement.
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

- Remove `--privileged` and `seccomp=unconfined` from the reusable image workflow's manifest container.
- Document why the job does not need host mounts or kernel capabilities.

## Why

The manifest job only logs in and performs Podman registry/manifest operations (`manifest create/add/annotate/push`). It does not build or run a container, so blanket privileged execution unnecessarily expands the runner trust boundary.

This addresses the tunaos scope of #1178. The bootc validation jobs that run `bootc install print-configuration` remain unchanged because their privilege requirements need maintainer validation on a bootc-capable runner.

## Validation

- `git diff --check`
- Confirmed the manifest job no longer contains `options: --privileged` or `seccomp=unconfined`.
- `actionlint` was unavailable in the environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789210545&installation_model_id=429180&pr_number=1483&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1483&signature=66924bbdc69c2e5cf62b1e6e14c6f80173ef05a86c0b0f417d7e8e4faa7fa355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->