### PR TITLE
ci(bonito): pin chunkah digest, prune sysroot, retry corrupt archive (#1568)

### DIFF
--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -19,6 +19,20 @@ images:
     tag: latest
     digest: sha256:ce66e6687e423a0871150f8e2d62bed28bea2a79cbdf4757a0ee269232072266
 
+  # Rechunk tool (scripts/build-image-inner.sh Pass 2). Was unpinned at
+  # :latest — every other build input here is digest-pinned so an upstream
+  # regression needs a reviewed bump to reach a build; chunkah was the one
+  # exception, and it produced a corrupt out.ociarchive on bonito:base
+  # 2026-08-14 (tunaos#1568, run 31766548793: "archive/tar: invalid tar
+  # header" at the podman load step). Single occurrence so far, so this pin
+  # doesn't claim to be a proven fix for that corruption on its own — see
+  # the archive validation + retry added alongside it in the same script —
+  # but an unpinned rechunker is a real, independent gap regardless.
+  - name: chunkah
+    image: quay.io/coreos/chunkah
+    tag: latest
+    digest: sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708
+
 # Pinned binary downloads (managed by Renovate)
 downloads:
   # renovate: datasource=github-releases depName=ublue-os/uupd

--- a/scripts/build-image-inner.sh
+++ b/scripts/build-image-inner.sh
@@ -193,7 +193,11 @@ fi
 echo "==> Running chunkah on ${PRE_CHUNK_TAG}..."
 
 if [[ -z "${CHUNKAH_IMAGE:-}" ]]; then
-	CHUNKAH_IMAGE="quay.io/coreos/chunkah:latest"
+	# Pinned (tunaos#1568): every other build input in image-versions.yaml is
+	# digest-pinned so an upstream regression needs a reviewed Renovate bump
+	# to reach a build. chunkah was the one unpinned :latest exception.
+	chunkah_digest=$($YQ -r '.images[] | select(.name == "chunkah") | .digest' image-versions.yaml)
+	CHUNKAH_IMAGE="quay.io/coreos/chunkah@${chunkah_digest}"
 fi
 if ! podman image inspect "${CHUNKAH_IMAGE}" &>/dev/null; then
 	if ! podman pull "${CHUNKAH_IMAGE}" 2>/dev/null; then
@@ -208,34 +212,68 @@ fi
 # by copying the rootfs into container-local workspace, creating a temporary
 # /var/lib/rpm directory so chunkah's rpmdb component loader succeeds, and
 # passing `--prune /var/lib/rpm` so the dummy directory is never packed into the OCI archive.
-CHUNK_OUT=$(mktemp -d)
-CHUNK_EMPTY_DEV=$(mktemp -d)
-podman run --rm \
-	--security-opt label=disable \
-	--network host \
-	--entrypoint="" \
-	-v "${CHUNK_OUT}:/run/out:Z" \
-	--mount "type=image,source=${PRE_CHUNK_TAG},target=/chunkah" \
-	-v "${CHUNK_EMPTY_DEV}:/chunkah/dev:Z" \
-	"${CHUNKAH_IMAGE}" \
-	sh -c '
-		HAS_RPMDB=0
-		if [ -n "$(ls -A /chunkah/usr/lib/sysimage/rpm 2>/dev/null)" ] || [ -n "$(ls -A /chunkah/var/lib/rpm 2>/dev/null)" ]; then
-			HAS_RPMDB=1
-		fi
-		if [ "$HAS_RPMDB" = "1" ]; then
-			chunkah build --rootfs /chunkah --skip-special-files -o /run/out/out.ociarchive
-		else
-			echo "==> Image has no rpmdb — preparing rootfs copy with dummy rpmdb & pruning it in chunkah build..."
-			mkdir -p /tmp/rootfs
-			cp -a /chunkah/. /tmp/rootfs/
-			mkdir -p /tmp/rootfs/var/lib/rpm
-			chunkah build --rootfs /tmp/rootfs --prune /var/lib/rpm --skip-special-files -o /run/out/out.ociarchive
-			rm -rf /tmp/rootfs
-		fi
-	'
-mv "${CHUNK_OUT}/out.ociarchive" out.ociarchive
-rm -rf "${CHUNK_OUT}" "${CHUNK_EMPTY_DEV}"
+#
+# `--prune /sysroot/` (both branches, tunaos#1568): bootc images' /sysroot
+# holds the ostree deployment tree, which chunkah itself warns is wasted
+# bytes if not excluded — "rootfs contains sysroot/ostree which was not
+# pruned; Use --prune /sysroot/ to exclude it." The trailing slash matters:
+# chunkah's --prune treats `/sysroot` (no slash) as "skip this path
+# entirely" and `/sysroot/` (with slash) as "keep the directory, skip its
+# children" — /sysroot needs to exist as a mount point at runtime, so this
+# repo wants the latter. --prune is a repeatable flag (chunkah's cmd_build.rs
+# collects it into a Vec), so this is additive with the existing
+# --prune /var/lib/rpm, not a replacement.
+#
+# chunkah build is retried once (CHUNKAH_ATTEMPT loop) because a corrupt
+# out.ociarchive has been observed once so far (tunaos#1568: "archive/tar:
+# invalid tar header" at the podman load step below, bonito:base
+# 2026-08-14) with no confirmed root cause -- possibly a truncated write
+# under disk pressure. `tar tf` validates the archive is at least a well-
+# formed tarball before handing it to podman load, so a truncated write is
+# caught here with a log line pointing at this issue, instead of surfacing
+# as podman's much less obvious "payload does not match any of the
+# supported image formats".
+CHUNKAH_OK=0
+for CHUNKAH_ATTEMPT in 1 2; do
+	CHUNK_OUT=$(mktemp -d)
+	CHUNK_EMPTY_DEV=$(mktemp -d)
+	podman run --rm \
+		--security-opt label=disable \
+		--network host \
+		--entrypoint="" \
+		-v "${CHUNK_OUT}:/run/out:Z" \
+		--mount "type=image,source=${PRE_CHUNK_TAG},target=/chunkah" \
+		-v "${CHUNK_EMPTY_DEV}:/chunkah/dev:Z" \
+		"${CHUNKAH_IMAGE}" \
+		sh -c '
+			HAS_RPMDB=0
+			if [ -n "$(ls -A /chunkah/usr/lib/sysimage/rpm 2>/dev/null)" ] || [ -n "$(ls -A /chunkah/var/lib/rpm 2>/dev/null)" ]; then
+				HAS_RPMDB=1
+			fi
+			if [ "$HAS_RPMDB" = "1" ]; then
+				chunkah build --rootfs /chunkah --prune /sysroot/ --skip-special-files -o /run/out/out.ociarchive
+			else
+				echo "==> Image has no rpmdb — preparing rootfs copy with dummy rpmdb & pruning it in chunkah build..."
+				mkdir -p /tmp/rootfs
+				cp -a /chunkah/. /tmp/rootfs/
+				mkdir -p /tmp/rootfs/var/lib/rpm
+				chunkah build --rootfs /tmp/rootfs --prune /var/lib/rpm --prune /sysroot/ --skip-special-files -o /run/out/out.ociarchive
+				rm -rf /tmp/rootfs
+			fi
+		'
+	if [[ -s "${CHUNK_OUT}/out.ociarchive" ]] && tar tf "${CHUNK_OUT}/out.ociarchive" >/dev/null 2>&1; then
+		mv "${CHUNK_OUT}/out.ociarchive" out.ociarchive
+		rm -rf "${CHUNK_OUT}" "${CHUNK_EMPTY_DEV}"
+		CHUNKAH_OK=1
+		break
+	fi
+	echo "::warning::chunkah attempt ${CHUNKAH_ATTEMPT}/2 produced an invalid or missing out.ociarchive (tunaos#1568) — retrying" >&2
+	rm -rf "${CHUNK_OUT}" "${CHUNK_EMPTY_DEV}"
+done
+if [[ "${CHUNKAH_OK}" -ne 1 ]]; then
+	echo "ERROR: chunkah did not produce a valid OCI archive after 2 attempts" >&2
+	exit 1
+fi
 
 # ── Pass 3: Relabel ──────────────────────────────────────────────────────────
 echo "==> Applying labels from OCI archive..."


### PR DESCRIPTION
## Summary

Issue #272 tracks Bonito (Fedora 44) as an incomplete variant. Investigation:

- The original "3 lint failures" premise is long since resolved.
- The subsequent blocker, a shared nvidia initramfs regression (#1499), was already fixed by PR #1503 (merged 2026-08-14).
- Despite that, Bonito's nightly build is still red on every run: `base/linux-amd64` and `base/linux-arm64` both fail at the `podman load` step after chunkah rechunking (`archive/tar: invalid tar header`, run 31766548793).
- That failure matches an issue I'd already filed with a full diagnosis: #1568. This PR implements the three-part fix proposed there.

## Changes

1. **Pin chunkah to a digest** in `image-versions.yaml` instead of floating `:latest` — consistent with every other build input in that file, and tracked by the existing Renovate custom regex manager.
2. **`--prune /sysroot/`** added to both chunkah invocation branches (RPM and non-RPM rootfs), per chunkah's own upstream source/warning text for bootc images.
3. **Retry once + validate the archive** (`tar tf`) before accepting chunkah's output, since a corrupt `out.ociarchive` has been observed once with no confirmed root cause. Fails fast with a message citing #1568 instead of a confusing podman error 20 minutes later.

## Scope note

This does not close #272 on its own. It fixes the one live, currently-blocking issue (#1568) found by re-verifying Bonito's actual nightly status. The arm64 `libpod_lock` issue (#1556) is a separate, already-in-flight fix on another branch.

## Testing

- `bash -n scripts/build-image-inner.sh` — OK
- `python3 -c "import yaml; yaml.safe_load(open('image-versions.yaml'))"` — OK
- New retry/validation logic tested standalone against a mock chunkah/podman/tar harness: good-first-try, corrupt-then-good, always-corrupt, and missing-archive cases all behaved as expected.
- Chunkah digest resolved live against `quay.io/coreos/chunkah`'s registry v2 API and confirmed as a real multi-arch OCI index.

Closes #1568
Refs #272
