### PR TITLE
docs: link orphaned docs in README Documentation section (#1496)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,9 +274,13 @@ Related Communities:
 - [Roll Your Own Guide](docs/ROLL_YOUR_OWN.md) — build your own custom TunaOS variant
 - [Agent Guide](docs/AGENT_GUIDE.md) — complete architecture and contributor reference
 - [Build Pipeline](docs/build-pipeline.md) — CI/CD workflow overview
+- [Build Pipeline Reference](docs/PIPELINE.md) — the build matrix, verification gates, and publish flow in detail
 - [mkosi Investigation](docs/mkosi-investigation.md) — mkosi as a build backend and DDI output: findings, not a production change (#999)
 - [Testing Guide](docs/TESTING.md) — ISO end-to-end test harness
 - [Secure Boot](docs/SECURE-BOOT.md) — which variants support Secure Boot out of the box
+- [Disk Encryption & TPM2](docs/LUKS-TPM.md) — LUKS2 passphrase setup and TPM2 auto-unlock
+- [CI/CD Spec](docs/CI_SPEC.md) — target/aspirational workflow spec; see Build Pipeline above for what's actually deployed
+- [CI Troubleshooting Playbook](docs/ci-troubleshooting.md) — quick reference for diagnosing recurring CI failures
 - [Improvement Plan](docs/IMPROVEMENT_PLAN.md) — roadmap and development progress
 - [Redfin Setup](docs/rhel-setup.md) — RHEL 10 local-build instructions
 - [Developer Docs](https://tunaos.org/docs/tunaos/building) — build and contribution guide
@@ -287,6 +291,8 @@ Related Communities:
 - [Variant Lifecycle Policy](VARIANT-LIFECYCLE.md) — Stable/Beta/Alpha admission gates and deprecation rules
 - [RFC Process](RFC-PROCESS.md) — how RFCs are proposed, reviewed, and decided
 - [Package Sourcing Policy](PACKAGE-SOURCING.md) — package origin rules, Tideforge-first, and allowlist (#1319)
+- [Issue Triage Policy](TRIAGE-POLICY.md) — triage states and SLAs (draft, #1195)
+- [Fedora Base Currency Policy](FEDORA-BASE-POLICY.md) — N+rawhide sequencing for Fedora-based variants (draft, #1171)
 - [Versioning](VERSIONING.md) — tag scheme and stability tiers
 - [Migration Guide](MIGRATION.md) — switching from other distros
 - [Security Policy](SECURITY.md) — vulnerability reporting and supported versions


### PR DESCRIPTION
Closes #1496.

Six published docs existed in the repo but weren't linked from README's
`## Documentation` section — undiscoverable to anyone browsing the README:

- `TRIAGE-POLICY.md`
- `FEDORA-BASE-POLICY.md`
- `docs/CI_SPEC.md`
- `docs/PIPELINE.md`
- `docs/LUKS-TPM.md`
- `docs/ci-troubleshooting.md`

All six now have an entry in the appropriate subsection (`Project Docs` or
`Policies & Planning`), matching the existing entries' format.

Notes on framing, since two of these needed a caveat to stay accurate rather
than misleading:
- `docs/CI_SPEC.md` is explicitly marked in its own header as a
  target/aspirational spec that differs from the deployed pipeline (it says
  so itself, pointing at `build-pipeline.md`) — the README entry carries that
  caveat rather than presenting it as current-state documentation.
- `TRIAGE-POLICY.md` and `FEDORA-BASE-POLICY.md` are both marked `Status:
  DRAFT` in their own headers — linked with a `(draft, #NNNN)` suffix so
  README doesn't imply they're adopted policy.

Also linked `docs/PIPELINE.md`, which is a distinct, longer file from the
already-linked `docs/build-pipeline.md` (160 lines vs. 90, different content)
and was itself an orphan not named in the issue but found during the same
grep sweep.

No content changes to any of the six docs — README only.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `ca5c64d7`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->