### PR TITLE
fix(nvidia): force sr_mod/cdrom/virtio_blk into the rebuilt initramfs (#1499)

### DIFF
--- a/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
@@ -176,8 +176,18 @@ if [[ ! -f /usr/lib/dracut/dracut.conf.d/99-nvidia.conf ]]; then
 	exit 1
 fi
 sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
-# as we need forced load, also must pre-load intel/amd iGPU else chromium web browsers fail to use hardware acceleration
-sed -i 's@ nvidia @ i915 amdgpu nvidia @g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
+# As we need forced load, also must pre-load intel/amd iGPU else chromium web
+# browsers fail to use hardware acceleration. tunaos#1499: also force
+# sr_mod/cdrom/virtio_blk — --no-hostonly alone stopped being enough to
+# guarantee these on the live ISO / installed-disk boot path on this
+# negativo17 conf; they started coming up missing from the rebuilt
+# initramfs on every *-nvidia nightly (10/10 red 08-03..08-13) while present
+# in the parent (non-nvidia) image's initramfs and in this image's own
+# initramfs before this 99-nvidia.conf edit. virtio_scsi/isofs/squashfs/
+# overlay/loop were unaffected, so this isn't a wholesale hostonly-detection
+# failure — just these three. Same mechanism as i915/amdgpu: force them in
+# explicitly rather than trust generic-mode autodetection to include them.
+sed -i 's@ nvidia @ i915 amdgpu nvidia sr_mod cdrom virtio_blk @g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
 
 # Make sure initramfs is rebuilt after nvidia drivers or kernel replacement
 /usr/bin/dracut --no-hostonly --kver "$QUALIFIED_KERNEL" --reproducible --tmpdir /boot --zstd -v --add ostree -f "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -118,6 +118,24 @@ OVERLAY_SH="${REPO_ROOT}/build_scripts/overlay/nvidia.sh"
   [ "$status" -eq 0 ]
 }
 
+@test "20-nvidia.sh force-includes sr_mod/cdrom/virtio_blk alongside the GPU drivers (tunaos#1499)" {
+  # --no-hostonly alone stopped guaranteeing these three in the rebuilt
+  # initramfs (10/10 red Bonito nightlies 08-03..08-13, verify-nvidia.sh's
+  # boot-driver-parity check: sr_mod/cdrom/virtio_blk missing, the other 5
+  # required drivers unaffected). Same fix mechanism as i915/amdgpu on the
+  # same line: force them in via the 99-nvidia.conf force_drivers sed rather
+  # than trust generic-mode autodetection.
+  run grep -E 's@ nvidia @.*sr_mod.*cdrom.*virtio_blk.*@g' "$INSTALL_SH"
+  [ "$status" -eq 0 ]
+  # Applied to the dracut.conf.d file that actually gets sourced, and after
+  # the omit_drivers->force_drivers rename (so it lands in force_drivers,
+  # not a dead omit_drivers key).
+  run awk '/omit_drivers.*force_drivers/{print NR; exit}' "$INSTALL_SH"
+  local rename_line="$output"
+  run awk '/sr_mod.*cdrom.*virtio_blk/{print NR; exit}' "$INSTALL_SH"
+  [ -n "$rename_line" ] && [ -n "$output" ] && [ "$rename_line" -lt "$output" ]
+}
+
 # ── contract: verify-nvidia.sh behavioral tests against a fixture root ─────
 #
 # The script takes TUNAOS_NVIDIA_VERIFY_ROOT (same pattern as


### PR DESCRIPTION
Fixes #1499 for Bonito — see scope correction below.

## The bug

`verify-nvidia.sh`'s boot-driver-parity check has been failing on every
`*-nvidia` Bonito nightly (10/10 red, 08-03 through 08-13, confirmed via
`gh run view --log-failed` on run 31663809614): the rebuilt initramfs is
missing `sr_mod`, `cdrom`, and `virtio_blk`, while the other 5 required
drivers (`isofs`, `squashfs`, `virtio_scsi`, `overlay`, `loop`) are present,
and the parent (non-nvidia) image's own initramfs carries all 8. `dracut
--no-hostonly` alone isn't enough to guarantee these three come through
negativo17's shipped `99-nvidia.conf`.

## The fix

Extend the `force_drivers` sed the script already uses for `i915`/`amdgpu`
(same line, same mechanism, same reasoning: don't trust generic-mode
autodetection for drivers the boot path actually needs — force them in
explicitly) to also force `sr_mod cdrom virtio_blk`.

Added a bats test that fails without the fix (verified by temporarily
reverting the source change and re-running — `not ok 10`) and passes with
it.

## Scope correction from how #1499 was filed

I originally claimed this was a shared regression also hitting Albacore,
Marlin, and Yellowfin. Re-checked each individually before writing this fix
and that claim doesn't hold up:

- **Albacore, Yellowfin**: their same-morning nightly failures are a
  *different*, already-fixed bug — `AKMODS_EL_VERSION` matching the dist
  tag twice (`sed: unterminated 's' command`), fixed by `80cc2e57` at
  **12:37 UTC today**, after their **03:2x UTC** failing runs. Their
  `*-nvidia` builds never reached the dracut step, so there's no evidence
  either way on whether they'd hit this initramfs issue.
- **Marlin**: unrelated. Every Marlin flavor — not just nvidia — fails at
  the `Gate` (boot-test) step on `hashFiles('verify-out/serial.log')
  failed`, an infra/tooling error with nothing to do with nvidia or dracut.

So this PR is scoped to what's actually confirmed: Bonito. Whether
Albacore/Yellowfin also need this fix will only be knowable once their
nvidia builds get past the now-fixed dist-tag bug on a future nightly.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `c93de4b5`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->