### PR TITLE
fix(ci): retry sudo podman login instead of trusting an unproven fix

### DIFF
--- a/.github/actions/ghcr-login/action.yml
+++ b/.github/actions/ghcr-login/action.yml
@@ -14,17 +14,60 @@ runs:
     # Podman login is required separately because some build steps invoke podman
     # directly rather than going through the Docker credential store.
     # Sudo podman is needed for privileged build operations (e.g. isogenerator).
-    # podman requires >=2048 open file descriptors to init its lock file
-    # (/libpod_lock). GitHub-hosted arm64 runners default to a lower
-    # ulimit -n, which made podman login fail with exit 125:
+    #
+    # `ulimit -n 4096` below is not load-bearing and is kept only because
+    # removing it is not free to re-verify. It was added as a fix for
+    # arm64's intermittent "Login to Podman (sudo)" failure:
     #   Error: failed to open 2048 locks in /libpod_lock: numerical result out of range
+    # (exit 125) -- but it never actually stopped the failure (grouper and
+    # yellowfin kept hitting it after this landed, tunaOS#1101). tunaOS#1495
+    # measured six live arm64 runners across both podman versions the fleet
+    # hands out (4.9.3 and 5.8.4, with and without a pre-existing
+    # containers.conf) and found `podman info`/`podman login` succeed at
+    # sudo's DEFAULT soft nofile of 1024 on every one of them -- the
+    # descriptor theory does not hold. A follow-up measurement reproduced
+    # ghcr-login's exact sequence (unsudo login, then sudo login, real
+    # credentials, no ulimit override) on the same six runners and it
+    # succeeded cleanly on all six too. Every mechanism available to an
+    # isolated diagnostic job has now been tried and has not reproduced the
+    # production failure; whatever triggers it lives in the full job's
+    # earlier steps (disk cleanup, KVM setup, apt installs) or in a fleet
+    # image batch that has since rotated out, and isolating that is not
+    # cheap. Retry rather than guess again at a resource limit.
     - name: Login to Podman (user)
       run: |
         ulimit -n 4096
         echo "${{ github.token }}" | podman login -u "${{ github.actor }}" --password-stdin ghcr.io
       shell: bash
 
+    # Retried with linear backoff, same idiom as the GHCR push retry in
+    # reusable-build-image.yml and the cosign retry in the Sign+attest step:
+    # a transient failure on a call this cheap should not fail the whole
+    # arm64 build. This is a mitigation for an unreproduced intermittent,
+    # not a fix for a diagnosed cause -- see the comment above.
+    #
+    # The loop ends on an explicit exit, not on falling off the bottom: a
+    # `for ... && break; sleep; done` with nothing after it exits with
+    # `sleep`'s status (near-always 0) even when every attempt failed, which
+    # would report this step as successful with podman never authenticated
+    # -- a later, more confusing failure the first time something tries to
+    # push or pull. `login_ok` makes exhaustion a real failure.
     - name: Login to Podman (sudo)
+      env:
+        MAX_RETRIES: 3
       run: |
-        sudo TOKEN="${{ github.token }}" ACTOR="${{ github.actor }}" bash -c 'ulimit -n 4096 && echo "$TOKEN" | podman login -u "$ACTOR" --password-stdin ghcr.io'
+        login_ok=0
+        for i in $(seq "${MAX_RETRIES}"); do
+          if sudo TOKEN="${{ github.token }}" ACTOR="${{ github.actor }}" \
+              bash -c 'ulimit -n 4096 && echo "$TOKEN" | podman login -u "$ACTOR" --password-stdin ghcr.io'; then
+            login_ok=1
+            break
+          fi
+          echo "::warning::sudo podman login failed (attempt ${i}/${MAX_RETRIES}); retrying..."
+          sleep $((5 * i))
+        done
+        if [[ "$login_ok" -ne 1 ]]; then
+          echo "::error::sudo podman login failed after ${MAX_RETRIES} attempts"
+          exit 1
+        fi
       shell: bash

--- a/tests/test_ghcr_login_podman_sudo_retry.py
+++ b/tests/test_ghcr_login_podman_sudo_retry.py
@@ -1,0 +1,109 @@
+"""The sudo podman login must retry, and retrying must not hide a real failure.
+
+Six live arm64 runners, both podman versions the fleet hands out (4.9.3 and
+5.8.4, with and without a pre-existing containers.conf), all showed the same
+thing: `podman login`/`podman info` succeed at sudo's DEFAULT soft nofile of
+1024 -- the descriptor-limit fix this action carried since #1101 does not
+address the failure at all. A follow-up measurement reproduced the exact
+login sequence (unsudo login, then sudo login, real credentials, no ulimit
+override) on the same six runners and it succeeded cleanly on all six too.
+See tunaOS#1495 for the measurements.
+
+Nothing available to an isolated diagnostic job reproduces the production
+failure, so this is a retry -- a mitigation for an unreproduced intermittent,
+following the same idiom this repo already trusts for GHCR push and cosign
+sign -- not a fix for a diagnosed cause.
+
+The one way a retry can make things worse than no retry at all: a
+`for ... && break; sleep; done` with nothing after it exits with `sleep`'s
+status (near-always 0) even when every attempt failed, silently reporting
+success while podman was never actually authenticated. These tests pin that
+exhaustion is a real, visible failure.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTION = ROOT / ".github/actions/ghcr-login/action.yml"
+
+
+@pytest.fixture(scope="module")
+def sudo_login_step():
+    action = yaml.safe_load(ACTION.read_text())
+    return next(
+        s for s in action["runs"]["steps"] if s.get("name") == "Login to Podman (sudo)"
+    )
+
+
+def test_the_step_retries_more_than_cosigns_own_two_attempts(sudo_login_step):
+    max_retries = sudo_login_step.get("env", {}).get("MAX_RETRIES")
+    assert max_retries is not None, "MAX_RETRIES is not set for the sudo login step"
+    assert int(max_retries) >= 3
+
+
+def _drive_step(sudo_login_step, tmp_path, login_cmd):
+    """Run the REAL step body, substituting a fake `sudo` so no real sudo call happens."""
+    # The real body embeds GitHub Actions expressions (${{ github.token }},
+    # ${{ github.actor }}), which are not valid bash -- substitute harmless
+    # literals, the same way a workflow runner would before executing this.
+    body = (
+        sudo_login_step["run"]
+        .replace("${{ github.token }}", "fake-token")
+        .replace("${{ github.actor }}", "fake-actor")
+    )
+    # The step invokes `sudo TOKEN=... ACTOR=... bash -c '...'`. Swap in a
+    # fake `sudo` on PATH that runs the given login_cmd instead of the real
+    # podman/bash construct, so this drives the loop/exit logic without
+    # requiring podman, sudo, or network access.
+    fake_sudo = tmp_path / "sudo"
+    fake_sudo.write_text(f"#!/usr/bin/env bash\n{login_cmd}\n")
+    fake_sudo.chmod(0o755)
+
+    script = tmp_path / "probe.sh"
+    script.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            PATH="{tmp_path}:$PATH"
+            MAX_RETRIES=3
+            {body}
+            echo "REACHED END"
+            """
+        )
+    )
+    return subprocess.run(["bash", str(script)], capture_output=True, text=True)
+
+
+def test_exhausting_every_retry_fails_the_step(sudo_login_step, tmp_path):
+    proc = _drive_step(sudo_login_step, tmp_path, "exit 1")
+    assert proc.returncode != 0, "the step must fail when every retry fails"
+    assert "REACHED END" not in proc.stdout, (
+        f"execution continued past exhausted retries: {proc.stdout!r}"
+    )
+    assert "sudo podman login failed after" in proc.stderr + proc.stdout
+
+
+def test_a_flake_that_clears_on_a_later_attempt_still_succeeds(sudo_login_step, tmp_path):
+    marker = tmp_path / "attempts"
+    login_cmd = (
+        f'n=0; [[ -f "{marker}" ]] && n=$(cat "{marker}"); n=$((n+1)); '
+        f'echo "$n" > "{marker}"; [[ "$n" -ge 2 ]]'
+    )
+    proc = _drive_step(sudo_login_step, tmp_path, login_cmd)
+    assert proc.returncode == 0, f"a flake that clears must not fail the step: {proc.stderr!r}"
+    assert "REACHED END" in proc.stdout
+
+
+def test_success_on_the_first_attempt_does_not_wait_out_the_backoff(sudo_login_step, tmp_path):
+    proc = _drive_step(sudo_login_step, tmp_path, "exit 0")
+    assert proc.returncode == 0
+    assert "failed (attempt" not in proc.stdout + proc.stderr


### PR DESCRIPTION
grouper and yellowfin have been losing ~6 README matrix cells to an intermittent arm64 failure:

```
Error: failed to open 2048 locks in /libpod_lock: numerical result out of range
```

exit 125, in `Login to Podman (sudo)`. #1101 diagnosed this as a file-descriptor shortage and fixed it with `ulimit -n 4096`. That fix landed 2026-08-07 and the failure kept recurring for six more days — the tell that the diagnosis was wrong, not that the runners got unusually unlucky.

## The measurement (#1495)

Six live arm64 runners, sampling across both podman versions the fleet actually hands out (4.9.3 and 5.8.4, with and without a pre-existing `containers.conf`):

- `sudo podman info` / `podman login` succeed at sudo's **default** soft nofile of 1024 on all six — the descriptor theory does not hold
- the hard nofile ceiling under sudo is 1048576, nowhere near a 2048 cap
- `ulimit -n 4096` is accepted, not rejected, so the `&&` chain was never the problem either
- reproducing ghcr-login's **exact sequence** — an unsudo login immediately followed by a sudo one, real credentials, no ulimit override — also succeeds cleanly on all six

Every mechanism available to an isolated diagnostic job has now been tried and none reproduce the production failure. Whatever triggers it lives in the full job's earlier steps (disk cleanup, KVM setup, apt installs) or in a fleet image batch that has since rotated out — not cheap to isolate, and guessing again at a resource limit already cost six days once.

## The fix

Retry, matching the idiom this repo already trusts for exactly this class of problem: the GHCR push retry in `reusable-build-image.yml`, and the cosign retry just added for Sign+attest (#1501). This is a **mitigation for an unreproduced intermittent**, not a fix for a diagnosed cause — the comment above the step says so plainly rather than implying the ulimit is doing real work.

The loop is deliberately **not** `for ... && break; sleep; done` with nothing after it — that construct exits with `sleep`'s status (near-always 0) even when every attempt failed, reporting the step successful with podman never actually authenticated. `login_ok` makes exhaustion a real, visible failure instead.

## Tests

`tests/test_ghcr_login_podman_sudo_retry.py` drives the **real** step body (GitHub Actions expressions substituted, a fake `sudo` on PATH standing in for the real login) through three cases: exhausting every retry fails the step, a flake that clears on attempt 2 still succeeds, and success on attempt 1 doesn't wait out the backoff. Also pins `MAX_RETRIES` meaningfully above cosign's own 2.

| Mutation | Result |
| :--- | :--- |
| revert to the original swallow-failure loop | 1 failed, 3 passed |
| drop `MAX_RETRIES` to 1 | 1 failed, 3 passed |

Full suite: `228 passed, 1 skipped`.

## Scope

This closes out the arm64-podman investigation from today's README-matrix survey (alongside #1501 for the cosign/Sigstore issue and #1504 for bonito-rawhide's unsigned kernel RPMs). Diagnostic workflow `.github/workflows/arm64-ulimit-probe.yml` (#1495) can be deleted once this is confirmed green on a real grouper/yellowfin nightly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->