### PR TITLE
ci: audit NVIDIA release asset parity

### DIFF
--- a/.github/workflows/audit-nvidia-release-assets.yml
+++ b/.github/workflows/audit-nvidia-release-assets.yml
@@ -1,0 +1,20 @@
+name: Audit NVIDIA release assets
+
+on:
+  schedule:
+    - cron: '30 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Check all NVIDIA editions have downloadable assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./scripts/audit-nvidia-release-assets.sh

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -118,7 +118,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | **Desktop parity floor (non-RPM bases)** | packaging | #133, tunaos-packages#323 | ⬜ Not started — P0 for Q4 (see #1294) |
 | **Q3 checkpoint (08-22): staff or descope #272/#1123/#1093/#1094** | strategist | #1299 | ⬜ Scheduled |
 | **Flavor equality mandate (docs wording + cadence parity)** | strategist | #1315, #1254 | 🟡 In progress — catalog parity gate merged 08-11 (#1322, #1281 closed); cadence parity pending (#1316) |
-| **NVIDIA flavor family (6 editions, 0 assets since 07-05)** | ci-maintainer | #1383 | 🔴 Broken — nightly overlay regressed 08-12 (#1382); staff test: nightly green + gnome-nvidia assets republished by 09-01 (#1376/#1379) |
+| **NVIDIA flavor family (6 editions, 0 assets since 07-05)** | ci-maintainer | #1383 | 🔴 Broken — nightly overlay regressed 08-12 (#1382); staff test: nightly green + gnome-nvidia assets republished by 09-01 (#1376/#1379); [asset audit](.github/workflows/audit-nvidia-release-assets.yml) now fails loudly while any edition is empty |
 | **Package sourcing policy (system-repos/tideforge-first + allowlist)** | strategist | #1319, #1323 | 🟡 In progress — PACKAGE-SOURCING.md drafted (planning PR open); third-party allowlist + per-variant audit due at 08-22 checkpoint |
 
 ---

--- a/scripts/audit-nvidia-release-assets.sh
+++ b/scripts/audit-nvidia-release-assets.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Audit the NVIDIA release surface without changing releases or assets.
+# A red result is intentional: it makes a missing downloadable artifact
+# visible to the release owners instead of allowing the catalog to look green.
+set -euo pipefail
+
+repo="${NVIDIA_AUDIT_REPO:-${GITHUB_REPOSITORY:-tuna-os/tunaos}}"
+minimum="${NVIDIA_MIN_ASSETS:-1}"
+
+command -v gh >/dev/null || {
+	echo "FAIL: gh is required to inspect release assets" >&2
+	exit 1
+}
+command -v jq >/dev/null || {
+	echo "FAIL: jq is required to inspect release assets" >&2
+	exit 1
+}
+
+case "$minimum" in
+	''|*[!0-9]*)
+		echo "FAIL: NVIDIA_MIN_ASSETS must be a non-negative integer" >&2
+		exit 1
+		;;
+esac
+
+flavors=(
+	gnome-nvidia
+	gnome50-nvidia
+	xfce-nvidia
+	niri-nvidia
+	cosmic-nvidia
+	kde-nvidia
+)
+
+fail=0
+for flavor in "${flavors[@]}"; do
+	release=$(GH_TOKEN="${GH_TOKEN:-}" gh api --paginate --slurp \
+		"repos/$repo/releases?per_page=100" \
+		| jq -c --arg prefix "$flavor-" \
+		'add | map(select(.tag_name | startswith($prefix))) | sort_by(.published_at) | last // empty')
+
+	if [ -z "$release" ]; then
+		echo "MISSING $flavor: no GitHub release found"
+	fail=1
+		continue
+	fi
+
+	tag=$(jq -r '.tag_name' <<<"$release")
+	assets=$(jq '.assets | length' <<<"$release")
+	echo "$flavor: $tag ($assets asset(s))"
+	if (( assets < minimum )); then
+		echo "FAIL $flavor: latest release has fewer than $minimum asset(s)" >&2
+		fail=1
+	fi
+done
+
+if (( fail )); then
+	echo "NVIDIA RELEASE ASSET AUDIT FAILED: restore downloadable assets for every NVIDIA edition" >&2
+	exit 1
+fi
+
+echo "NVIDIA RELEASE ASSET AUDIT PASSED"


### PR DESCRIPTION
## Summary

- add a read-only audit for the six NVIDIA release flavors
- run it daily and manually with `contents: read` permissions
- link the audit from the NVIDIA flavor-family roadmap row

## Why

Issue #1383 identified that NVIDIA releases can remain in the catalog with zero downloadable assets while the failure is buried in overlay/build jobs. The live audit currently reproduces that finding: the latest gnome-nvidia, gnome50-nvidia, xfce-nvidia, niri-nvidia, and cosmic-nvidia releases have zero assets, and no kde-nvidia release exists. The new check fails loudly until every edition has at least one asset, making the flavor-equality regression visible to release owners.

This does not fabricate or upload artifacts; the underlying overlay failures remain tracked by #1376, #1379, and #1382.

## Validation

- `bash -n scripts/audit-nvidia-release-assets.sh`
- `git diff --check`
- Live GitHub API audit reproduced the expected failure and enumerated the missing/empty NVIDIA releases

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789229646&installation_model_id=429180&pr_number=1515&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1515&signature=24caf5eaa683ababf54447fa2e1f246b9e8fa25e71f5fedca30757c5451f3dae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->