### PR TITLE
fix(nvidia): force copy-up of SELinux policy store before semodule (#1562)

### DIFF
--- a/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
@@ -150,6 +150,14 @@ if [[ -f /usr/lib/systemd/system/ublue-nvctk-cdi.service ]]; then
 	systemctl enable ublue-nvctk-cdi.service
 fi
 if [[ -f /usr/share/selinux/packages/nvidia-container.pp ]]; then
+	# Force copy-up of /etc/selinux/targeted into the top layer so libsemanage's
+	# atomic directory renames (tmp -> active) succeed on overlayfs.
+	if [[ -d /etc/selinux/targeted ]]; then
+		rm -rf /etc/selinux/targeted/tmp /etc/selinux/targeted/previous
+		cp -a /etc/selinux/targeted /etc/selinux/targeted.copyup
+		rm -rf /etc/selinux/targeted
+		mv /etc/selinux/targeted.copyup /etc/selinux/targeted
+	fi
 	semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
 fi
 

--- a/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
@@ -154,6 +154,7 @@ if [[ -f /usr/share/selinux/packages/nvidia-container.pp ]]; then
 	# atomic directory renames (tmp -> active) succeed on overlayfs.
 	if [[ -d /etc/selinux/targeted ]]; then
 		rm -rf /etc/selinux/targeted/tmp /etc/selinux/targeted/previous
+		rm -rf /etc/selinux/targeted.copyup
 		cp -a /etc/selinux/targeted /etc/selinux/targeted.copyup
 		rm -rf /etc/selinux/targeted
 		mv /etc/selinux/targeted.copyup /etc/selinux/targeted


### PR DESCRIPTION
Fixes #1562.

### Summary
- Added an explicit copy-up step for `/etc/selinux/targeted` in `build_scripts/overlay/overrides/nvidia/20-nvidia.sh` prior to running `semodule --install /usr/share/selinux/packages/nvidia-container.pp`.
- Cleans up stale `/etc/selinux/targeted/tmp` and `/etc/selinux/targeted/previous` directories and rematerializes the SELinux policy store in the top container layer.
- Resolves the `libsemanage.semanage_commit_sandbox: Error while renaming /etc/selinux/targeted/tmp to /etc/selinux/targeted/active (Directory not empty)` failure on buildahs
