### PR TITLE
fix(nvidia): keep kernel dracut temp files on boot fs

### DIFF
--- a/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
+++ b/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
@@ -128,7 +128,12 @@ else
 	# redundant for a source that was never signed to begin with, and
 	# failing on its absence here blocks every *-nvidia flavor of the one
 	# variant that runs on a base image strict enough to enforce it.
-	rpm -ivh --nosignature "${RPM_FILES[@]}"
+	# The kernel RPM's %posttrans runs rpm-ostree kernel-install, which invokes
+	# dracut before this script's explicit rebuild below. /boot is a tmpfs mount
+	# in Containerfile.overlay; keep dracut's temporary output on that same
+	# filesystem so its final rename cannot fail with EXDEV (Invalid cross-device
+	# link) when a newer kernel package is installed.
+	TMPDIR=/boot rpm -ivh --nosignature "${RPM_FILES[@]}"
 
 	# Remove the OLD kernel's module directory outright. `rpm --erase` above
 	# removes only rpm-OWNED files; generated ones (initramfs.img, depmod

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -398,6 +398,13 @@ run_swap() {
   grep -q -- 'rpm -ivh --nosignature' "${BATS_TEST_TMPDIR}/tool.log"
 }
 
+@test "kernel-swap keeps automatic dracut temporary output on the boot filesystem" {
+  # The kernel RPM's post-transaction scriptlet invokes dracut before the
+  # overlay's explicit rebuild. With /boot mounted as tmpfs, leaving dracut's
+  # default temp directory elsewhere makes its final rename fail with EXDEV.
+  grep -qF 'TMPDIR=/boot rpm -ivh --nosignature' "$SWAP_SH"
+}
+
 @test "kernel-swap fails loudly when the cache holds no kernel at all" {
   make_swap_stubs "$AKMODS_KVER"
   make_swap_fixture


### PR DESCRIPTION
## Summary

- Keep the kernel RPM transaction's automatic dracut temp output on `/boot`.
- Add a regression assertion for the tmpdir contract.

## Why

`Containerfile.overlay` mounts `/boot` as tmpfs. The kernel RPM post-transaction invokes `rpm-ostree kernel-install` and dracut; with its default temp directory on another filesystem, the final rename fails with `Invalid cross-device link` (EXDEV) on the 6.12.0-257 kernel swap. The later explicit NVIDIA dracut invocation already uses `/boot`, so scoping `TMPDIR=/boot` to the RPM transaction aligns the automatic invocation as well.

Closes #1382.

## Validation

- `git diff --check` passed.
- `bash -n build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh` passed.
- Bats suite was not runnable because `bats` is not installed in the checkout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->