### PR TITLE
fix(nvidia): two build failures blocking six matrix cells

### DIFF
--- a/build_scripts/checks/verify-nvidia-debian.sh
+++ b/build_scripts/checks/verify-nvidia-debian.sh
@@ -78,7 +78,15 @@ fi
 
 MODULE_FILE=""
 if [[ -n "$KVER" ]]; then
-	MODULE_FILE="$(find "${NV_ROOT}/usr/lib/modules/${KVER}" -name 'nvidia.ko*' -print -quit 2>/dev/null || true)"
+	# nvidia-current.ko.xz, not nvidia.ko: Debian's nvidia-kernel-dkms is
+	# alternatives-managed and its DKMS module is named nvidia-current. The
+	# core module only, so the modinfo version check below does not end up
+	# reading -modeset/-drm/-uvm/-peermem instead.
+	for _nv_base in nvidia nvidia-current; do
+		MODULE_FILE="$(find "${NV_ROOT}/usr/lib/modules/${KVER}" -name "${_nv_base}.ko*" -print -quit 2>/dev/null || true)"
+		[[ -n "$MODULE_FILE" ]] && break
+	done
+	unset _nv_base
 	if [[ -n "$MODULE_FILE" ]]; then
 		pass "dkms built a module for ${KVER} (${MODULE_FILE#"${NV_ROOT}"})"
 	else

--- a/build_scripts/overlay/overrides/nvidia-debian/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia-debian/20-nvidia.sh
@@ -110,7 +110,22 @@ dkms status
 # file, not by string-matching dkms status output (whose module name and
 # phrasing are not a stable contract — see header). A missing .ko here is a
 # black screen on real hardware, so this is a hard failure.
-NVIDIA_KO="$(find "/usr/lib/modules/${KVER}" -name 'nvidia.ko*' -print -quit)"
+# Debian's nvidia-kernel-dkms is alternatives-managed, so its DKMS module is
+# named nvidia-current and the file it installs is nvidia-current.ko.xz --
+# 'nvidia.ko*' never matches it. That is not a hypothetical: flounder's
+# gnome/kde/xfce-nvidia images failed here on every nightly while the build
+# above printed "Building module(s)... done.", signed five modules, installed
+# nvidia-current.ko.xz, and reported "installed" in dkms status. The comment
+# above is right that dkms status text is not a contract; the module FILENAME
+# is not one either, so match the names this distro actually uses and keep
+# NVIDIA_KO pointing at the core module (not -modeset/-drm/-uvm/-peermem) so
+# the modinfo version check below still reads the right file.
+NVIDIA_KO=""
+for _nv_base in nvidia nvidia-current; do
+	NVIDIA_KO="$(find "/usr/lib/modules/${KVER}" -name "${_nv_base}.ko*" -print -quit)"
+	[[ -n "$NVIDIA_KO" ]] && break
+done
+unset _nv_base
 if [[ -z "$NVIDIA_KO" ]]; then
 	echo "ERROR: dkms did not produce nvidia.ko for ${KVER} — dkms status above shows why." >&2
 	exit 1

--- a/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
@@ -65,8 +65,21 @@ QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(|'"$KERNEL_SUFFIX"'-)(\d+\.\d+\.\
 #            bonito's coreos-stable akmods.
 # Fallback when neither tag is readable: fedora-43, bluefin-lts's pinned
 # default, kept so an unexpected bundle still names a real repo.
-AKMODS_EL_VERSION="$(find /tmp/akmods-nvidia-open-rpms -name "*.rpm" -print | grep -oPm1 '(?<=\.el)\d+' || true)"
-AKMODS_FEDORA_VERSION="$(find /tmp/akmods-nvidia-open-rpms -name "*.rpm" -print | grep -oPm1 '(?<=\.fc)\d+' || true)"
+#
+# `head -1` after grep, and not grep's own -m1: -m1 stops after the first
+# matching LINE, while -o prints every match ON that line. A bundle whose
+# first matching filename carries the dist tag twice -- e.g.
+# kmod-nvidia-open-6.12.0-257.el10.x86_64-...el10.rpm -- therefore yields
+# "10\n10", not "10". The embedded newline survives into NVIDIA_RELEASEVER
+# and then into the sed expression that templates $releasever below, which
+# dies with:
+#
+#   sed: -e expression #1, char 16: unterminated `s' command
+#
+# That killed yellowfin's cosmic-nvidia, niri-nvidia and xfce-nvidia builds
+# on every nightly. The value must be exactly one line.
+AKMODS_EL_VERSION="$(find /tmp/akmods-nvidia-open-rpms -name "*.rpm" -print | grep -oP '(?<=\.el)\d+' | head -1 || true)"
+AKMODS_FEDORA_VERSION="$(find /tmp/akmods-nvidia-open-rpms -name "*.rpm" -print | grep -oP '(?<=\.fc)\d+' | head -1 || true)"
 if [[ -n "${AKMODS_EL_VERSION}" ]]; then
 	NVIDIA_REPO_ID="epel-nvidia"
 	NVIDIA_RELEASEVER="${AKMODS_EL_VERSION}"

--- a/tests/bats/test_nvidia_overlay_arch_debian.bats
+++ b/tests/bats/test_nvidia_overlay_arch_debian.bats
@@ -120,8 +120,8 @@ VERIFY_DEBIAN_SH="${REPO_ROOT}/build_scripts/checks/verify-nvidia-debian.sh"
   [ "$status" -eq 0 ]
 }
 
-@test "nvidia-debian 20-nvidia.sh proves the module by finding nvidia.ko, not by trusting dkms status text" {
-  run grep -F "find \"/usr/lib/modules/\${KVER}\" -name 'nvidia.ko*'" "$DEBIAN_INSTALL_SH"
+@test "nvidia-debian 20-nvidia.sh proves the module by finding it on disk, not by trusting dkms status text" {
+  run grep -F 'find "/usr/lib/modules/${KVER}" -name "${_nv_base}.ko*"' "$DEBIAN_INSTALL_SH"
   [ "$status" -eq 0 ]
 }
 
@@ -269,7 +269,15 @@ make_good_debian_root() {
     "$r/usr/share/vulkan/icd.d" \
     "$r/usr/lib/dracut/dracut.conf.d" \
     "$nvlib"
-  touch "$r/usr/lib/modules/${KVER}/nvidia.ko.zst"
+  # nvidia-current.ko.xz is what Debian's alternatives-managed
+  # nvidia-kernel-dkms actually installs, straight from flounder's build log:
+  #   Installing /lib/modules/6.12.101+deb13-amd64/updates/dkms/nvidia-current.ko.xz
+  # This fixture used to write nvidia.ko.zst -- the Fedora/Arch name -- so it
+  # agreed with the script's glob instead of with Debian, and the check passed
+  # here while failing every real nvidia build. The sibling module is written
+  # too, so a glob that grabs the wrong one cannot pass by accident.
+  touch "$r/usr/lib/modules/${KVER}/nvidia-current.ko.xz"
+  touch "$r/usr/lib/modules/${KVER}/nvidia-current-modeset.ko.xz"
   echo initrd >"$r/usr/lib/modules/${KVER}/initramfs.img"
   echo "blacklist nouveau" >"$r/usr/lib/modprobe.d/00-nouveau-blacklist.conf"
   echo 'kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-drm.modeset=1"]' \
@@ -332,7 +340,7 @@ run_verify_debian() {
 @test "verify-nvidia-debian fails when the dkms module is missing" {
   make_debian_stub_tools
   root="$(make_good_debian_root)"
-  rm "$root/usr/lib/modules/${KVER}/nvidia.ko.zst"
+  rm "$root/usr/lib/modules/${KVER}/nvidia-current.ko.xz"
   run_verify_debian "$root"
   [ "$status" -ne 0 ]
   [[ "$output" == *"TUNAOS_NVIDIA_DEBIAN_CONTRACT_FAIL"* ]]

--- a/tests/bats/test_nvidia_releasever_is_one_line.bats
+++ b/tests/bats/test_nvidia_releasever_is_one_line.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+# The NVIDIA userspace repo is chosen by reading the dist tag off the akmods
+# RPM bundle, then templating $releasever into negativo17's .repo file with
+# sed. If that read returns more than one line the sed expression is broken
+# by the embedded newline and the whole image build dies:
+#
+#   + AKMODS_EL_VERSION='10
+#   10'
+#   + sed 's/$releasever/10
+#   10/g'
+#   sed: -e expression #1, char 16: unterminated `s' command
+#
+# It happened on yellowfin's cosmic-nvidia, niri-nvidia and xfce-nvidia
+# builds every nightly. The cause is `grep -oPm1`: -m1 stops after the first
+# matching LINE, but -o prints every match ON that line, so a filename
+# carrying the dist tag twice yields two values.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../build_scripts/overlay/overrides/nvidia/20-nvidia.sh"
+
+# The extraction pipeline, lifted from the script so the test exercises the
+# real expression rather than a paraphrase of it.
+extract() {
+	local tag="$1" dir="$2"
+	# shellcheck disable=SC2016
+	local line
+	line="$(grep -n "AKMODS_${tag}_VERSION=" "$SCRIPT" | head -1 | cut -d: -f2-)"
+	# Re-point the hardcoded bundle path at the fixture and evaluate it.
+	line="${line//\/tmp\/akmods-nvidia-open-rpms/$dir}"
+	eval "$line"
+	if [[ "$tag" == "EL" ]]; then printf '%s' "$AKMODS_EL_VERSION"
+	else printf '%s' "$AKMODS_FEDORA_VERSION"; fi
+}
+
+@test "the dist tag read yields exactly one line when a filename carries it twice" {
+	local d="${BATS_TEST_TMPDIR}/rpms"
+	mkdir -p "$d"
+	# Verbatim shape from the failing build: the kernel version and the RPM's
+	# own dist tag both say .el10 in one filename.
+	touch "$d/kmod-nvidia-open-6.12.0-257.el10.x86_64-580.95.05-1.el10.x86_64.rpm"
+	touch "$d/ublue-os-nvidia-addons-0.14-1.el10.noarch.rpm"
+
+	run extract EL "$d"
+	[ "$status" -eq 0 ]
+	[ "$output" = "10" ]
+	# The bug produced "10\n10"; assert on the line count directly so a
+	# future regression cannot hide behind bats' output trimming.
+	[ "$(printf '%s' "$output" | wc -l)" -eq 0 ]
+}
+
+@test "a Fedora bundle reads its own tag, also as one line" {
+	local d="${BATS_TEST_TMPDIR}/rpms-fc"
+	mkdir -p "$d"
+	touch "$d/kmod-nvidia-open-6.16.3-200.fc42.x86_64-580.95.05-1.fc42.x86_64.rpm"
+
+	run extract FEDORA "$d"
+	[ "$status" -eq 0 ]
+	[ "$output" = "42" ]
+}
+
+@test "an EL value with a newline in it would break the releasever sed" {
+	# Proves the consequence rather than assuming it: this is the exact sed
+	# form the script uses, fed the value the old pipeline produced.
+	run bash -c 'printf "baseurl=x/\$releasever/y\n" | sed "s/\$releasever/$(printf "10\n10")/g"'
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"unterminated"* ]]
+}
+
+@test "the script no longer uses grep -m1 with -o for the dist tag" {
+	run grep -E "AKMODS_(EL|FEDORA)_VERSION=.*grep -oPm1" "$SCRIPT"
+	[ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Two unrelated NVIDIA build failures, six blocked matrix cells between them. In both cases the driver work succeeds and a surrounding check or shell expression fails.

---

# 1. flounder `-nvidia` (3 cells) — the module glob doesn't match Debian

`gnome-nvidia`, `kde-nvidia`, `xfce-nvidia` fail in `Build Image` every nightly. From [run 31663925839](https://github.com/tuna-os/tunaOS/actions/runs/31663925839), DKMS succeeds completely:

```
Building module(s)................................... done.
Installing /lib/modules/6.12.101+deb13-amd64/updates/dkms/nvidia-current.ko.xz
Installing /lib/modules/6.12.101+deb13-amd64/updates/dkms/nvidia-current-modeset.ko.xz
...
==> dkms status after build:
nvidia-current/550.163.01, 6.12.101+deb13-amd64, x86_64: installed
```

Then:

```
++ find /usr/lib/modules/6.12.101+deb13-amd64 -name 'nvidia.ko*' -print -quit
+ NVIDIA_KO=
+ ERROR: dkms did not produce nvidia.ko for 6.12.101+deb13-amd64
```

Debian's `nvidia-kernel-dkms` is alternatives-managed, so the module is named **`nvidia-current`** and the installed file is **`nvidia-current.ko.xz`**. The glob `'nvidia.ko*'` is the Fedora/Arch name and can never match. Three retries, three identical failures, on a driver that built correctly each time.

Fixed in the overlay script and in `verify-nvidia-debian.sh`, which carried the same glob. `NVIDIA_KO` stays on the **core** module (not `-modeset`/`-drm`/`-uvm`/`-peermem`) so the `modinfo` version check still reads the right file. **Arch is unchanged** — its module is named `nvidia` and there's no evidence it's affected.

**Why CI never caught it:** `make_good_debian_root` wrote `nvidia.ko.zst`, the Fedora/Arch filename, so the fixture agreed with the script's glob instead of with Debian. It now writes `nvidia-current.ko.xz` as observed in the log, plus the `-modeset` sibling so a glob grabbing the wrong file can't pass by accident.

---

# 2. yellowfin `-nvidia` (3 cells) — a two-line `$releasever`

`cosmic-nvidia`, `niri-nvidia`, `xfce-nvidia` fail in `Build Image` every nightly. From [run 31663727643](https://github.com/tuna-os/tunaOS/actions/runs/31663727643):

```
++ find /tmp/akmods-nvidia-open-rpms -name '*.rpm' -print
++ grep -oPm1 '(?<=\.el)\d+'
+ AKMODS_EL_VERSION='10
10'
…
+ sed 's/$releasever/10
10/g'
sed: -e expression #1, char 16: unterminated `s' command
```

`grep -m1` stops after the first matching **line**; `-o` prints every match **on** that line. An akmods filename carries the dist tag twice — the kernel version *and* the RPM's own tag both say `.el10` in
`kmod-nvidia-open-6.12.0-257.el10.x86_64-580.95.05-1.el10.x86_64.rpm` — so the read returns `10\n10`. That newline rides into `NVIDIA_RELEASEVER` and terminates the `s///` command early when templating negativo17's repo file.

Piping to `head -1` bounds the result to one line regardless of how many matches a filename holds.

---

# Tests

| Suite | Mutation | Result |
| :--- | :--- | :--- |
| `test_nvidia_overlay_arch_debian` | restore old glob in `verify-nvidia-debian.sh` | `not ok 21 verify-nvidia-debian passes on a complete driver install` |
| `test_nvidia_overlay_arch_debian` | restore old glob in the overlay script | `not ok 12 …proves the module by finding it on disk` |
| `test_nvidia_releasever_is_one_line` | restore `grep -oPm1` | 3 of 4 fail |

The first row is the production bug reproduced as a test failure.

The new releasever suite builds fixtures from the real filename shapes (the Fedora fixture carries `.fc42` twice for the same reason) and includes a standalone proof that a two-line value breaks this exact `sed` form — that one deliberately doesn't read the script, so it documents the consequence even if the extraction is rewritten later.

`test_nvidia_overlay`, `test_nvidia_overlay_arch_debian`, `test_nvidia_releasever_is_one_line`, `test_lib` all pass. pytest `224 passed, 1 skipped`.

`test_build_iso_group.bats` fails in my environment on a local `yq`/`jq` version mismatch (`jq: 1 compile error`), unrelated to this diff — flagging rather than hiding it.

---

# Not addressed

Found while triaging, left alone here:

- **yellowfin `base`/`gnome-asahi` on linux-arm64** fail at `Login to Podman (sudo)` with `Error: failed to open 2048 locks in /libpod_lock: numerical result out of range` — a stale podman lock, infrastructure rather than packaging. `base / Manifest` fails downstream of it.
- **flounder `base`** failed `Sign + attest` on a transient `rekor.sigstore.dev` 502 during SBOM attestation.