### PR TITLE
ci: guard the good-first-issue onboarding pool

### DIFF
--- a/.github/workflows/gfi-pool.yml
+++ b/.github/workflows/gfi-pool.yml
@@ -1,0 +1,20 @@
+name: Good-first-issue pool
+
+on:
+  schedule:
+    - cron: '30 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check onboarding labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/check-gfi-pool.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,15 +12,28 @@ just fix && just check
 
 ## Contributor onboarding
 
-New here? Start with a **[good first issue](https://github.com/tuna-os/tunaOS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)** — a curated, maintainer-sized task covering documentation parity, a small script fix, or test coverage. Before starting, leave a comment saying you are taking the issue so the work is not duplicated.
+New here? Start with a **[good first issue](https://github.com/tuna-os/tunaOS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)** or **[help wanted](https://github.com/tuna-os/tunaOS/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)** issue — a curated, maintainer-sized task covering documentation parity, a small script fix, or test coverage. Before starting, leave a comment saying you are taking the issue so the work is not duplicated.
 
 The current starter runway includes:
 
-- [#1308](https://github.com/tuna-os/tunaOS/issues/1308) — build a documentation-parity checklist for published editions
-- [#1350](https://github.com/tuna-os/tunaOS/issues/1350) — document the `pantheon` desktop suffix
+- [#1496](https://github.com/tuna-os/tunaOS/issues/1496) — link orphaned docs in the README Documentation section
+- [#1308](https://github.com/tuna-os/tunaOS/issues/1308) — seed and maintain the good-first-issue backlog
 - [#1351](https://github.com/tuna-os/tunaOS/issues/1351) — add a Gurnard/Pantheon desktop guide
-- [#1366](https://github.com/tuna-os/tunaOS/issues/1366) — document checksum and SBOM verification
-- [#1385](https://github.com/tuna-os/tunaOS/issues/1385) — document supported ARM laptop hardware
+
+This list is a snapshot, not a second issue tracker. Use the label queries
+above for the current queue; weekly triage must remove completed links and add
+new bounded tasks rather than letting this list go stale.
+
+The repository checks this queue weekly. To verify it locally (requires the
+GitHub CLI and read access), run:
+
+```bash
+GITHUB_REPOSITORY=tuna-os/tunaos ./scripts/check-gfi-pool.sh
+```
+
+The check is a read-only alarm, not an auto-labeler. If either onboarding
+label falls below three open issues, add or refresh a bounded task during
+weekly triage before changing the contributor-facing links.
 
 These tasks are intentionally independent of the image build pipeline. If one is claimed or closed, use the same issue search to choose another bounded task.
 

--- a/scripts/check-gfi-pool.sh
+++ b/scripts/check-gfi-pool.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Verify that the contributor onboarding labels still expose a usable queue.
+# This is intentionally read-only: it reports a regression for a maintainer
+# to fix rather than changing issue labels automatically.
+set -euo pipefail
+
+repo="${GFI_REPO:-${GITHUB_REPOSITORY:-tuna-os/tunaos}}"
+minimum="${GFI_MINIMUM:-3}"
+
+command -v gh >/dev/null || {
+	echo "FAIL: gh is required to query the good-first-issue pool" >&2
+	exit 1
+}
+command -v jq >/dev/null || {
+	echo "FAIL: jq is required to count the good-first-issue pool" >&2
+	exit 1
+}
+
+case "$minimum" in
+	''|*[!0-9]*)
+		echo "FAIL: GFI_MINIMUM must be a non-negative integer" >&2
+		exit 1
+		;;
+esac
+
+count_for_label() {
+	local label="$1"
+	gh issue list \
+		--repo "$repo" \
+		--state open \
+		--label "$label" \
+		--limit 100 \
+		--json number \
+		| jq 'length'
+}
+
+gfi_count=$(count_for_label 'good first issue')
+help_count=$(count_for_label 'help wanted')
+
+echo "good first issue: $gfi_count open issue(s)"
+echo "help wanted:      $help_count open issue(s)"
+
+if (( gfi_count < minimum || help_count < minimum )); then
+	echo "FAIL: each onboarding label must have at least $minimum open issue(s)" >&2
+	exit 1
+fi
+
+echo "GFI POOL OK: both labels meet the minimum of $minimum"


### PR DESCRIPTION
## Summary

- add a read-only `scripts/check-gfi-pool.sh` guard for the `good first issue` and `help wanted` queues
- run the guard weekly and on demand through GitHub Actions with read-only issue permissions
- refresh `CONTRIBUTING.md`'s starter snapshot and document the local check

## Why

Issue #1277 identified that the contributor-facing label query could silently become empty. The direct label repairs and roadmap bookkeeping have landed, but there was no mechanism to detect a future regression. This PR makes the minimum pool of three open issues explicit and reports when weekly triage needs to replenish it; it never changes labels automatically.

## Validation

- `bash -n scripts/check-gfi-pool.sh`
- `git diff --check`
- `GH_TOKEN=... GITHUB_REPOSITORY=tuna-os/tunaos ./scripts/check-gfi-pool.sh` (3 open issues under each label)
- YAML parser unavailable locally; workflow uses standard GitHub Actions syntax and read-only permissions

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789229145&installation_model_id=429180&pr_number=1512&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1512&signature=9fa8252f8b7d068a1eb7cdc3f17b9c8df82327b047a003c5609d723a9c68c61d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->