### PR TITLE
fix(ci): retry the README status push instead of dying on one GitHub 500

### DIFF
--- a/.github/workflows/update-build-status.yml
+++ b/.github/workflows/update-build-status.yml
@@ -59,6 +59,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: automation/readme-build-status
+          MAX_RETRIES: 3
         run: |
           set -euo pipefail
           if git diff --quiet -- README.md; then
@@ -74,7 +75,29 @@ jobs:
           git checkout -b "$BRANCH"
           git add README.md
           git commit -m "docs: refresh build matrix status ($(date -u +%Y-%m-%d))"
-          git push --force origin "$BRANCH"
+
+          # Retried with linear backoff, same idiom as the GHCR push retry in
+          # reusable-build-image.yml: the 2026-08-13 13:30 UTC run died on a
+          # single unretried attempt hitting a transient GitHub 500 --
+          #   remote: Internal Server Error
+          #   ! [remote rejected] automation/readme-build-status ->
+          #     automation/readme-build-status (Internal Server Error)
+          # -- which froze the table exactly the way the merge-queue rejection
+          # did before this workflow started opening a PR at all. One flaky
+          # push should not cost the whole refresh.
+          push_ok=0
+          for i in $(seq "${MAX_RETRIES}"); do
+            if git push --force origin "$BRANCH"; then
+              push_ok=1
+              break
+            fi
+            echo "::warning::git push failed (attempt ${i}/${MAX_RETRIES}); retrying..."
+            sleep $((5 * i))
+          done
+          if [[ "$push_ok" -ne 1 ]]; then
+            echo "::error::git push failed after ${MAX_RETRIES} attempts"
+            exit 1
+          fi
 
           if [[ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]]; then
             gh pr create --base main --head "$BRANCH" \

--- a/tests/test_readme_build_status_refresh.py
+++ b/tests/test_readme_build_status_refresh.py
@@ -89,6 +89,40 @@ def test_the_refresh_lands_through_a_pull_request(run_blocks):
     )
 
 
+def test_the_push_survives_a_transient_github_error(run_blocks):
+    # The 2026-08-13 13:30 UTC run committed the refresh and then died on a
+    # single unretried `git push --force` hitting GitHub's transient
+    #   remote: Internal Server Error
+    # -- exactly the failure mode this workflow already retries for the GHCR
+    # push in reusable-build-image.yml. A bare, unretried push froze the
+    # table the same way the pre-PR merge-queue rejection did, just from a
+    # different cause. Pin that the push is inside a retry loop, not a bare
+    # command that gives up on the first flake.
+    joined = "\n".join(run_blocks)
+    push_block = next(
+        (block for block in run_blocks if "git push --force origin" in block), None
+    )
+    assert push_block is not None, "no run block pushes the refresh branch"
+
+    lines = push_block.splitlines()
+    push_line = next(i for i, l in enumerate(lines) if "git push --force origin" in l)
+    # A bare push (not inside an `if`/loop conditional) is the original bug:
+    # the very next non-blank, non-comment line after it must not be able to
+    # run unconditionally after a failed push under `set -e` -- i.e. the push
+    # has to be the condition of an `if`, not a standalone statement.
+    stripped = lines[push_line].strip()
+    assert stripped.startswith("if ") or stripped.startswith("if["), (
+        "`git push --force origin \"$BRANCH\"` runs as a bare statement; one "
+        "transient GitHub error kills the whole job with nothing retried. "
+        f"got: {stripped!r}"
+    )
+    assert "for i in $(seq" in joined and "push_ok" in joined, (
+        "the push is not wrapped in a retry loop with an explicit success "
+        "flag; a `for ... && break; sleep; done` with nothing after it would "
+        "silently report success even if every attempt failed"
+    )
+
+
 def test_the_workflow_may_open_that_pull_request(workflow):
     permissions = workflow.get("permissions") or {}
     assert permissions.get("pull-requests") == "write", (


### PR DESCRIPTION
## Summary

- The `Update README build status` workflow's 2026-08-13 13:30 UTC run regenerated the table, committed it, then died on the very first `git push --force`, hitting a transient GitHub `Internal Server Error`. With no retry, that one 500 killed the whole refresh — leaving the README table frozen at 2026-07-14/15 even though the merge-queue rejection #1488 fixed is long gone; this is just a different single point of failure with the same symptom.
- Wraps the push in the same linear-backoff retry loop already used for `ghcr-login` and `cosign_retry` elsewhere in this repo, with an explicit `push_ok` flag so an exhausted retry is a real job failure rather than silently falling through to `gh pr create` with nothing pushed.

## Test plan

- [x] `tests/test_readme_build_status_refresh.py::test_the_push_survives_a_transient_github_error` (new) pins that the push is the condition of an `if`, not a bare statement, and lives inside a retry loop with an explicit success flag.
- [x] Mutation-verified: reverting to the bare `git push --force origin "$BRANCH"` fails the new test; restoring the fix passes all 7 tests in the file.
- [x] `python3 -m pytest tests/test_readme_build_status_refresh.py -q` → 7 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->