### PR TITLE
fix(marlin): make CachyOS kernel initramfs selection deterministic

### DIFF
--- a/Containerfile.arch
+++ b/Containerfile.arch
@@ -166,9 +166,17 @@ RUN --mount=type=bind,from=context,source=/,target=/run/context \
 # It used to be a printf here. That is how five composefs variants ended up with
 # one erofs driver between them: the fix was made while chasing marlin and had
 # nowhere shared to live.
+# Only one kernel module tree exists at this stage (the cachyos overlay that
+# can introduce a second one runs later, in Containerfile.overlay — see its
+# own dracut loop, tunaOS#1563), so `tail -1` currently picks the only
+# candidate either way. Looped for the same reason as there: readdir order
+# is unspecified, so a single `find | tail -1` is a guess that happens to
+# have one right answer today, not a guarantee it stays that way.
 RUN --mount=type=bind,from=context,source=/,target=/run/context \
     /run/context/build_scripts/bootc/dracut-config.sh && \
-    dracut --force "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v '\.img' | tail -1)/initramfs.img"
+    for moddir in $(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d ! -name '*.img'); do \
+        dracut --force "${moddir}/initramfs.img"; \
+    done
 
 # systemd-firstboot asks the CONSOLE for a timezone and blocks there forever.
 #

--- a/build_scripts/overlay/cachyos.sh
+++ b/build_scripts/overlay/cachyos.sh
@@ -38,7 +38,19 @@ Include = /etc/pacman.d/cachyos-mirrorlist
 EOF
 fi
 
-pacman -Syu --noconfirm --needed \
+# This stage's parent image already has a kernel: Containerfile.arch's base
+# build detects the [cachyos] repo in pacman.conf to decide KERNEL_PKG, but
+# that repo isn't registered until the block above runs, in THIS later
+# overlay stage — so the base build always installed stock `linux` (this
+# overlay is x86_64-only, unlike asahi's aarch64-only marlin path) and
+# already baked it an initramfs. Installing linux-cachyos without removing
+# it left two kernel module trees on the image (tunaOS#1563), and the plain
+# `pacman -Syu` below could independently bump the stock kernel to a third.
+# Remove it first, the same way asahi.sh removes marlin's aarch64 stock
+# kernel before installing linux-asahi.
+pacman -Rdd --noconfirm linux linux-headers 2>/dev/null || true
+
+pacman -Sy --noconfirm --needed \
 	cachyos-keyring cachyos-mirrorlist cachyos-settings \
 	linux-cachyos linux-cachyos-headers tpm2-tss
 
@@ -46,6 +58,23 @@ pacman -Syu --noconfirm --needed \
 install -D /dev/null /etc/cachyos-release
 printf 'CachyOS\n' >/etc/cachyos-release
 
-# Rebuild initramfs via dracut
-dracut --force --omit "tpm2-tss" "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v '\.img' | tail -1)/initramfs.img"
+# Rebuild initramfs via dracut for every kernel module tree actually present,
+# not a `find | tail -1` guess (tunaOS#1563): readdir order is unspecified,
+# so which tree got the initramfs was a per-image gamble. When bootc's
+# BLS/composefs setup picked a different entry than dracut did, install
+# failed with "initramfs not found"; when the gamble half-landed, the
+# booted kernel and its module tree disagreed and boot stalled before
+# graphical.target. The stock kernel is removed above, so normally only the
+# cachyos tree remains — looping keeps this correct even if that ever stops
+# holding, instead of re-introducing the same guess with different odds.
+mapfile -t _cachyos_moddirs < <(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d ! -name '*.img')
+if [[ "${#_cachyos_moddirs[@]}" -eq 0 ]]; then
+	echo "ERROR: no kernel module directory found under /usr/lib/modules" >&2
+	exit 1
+fi
+for _moddir in "${_cachyos_moddirs[@]}"; do
+	dracut --force --omit "tpm2-tss" "${_moddir}/initramfs.img"
+done
+unset _cachyos_moddirs _moddir
+
 pacman -Scc --noconfirm || true


### PR DESCRIPTION
Fixes #1563\n\nContributes to #1570.\n\nThe CachyOS overlay inherited the stock Arch kernel, then installed `linux-cachyos` and rebuilt only the directory returned by `find | tail -1`. With two or three module trees, the selected tree was nondeterministic: some images had no initramfs for the boot-selected kernel, while others stalled before graphical.target.\n\nThis change removes the stock `linux`/`linux-headers` packages before installing CachyOS, uses `pacman -Sy` for the targeted install, and rebuilds an initramfs for every remaining module tree.\n\nValidation: `bash -n build_scripts/overlay/cachyos.sh`; `git diff --check`.