### PR TITLE
fix(sign): retry cosign past a transient Sigstore blip

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -849,14 +849,41 @@ jobs:
       - name: Sign images and attest SBOMs
         env:
           REQUIRE_SBOM: ${{ inputs.sbom }}
+          MAX_RETRIES: 3
         run: |
           set -euo pipefail
           identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/reusable-build-image.yml@${GITHUB_REF}"
           issuer="https://token.actions.githubusercontent.com"
           index_ref="${IMAGE_REGISTRY}/${IMAGE_NAME}@${INDEX_DIGEST}"
 
-          cosign sign "$index_ref"
-          cosign verify "$index_ref" \
+          # cosign's own retry (2 attempts, sub-second apart) is not enough
+          # for a Rekor transparency-log blip that lasts minutes, which is
+          # what a real outage looks like -- not what cosign is built to
+          # ride out. Measured against run 31663727643 (flounder base):
+          #
+          #   Error: signing ... creating bundle: signing bundle: error
+          #   signing bundle: Post "https://rekor.sigstore.dev/api/v1/log/entries":
+          #   giving up after 2 attempt(s): status 502 Bad Gateway
+          #
+          # and the same signature recurred across albacore, skipjack,
+          # sailfin, bonito and bonito-rawhide within the same run window --
+          # builds that had genuinely succeeded, failing only at this step.
+          # A single unwrapped invocation turns a transient Sigstore blip
+          # into a red Promote for every flavor whose Sign+attest lands
+          # inside the window. Wrap each cosign call the same way the GHCR
+          # push retries above do: linear backoff, MAX_RETRIES attempts.
+          cosign_retry() {
+            local i
+            for i in $(seq "${MAX_RETRIES}"); do
+              "$@" && return 0
+              echo "::warning::${1} failed (attempt ${i}/${MAX_RETRIES}); retrying..." >&2
+              sleep $((5 * i))
+            done
+            return 1
+          }
+
+          cosign_retry cosign sign "$index_ref"
+          cosign_retry cosign verify "$index_ref" \
             --certificate-identity "$identity" \
             --certificate-oidc-issuer "$issuer" >/dev/null
 
@@ -870,15 +897,15 @@ jobs:
             ref="${IMAGE_REGISTRY}/${IMAGE_NAME}@${digest}"
             sbom="supply-chain/sboms/sbom-${IMAGE_NAME}-${DEFAULT_TAG}-${safeplatform}.spdx.json"
 
-            cosign sign "$ref"
-            cosign verify "$ref" \
+            cosign_retry cosign sign "$ref"
+            cosign_retry cosign verify "$ref" \
               --certificate-identity "$identity" \
               --certificate-oidc-issuer "$issuer" >/dev/null
             signed=$((signed + 1))
 
             if [[ -f "$sbom" ]]; then
-              cosign attest --type spdxjson --predicate "$sbom" "$ref"
-              cosign verify-attestation "$ref" \
+              cosign_retry cosign attest --type spdxjson --predicate "$sbom" "$ref"
+              cosign_retry cosign verify-attestation "$ref" \
                 --type spdxjson \
                 --certificate-identity "$identity" \
                 --certificate-oidc-issuer "$issuer" >/dev/null

--- a/tests/test_sign_step_retries_cosign.py
+++ b/tests/test_sign_step_retries_cosign.py
@@ -1,0 +1,157 @@
+"""The Sign+attest step must not die on cosign's very first flake.
+
+cosign has its own internal retry -- two attempts, sub-second apart -- which
+is built to ride out a dropped packet, not a Sigstore outage. Measured
+directly from run 31663727643 (flounder, base):
+
+    Error: signing ghcr.io/tuna-os/flounder@sha256:...: creating bundle:
+    signing bundle: error signing bundle: Post
+    "https://rekor.sigstore.dev/api/v1/log/entries": giving up after
+    2 attempt(s): status 502 Bad Gateway
+
+The same signature recurred, in the same ~90-minute run window, across
+albacore, skipjack, sailfin, bonito and bonito-rawhide -- builds that had
+genuinely succeeded, failing only at this one unwrapped `cosign sign`. One
+outside outage took down Sign+attest fleet-wide because nothing in this repo
+retried past cosign's own two attempts.
+
+The fix wraps every cosign invocation in a `cosign_retry` helper, following
+the same linear-backoff idiom the "Push to GHCR" step already uses for GHCR
+blob-push flakiness. These tests pin that the wrapper exists, that every
+sign/verify/attest call goes through it, and that its own failure still
+kills the job -- an unenforced retry that swallows a real, permanent
+signing failure would be worse than no retry at all.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/reusable-build-image.yml"
+
+COSIGN_SUBCOMMANDS = ("sign", "verify", "verify-attestation", "attest")
+
+
+@pytest.fixture(scope="module")
+def sign_step():
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    step = next(
+        s
+        for s in workflow["jobs"]["sign"]["steps"]
+        if s.get("name") == "Sign images and attest SBOMs"
+    )
+    return step
+
+
+def test_a_retry_helper_is_defined(sign_step):
+    assert "cosign_retry()" in sign_step["run"], (
+        "no cosign_retry helper defined in the Sign+attest step"
+    )
+
+
+def test_every_cosign_invocation_goes_through_the_retry_helper(sign_step):
+    run = sign_step["run"]
+    # Strip the function definition itself so its body (which legitimately
+    # calls "$@", not "cosign") doesn't produce false matches or hide a bare
+    # `cosign ...` call sitting right next to it.
+    body = re.sub(r"cosign_retry\(\) \{.*?\n\}\n", "", run, flags=re.S)
+    assert "cosign_retry() {" not in body, "failed to strip the helper definition before scanning"
+
+    for sub in COSIGN_SUBCOMMANDS:
+        # Every line invoking `cosign <sub>` must carry the retry helper's
+        # name on that same line -- a bare cosign call anywhere here is
+        # exactly the gap that let one Sigstore blip fail Sign+attest
+        # fleet-wide.
+        for line in body.splitlines():
+            if re.search(rf"\bcosign {sub}\b", line) and "cosign_retry" not in line:
+                pytest.fail(f"cosign {sub} is invoked without cosign_retry: {line.strip()!r}")
+
+
+def test_the_helper_retries_more_than_once():
+    # cosign's own retry is 2 attempts; if MAX_RETRIES resolves to 1 or 2,
+    # this wrapper adds nothing over what cosign already does internally.
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    sign_job = workflow["jobs"]["sign"]
+    step = next(
+        s
+        for s in sign_job["steps"]
+        if s.get("name") == "Sign images and attest SBOMs"
+    )
+    max_retries = step.get("env", {}).get("MAX_RETRIES")
+    assert max_retries is not None, "MAX_RETRIES is not set for the Sign+attest step"
+    assert int(max_retries) >= 3, (
+        f"MAX_RETRIES={max_retries!r} does not meaningfully exceed cosign's "
+        "own 2-attempt internal retry"
+    )
+
+
+def _extract_helper_source(sign_step_run: str) -> str:
+    match = re.search(r"cosign_retry\(\) \{.*?\n\}\n", sign_step_run, re.S)
+    assert match, "could not extract the cosign_retry function body"
+    return match.group(0)
+
+
+def test_the_helper_itself_fails_the_job_when_retries_are_exhausted(sign_step, tmp_path):
+    """A retry helper that swallows a permanent failure is worse than none.
+
+    Drives the REAL helper extracted from the workflow file -- not a
+    reimplementation -- against a command that always fails, and checks
+    that under `set -e` (exactly how the step invokes it: a bare statement,
+    not inside if/&&/||) the calling script dies rather than continuing.
+    """
+    helper_src = _extract_helper_source(sign_step["run"])
+    script = tmp_path / "probe.sh"
+    script.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            MAX_RETRIES=3
+            {helper_src}
+            cosign_retry false
+            echo "UNREACHABLE"
+            """
+        )
+    )
+    proc = subprocess.run(["bash", str(script)], capture_output=True, text=True)
+    assert proc.returncode != 0, "the script did not fail when retries were exhausted"
+    assert "UNREACHABLE" not in proc.stdout, (
+        f"execution continued past exhausted retries: {proc.stdout!r}"
+    )
+
+
+def test_the_helper_succeeds_as_soon_as_the_command_does(sign_step, tmp_path):
+    """A flake that clears on attempt 2 must not be treated as a failure."""
+    helper_src = _extract_helper_source(sign_step["run"])
+    marker = tmp_path / "attempts"
+    script = tmp_path / "probe.sh"
+    script.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            MAX_RETRIES=3
+            {helper_src}
+            flaky() {{
+              local n=0
+              [[ -f "{marker}" ]] && n=$(cat "{marker}")
+              n=$((n + 1))
+              echo "$n" > "{marker}"
+              [[ "$n" -ge 2 ]]
+            }}
+            cosign_retry flaky
+            echo "REACHED after $(cat "{marker}") attempt(s)"
+            """
+        )
+    )
+    proc = subprocess.run(["bash", str(script)], capture_output=True, text=True)
+    assert proc.returncode == 0, f"helper did not recover from a transient flake: {proc.stderr!r}"
+    assert "REACHED after 2 attempt(s)" in proc.stdout


### PR DESCRIPTION
Surveying every README variant's real CI state (not the month-stale table) turned up one failure signature repeating across **six different variants in the same run window**:

```
Error: signing ghcr.io/tuna-os/flounder@sha256:...: creating bundle:
signing bundle: error signing bundle: Post
"https://rekor.sigstore.dev/api/v1/log/entries": giving up after
2 attempt(s): status 502 Bad Gateway
```

albacore, skipjack, sailfin, bonito, bonito-rawhide, and flounder all hit this on flavors whose builds had **genuinely succeeded** — the image was fine, `Sign+attest` killed it.

## Why

`cosign sign`/`verify`/`attest`/`verify-attestation` are called bare in `reusable-build-image.yml`, with zero retry wrapping on this repo's side. cosign has its own internal retry — 2 attempts, sub-second apart — which rides out a dropped packet, not a Rekor transparency-log outage lasting minutes. One external blip turns a whole run window's worth of otherwise-green images red at the very last step, fleet-wide.

## The fix

Wrap every cosign call in a `cosign_retry` helper: linear backoff, `MAX_RETRIES=3`. This follows the exact idiom the `Push to GHCR` step already uses a few hundred lines up for GHCR blob-push flakiness — same shape, same repo convention. Nothing about *what* gets signed or *how* verification works changes; this only widens the window an outage has to clear before the job gives up.

## Tests

`tests/test_sign_step_retries_cosign.py` extracts the **real** helper source from the workflow file — not a reimplementation — and drives it directly:

- recovers from a flake that clears on attempt 2
- as actually invoked in the step (a bare statement under `set -euo pipefail`, not inside `if`/`&&`/`||`) still **fails the job** when retries are genuinely exhausted — a wrapper that swallows a permanent signing failure would be worse than no retry at all
- every `cosign sign`/`verify`/`attest`/`verify-attestation` call goes through the helper
- `MAX_RETRIES` is set meaningfully above cosign's own 2

Mutation-verified six ways — one bare cosign call, `MAX_RETRIES` dropped to 2, the helper unconditionally returning success, and the helper never retrying at all each fail a distinct test.

Worth flagging honestly: two of the first four mutation attempts were **no-ops** — my replacement string's indentation didn't match the actual YAML-block whitespace on disk, so `.replace()` silently matched nothing and the "pass" meant nothing. Caught by checking `match count` before trusting a green mutation run; re-ran both with whitespace read back from the file, and they now fail correctly.

Full suite: `229 passed, 1 skipped`.

## Scope

This does not touch the other failure modes the same survey found — the arm64 podman `libpod_lock` issue (#26, being measured separately), a `hashFiles`-and-Gate-boot-check overlap on yellowfin, or genuine build failures on a handful of nvidia flavors. Sign+attest reliability is the one lever here that pays off across the whole fleet at once.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->