### PR TITLE
ci: add missing checkout to catalog-facts merge job

### DIFF
--- a/.github/workflows/catalog-facts.yml
+++ b/.github/workflows/catalog-facts.yml
@@ -151,6 +151,10 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: facts-*


### PR DESCRIPTION
## Summary

A prior fix for #1390 was prepared but blocked on `workflows` push permission for the agent that filed it. Redid it via the normal fork+PR flow.

`.github/workflows/catalog-facts.yml`'s `merge` job reads `.github/build-config.yml` (added in 45a9991, browser catalog parity check) but never checks out the repo — only the `facts` jobs do that. Result: `Merge and publish` has failed every night since 08-11 (`open .github/build-config.yml: no such file or directory`).

Added `actions/checkout` as the first step of the `merge` job, matching the pattern already used in the `facts` jobs. Also set `persist-credentials: false` since this job only reads a file and never pushes — consistent with the direction #1180 (still open) is taking the rest of the repo's checkout steps.

## Test plan
- [x] `yaml.safe_load` — parses cleanly
- [x] Confirmed the failure is still live today (run 31677712806, 2026-08-13, same error)
- [x] Confirmed `.github/build-config.yml` exists on `main` — the fix is purely "check it out before reading it," no other logic change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `6e5c4a55`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->