### PR TITLE
docs: fix stale COPR framing in Fedora Magazine pitch draft

### DIFF
--- a/docs/FEDORA-MAGAZINE-PITCH.md
+++ b/docs/FEDORA-MAGAZINE-PITCH.md
@@ -23,12 +23,14 @@ failure, verified upgrades. The desktop updates like a container fleet, and
 stays on a current GNOME while the base tracks Fedora's lifecycle.
 
 **Why it fits Fedora Magazine.** Fedora is where the container-native desktop
-idea is most alive — the COPR backports, the bootc work, and the growing
-group of Fedora-based immutable spins (including our Niri and XFCE flavors,
-which build on Fedora infrastructure). TunaOS has also been packaging GNOME
-49/50/51 backports via Fedora COPR for CentOS Stream 10 and Fedora bases, so
-the post can cover both the Bonito image itself and the wider packaging
-effort — genuinely Fedora ecosystem news, not an advert.
+idea is most alive — the bootc work, and the growing group of Fedora-based
+immutable spins (including our Niri and XFCE flavors, which build on Fedora
+infrastructure). TunaOS also packages current GNOME backports (49/50/51) for
+CentOS Stream 10 and Fedora bases through its own native RPM build chain,
+published to a project-run repository — Fedora COPR is legacy/compatibility
+infrastructure for us now, being phased out — so the post can cover both the
+Bonito image itself and the wider packaging effort — genuinely Fedora
+ecosystem news, not an advert.
 
 **What we'd include.** A short tour of Bonito: what it is, how bootc changes
 the update model, what works today (Fedora 44 base, GNOME, Niri, XFCE


### PR DESCRIPTION
## Summary

#1137's proposed action #1 (draft the pitch) is already done — `docs/FEDORA-MAGAZINE-PITCH.md` is a submission-ready draft. Checked it against the actual current packaging architecture before leaving it as-is, since this is about to be emailed to real Fedora Magazine editors.

Found the same stale-COPR framing I already fixed in the Gurnard blog post (docs#203) and ADOPTERS.md (#1456): the pitch said TunaOS packages GNOME backports "via Fedora COPR." `tunaos-packages/README.md` states COPR is legacy/compatibility infrastructure being retired in favor of a native RPM + Cloudflare R2 pipeline, and the actual GNOME 49/50/51 build workflows publish there, not to a COPR project. Corrected the "Why it fits Fedora Magazine" paragraph to describe the native pipeline, still noting the legacy COPR presence accurately (being phased out, not the current story).

Double-checked the rest of the pitch's technical claims (Fedora 44 base, GNOME/Niri/XFCE flavors) against `.github/build-config.yml` — all accurate, no other changes needed.

## Test plan
- [x] Confirmed bonito's flavor list in `build-config.yml` includes `niri` and `xfce` — the pitch's claim holds
- [x] Cross-checked the COPR correction against the same evidence already used for docs#203/#1456 (`tunaos-packages/README.md`'s own "legacy/compatibility" framing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `bb87a636`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->