### PR TITLE
docs: sync DistroWatch draft's variant statuses with ROADMAP.md

### DIFF
--- a/docs/DISTROWATCH-SUBMISSION.md
+++ b/docs/DISTROWATCH-SUBMISSION.md
@@ -57,13 +57,13 @@ release cadence, verified boot reports, and an active community on Matrix.
 | Yellowfin | AlmaLinux Kitten 10 | GNOME | Stable |
 | Albacore | AlmaLinux 10 | GNOME | Stable |
 | Bonito | Fedora | GNOME | Beta |
-| Skipjack | CentOS Stream 10 | KDE Plasma | Stable |
+| Skipjack | CentOS Stream 10 | KDE Plasma | Beta |
 | Tromsø | BuildStream-based | KDE Plasma 6 | Stable |
 | XFCE Linux | BuildStream-based | XFCE 4.20 | Stable |
 | COSMIC | EL10 cell (Tideforge-built) | COSMIC | Beta |
 | Niri | Fedora | Niri | Beta |
-| Gurnard | Ubuntu 24.04 LTS | Pantheon | New (08-2026) |
-| Marlin | Arch | GNOME | Alpha |
+| Gurnard | Ubuntu 24.04 LTS | Pantheon | Experimental |
+| Marlin | Arch | GNOME | Beta |
 
 ## Suggested pitch to DistroWatch Weekly editors
 


### PR DESCRIPTION
Follow-up on #1333 — re-verified the submission draft (`docs/DISTROWATCH-SUBMISSION.md`) against `ROADMAP.md` before it goes in front of real users on a third-party site, the same discipline the previous pass on this issue used (which caught the Yellowfin/Albacore base swap, PR merged as #1491).

## What was wrong

ROADMAP.md is explicit that its variant table "is the canonical per-variant status; tunaos.org wiki and blog copy must track it." Three rows in the DistroWatch draft had drifted from it:

| Variant | Draft said | ROADMAP says |
|---|---|---|
| Skipjack | Stable | Beta |
| Marlin | Alpha | Beta |
| Gurnard | "New (08-2026)" (no status) | **Experimental** |

Gurnard is the one that matters most: ROADMAP flags Hummingbird/Gurnard as Experimental under an explicit maintainer directive (#1315) specifically because they predate the variant-admission gate and have no named owner or acceptance criteria yet — exactly the kind of distinction a first-impression listing for new users should get right, not soften.

## Fix

Updated the three rows to match ROADMAP.md's canonical status column. No other changes.

## Scope

Per the prior comment on this issue, actions #2/#3 (actually submitting the DistroWatch form, timing it for Fedora 45 release week) remain live external actions for a maintainer to take when that window arrives — not actioned here.

---
🐝 **Hive Agent**: `contributor` | **SHA:** `ef389ca1`