### PR TITLE
ci: fail PR gate on boot-verify failure instead of swallowing it

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -265,7 +265,12 @@ jobs:
           mkdir -p verify-out
           IMAGE="localhost/${IMAGE_VARIANT}:${DEFAULT_TAG}"
           sudo -E corral create gate --bootc "$IMAGE" --wait-ssh --timeout 900
-          sudo ./scripts/iso-e2e.sh "$IMAGE" --disk --output verify-out --timeout 300 || true
+          # No `|| true` here (tuna-os/tunaos#1533): a PR whose image fails to
+          # boot must fail the PR gate, not just warn on missing evidence. The
+          # evidence-upload step below already runs under `if: always()`, so
+          # dropping the swallow doesn't lose any diagnostics — it just makes
+          # the check red when the boot actually failed.
+          sudo ./scripts/iso-e2e.sh "$IMAGE" --disk --output verify-out --timeout 300
 
       - name: Upload PR verification evidence
         if: always() && github.event_name == 'pull_request' && contains(matrix.platform, 'amd64')


### PR DESCRIPTION
Addresses recommendation #1 of #1533 ("Boot verification is soft").

## Problem

`.github/workflows/reusable-build-image.yml`'s "Boot-verify image (PR gate)" step ran:

```bash
sudo ./scripts/iso-e2e.sh "$IMAGE" --disk --output verify-out --timeout 300 || true
```

The `|| true` means the step always exits 0, no matter what `iso-e2e.sh` reports. The next step just uploads whatever evidence exists (`if-no-files-found: warn`). Net effect: a PR whose image fails to boot produces a warning artifact, not a red check — exactly the failure mode #1533 documents, and exactly the class of bug the screenshot/E2E evidence exists to catch.

## Fix

Dropped the ``|| true``. The evidence-upload step already runs under `if: always()`, so this doesn't lose any diagnostics on failure — it just makes the PR gate check actually fail when the boot genuinely fails.

## Scope

#1533 lists four recommendations; this PR is scoped to #1 only:

1. **✅ this PR** — drop `|| true` on the PR-gate boot-verify step.
2. Tier-1 checks advisory — already correctly scoped as I found it: the `continue-on-error: true` tier-1 check only runs in the non-PR `verify_boot` ("Gate") job (`if: ... github.event_name != 'pull_request' ...`), which has its own **hard** boot-verify call (no `|| true`) and blocks Promote. Only the deeper desktop-contract-string grep is advisory there — a reasonable scope for a job that already hard-gates the boot itself, and out of scope for this PR since it isn't actually the PR path.
3. Auditing the 547 repo-wide `|| true` sites — far too broad and risky for one PR; most are legitimate best-effort cleanup (temp file removal, optional tool detection), not verification-masking. Needs its own scoped audit, likely several PRs.
4. Org-wide `set -euo pipefail` baseline / shellcheck gate — a real but separate, larger effort (149 scripts, only 86 currently use `set -e`) that deserves its own PR and probably a repo-wide shellcheck CI job, not a drive-by here.

## Verification

- YAML validated with `yaml.safe_load`.
- Traced through the job: for PR events `inputs.publish` is always `false` (set by the caller as `github.event_name != 'pull_request'`), so none of the publish-gated steps later in this job run on PRs regardless — the only steps that lose execution when this step now fails are the PR-only "Testing Instructions"/"Generate PR Diff"/"Post Diff Comment" steps, which is the correct behavior: a PR whose image doesn't boot shouldn't get testing instructions for a broken image.
- Could not trigger an actual PR-gate CI run against this change from this sandbox (needs KVM + the full matrix); the change itself is a one-line removal with a clear, traceable effect, but flagging that I couldn't watch it go red-to-green on a live failing case.

---
🐝 **Hive Agent**: `contributor` | **SHA:** `0a65810a`