### PR TITLE
fix(changelog): use tuna-os commit links

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -34,7 +34,7 @@ OTHER_NAMES = {
 }
 
 COMMITS_FORMAT = "### Commits\n| Hash | Subject |\n| --- | --- |{commits}\n\n"
-COMMIT_FORMAT = "\n| **[{short}](https://github.com/hanthor/albacore-lts/commit/{githash})** | {subject} |"
+COMMIT_FORMAT = "\n| **[{short}](https://github.com/tuna-os/albacore-lts/commit/{githash})** | {subject} |"
 
 CHANGELOG_TITLE = "{tag}: {pretty}"
 CHANGELOG_FORMAT = """\

--- a/tests/test_changelogs.py
+++ b/tests/test_changelogs.py
@@ -15,6 +15,7 @@ Tests core logic extractable from the script:
 import pytest
 import re
 from itertools import product
+from pathlib import Path
 
 
 # ── Constants from the script ───────────────────────────────────────────────
@@ -262,6 +263,15 @@ def test_changelog_format_handwritten_placeholder():
     handwritten = """This is an automatically generated changelog for release `42.20250101`."""
     assert "automatically generated" in handwritten
     assert "42.20250101" in handwritten
+
+
+def test_commit_links_use_current_repository_org():
+    """Generated commit links must follow the current tuna-os repository."""
+    repo_root = Path(__file__).resolve().parents[1]
+    changelog_source = (repo_root / ".github" / "changelogs.py").read_text()
+
+    assert "https://github.com/tuna-os/albacore-lts/commit/" in changelog_source
+    assert "https://github.com/hanthor/albacore-lts/commit/" not in changelog_source
 
 
 # ── RETRIES Constant ────────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

- Update generated changelog commit links from the retired `hanthor/albacore-lts` path to `tuna-os/albacore-lts`.
- Add a regression test that rejects the stale organization URL.

## Why

Hive advisory report #922 identified stale `hanthor` organization references as cross-repository rename debt. The old URL can lead release readers to an obsolete repository path.

## Validation

- `git diff --check`
- Dependency-free Python assertion and syntax compilation passed.
- `python3 -m pytest -q tests/test_changelogs.py` could not run because `pytest` is not installed in the environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789222822&installation_model_id=429180&pr_number=1507&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1507&signature=ab2eed757281ebfe48e96e180e26314d40943399f1472b0287368f6592f4e848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->