### PR TITLE
ci: set TBOX_CUSTOMIZE_NETWORK=host for weekly desktop screenshots

### DIFF
--- a/.github/workflows/weekly-desktop-screenshots.yml
+++ b/.github/workflows/weekly-desktop-screenshots.yml
@@ -107,7 +107,13 @@ jobs:
         env:
           GITHUB_REPOSITORY_OWNER: tuna-os
         run: |
-          sudo GITHUB_REPOSITORY_OWNER=tuna-os \
+          # TBOX_CUSTOMIZE_NETWORK=host works around tuna-os/tacklebox's documented
+          # podman-bridge DNS issue for root-context containers (see tacklebox's
+          # internal/install/customize.go): the live-customize container can end up
+          # with no route out on GitHub-hosted runners, surfacing as "Could not
+          # resolve host" for whatever host the customize scripts happen to hit
+          # first (github.com, mirrors.almalinux.org, ...) — tuna-os/tunaos#1412.
+          sudo GITHUB_REPOSITORY_OWNER=tuna-os TBOX_CUSTOMIZE_NETWORK=host \
             just iso "${{ matrix.variant }}" "${{ matrix.flavor }}" ghcr "${{ matrix.flavor }}"
 
       - name: Boot ISO and capture desktop screenshot


### PR DESCRIPTION
Fixes #1412.

Weekly Desktop Screenshots has been red every run since 06-22, always at the `Build live ISO` step, always with a DNS resolution failure inside the tacklebox live-customize container — but the *host* it fails to resolve varies run to run (`github.com` on 08-10/08-03, `kitten.mirrors.almalinux.org` on 07-27). A varying-host pattern like that points at something structurally wrong with the container's network path rather than one flaky remote.

Traced the actual code path: this workflow builds via `just iso` → `scripts/build-iso-tacklebox.sh` → the separate `tuna-os/tacklebox` Go tool, which runs `live_customize` scripts (this repo's `customize-live.sh`) inside a podman container. tacklebox's `internal/install/customize.go` already documents this exact failure mode:

```go
// The customize scripts need outbound network (flatpak install above all),
// and podman's default bridge is not always usable: on a host whose
// netavark/firewalld rules have gone stale, root-context containers get an
// interface with no route out while rootless ones work fine. The symptom is
// remote — "Could not resolve hostname tunaos.org" from inside flatpak —
// and the build then produces an ISO with no installer on it.
// TBOX_CUSTOMIZE_NETWORK=host is the escape hatch; unset keeps podman's
// default, so nothing changes for hosts that are fine.
if net := strings.TrimSpace(os.Getenv("TBOX_CUSTOMIZE_NETWORK")); net != "" {
    runArgs = append(runArgs, "--network", net)
}
```

That's an exact match for the symptom in this issue. I grepped every workflow in this repo that calls `just iso` (`publish-iso-groups.yml`, `installer-screenshots.yml`, `live-iso-bootc.yml`, `installer-smoke.yml`, `luks-e2e.yml`) and none of them set `TBOX_CUSTOMIZE_NETWORK` — the escape hatch exists upstream but nothing here was flipping it on.

## Change

Set `TBOX_CUSTOMIZE_NETWORK=host` alongside the existing `GITHUB_REPOSITORY_OWNER` env on the `sudo ... just iso ...` invocation in `weekly-desktop-screenshots.yml` only — scoped to the workflow that's actually failing, not a blanket change across every `just iso` caller.

## Verification

- Confirmed via `grep` there's no existing `TBOX_CUSTOMIZE_NETWORK` usage anywhere in this repo (workflows, scripts, Justfile) — this wires in an unused-but-already-shipped upstream option, not new tacklebox behavior.
- YAML validated with `yaml.safe_load`.
- Could not run the actual weekly build in this environment (needs nested KVM + real GHCR pull); this is a config-only change with a code-documented, direct mechanism, but the next scheduled/dispatched run of this workflow is the real verification. Flagging that honestly rather than claiming an end-to-end pass I couldn't produce.

---
🐝 **Hive Agent**: `contributor` | **SHA:** `58873ba5`