### PR TITLE
docs: fix Yellowfin base in DistroWatch draft, wire referral metric

### DIFF
--- a/ADOPTION-METRICS.md
+++ b/ADOPTION-METRICS.md
@@ -25,6 +25,7 @@ publish, and *how* the snapshot feeds roadmap decisions.
 |------|--------|--------|--------------------------|------------------------------|
 | Discovery | GitHub stars / forks | GitHub API | 56 / 3 | ≥100 stars |
 | Discovery | Docs site visits, top variant pages | Cloudflare analytics on tunaos.org | not measured | ≥1k visits/mo, variant-page ranking |
+| Discovery | DistroWatch referral traffic | Cloudflare analytics referrer field, tunaos.org | not submitted yet — draft ready ([docs/DISTROWATCH-SUBMISSION.md](./docs/DISTROWATCH-SUBMISSION.md), tunaos#1333) | Submission live; referral share visible in the monthly snapshot |
 | Download | ISO downloads by variant+desktop | R2 access logs (tunaos.org/download) | **not measured** | ≥1k ISO downloads/mo; variant ranking |
 | Download | GitHub Release asset downloads | Releases API (resumed 08-09, #1106) | 0 (assets were empty shells) | assets present on all flavors; downloads counted |
 | Install | Installs / successful boots | opt-in telemetry or boot-report gating | **not measured** | Q4 design decision (#577 GUI gate, #763) |

--- a/docs/DISTROWATCH-SUBMISSION.md
+++ b/docs/DISTROWATCH-SUBMISSION.md
@@ -54,7 +54,7 @@ release cadence, verified boot reports, and an active community on Matrix.
 
 | Variant | Base | Desktop | Status |
 |---|---|---|---|
-| Yellowfin | AlmaLinux 10 | GNOME | Stable |
+| Yellowfin | AlmaLinux Kitten 10 | GNOME | Stable |
 | Albacore | AlmaLinux 10 | GNOME | Stable |
 | Bonito | Fedora | GNOME | Beta |
 | Skipjack | CentOS Stream 10 | KDE Plasma | Stable |


### PR DESCRIPTION
## Summary

#1333's proposed action #1 (draft the DistroWatch submission) is already done — `docs/DISTROWATCH-SUBMISSION.md` is a thorough, submission-ready draft. Before leaving it as-is, checked it against `ROADMAP.md`'s canonical variant table since this content is about to go in front of real prospective users on a third-party site.

- Found a factual error: the variant matrix listed Yellowfin's base as "AlmaLinux 10" — that's actually Albacore's base. Yellowfin is AlmaLinux **Kitten** 10 (the rolling-preview track), per `ROADMAP.md`'s Active Variants table. Fixed.
- Action #4 (track referral traffic in ADOPTION-METRICS.md) wasn't wired yet — added a DistroWatch referral row to the Discovery tier, matching the existing table format, current status "not submitted yet."

Didn't touch actions #2 (submit via the form) or #3 (time the submission for Fedora 45 week) — actually submitting to a third-party directory on the org's behalf is a live, public, external action for a maintainer to take, not something to originate as a hive agent, and the submission window (Oct 20+) hasn't arrived yet regardless.

## Test plan
- [x] Cross-checked every variant's base OS in the draft against `ROADMAP.md`'s Active Variants table — found and fixed the one mismatch (Yellowfin)
- [x] Confirmed `ADOPTION-METRICS.md` had no DistroWatch-specific tracking row before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `e1414926`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->