### PR TITLE
ci: fix DNS for weekly desktop screenshot customization

### DIFF
--- a/.github/workflows/weekly-desktop-screenshots.yml
+++ b/.github/workflows/weekly-desktop-screenshots.yml
@@ -107,7 +107,11 @@ jobs:
         env:
           GITHUB_REPOSITORY_OWNER: tuna-os
         run: |
-          sudo GITHUB_REPOSITORY_OWNER=tuna-os \
+          # The pinned tacklebox supports this escape hatch for hosts where
+          # root-context podman's bridge DNS is broken. The customize script
+          # fetches installer Flatpaks from GitHub/tunaos.org; host networking
+          # gives that nested container the runner's working resolver.
+          sudo TBOX_CUSTOMIZE_NETWORK=host GITHUB_REPOSITORY_OWNER=tuna-os \
             just iso "${{ matrix.variant }}" "${{ matrix.flavor }}" ghcr "${{ matrix.flavor }}"
 
       - name: Boot ISO and capture desktop screenshot

--- a/tests/bats/test_customize_live.bats
+++ b/tests/bats/test_customize_live.bats
@@ -172,6 +172,12 @@ detect() {
   [ "$status" -eq 0 ]
 }
 
+@test "weekly desktop screenshots use host networking for tacklebox customize" {
+  run grep 'sudo TBOX_CUSTOMIZE_NETWORK=host' \
+    "${REPO_ROOT}/.github/workflows/weekly-desktop-screenshots.yml"
+  [ "$status" -eq 0 ]
+}
+
 @test "dev ISO marker enables SSH without changing production images" {
   grep -q '\.enable-sshd' "${REPO_ROOT}/scripts/build-iso-tacklebox.sh"
   grep -q 'tunaos-live-ssh-credentials.service' "${SCRIPT}"


### PR DESCRIPTION
## Summary

- enable tacklebox host networking for the weekly desktop screenshot ISO build
- add a regression assertion covering the workflow wiring

## Root cause

The pinned tacklebox customize pipeline supports `TBOX_CUSTOMIZE_NETWORK=host` for root-context Podman environments whose bridge DNS cannot resolve external hosts. The screenshot workflow did not set it, so the nested live-customize container intermittently failed to resolve GitHub and mirror hosts while downloading installer Flatpaks.

The setting is passed explicitly through `sudo`, ensuring it reaches tacklebox and its nested customize container.

## Validation

- `bash -n live-iso/common/src/customize-live.sh`
- `bash -n scripts/lib/common.sh`
- workflow/static regression assertion passed
- `git diff --check`
- PyYAML, actionlint, and Bats were unavailable locally

Relates to #1412.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789235533&installation_model_id=429180&pr_number=1518&repository=tuna-os%2FtunaOS&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2FtunaOS%2Fpull%2F1518&signature=d011d77a8ccd14f8470c088bd8444363de296bf52beea7058c65083f4c709a2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->