### PR TITLE
ci: close superseded weekly boot reports

### DIFF
--- a/.github/workflows/weekly-boot-report.yml
+++ b/.github/workflows/weekly-boot-report.yml
@@ -129,5 +129,30 @@ jobs:
             --label "boot-report" \
             --body-file "${{ steps.report.outputs.body_file }}")
           echo "==> Report: ${ISSUE_URL}"
+
+          # A weekly report is a snapshot, not a durable work item. Keep the
+          # latest issue open for review and close every older open report so
+          # generated snapshots do not accumulate indefinitely (#660).
+          CURRENT_NUMBER="${ISSUE_URL##*/}"
+          SUPERSEDED_REPORTS=$(mktemp)
+          trap 'rm -f "$SUPERSEDED_REPORTS"' EXIT
+          gh issue list \
+            --repo "$REPO" \
+            --label "boot-report" \
+            --state open \
+            --limit 100 \
+            --json number,title \
+            --jq ".[] | select(.number != ${CURRENT_NUMBER}) | [.number, .title] | @tsv" \
+            > "$SUPERSEDED_REPORTS"
+          CLOSED_REPORTS=$(grep -c . "$SUPERSEDED_REPORTS" || true)
+          while IFS=$'\t' read -r number title; do
+            [[ -z "$number" ]] && continue
+            gh issue close "$number" \
+              --repo "$REPO" \
+              --reason "completed" \
+              --comment "Superseded by the latest weekly boot report: ${ISSUE_URL}."
+            echo "==> Closed superseded boot report #${number}: ${title}"
+          done < "$SUPERSEDED_REPORTS"
           echo "## Boot report" >> "$GITHUB_STEP_SUMMARY"
           echo "- Issue: ${ISSUE_URL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Superseded open reports closed: ${CLOSED_REPORTS}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- after publishing the latest weekly boot report, list open issues carrying the `boot-report` label
- close every older report with a comment linking to the replacement issue
- include the number of superseded reports closed in the workflow summary

## Why

Issue #660 is one of several historical auto-generated reports that remained open after newer weekly snapshots superseded them. The workflow created reports but had no lifecycle step to close them, allowing the backlog to accumulate.

## Validation

- `git diff --check`
- verified the `gh issue close --reason completed --comment` CLI contract
- Python YAML/pytest and actionlint checks were unavailable in the environment (missing PyYAML, pytest, and actionlint)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789221971&installation_model_id=429180&pr_number=1506&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1506&signature=61b0d8fa0e3fbbf5342e633207242d8939d28ebd889e9e4cabc3a558e1f51978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->