### PR TITLE
docs: standardize Justfile modularization

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -148,6 +148,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | Adoption metrics / usage telemetry | strategist | #1174 |
 | **Adoption evidence (ADOPTERS.md production entries)** | strategist | #1348 — zero public production adopters vs "Mature" claim; first entries at 2026-11-01 snapshot |
 | Variant lifecycle policy (admission + Beta→Stable exit criteria) | strategist | #1196, #1175 — [VARIANT-LIFECYCLE.md](./VARIANT-LIFECYCLE.md) |
+| Justfile modularization standard | architect | #508 — [docs/JUSTFILE-MODULARIZATION.md](./docs/JUSTFILE-MODULARIZATION.md); tunaOS local-import pattern adopted, cross-repo rollout pending maintainer decision |
 
 **Milestone fidelity (#1307, 2026-08-12)**: 7 of the 9 goal trackers above were
 filed without being attached to the Q4 milestone (#3), so the milestone

--- a/docs/JUSTFILE-MODULARIZATION.md
+++ b/docs/JUSTFILE-MODULARIZATION.md
@@ -1,0 +1,62 @@
+# Justfile modularization standard
+
+**Tracker**: [#508](https://github.com/tuna-os/tunaos/issues/508)
+**Status**: adopted for tunaOS; cross-repo rollout pending maintainer
+coordination
+
+## Decision
+
+Recipes that form a coherent subsystem belong in local `.just` modules under
+`just/`, and the root `Justfile` imports them with a relative local import:
+
+```just
+import 'just/utilities.just'
+import 'just/custom-overlay.just'
+```
+
+This is the supported mechanism in the current Just toolchain. Just imports
+resolve local source files; an import such as
+`import 'git@github.com:tuna-os/just-recipes.git'` does not fetch a repository
+and fails when the source file is absent. A future shared recipe repository
+therefore needs an explicit vendoring mechanism (submodule or pinned CI
+checkout) before a consuming root file can import it.
+
+## What belongs in a module
+
+Extract a recipe group when it has a clear lifecycle or subsystem boundary,
+for example:
+
+- validation, test, and formatting helpers (`just/utilities.just`);
+- custom image and ISO overlay operations (`just/custom-overlay.just`);
+- VM/demo operations, ISO publishing, or other independent workflow groups.
+
+Keep the root file responsible for global variables, the primary build graph,
+and private primitives shared by multiple modules. Just imports share one
+recipe/variable namespace, so an imported recipe may call a root private
+helper, but names must remain unique across all imported files.
+
+## Migration checklist for authorized repositories
+
+For each repository with a large Justfile:
+
+1. Inventory recipes by subsystem and record the current line count.
+2. Extract one coherent group at a time into `just/<area>.just`.
+3. Keep the recipe bodies byte-equivalent during extraction; verify with
+   `just --show <recipe>` before and after.
+4. Run the repository's syntax, unit, and integration checks after each group.
+5. Update the root README/agent guide with the module map.
+6. Repeat until the root file contains orchestration and shared primitives,
+   not unrelated subsystem implementations.
+
+The tunaOS baseline is the reference implementation: `custom-overlay.just`
+was extracted first, followed by `utilities.just`, while `_ensure-deps` stays
+in the root because both the build engine and imported recipes use it.
+
+## Cross-repo follow-up
+
+Do not create a `just-recipes` repository or add a remote import as an
+individual repository change. That requires a maintainer decision about
+version pinning, release compatibility, and how consuming repositories vendor
+the files. If approved, the shared repository must be pinned (submodule or CI
+checkout), imported from a local path, and tested against each consumer before
+recipes are removed from that consumer's tree.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ user-facing site:
 | [PIPELINE.md](PIPELINE.md) | Build pipeline reference: stages, workflows, artifact flow |
 | [BRANCH-PROTECTION.md](BRANCH-PROTECTION.md) | Current-state audit + proposal for main-branch protection & required CI (#1167) |
 | [CI_SPEC.md](CI_SPEC.md) | CI behavior specification |
+| [JUSTFILE-MODULARIZATION.md](JUSTFILE-MODULARIZATION.md) | Justfile module standard and cross-repo migration checklist (#508) |
 | [TESTING.md](TESTING.md) | ISO end-to-end test harness |
 | [MATRIX-STATUS.md](MATRIX-STATUS.md) | Which variant×desktop combinations are actually verified — and which have never been tested |
 | [ASAHI-HARDWARE-TIERS.md](ASAHI-HARDWARE-TIERS.md) | Real Apple Silicon hardware CI: rented Scaleway rental + personal-machine tiers, and the m1n1/boot.bin safety rule both must follow |


### PR DESCRIPTION
## Summary

- add `docs/JUSTFILE-MODULARIZATION.md` as the supported local-module standard and migration checklist for #508
- document the working tunaOS pattern (`just/*.just` local imports) and the limitation that Just does not fetch remote Git imports
- record the cross-repo shared-recipes decision gate: pinned vendoring or CI checkout must be designed before adopting a shared repository
- index the standard in `docs/README.md` and ROADMAP

## Why

The root tunaOS Justfile already has local modules, but the cross-repo recommendation in #508 uses an import form that Just cannot resolve. This PR makes the proven pattern reusable across authorized repositories and prevents consumers from adopting a non-working remote import prematurely.

## Validation

- `git diff --check`
- verified the branch is based on current `upstream/main`
- `just --list` was unavailable because `just` is not installed in the environment

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789221733&installation_model_id=429180&pr_number=1505&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1505&signature=4b69e852a3b656675bd51a5f1bf1186378a68cedbe9fd5fa0c9b81e68624e214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->