### PR TITLE
docs: mark Fedora base policy adopted

### DIFF
--- a/FEDORA-BASE-POLICY.md
+++ b/FEDORA-BASE-POLICY.md
@@ -1,6 +1,6 @@
 # Fedora Base Currency Policy
 
-**Status**: DRAFT — proposed 2026-08-13 by the strategist agent for review
+**Status**: ADOPTED — 2026-08-13 via PR #1432
 **Owner**: tuna-os (hanthor) / strategist
 **Tracks**: #1171 (Fedora 45 planning), #272 (Bonito / Fedora 44 GA), #637 (rawhide variant)
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Related Communities:
 - [RFC Process](RFC-PROCESS.md) — how RFCs are proposed, reviewed, and decided
 - [Package Sourcing Policy](PACKAGE-SOURCING.md) — package origin rules, Tideforge-first, and allowlist (#1319)
 - [Issue Triage Policy](TRIAGE-POLICY.md) — triage states and SLAs (draft, #1195)
-- [Fedora Base Currency Policy](FEDORA-BASE-POLICY.md) — N+rawhide sequencing for Fedora-based variants (draft, #1171)
+- [Fedora Base Currency Policy](FEDORA-BASE-POLICY.md) — adopted N+rawhide sequencing for Fedora-based variants (#1171)
 - [Versioning](VERSIONING.md) — tag scheme and stability tiers
 - [Migration Guide](MIGRATION.md) — switching from other distros
 - [Security Policy](SECURITY.md) — vulnerability reporting and supported versions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,7 +146,7 @@ CI pipeline builds are green on amd64, amd64-v2, and arm64 for core variants.
 | **Package sourcing policy (system-repos/tideforge-first + allowlist)** | strategist | #1319, #1323 (audit → #1187) |
 | Bonito (Fedora 44) GA carryover | ci-maintainer | #272 — blocked on #1499 (nightly red 08-03–08-13) |
 | Redfin (RHEL 10) alpha GA | ci-maintainer | #609 |
-| Fedora 45 base readiness | ci-maintainer | #1171 — [FEDORA-BASE-POLICY.md](./FEDORA-BASE-POLICY.md) drafted 08-13: N+rawhide model, Fedora 45 planning sequenced after Bonito (#272) GA, not parallel |
+| Fedora 45 base readiness | ci-maintainer | #1171 — [FEDORA-BASE-POLICY.md](./FEDORA-BASE-POLICY.md) adopted 08-13: N+rawhide model, Fedora 45 planning sequenced after Bonito (#272) GA, not parallel |
 | Adoption metrics / usage telemetry | strategist | #1174 |
 | **Adoption evidence (ADOPTERS.md production entries)** | strategist | #1348 — zero public production adopters vs "Mature" claim; first entries at 2026-11-01 snapshot |
 | Variant lifecycle policy (admission + Beta→Stable exit criteria) | strategist | #1196, #1175 — [VARIANT-LIFECYCLE.md](./VARIANT-LIFECYCLE.md) |


### PR DESCRIPTION
## Summary

- mark the Fedora base-currency policy adopted after PR #1432
- update the Q4 roadmap row so it no longer describes the policy as a draft
- update the README policy index consistently

## Why

Issue #1171's substantive work already landed in PR #1432: the roadmap row and `FEDORA-BASE-POLICY.md` now define the N+rawhide model and sequence Fedora 45 after Bonito/Fedora 44 GA. The remaining “DRAFT” labels made the policy appear unresolved, so this follow-up records its adopted status across the canonical policy and its references.

## Validation

- `git diff --check`

Closes #1171