### PR TITLE
fix(live-iso): self-heal missing flatpak on grouper/bonito-rawhide (#1397)

### DIFF
--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -398,8 +398,34 @@ if [[ -n "${INSTALLER_APP}" ]]; then
 	ensure_dbus_daemon
 	dbus-daemon --system --fork --nopidfile || true
 
-	if ! command -v flatpak &>/dev/null; then
-		echo "ERROR: flatpak not installed; cannot pre-install ${INSTALLER_APP}" >&2
+	# grouper (Ubuntu/apt) and bonito-rawhide (Fedora/dnf) don't ship flatpak
+	# in their base image, so the pre-install below always died with "flatpak
+	# not installed" (tunaOS#1397). Same failure shape as ensure_dbus_daemon
+	# above: try the flatpak package on whichever package manager is present
+	# before giving up, rather than failing every live-customize run for
+	# these bases outright. Portage (guppy/Gentoo) is deliberately not in this
+	# list — emerge is a compile-from-source install with no timeout budget
+	# here and no precedent in this file; guppy keeps failing loud below until
+	# someone verifies an emerge-based install is safe to add.
+	ensure_flatpak() {
+		command -v flatpak >/dev/null 2>&1 && return 0
+		echo "flatpak missing; installing it for the customize step"
+		if command -v dnf5 >/dev/null 2>&1; then
+			dnf5 install -y flatpak
+		elif command -v dnf >/dev/null 2>&1; then
+			dnf install -y flatpak
+		elif command -v zypper >/dev/null 2>&1; then
+			zypper --non-interactive install -y flatpak
+		elif command -v pacman >/dev/null 2>&1; then
+			pacman -Sy --noconfirm --needed flatpak
+		elif command -v apt-get >/dev/null 2>&1; then
+			apt-get update -qq && apt-get install -y --no-install-recommends flatpak
+		fi
+		command -v flatpak >/dev/null 2>&1
+	}
+
+	if ! ensure_flatpak; then
+		echo "ERROR: flatpak not installed and could not be installed; cannot pre-install ${INSTALLER_APP}" >&2
 		exit 1
 	fi
 	# openSUSE's CA bundle is generated under /var, while bootc image stages


### PR DESCRIPTION
Ref #1397.

Live Overlay Artifacts has failed on every recent run for
guppy/grouper/bonito-rawhide: `customize-live.sh` hard-exits with "flatpak
not installed; cannot pre-install \${INSTALLER_APP}" whenever the base
image doesn't ship flatpak.

This mirrors the exact fix pattern already proven in the same file for the
identical failure shape: `ensure_dbus_daemon()`, added because "every
cosmic flavor plus sailfin/grouper/guppy/marlin died here with
`dbus-daemon: command not found`" — it tries each package manager before
giving up rather than failing outright. Added `ensure_flatpak()` following
the same structure:

- **grouper** (Ubuntu) → `apt-get install flatpak`
- **bonito-rawhide** (Fedora) → `dnf install flatpak`

Both are standard packages on their respective package managers, so this
should genuinely fix these two rather than just relocate the failure.

**guppy (Gentoo/portage) is deliberately not covered** — `emerge` is a
compile-from-source install with no precedent anywhere in this file and no
timeout budget to verify it's safe blind. It keeps failing loud exactly as
today, per my prior comment on the issue recommending against guessing at
an emerge-based install without a way to test it.

## Validation

- `bash -n` — syntax OK
- No shellcheck available in this environment
- No live container build available to verify end-to-end (same constraint
  as every build-script change this session) — the change is a close
  structural mirror of `ensure_dbus_daemon()`, which is proven in
  production for the same three bases, rather than novel logic

Does not address the hummingbird half of #1397 — separate finding, updated
directly on the issue (the desktop flavors aren't in the nightly build
matrix at all, not a build failure).
---
🐝 **Hive Agent**: `contributor` | **SHA:** `96bb73e7`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->