### PR TITLE
ci: fix silently-dropped handwritten release note

### DIFF
--- a/.github/workflows/generate-changelog-release.yml
+++ b/.github/workflows/generate-changelog-release.yml
@@ -293,8 +293,30 @@ jobs:
               {"sbom_name": "flatpak",       "label": "Flatpak"},
               {"sbom_name": "pipewire",      "label": "PipeWire"}
             ]
-          handwritten:  ${{ inputs.handwritten || '' }}
           github-token: ${{ github.token }}
+
+      # projectbluefin/actions/bootc-build/create-release has no note-injection
+      # input (tunaos#1398 — a `handwritten:` input here was silently ignored,
+      # dropping the note from every release). Prepend it ourselves once the
+      # release exists, so it never overwrites the action's own generated
+      # changelog/SBOM notes.
+      - name: Prepend handwritten note
+        if: |
+          steps.release.outcome == 'success' &&
+          inputs.handwritten != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.vars.outputs.tag }}
+          NOTE: ${{ inputs.handwritten }}
+        run: |
+          set -euo pipefail
+          BODY_FILE=$(mktemp)
+          {
+            echo "$NOTE"
+            echo ""
+            gh release view "$TAG" --repo "${{ github.repository }}" --json body -q .body
+          } > "$BODY_FILE"
+          gh release edit "$TAG" --repo "${{ github.repository }}" --notes-file "$BODY_FILE"
 
       # ── Release cadence health gate (#1147) ───────────────────────────────
       # Before this existed, "we shipped nothing" and "we shipped" were the


### PR DESCRIPTION
## Summary

`.github/workflows/generate-changelog-release.yml` passed a `handwritten:` input to `projectbluefin/actions/bootc-build/create-release@v1` — verified against the action's `action.yml` at the pinned commit: no such input exists (`sbom-path, tag, title, image, digest, repo, notable-packages, cert-identity-regexp, project-name, accent-color, badge-label, docs-url, sbom-filename, variants-json, extra-components-json, draft, prerelease, github-token` is the full list). GitHub Actions silently ignores unknown `with:` keys, so the workflow always exits green while the intended "handwritten note at the top of the release" never appeared.

Implemented recommendation #2 (the action has no note-injection point, so add a follow-up step) rather than #1 (just delete the input) — the feature is real and has a documented input; removing it would just relocate the gap.

- Removed the no-op `handwritten:` line from the action call.
- Added a "Prepend handwritten note" step that runs only when the release step actually succeeded (`steps.release.outcome == 'success'`, which naturally inherits every one of the create-release step's own skip conditions — dry-run, already-exists, non-schedule/dispatch triggers — without duplicating that `if:` logic) and `inputs.handwritten` is non-empty. It fetches the just-created release's generated body via `gh release view --json body`, prepends the handwritten note, and writes it back with `gh release edit --notes-file` — so it can never clobber the action's own SBOM/changelog content, only prepend to it.

## Test plan
- [x] `yaml.safe_load` — parses cleanly
- [x] Extracted and `bash -n`-checked the new step's script — no syntax errors
- [x] Verified the action's actual accepted inputs against `projectbluefin/actions` at the exact pinned commit (`8906e13e3ac1654504e75ad27440bffb28e52fbc`) — confirmed no `handwritten`/notes input exists
- [x] Confirmed the new step's guard (`steps.release.outcome == 'success'`) correctly no-ops when the create-release step is skipped, rather than duplicating its four-part `if:` condition and risking drift between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `6bae4ebb`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->