### PR TITLE
docs: retract false castrojo warm-path claim in CFP doc (#1340)

### DIFF
--- a/docs/CFP-FOSDEM-2027.md
+++ b/docs/CFP-FOSDEM-2027.md
@@ -60,10 +60,25 @@ this is an open-source project's architecture talk with live demos.
 bootc is a CNCF Sandbox project, and TunaOS is one of the more complete
 production bootc *desktop* deployments (37 published editions, daily GNOME
 releases, keyless-signed artifacts) — a concrete adoption story for a
-sandbox project working toward incubation. This isn't cold outreach: Jorge
-Castro (castrojo), CNCF Developer Relations and a Universal Blue founder, is
-already a 201-commit contributor and CODEOWNERS entry on this repo
-(verified via the GitHub API and `.github/CODEOWNERS`, 2026-08-13).
+sandbox project working toward incubation.
+
+**Correction (2026-08-13):** an earlier version of this section claimed
+Jorge Castro (castrojo, CNCF Developer Relations and a Universal Blue
+founder)'s "201-commit contributor and CODEOWNERS entry" status meant this
+wasn't cold outreach. That doesn't hold up — re-verified via the GitHub
+API: every one of castrojo's 201 commits predates `tuna-os/tunaOS`'s own
+creation (2025-07-30), the latest is 2025-05-28, and a search across this
+repo's issues/PRs turns up zero comments, authored issues, or reviews from
+castrojo, ever. Same pattern as the retracted shimonenator claim (#1317)
+and the tulilirockz "warm path" correction (#1339): the commits are
+inherited pre-fork history from bluefin-lts, not real engagement with this
+repo. `.github/CODEOWNERS` still lists castrojo (and tulilirockz), but
+given both show zero real post-fork activity, that file itself looks like
+it was carried over unchanged from the fork rather than reflecting actual
+current maintainers — worth a maintainer's separate look, not assumed here.
+
+Treat this as cold outreach unless a maintainer confirms an actual current
+relationship.
 
 This makes the FOSDEM talk (Containers devroom) a natural fit for a
 CNCF-adjacent bootc ecosystem showcase, not just a standalone project talk.


### PR DESCRIPTION
Ref #1340.

`docs/CFP-FOSDEM-2027.md` (landed via #1457, closing #1340) claims
castrojo's "201-commit contributor and CODEOWNERS entry" status means the
CNCF/bootc showcase angle "isn't cold outreach." I verified this before
today and reported the raw commit count (201) as real, but I hadn't
checked *when* those commits happened relative to this repo's own history
— doing that now:

- Every one of castrojo's 201 commits predates `tuna-os/tunaOS`'s own
  creation (2025-07-30) — the latest is 2025-05-28, over two months before
  this repo existed.
- A search across this repo's issues/PRs (`gh api search/issues` for
  author/commenter/reviewed-by castrojo) returns **zero** results.

Same misattribution pattern already retracted for shimonenator (#1317) and
corrected for tulilirockz (#1339): the commits are inherited pre-fork
history from bluefin-lts, not real engagement with `tuna-os/tunaOS`.

Also flagged (not fixed — a maintainer call): `.github/CODEOWNERS` still
lists both castrojo and tulilirockz despite neither showing real post-fork
activity. That file looks like it was carried over unchanged from the
fork rather than reflecting actual current maintainers.

Corrected the doc to say this should be treated as cold outreach unless a
maintainer confirms an actual current relationship — matching how the
tulilirockz correction was framed in the Chainguard brief.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `6b6a1a5a`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaOS/pr/1524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->