### PR TITLE
docs: record gtk-office-suite roadmap completion

### DIFF
--- a/Q3_CHECKPOINT-2026-08-22.md
+++ b/Q3_CHECKPOINT-2026-08-22.md
@@ -45,7 +45,7 @@ Make Q3 carryover an explicit decision, not a discovery. For every open Q3 goal,
 - **GFI pool is ZERO usable (#1362)**: the #1308 seeds never landed (letters#8 is on an archived repo); CONTRIBUTING's good-first-issue link is dead. No seeds → no external capacity → the retention-window opportunity above is moot. Seed 20+ GFIs by 09-15 (#1362; outreach #1354 tracks 3→8).
 - **Q4 dependency risk**: Q4 is 0/13 items closed (was 0/9); Bonito GA and Redfin GA already appear as Q4 rows — every Q3 descope adds Q4 load before Q4 starts. #1159/#1307 track Q4 goal fidelity.
 - **Release parity**: GNOME releases are now daily (08-09 → 08-11, 3 assets each). kde/xfce/niri/gnome-nvidia still stale 30–37 days (#1254). Browser-catalog parity gate (#1322) fixed the on-demand path; the scheduled GitHub Releases pipeline remains GNOME-only.
-- **New planning debt (mid-cycle)**: wootc ROADMAP merged (wootc#116) but CONTRIBUTING/LICENSE still missing (#1358); gtk-office-suite planning gap open (#1359); tromso stable release untracked (no releases, no milestones — core build tooling; filed as new tracker this cycle).
+- **New planning debt (mid-cycle)**: wootc ROADMAP merged (wootc#116) but CONTRIBUTING/LICENSE still missing (#1358); gtk-office-suite ROADMAP merged (gtk-office-suite#189, resolving #1359; README/tracker follow-up in gtk-office-suite#218); tromso stable release untracked (no releases, no milestones — core build tooling; filed as new tracker this cycle).
 - **Enterprise posture**: ADOPTERS.md empty vs Q4 "Mature" claim (#1348); RHEL10/AlmaLinux topics on repo but Redfin alpha dropped (#1123); branch protection unverified (#1167).
 
 ## Strategist recommendation (input — decision authority stays with maintainer)


### PR DESCRIPTION
## What changed

- Update the Q3 checkpoint’s planning-debt entry to record that `gtk-office-suite#189` delivered the requested `ROADMAP.md`.
- Link the follow-up `gtk-office-suite#218`, which corrects the stale self-description/tracking row and adds the missing README link.

## Why

Issue #1359 is resolved in the target repository, but the tunaOS checkpoint still described the planning gap as open. This keeps the organization-level planning record aligned with the delivered roadmap and follow-up work.

## Validation

- `git diff --check`
- Confirmed issue #1359’s digest and `gtk-office-suite#189` resolution through the GitHub connector.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789222940&installation_model_id=429180&pr_number=1508&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1508&signature=050d6a0708c212ae2faa1539e7d80001db4a0c5e5bc701ee6388bce06cada823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->