### PR TITLE
security: replace secrets: inherit with least-privilege mappings

### DIFF
--- a/.github/workflows/archive/build.yml
+++ b/.github/workflows/archive/build.yml
@@ -249,7 +249,10 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.base_matrix)}}
     uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
+    # No `secrets:` block: reusable-build-image.yml's workflow_call declares
+    # no explicit secrets input (it only uses the auto-provided
+    # GITHUB_TOKEN), so `secrets: inherit` was passing every repo/org secret
+    # for nothing (tuna-os/tunaos#1536).
     with:
       image-name: ${{ matrix.image_name }}
       image-desc: ${{ matrix.description }} no-DE base
@@ -277,7 +280,10 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.base_matrix)}}
     uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
+    # No `secrets:` block: reusable-build-image.yml's workflow_call declares
+    # no explicit secrets input (it only uses the auto-provided
+    # GITHUB_TOKEN), so `secrets: inherit` was passing every repo/org secret
+    # for nothing (tuna-os/tunaos#1536).
     with:
       image-name: ${{ matrix.image_name }}
       image-desc: ${{ matrix.description }} HWE no-DE base
@@ -308,7 +314,10 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.base_matrix)}}
     uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
+    # No `secrets:` block: reusable-build-image.yml's workflow_call declares
+    # no explicit secrets input (it only uses the auto-provided
+    # GITHUB_TOKEN), so `secrets: inherit` was passing every repo/org secret
+    # for nothing (tuna-os/tunaos#1536).
     with:
       image-name: ${{ matrix.image_name }}
       image-desc: ${{ matrix.description }} GDX no-DE base
@@ -341,7 +350,10 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.base_matrix)}}
     uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
+    # No `secrets:` block: reusable-build-image.yml's workflow_call declares
+    # no explicit secrets input (it only uses the auto-provided
+    # GITHUB_TOKEN), so `secrets: inherit` was passing every repo/org secret
+    # for nothing (tuna-os/tunaos#1536).
     with:
       image-name: ${{ matrix.image_name }}
       image-desc: ${{ matrix.description }} GNOME
@@ -373,7 +385,10 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.kde_matrix)}}
     uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
+    # No `secrets:` block: reusable-build-image.yml's workflow_call declares
+    # no explicit secrets input (it only uses the auto-provided
+    # GITHUB_TOKEN), so `secrets: inherit` was passing every repo/org secret
+    # for nothing (tuna-os/tunaos#1536).
     with:
       image-name: ${{ matrix.image_name }}
       image-desc: ${{ matrix.description }} KDE
@@ -405,7 +420,10 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.niri_hwe_gdx_matrix)}}
     uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
+    # No `secrets:` block: reusable-build-image.yml's workflow_call declares
+    # no explicit secrets input (it only uses the auto-provided
+    # GITHUB_TOKEN), so `secrets: inherit` was passing every repo/org secret
+    # for nothing (tuna-os/tunaos#1536).
     with:
       image-name: ${{ matrix.image_name }}
       image-desc: ${{ matrix.description }} Niri
@@ -436,7 +454,10 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.hwe_gdx_matrix)}}
     uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
+    # No `secrets:` block: reusable-build-image.yml's workflow_call declares
+    # no explicit secrets input (it only uses the auto-provided
+    # GITHUB_TOKEN), so `secrets: inherit` was passing every repo/org secret
+    # for nothing (tuna-os/tunaos#1536).
     with:
       image-name: ${{ matrix.image_name }}
       image-desc: ${{ matrix.description }} GNOME HWE
@@ -467,7 +488,10 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.hwe_gdx_matrix)}}
     uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
+    # No `secrets:` block: reusable-build-image.yml's workflow_call declares
+    # no explicit secrets input (it only uses the auto-provided
+    # GITHUB_TOKEN), so `secrets: inherit` was passing every repo/org secret
+    # for nothing (tuna-os/tunaos#1536).
     with:
       image-name: ${{ matrix.image_name }}
       image-desc: ${{ matrix.description }} GNOME GDX
@@ -499,7 +523,10 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.kde_hwe_gdx_matrix)}}
     uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
+    # No `secrets:` block: reusable-build-image.yml's workflow_call declares
+    # no explicit secrets input (it only uses the auto-provided
+    # GITHUB_TOKEN), so `secrets: inherit` was passing every repo/org secret
+    # for nothing (tuna-os/tunaos#1536).
     with:
       image-name: ${{ matrix.image_name }}
       image-desc: ${{ matrix.description }} KDE HWE
@@ -530,7 +557,10 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.kde_hwe_gdx_matrix)}}
     uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
+    # No `secrets:` block: reusable-build-image.yml's workflow_call declares
+    # no explicit secrets input (it only uses the auto-provided
+    # GITHUB_TOKEN), so `secrets: inherit` was passing every repo/org secret
+    # for nothing (tuna-os/tunaos#1536).
     with:
       image-name: ${{ matrix.image_name }}
       image-desc: ${{ matrix.description }} KDE GDX
@@ -562,7 +592,10 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.niri_hwe_gdx_matrix)}}
     uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
+    # No `secrets:` block: reusable-build-image.yml's workflow_call declares
+    # no explicit secrets input (it only uses the auto-provided
+    # GITHUB_TOKEN), so `secrets: inherit` was passing every repo/org secret
+    # for nothing (tuna-os/tunaos#1536).
     with:
       image-name: ${{ matrix.image_name }}
       image-desc: ${{ matrix.description }} Niri HWE
@@ -593,7 +626,10 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.niri_hwe_gdx_matrix)}}
     uses: ./.github/workflows/reusable-build-image.yml
-    secrets: inherit
+    # No `secrets:` block: reusable-build-image.yml's workflow_call declares
+    # no explicit secrets input (it only uses the auto-provided
+    # GITHUB_TOKEN), so `secrets: inherit` was passing every repo/org secret
+    # for nothing (tuna-os/tunaos#1536).
     with:
       image-name: ${{ matrix.image_name }}
       image-desc: ${{ matrix.description }} Niri GDX

--- a/.github/workflows/asahi-hw-nightly.yml
+++ b/.github/workflows/asahi-hw-nightly.yml
@@ -77,7 +77,10 @@ jobs:
     uses: ./.github/workflows/asahi-hw-nightly-one.yml
     with:
       image: ghcr.io/tuna-os/${{ matrix.flavor }}:gnome-asahi
-    secrets: inherit
+    secrets:
+      ASAHI_HW_TIER2_SSH_KEY: ${{ secrets.ASAHI_HW_TIER2_SSH_KEY }}
+      ASAHI_HW_TIER2_HOST: ${{ secrets.ASAHI_HW_TIER2_HOST }}
+      ASAHI_HW_TIER2_USER: ${{ secrets.ASAHI_HW_TIER2_USER }}
 
   # Dispatch mode: one explicit ref, for iterating on a single build (e.g. a
   # -testing tag) before it's promoted.
@@ -87,4 +90,7 @@ jobs:
     uses: ./.github/workflows/asahi-hw-nightly-one.yml
     with:
       image: ${{ inputs.image }}
-    secrets: inherit
+    secrets:
+      ASAHI_HW_TIER2_SSH_KEY: ${{ secrets.ASAHI_HW_TIER2_SSH_KEY }}
+      ASAHI_HW_TIER2_HOST: ${{ secrets.ASAHI_HW_TIER2_HOST }}
+      ASAHI_HW_TIER2_USER: ${{ secrets.ASAHI_HW_TIER2_USER }}

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -1112,7 +1112,10 @@ jobs:
     uses: ./.github/workflows/verify-asahi-one.yml
     with:
       image: ${{ vars.IMAGE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}/${{ inputs.image-name }}:${{ inputs.default-tag }}-testing
-    secrets: inherit
+    # No `secrets:` block: verify-asahi-one.yml's workflow_call declares no
+    # explicit secrets input (it only uses the auto-provided GITHUB_TOKEN),
+    # so `secrets: inherit` was passing every repo/org secret for nothing
+    # (tuna-os/tunaos#1536).
 
   tag-image:
     name: Promote


### PR DESCRIPTION
Fixes #1536.

Three workflows passed `secrets: inherit` to called reusable workflows — every repo/org secret in scope, same class as the previously-fixed #370, and two of the three are regressions introduced after that fix.

## Changes

1. **`asahi-hw-nightly.yml`** (2 callers of `asahi-hw-nightly-one.yml`) — that workflow's `workflow_call` declares exactly 3 secrets: `ASAHI_HW_TIER2_SSH_KEY`, `ASAHI_HW_TIER2_HOST`, `ASAHI_HW_TIER2_USER`. Replaced `inherit` with an explicit mapping of just those three. **This is the highest-severity of the three**: the workflow accepts a `workflow_dispatch` `image` input, so a crafted dispatch previously ran on real hardware CI with every secret in scope, not just the three tier-2 hardware credentials it actually needs.
2. **`reusable-build-image.yml` `verify_asahi`** (1 caller of `verify-asahi-one.yml`) — that workflow's `workflow_call` declares **no** explicit secrets input, so it only ever used the auto-provided `GITHUB_TOKEN`. Dropped the `secrets:` block entirely (no mapping needed — `GITHUB_TOKEN` is always available) rather than adding a no-op explicit mapping, with a comment explaining why.
3. **`archive/build.yml`** (12 callers of `reusable-build-image.yml`) — same situation: `reusable-build-image.yml`'s `workflow_call` declares no secrets input. Dropped `secrets:` from all 12 call sites.

## Note on scope vs. the issue text

The issue reported 10 instances in `archive/build.yml` at specific line numbers; I found **12** live instances there (two more `build-*` jobs — `build-niri-hwe`, `build-niri-gdx` — were added to this archived-but-still-`on: pull_request`-live workflow since the issue was filed). Fixed all 12, not just the originally-reported 10.

## Verification

- `yaml.safe_load` on all three modified files — all parse cleanly.
- `grep -rn "secrets: inherit" .github/workflows/` after the change: zero live matches, only the explanatory comments left behind at the two now-secrets-less call sites.
- Cross-checked each called workflow's own `on.workflow_call.secrets` declaration (source of truth for what a caller actually needs to pass) rather than guessing from the finding text alone: `asahi-hw-nightly-one.yml` declares the 3 ASAHI_HW_TIER2_* secrets; `verify-asahi-one.yml` and `reusable-build-image.yml` declare none.

---
🐝 **Hive Agent**: `contributor` | **SHA:** `c6e127a6`