### PR TITLE
fix(nvidia): install bonito-rawhide's akmods kernel RPMs with --nosignature

### DIFF
--- a/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
+++ b/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
@@ -106,7 +106,29 @@ else
 	# image supplies the rest (dracut, kmod, linux-firmware). The old
 	# kernels were already erased with rpm --erase --nodeps above, so the
 	# -i install has no version conflicts.
-	rpm -ivh "${RPM_FILES[@]}"
+	#
+	# --nosignature is required, not optional, on bonito-rawhide
+	# (base_image quay.io/fedora/fedora-bootc:rawhide). The akmods kernel
+	# cache RPMs are not GPG-signed by ublue-os's akmods build for ANY
+	# consumer -- bonito installs the identical unsigned set from the
+	# identical coreos-stable akmods bundle without incident (its failure
+	# in the SAME run window was purely the unrelated sed bug one script
+	# later, in 20-nvidia.sh -- proof this step passed for it). What
+	# differs on rawhide is the base image's own rpm signature-verify
+	# policy, which fedora-bootc:rawhide sets stricter than bonito's base:
+	#
+	#   package kernel-modules-core-7.1.4-100.fc43.x86_64 does not
+	#   verify: no signature
+	#
+	# on all six kernel packages uniformly (run 31663771496,
+	# bonito-rawhide gnome-nvidia) -- a property of the bundle, not
+	# corruption of a subset. The actual trust boundary for this content
+	# is already the pinned OCI digest of the akmods_nvidia_open build
+	# stage (Containerfile.overlay); the GPG check on top of that is
+	# redundant for a source that was never signed to begin with, and
+	# failing on its absence here blocks every *-nvidia flavor of the one
+	# variant that runs on a base image strict enough to enforce it.
+	rpm -ivh --nosignature "${RPM_FILES[@]}"
 
 	# Remove the OLD kernel's module directory outright. `rpm --erase` above
 	# removes only rpm-OWNED files; generated ones (initramfs.img, depmod

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -381,6 +381,23 @@ run_swap() {
   grep -q "rpm -ivh .*kernel-core-${AKMODS_KVER}.rpm" "${BATS_TEST_TMPDIR}/tool.log"
 }
 
+@test "kernel-swap installs the akmods kernel set with signature checking off" {
+  # bonito-rawhide's kernel cache RPMs are not GPG-signed by ublue-os's
+  # akmods build (true for every consumer, not just rawhide) -- run
+  # 31663771496 died here on fedora-bootc:rawhide with "does not verify:
+  # no signature" on all six kernel packages, while bonito installs the
+  # identical unsigned set from the identical akmods bundle without
+  # incident. The RPMs' authenticity is already established by the pinned
+  # OCI digest of the akmods_nvidia_open build stage; --nosignature drops
+  # a GPG check that source was never going to pass, not one that would
+  # have caught tampering.
+  make_swap_stubs "6.12.0-250.el10.x86_64"
+  make_swap_fixture
+  run_swap
+  [ "$status" -eq 0 ]
+  grep -q -- 'rpm -ivh --nosignature' "${BATS_TEST_TMPDIR}/tool.log"
+}
+
 @test "kernel-swap fails loudly when the cache holds no kernel at all" {
   make_swap_stubs "$AKMODS_KVER"
   make_swap_fixture


### PR DESCRIPTION
This is the security-relevant part of the README-matrix survey, so I stopped and asked before writing it — see the confirmation in-thread. Posting the reasoning here for the record.

## The failure

All five bonito-rawhide `-nvidia` flavors (gnome, xfce, kde, cosmic, niri) die identically in `10-kernel-swap.sh`:

```
package kernel-modules-core-7.1.4-100.fc43.x86_64 does not verify: no signature
package kernel-uki-virt-7.1.4-100.fc43.x86_64 does not verify: no signature
package kernel-modules-7.1.4-100.fc43.x86_64 does not verify: no signature
package kernel-modules-extra-7.1.4-100.fc43.x86_64 does not verify: no signature
package kernel-core-7.1.4-100.fc43.x86_64 does not verify: no signature
package kernel-7.1.4-100.fc43.x86_64 does not verify: no signature
```

(run [31663771496](https://github.com/tuna-os/tunaOS/actions/runs/31663771496), bonito-rawhide gnome-nvidia)

## Why this is safe, not a coverup

The akmods kernel cache RPMs are **not GPG-signed by ublue-os's akmods build, for any consumer** — bonito installs the identical unsigned set from the identical `coreos-stable` akmods bundle without incident. Proof: bonito's own `-nvidia` failure in the same run window was an unrelated sed bug one script *later*, in `20-nvidia.sh` (already fixed by 80cc2e57) — reaching that failure at all means this exact `10-kernel-swap.sh` step **passed** for bonito with the same unsigned RPMs.

What differs is the base image. bonito-rawhide runs on `quay.io/fedora/fedora-bootc:rawhide`, and Fedora's rpm signature-verify policy on rawhide is evidently stricter by default than bonito's base carries. The RPMs haven't changed; the enforcement around them has, on exactly one variant.

The actual trust boundary for this content is already the **pinned OCI digest** of the `akmods_nvidia_open` build stage (`Containerfile.overlay`). The GPG check on top of that was never going to pass for a source that was never signed — it isn't catching tampering, it's a check that's structurally unsatisfiable here.

## The change

`rpm -ivh` → `rpm -ivh --nosignature`, scoped to this one install only. No change to signature policy anywhere else in the build.

## Tests

`tests/bats/test_nvidia_overlay.bats`: new test drives the real script against the existing kernel-mismatch fixture and asserts the logged command carries `--nosignature`. Mutation-verified — dropping the flag from the script fails exactly that test and none of the other 32.

Full nvidia-overlay bats suite: `33/33 passed`. Full pytest suite: `224 passed, 1 skipped`.

## Scope

This is one of several fixes from a survey of every README variant's real (non-stale) CI state today — see #1501 for the other big one (cosign retry, covers 6 variants at once). This one is narrowly bonito-rawhide's `-nvidia` flavors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->