### PR TITLE
docs: mark triage policy adopted and index it

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -139,7 +139,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | Supply chain hardening | sec-check | #1193 (tracker; #212/#301 closed) — coordinates with #1187 (package signing/SBOM is the largest hardening item, tracked there in detail) |
 | Release automation | ci-maintainer | CI health, VERSIONING.md, #1186 |
 | Community governance model | strategist | #1168 |
-| Issue triage policy (queue actionability) | strategist | #1195 — [TRIAGE-POLICY.md](./TRIAGE-POLICY.md) drafted 08-13: milestone-only roadmap signal, verify-before-trust closure, tiered SLA |
+| Issue triage policy (queue actionability) | strategist | #1195 — [TRIAGE-POLICY.md](./TRIAGE-POLICY.md) adopted via #1438 (08-13): milestone-only roadmap signal, verify-before-trust closure, tiered SLA |
 | Package signing / SBOM | sec-check | Supply chain, #1187 |
 | **Package sourcing policy (system-repos/tideforge-first + allowlist)** | strategist | #1319, #1323 (audit → #1187) |
 | Bonito (Fedora 44) GA carryover | ci-maintainer | #272 |

--- a/TRIAGE-POLICY.md
+++ b/TRIAGE-POLICY.md
@@ -1,6 +1,6 @@
 # tunaOS Issue Triage Policy
 
-**Status**: DRAFT — proposed 2026-08-13 by the strategist agent for review
+**Status**: ADOPTED — merged via [#1438](https://github.com/tuna-os/tunaOS/pull/1438) on 2026-08-13
 **Owner**: tuna-os (hanthor) / strategist
 **Tracks**: #1195 (this finding), #1168 (Q4 community governance goal)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ user-facing site:
 | [mkosi-investigation.md](mkosi-investigation.md) | Notes from the mkosi-based image build investigation |
 | [PIPELINE.md](PIPELINE.md) | Build pipeline reference: stages, workflows, artifact flow |
 | [BRANCH-PROTECTION.md](BRANCH-PROTECTION.md) | Current-state audit + proposal for main-branch protection & required CI (#1167) |
+| [../TRIAGE-POLICY.md](../TRIAGE-POLICY.md) | Adopted issue-queue triage policy: verified closure, deduplication, milestone signal, and tiered SLA (#1195) |
 | [CI_SPEC.md](CI_SPEC.md) | CI behavior specification |
 | [TESTING.md](TESTING.md) | ISO end-to-end test harness |
 | [MATRIX-STATUS.md](MATRIX-STATUS.md) | Which variant×desktop combinations are actually verified — and which have never been tested |


### PR DESCRIPTION
## Summary

- Mark `TRIAGE-POLICY.md` as adopted after its implementation merged in #1438.
- Update the Q4 roadmap row to point to the adopted policy.
- Add the policy to the developer documentation index.

## Why

Issue #1195's policy was already implemented and merged, but the repository still described it as a draft and did not expose it from `docs/README.md`. This follow-up aligns the status, roadmap, and documentation navigation without changing the policy itself.

## Validation

- `git diff --check`
- `markdownlint` was unavailable in the environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789212460&installation_model_id=429180&pr_number=1486&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1486&signature=a8e57bdeec8394db7ffcd28d1cdfa1633b15d0f3233a2a0ed3557aaa477c88e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->