### PR TITLE
test: add negative/trust-boundary checks for keyless signing

### DIFF
--- a/tests/bats/test_signing_trust_boundary.bats
+++ b/tests/bats/test_signing_trust_boundary.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# Keyless signing must reject an unapproved workflow/ref, and untrusted
+# (fork/PR) events must never be able to reach a signing job. Cosign itself
+# enforces the identity/issuer check at verify time (tunaos#1187 acceptance
+# criteria); these are the static, repo-checkable proxies for that: every
+# certificate-identity is pinned to this exact workflow file (not a wildcard
+# an attacker-controlled fork could satisfy), and every signing job's trigger
+# excludes pull_request.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+
+@test "reusable-build-image.yml sign job never runs on pull_request" {
+  workflow="${REPO_ROOT}/.github/workflows/reusable-build-image.yml"
+  # The sign job's own if: condition, not just the caller's trigger — a
+  # belt-and-suspenders check independent of how the workflow is invoked.
+  grep -A5 '^  sign:' "$workflow" | grep -q "github.event_name != 'pull_request'"
+}
+
+@test "reusable-build-artifacts.yml and publish-iso-groups.yml are not pull_request-triggered" {
+  # Both are workflow_call / workflow_dispatch only — a fork's pull_request
+  # event cannot invoke either directly. (reusable-build-artifacts.yml is
+  # only ever called from build-variant.yml, itself schedule/workflow_dispatch
+  # only — see tunaos#1178.)
+  run grep -A3 '^on:' "${REPO_ROOT}/.github/workflows/reusable-build-artifacts.yml"
+  [[ "$output" != *"pull_request"* ]]
+
+  run grep -A3 '^on:' "${REPO_ROOT}/.github/workflows/publish-iso-groups.yml"
+  [[ "$output" != *"pull_request"* ]]
+}
+
+@test "every certificate-identity is pinned to its own exact workflow path" {
+  # A wildcard or partial-match identity would let a signature from a
+  # different workflow (e.g. an attacker's fork running under a similar
+  # name) verify successfully. Each identity string must name the specific
+  # .github/workflows/<file>.yml this job lives in.
+  declare -A expect=(
+    ["reusable-build-image.yml"]="reusable-build-image.yml"
+    ["reusable-build-artifacts.yml"]="reusable-build-artifacts.yml"
+    ["publish-iso-groups.yml"]="publish-iso-groups.yml"
+  )
+  for file in "${!expect[@]}"; do
+    workflow="${REPO_ROOT}/.github/workflows/${file}"
+    line=$(grep 'identity=' "$workflow")
+    [[ -n "$line" ]]
+    [[ "$line" == *".github/workflows/${expect[$file]}"* ]]
+  done
+}
+
+@test "verify calls use the fixed GitHub Actions OIDC issuer, not a wildcard" {
+  for file in reusable-build-image.yml reusable-build-artifacts.yml publish-iso-groups.yml; do
+    workflow="${REPO_ROOT}/.github/workflows/${file}"
+    grep -q 'issuer="https://token.actions.githubusercontent.com"' "$workflow"
+    grep -q -- '--certificate-oidc-issuer "\$issuer"' "$workflow"
+  done
+}


### PR DESCRIPTION
## Summary

#1187's acceptance criteria includes two items my earlier work (PR #1435, provenance attestation) didn't cover:

> Add a negative test proving an artifact signed by an unapproved workflow/ref is rejected.
> Add a fork/PR test proving untrusted events cannot reach the signing job.

A true negative test (actually sign with one identity, verify with another, assert rejection) needs live Sigstore/cosign infrastructure this sandbox doesn't have. Added the static, repo-checkable equivalent instead, in the same grep-based bats style already used by `test_artifact_signing.bats`/`test_sbom_scope.bats`:

- Every `certificate-identity` string across the three signing workflows (`reusable-build-image.yml`, `reusable-build-artifacts.yml`, `publish-iso-groups.yml`) is pinned to its own exact workflow file path — not a wildcard a different workflow (e.g. a fork's) could satisfy.
- Every `certificate-oidc-issuer` is the fixed GitHub Actions issuer.
- `reusable-build-image.yml`'s `sign` job has an explicit `github.event_name != 'pull_request'` guard.
- The other two signing workflows are `workflow_call`/`workflow_dispatch` only — no `pull_request` trigger reaches them at all.

## Test plan
- [x] Ran the new bats file for real against the actual repo (bootstrapped `bats-core` locally): all 4 tests pass
- [x] Sanity-checked the tests actually catch a regression — mutated one workflow's identity string to a wrong path, confirmed the corresponding test fails, then reverted
- [x] Confirmed `test.yml`'s CI job globs `tests/bats/*.bats`, so this file needs no separate CI wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `31df2b01`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->