### PR TITLE
docs: audit Tacklebox decoupling goal against #306's original scope

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,7 +135,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 
 | Goal | Owner | Dependencies |
 |------|-------|--------------|
-| Tacklebox decoupling | architect | #1192 (tracker; #306 closed) |
+| Tacklebox decoupling | architect | #1192 (tracker; #306 closed) — audited 2026-08-14: of #306's 4 recommendations, 3 already landed (`TACKLEBOX_SHA`/`TACKLEBOX_IMAGE` version pinning via `scripts/lib/common.sh`; tacklebox runs as a `ghcr.io/tuna-os/tacklebox` container image, not a host-installed binary; the flagged `ghcr.io/hanthor/bluefin:lts` `iso.toml` reference no longer exists in this repo's own build path). Real remaining gap: **the version pin has no single source of truth** — `image-versions.yaml` (`4fa6041`, renovate-tracked) diverges from hardcoded overrides in `publish-iso-groups.yml` (`a105d6d3`) and `luks-e2e.yml` (`fd95174`, the documented floor SHA, not the current pin). Consolidating those onto one pin needs real boot evidence before merging (see Build Health note above on why `publish-iso-groups.yml`'s divergence was left as a deliberate, not accidental, gap) — flagged as the concrete next step, not actioned blind |
 | Upstream snapshot automation | ci-maintainer | #1194 (tracker; #307 closed) |
 | Branch protection + required CI | strategist | CI health, #1167 — audited 2026-08-13: [BRANCH-PROTECTION.md](./docs/BRANCH-PROTECTION.md), active `main` ruleset has no required-status-checks rule; proposed list is `lint`, `lint-summary`, `unit-tests` |
 | Supply chain hardening | sec-check | #1193 (tracker; #212/#301 closed) — coordinates with #1187 (package signing/SBOM is the largest hardening item, tracked there in detail) |

--- a/docs/TACKLEBOX-CONTRACT.md
+++ b/docs/TACKLEBOX-CONTRACT.md
@@ -1,0 +1,61 @@
+# Tacklebox ISO recipe contract
+
+`scripts/build-iso-tacklebox.sh` is the TunaOS adapter for Tacklebox. The
+adapter owns source-image resolution, customization files, and output naming;
+Tacklebox owns turning the recipe into a bootable ISO. The generated
+`.build/iso-tacklebox/<variant>-<flavor>/recipe.json` is the boundary between
+those responsibilities.
+
+## Recipe shape
+
+The adapter emits one JSON object with these fields:
+
+| Field | Producer | Contract |
+| --- | --- | --- |
+| `media_name` | TunaOS | Stable human-readable name: `tunaos-<variant>-<flavor>`. |
+| `size` | TunaOS | `10G`; the target filesystem must have room for the image and live payload. |
+| `shared_store.format` | TunaOS | `ext4`; Tacklebox uses the shared store for the bootable environment. |
+| `kargs` | TunaOS | Array of kernel arguments. `console=ttyS0` is required for serial diagnostics in CI. |
+| `bootable_environments` | TunaOS | Exactly one live environment for the selected variant/flavor. |
+| `offline_payloads` | TunaOS | Exactly one payload mapping for the same source image, using the canonical GHCR ref. |
+
+The environment object contains:
+
+- `id`: `<variant>-<flavor>`.
+- `image`: the resolved source image returned by `tunaos_image_ref`.
+- `desktop`: the session-manager name (`gnome`, `kde`, `niri`, `cosmic`, or
+  `xfce`) inferred from the flavor.
+- `live_customize`: a one-item array containing the generated
+  `customize-live.sh` path.
+- `modes`: exactly `["live"]` for this adapter.
+
+The payload mapping uses `source` equal to the resolved image and `ref` equal
+to the canonical published `ghcr.io/<owner>/<variant>:<tag>` reference. This
+keeps local builds and registry builds consistent with the image reference
+embedded in the installed system.
+
+## Invariants
+
+Changes to the adapter must preserve these invariants:
+
+1. The source image and offline payload refer to the same build input.
+2. The environment is live-only and has one customization entry.
+3. The customization directory is private to the build output directory; a
+   developer-only `.enable-sshd` marker must never modify the source tree.
+4. The recipe path and output directory are passed to the same Tacklebox
+   invocation.
+5. The final ISO is copied to the repository root using the filename contract
+   consumed by publish and end-to-end workflows:
+   `<variant>-<flavor>-<VERSION_ID>-<arch>.iso`.
+
+Tacklebox changes that alter the accepted recipe fields or the meaning of
+these invariants require updating this document and the adapter's tests in
+the same change.
+
+## Validation boundary
+
+The adapter's shell tests validate the generated recipe shape without pulling
+an image or running privileged filesystem operations. Full compatibility is
+validated by the live ISO and ISO E2E workflows, which exercise Tacklebox with
+the pinned version selected by `image-versions.yaml` unless an explicit
+workflow override is supplied.

--- a/scripts/build-iso-tacklebox.sh
+++ b/scripts/build-iso-tacklebox.sh
@@ -91,7 +91,8 @@ fi
 # ponytail: tacklebox runner delegated to common.sh tunaos_run_tacklebox
 
 # ── Generate the recipe ─────────────────────────────────────────────────────
-# Schema: github.com/tuna-os/tacklebox/blob/main/internal/recipe/
+# Contract: docs/TACKLEBOX-CONTRACT.md
+# Tacklebox schema: github.com/tuna-os/tacklebox/blob/main/internal/recipe/
 # Single-environment, live-only — minimum useful recipe for a smoke ISO.
 
 OUT_DIR="$(pwd)/.build/iso-tacklebox/${VARIANT}-${FLAVOR}"


### PR DESCRIPTION
#1192 is already correctly wired as this goal's tracker — Q4 milestone assigned, ROADMAP linking already fixed by a prior PR. The 'roadmap gap' #1192 describes (no tracker, #306 closed) is resolved.

What's still genuinely open is the underlying goal, which had never been audited against #306's original 4 recommendations.

## Audit

| #306 recommendation | Status |
|---|---|
| 1. Vendor/pin tacklebox at a specific version | ✅ Done — `TACKLEBOX_SHA`/`TACKLEBOX_IMAGE` in `scripts/lib/common.sh`, defaulting to `image-versions.yaml` |
| 2. Define a proper interface/contract | ✅ Documented in `docs/TACKLEBOX-CONTRACT.md`; `build-iso-tacklebox.sh` points to the contract beside recipe generation |
| 3. Containerize the ISO build | ✅ Done — tacklebox runs as `ghcr.io/tuna-os/tacklebox`, not a host-installed binary |
| 4. Clean up the `iso.toml` → `ghcr.io/hanthor/bluefin:lts` reference | ✅ Moot — that file/path no longer exists in this repo's own ISO build path |

## Remaining follow-up

The version pin has no single source of truth:

- `image-versions.yaml`: `4fa6041...` (Renovate-tracked canonical pin)
- `publish-iso-groups.yml`: hardcoded `a105d6d3...` (older)
- `luks-e2e.yml`: hardcoded `fd95174...` (documented floor SHA, not current pin)

ROADMAP's Build Health note already flags the `publish-iso-groups.yml` divergence as requiring real boot evidence before consolidation. This PR documents the adapter contract without changing those pins blindly.

## Validation

- `git diff --check` passed.
- The relevant Bats suite was unavailable because `bats` is not installed in the environment.

Related: #1192