### PR TITLE
fix(ci): survive real Rekor outages and bound the syft scan externally

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -444,7 +444,14 @@ jobs:
           set -euo pipefail
           IMAGE="${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${SAFE_PLATFORM}"
           OUT="sbom-${IMAGE_NAME}-${DEFAULT_TAG}-${SAFE_PLATFORM}.spdx.json"
-          $SYFT_CMD "$IMAGE" --scope squashed -o spdx-json="$OUT"
+          # timeout-minutes above is enforced by the runner agent, which is
+          # exactly the thing that wedges when syft OOM-thrashes the runner:
+          # on 08-14 (tunaOS#1567) the guppy base job sat in this step for
+          # 51 minutes past its 20-minute limit, died for lost communication
+          # and uploaded no logs. GOMEMLIMIT is advisory, so bound the scan
+          # externally: `timeout` fails the step fast (exit 124), with logs,
+          # while the agent is still healthy enough to report it.
+          timeout --kill-after=30s 18m $SYFT_CMD "$IMAGE" --scope squashed -o spdx-json="$OUT"
           jq -e '
             .spdxVersion | startswith("SPDX-")
           ' "$OUT" >/dev/null
@@ -849,7 +856,7 @@ jobs:
       - name: Sign images and attest SBOMs
         env:
           REQUIRE_SBOM: ${{ inputs.sbom }}
-          MAX_RETRIES: 3
+          MAX_RETRIES: 6
         run: |
           set -euo pipefail
           identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/reusable-build-image.yml@${GITHUB_REF}"
@@ -870,14 +877,21 @@ jobs:
           # builds that had genuinely succeeded, failing only at this step.
           # A single unwrapped invocation turns a transient Sigstore blip
           # into a red Promote for every flavor whose Sign+attest lands
-          # inside the window. Wrap each cosign call the same way the GHCR
-          # push retries above do: linear backoff, MAX_RETRIES attempts.
+          # inside the window.
+          #
+          # The backoff must be sized against a real outage, not a hiccup:
+          # the 08-14 nightlies (tunaOS#1560) saw Rekor 502 continuously for
+          # 45+ minutes, and the original 3x linear backoff (~30s total)
+          # failed 25 Sign+attest jobs across 7 variants without riding out
+          # a single one. Exponential 15s..8m doubles per attempt (~15.75min
+          # of sleep worst-case per call); this job has no timeout-minutes
+          # (360m default) and only a failing call burns the window.
           cosign_retry() {
             local i
             for i in $(seq "${MAX_RETRIES}"); do
               "$@" && return 0
               echo "::warning::${1} failed (attempt ${i}/${MAX_RETRIES}); retrying..." >&2
-              sleep $((5 * i))
+              sleep $(( 15 * (2 ** (i - 1)) ))
             done
             return 1
           }


### PR DESCRIPTION
Two workflow fixes from the 08-14 all-variant failure sweep (#1570) that the hive App cannot push while it lacks the `workflows` permission (#1557). This PR also serves as the live proof for #1557 that the Claude Code session App **can** push `.github/workflows/` changes and is a usable merge path until the hive App's permission is granted.

## Fixes #1560 — cosign retry sized against a real Rekor outage

The 3× linear `cosign_retry` (~30s total) was written, per its own comment, for "a Rekor transparency-log blip that lasts minutes" — and rode out none of the 45+ minute 08-14 outage: 25 Sign+attest jobs failed across 7 variants whose builds and signatures were otherwise green, blocking every one of their Promotes.

- `MAX_RETRIES: 3 → 6`, backoff `5·i` seconds → exponential `15s, 30s, 1m, 2m, 4m, 8m` (~15.75 min worst case per call).
- Safe budget-wise: the `sign` job has no `timeout-minutes` (360 m default) and only a genuinely failing call burns the window.
- Comment updated with the measured 08-14 evidence so the sizing rationale is in-file.

This doesn't make a 45-minute outage survivable in one attempt window (that would need decoupling attest into a re-runnable job — left to #1560's remaining options), but it converts the common minutes-long blips from a red night into a wait.

## Fixes #1567 — external hard bound on the syft SBOM scan

`timeout-minutes: 20` on the Generate SBOM step is enforced by the runner agent — exactly the process that wedges when syft OOM-thrashes the runner. On 08-14 the guppy base job sat in this step for ~51 minutes past that limit, then died for lost communication with **no logs uploaded** (the image had already built and pushed). `GOMEMLIMIT` is advisory and did not prevent it.

- Wrap the invocation: `timeout --kill-after=30s 18m $SYFT_CMD …` — inside the step's 20-minute budget, so resource exhaustion now fails the step fast (exit 124) with logs while the agent is still healthy, instead of killing the runner and the whole variant night.

## Verification

- `yaml.safe_load` passes on the edited workflow.
- Behavior change is confined to the two edited steps; retry semantics on success paths are unchanged (first attempt succeeds → zero added latency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_