### PR TITLE
docs: reconcile package-sourcing policy status with completed audit

### DIFF
--- a/PACKAGE-SOURCING.md
+++ b/PACKAGE-SOURCING.md
@@ -101,9 +101,14 @@ OBS), and `guppy` (Gentoo overlays) before the audit is called complete.
 
 ## Audit & transition plan
 
-1. **Audit (Q3 checkpoint 2026-08-22, [#1323](https://github.com/tuna-os/tunaos/issues/1323))**: inventory every manifest's external
-   `apt:`/`dnf:`/`zypper:`/`pacman:`/`emerge:` source across all published
-   variants; classify each as tier 1/2/3 or violation; publish the table.
+1. **Audit** — **done 2026-08-13, ahead of the 08-22 checkpoint** (see
+   "Audit findings" above; [#1323](https://github.com/tuna-os/tunaos/issues/1323)).
+   Found 2 clear violations (`trixieua/morewaita-icon-theme`,
+   `ublue-os/packages`/`krunner-bazaar`), one large gap (niri's 6-COPR
+   dependency chain), and confirmed `negativo17`/`rpmfusion` as the
+   Tier-3 allowlist candidates #1319 already named. Not yet covered:
+   apt/AUR/OBS usage on `marlin`/`flounder`/`sailfin`/`guppy` — a
+   follow-up audit pass, not silently dropped.
 2. **Migrate (Q3–Q4)**: move tier-3/✗ sources that have in-house equivalents
    to Tideforge; drive the 14-recipe COSMIC build-out already tracked in
    [ROADMAP.md](./ROADMAP.md) ([#964](https://github.com/tuna-os/tunaos/issues/964) COSMIC-off-PPA is the flagship migration).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -121,7 +121,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | **Q3 checkpoint (08-22): staff or descope #272/#1123/#1093/#1094** | strategist | #1299 | ⬜ Scheduled |
 | **Flavor equality mandate (docs wording + cadence parity)** | strategist | #1315, #1254 | 🟡 In progress — catalog parity gate merged 08-11 (#1322, #1281 closed); cadence parity pending (#1316) |
 | **NVIDIA flavor family (6 editions, 0 assets since 07-05)** | ci-maintainer | #1383 | 🔴 Broken — nightly overlay regressed 08-12 (#1382); staff test: nightly green + gnome-nvidia assets republished by 09-01 (#1376/#1379) |
-| **Package sourcing policy (system-repos/tideforge-first + allowlist)** | strategist | #1319, #1323 | 🟡 In progress — PACKAGE-SOURCING.md drafted (planning PR open); third-party allowlist + per-variant audit due at 08-22 checkpoint |
+| **Package sourcing policy (system-repos/tideforge-first + allowlist)** | strategist | #1319, #1323 | 🟡 In progress — PACKAGE-SOURCING.md merged; DNF/COPR audit done 08-13, ahead of the 08-22 checkpoint (2 violations, 6-COPR niri gap, negativo17/rpmfusion allowlist candidates confirmed — #1453); apt/AUR/OBS bases still unaudited, maintainer allowlist sign-off and Phase 2 migration still pending |
 
 ---
 


### PR DESCRIPTION
Follow-up on #1323 — re-checked current state and found real drift, not just "nothing to do."

## What was stale

Both `ROADMAP.md`'s Q3 status line and `PACKAGE-SOURCING.md`'s own "Audit & transition plan" §1 still described the third-party repo audit as a **future** deliverable due at the 08-22 Q3 checkpoint — but the audit already landed early on 2026-08-13 (PR #1453, merged), and its real findings are sitting right there in the same document's "Audit findings" section, one heading above the still-future-tense plan text. The doc was contradicting itself.

## Changes

- **ROADMAP.md**: Q3 goal-table status line updated from "PACKAGE-SOURCING.md drafted (planning PR open); ... audit due at 08-22 checkpoint" to reflect what's actually true now: policy doc merged, DNF/COPR audit done 08-13 (2 violations, niri's 6-COPR dependency chain, `negativo17`/`rpmfusion` confirmed as the Tier-3 allowlist candidates #1319 named), and what's genuinely still open (apt/AUR/OBS bases unaudited, maintainer allowlist sign-off, Phase 2 migration).
- **PACKAGE-SOURCING.md**: rewrote transition-plan step 1 from a forward-looking task description to a completion summary pointing at the audit-findings table, instead of describing work the document itself already shows finished.

No code changes — pure status reconciliation between the roadmap, the policy doc, and reality.

---
🐝 **Hive Agent**: `contributor` | **SHA:** `4f494170`