### PR TITLE
docs: record variant admission decisions and capacity gate

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -147,7 +147,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | Fedora 45 base readiness | ci-maintainer | #1171 — [FEDORA-BASE-POLICY.md](./FEDORA-BASE-POLICY.md) drafted 08-13: N+rawhide model, Fedora 45 planning sequenced after Bonito (#272) GA, not parallel |
 | Adoption metrics / usage telemetry | strategist | #1174 |
 | **Adoption evidence (ADOPTERS.md production entries)** | strategist | #1348 — zero public production adopters vs "Mature" claim; first entries at 2026-11-01 snapshot |
-| Variant lifecycle policy (Beta→Stable exit criteria) | strategist | #1175 |
+| Variant lifecycle policy (admission + Beta→Stable exit criteria) | strategist | #1196, #1175 — [VARIANT-LIFECYCLE.md](./VARIANT-LIFECYCLE.md) |
 
 **Milestone fidelity (#1307, 2026-08-12)**: 7 of the 9 goal trackers above were
 filed without being attached to the Q4 milestone (#3), so the milestone

--- a/VARIANT-LIFECYCLE.md
+++ b/VARIANT-LIFECYCLE.md
@@ -57,6 +57,36 @@ count as proposals too: they multiply the boot/publish/signing surface (#1187,
 #1193) and must clear the same gate — ROADMAP row, owner, acceptance criteria,
 capacity — before the first build job lands.
 
+#### Admission record
+
+The following additions were already present in the build matrix when this
+policy was written. They are recorded here so the gate is actionable rather
+than silently grandfathering them. Until each row has a capacity sign-off, its
+status is **held**: existing build definitions may be tested, but the flavor
+must not be promoted or gain additional ISO coverage.
+
+| Addition (opened 2026-08-08) | Tracker | Owner | Incremental cells | Acceptance evidence | Status |
+|---|---|---|---:|---|---|
+| `grouper:gnome-zfs` | #1185 | ci-maintainer | 1 image; 0 ISO | Install-to-ZFS boot E2E (#625), LUKS E2E, desktop contract | Held pending capacity sign-off |
+| `marlin:gnome-nvidia` | #1191 | ci-maintainer | 1 image + 1 ISO (amd64) | NVIDIA driver load, boot gate, LUKS E2E, desktop contract | Held pending capacity sign-off |
+| `flounder:gnome-nvidia` | #1191 | ci-maintainer | 1 image + 1 ISO (amd64) | NVIDIA driver load, boot gate, LUKS E2E, desktop contract | Held pending capacity sign-off |
+| `flounder-sid:gnome-nvidia` | #1191 | ci-maintainer | 1 image; 0 ISO (amd64) | NVIDIA driver load, boot gate, LUKS E2E, desktop contract | Held pending capacity sign-off |
+
+The cell count is the minimum incremental matrix impact, not a claim that the
+work is free: an ISO cell also consumes grouped-ISO or on-demand publishing
+and boot-gate capacity. The owner must attach a capacity note to the tracker
+before changing a row to **admitted**. That note must record, for the current
+matrix revision:
+
+1. image, ISO, boot-gate, LUKS-E2E, and desktop-contract cell counts;
+2. expected CI minutes and peak concurrent jobs;
+3. the available CI/runner envelope and the milestone work it could displace;
+4. the first review date and the rollback/descope trigger.
+
+For these four retroactive records, the interim decision is **no promotion or
+new ISO surface through 2026-09-30**. A later capacity sign-off may admit the
+existing cells without reopening the general Q3 flavor freeze.
+
 ### 2. Beta
 
 - Image builds and boot-gate green on the publishing track.

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ user-facing site:
 | [SCREENSHOTS.md](SCREENSHOTS.md) | TunaOS screenshot gallery |
 | [IMAGE-FACTORY-GATE.md](IMAGE-FACTORY-GATE.md) | Image factory completion gate & definition of done (#1283) |
 | [IMAGE-FACTORY-LIFECYCLE-GATE.md](IMAGE-FACTORY-LIFECYCLE-GATE.md) | Image factory lifecycle coverage & required gate (#1278) |
+| [../VARIANT-LIFECYCLE.md](../VARIANT-LIFECYCLE.md) | Variant/flavor admission, capacity, promotion, and deprecation policy (#1196, #1175) |
 | [CFP-FOSDEM-2027.md](CFP-FOSDEM-2027.md) | FOSDEM 2027 CFP draft |
 | [DISTROWATCH-SUBMISSION.md](DISTROWATCH-SUBMISSION.md) | DistroWatch project submission draft |
 | [REDDIT-LEMMY-PLAYBOOK.md](REDDIT-LEMMY-PLAYBOOK.md) | Release-announcement playbook for Reddit / Lemmy |


### PR DESCRIPTION
Closes #1196

## What changed
- add an admission register for the four 2026-08-08 additions: Grouper ZFS and the Marlin, Flounder, and Flounder Sid NVIDIA flavors
- record owner, incremental image/ISO cells, flavor-specific acceptance evidence, and held status pending capacity sign-off
- define the minimum capacity note required before a proposal can be admitted
- link the lifecycle policy from the docs index and ROADMAP

## Why
The existing lifecycle policy defined entry criteria but did not make the four already-landed additions auditable or provide a concrete capacity-record format. This follow-up preserves testing while preventing promotion or additional ISO surface until capacity is documented.

## Validation
- `git diff --check`
- reviewed the corresponding `.github/build-config.yml` entries to verify the four cell counts and ISO settings
- `just check` was unavailable because `just` is not installed in the checkout environment

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->