### PR TITLE
docs: clarify variant promotion evidence scope

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,6 +33,13 @@ means GA, `Beta` means published for testing on tunaos.org/download. This
 table is the canonical per-variant status; tunaos.org wiki and blog copy must
 track it. Notably **Bonito is Beta** (GA tracked in [#272](https://github.com/tuna-os/tunaos/issues/272)) — it is neither "Production" nor "Experimental".
 
+`Stable` is an all-cells claim: every advertised desktop, edition, and
+supported architecture for that variant must have the evidence ledger required
+by [VARIANT-LIFECYCLE.md](VARIANT-LIFECYCLE.md). A passing GNOME/default cell
+does not promote the other cells. Promotion or a deliberate narrower support
+claim must link the per-cell boot-gate, LUKS-E2E, desktop-contract, and
+user-install evidence in its PR.
+
 > **Experimental** (per maintainer #1315): Hummingbird and Gurnard/Pantheon are
 > configured in `.github/build-config.yml` and building, but predate the
 > admission gate in [VARIANT-LIFECYCLE.md](VARIANT-LIFECYCLE.md) (#1196) — they

--- a/VARIANT-LIFECYCLE.md
+++ b/VARIANT-LIFECYCLE.md
@@ -96,20 +96,37 @@ existing cells without reopening the general Q3 flavor freeze.
 
 ### 3. Stable — promotion criteria (#1175)
 
-Promotion Beta → Stable requires **all** of:
+The promotion unit is a **published release cell**: base variant × desktop
+flavor × hardware/filesystem edition × supported architecture. A base variant
+may be shown as `Stable` in ROADMAP only when every cell that it advertises as
+part of that variant has passed the applicable gates below. A passing GNOME
+cell does not make a variant with failing KDE, Niri, NVIDIA, ZFS, or arm64
+cells Stable. If coverage is intentionally narrower, the ROADMAP row must say
+which cells are supported rather than implying that the whole variant is GA.
+
+Promotion Beta → Stable requires **all applicable gates for every advertised
+cell**:
 
 - **Boot-gate green for 4 consecutive weeks** of daily runs with no regressions.
-- **LUKS E2E green** for the variant.
+- **LUKS E2E green** for the variant and each supported install/storage mode.
 - **Desktop-contract pass** — beyond session start: window painted (#1217),
   browser/CI ISO parity gate (#1204) where applicable.
 - **≥1 user-proven install**, or a documented telemetry proxy until #1174
   (adoption metrics) lands.
 
+The promotion PR must link an evidence ledger with one row per published cell,
+including the boot-gate window, LUKS-E2E run, desktop-contract run, and
+user-install evidence. The strategist records the decision in ROADMAP only
+after reviewing that ledger; a green default desktop is not a proxy for an
+unverified flavor.
+
 ### 4. Deprecated
 
 A variant is deprecated when **any** of:
 
-- Its base is superseded (e.g., Fedora 44 → Fedora 45, #1171).
+- Its base is superseded (e.g., Fedora 44 → Fedora 45, #1171). Fedora-based
+  variants additionally follow the sequencing and one-active-GA-base rule in
+  [FEDORA-BASE-POLICY.md](FEDORA-BASE-POLICY.md).
 - Its base reaches upstream EOL.
 - No green run for 60 consecutive days (unmaintained).
 


### PR DESCRIPTION
## What changed

- Clarify that Stable promotion is evaluated per published release cell: base × desktop × edition/filesystem × supported architecture.
- Require every advertised cell to pass the applicable boot-gate, LUKS-E2E, desktop-contract, and user-install evidence before a variant is labeled Stable.
- Require a per-cell evidence ledger in promotion PRs.
- Clarify narrower support claims in ROADMAP rather than implying full-variant GA.
- Link Fedora base replacement to the existing Fedora base currency policy.

## Why

Issue #1175's lifecycle policy and ROADMAP references already exist, but the promotion unit was ambiguous for the growing multi-desktop and edition matrix. This refinement prevents a passing default desktop from masking unverified cells and makes the policy actionable for future Beta→Stable decisions.

## Validation

- `git diff --check`
- Documentation-only change; no runtime tests required.
- Markdown linter unavailable in the checkout.

Fixes #1175