### PR TITLE
docs: add Asahi Linux ecosystem entry, community hardware-testing call (#1373)

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -43,6 +43,7 @@ _(None listed yet — be the first!)_
 | [Cloudflare R2](https://www.cloudflare.com/developer-platform/products/r2/) | Package/artifact distribution — native EL10 RPM repository (GNOME 51 onward), ISOs, and boot screenshots | [cloudflare.com/r2](https://www.cloudflare.com/developer-platform/products/r2/) |
 | [Tideforge](https://tideforge.org) | Build service — COSMIC packages built from source for the EL10 desktop cells | [tideforge.org](https://tideforge.org) |
 | [GHCR](https://ghcr.io) | Image registry — all published TunaOS image flavors | [github.com/orgs/tuna-os/packages](https://github.com/orgs/tuna-os/packages) |
+| [Asahi Linux](https://asahilinux.org) | Hardware enablement — bootc-installer-asahi's payload layout is modeled on fedora-asahi/nixos-asahi conventions; targets M1/M2 Macs via Asahi's kernel/firmware work | [github.com/AsahiLinux](https://github.com/AsahiLinux) |
 
 ## Adding Your Organization
 

--- a/docs/ASAHI-HARDWARE-TIERS.md
+++ b/docs/ASAHI-HARDWARE-TIERS.md
@@ -145,6 +145,20 @@ human at the keyboard — bootc's rollback covers "new deployment doesn't
 confirm," not "new deployment hangs the whole boot before bootc's own health
 check can run").
 
+## Community testing (informal, not a CI tier)
+
+Tiers 2 and 3 above are maintainer-controlled: one is funded infrastructure,
+the other is a specific person's laptop. Neither can be volunteered into by
+a community member. If you own Apple Silicon hardware and want to try
+[bootc-installer-asahi](https://github.com/tuna-os/bootc-installer-asahi)
+independently of either tier, that's welcome — it's not part of the CI gate,
+but real-hardware reports are exactly the signal that motivated M1/M2
+support in the first place (tunaOS#911, the `gnome-asahi` unbootable-image
+incident). Report results as an issue in
+[bootc-installer-asahi](https://github.com/tuna-os/bootc-installer-asahi/issues),
+tagged `hardware-report`, with the Mac model and which image/flavor you
+tried.
+
 ## What is deliberately not in this PR
 
 - A Scaleway provisioning/teardown script. Writing one against an API this


### PR DESCRIPTION
Ref #1373.

Step 1 (blog post) was already done — tuna-os/docs#174, merged and
published (`draft: false`). That public post is what satisfies step 3's
"once the relationship is public" condition.

This PR:
- Adds Asahi Linux to `ADOPTERS.md`'s Ecosystem & Downstream Projects
  table, framed the same factual way as every other entry (Fedora, Debian,
  Niri, elementary OS — "base OS" / "desktop environment" style
  relationships, not adopter claims): bootc-installer-asahi's payload
  layout is explicitly modeled on fedora-asahi/nixos-asahi conventions per
  the blog post itself.
- Adds a "Community testing" section to `docs/ASAHI-HARDWARE-TIERS.md`,
  distinct from the doc's two existing tiers (which are both
  maintainer-controlled — funded Scaleway rental or a specific person's
  laptop, neither volunteerable into). This is informal: no CI
  infrastructure claimed, just a documented place
  (`hardware-report`-labeled issues on bootc-installer-asahi, label
  created) for anyone with real Apple Silicon hardware to report results.

Not done, deliberately: step 2 (actually cross-posting to r/AsahiLinux or
Asahi's Matrix/Discord) is a live external-community action — outside what
a repo-PR contributor should take unilaterally, consistent with how every
other live-outreach action has been handled this session (drafted/prepared,
never posted).
---
🐝 **Hive Agent**: `contributor` | **SHA:** `a0a3b85d`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->