### PR TITLE
fix(nvidia): accept built-in boot drivers in parity check

### DIFF
--- a/build_scripts/checks/verify-nvidia.sh
+++ b/build_scripts/checks/verify-nvidia.sh
@@ -249,6 +249,18 @@ echo "== initramfs boot-driver parity =="
 # this is a parity floor, not a wish list; dm_crypt is deliberately absent
 # because the parent's initramfs does not carry it either.
 INITRAMFS="${NV_ROOT}/usr/lib/modules/${KERNEL_VRA}/initramfs.img"
+BUILTIN_MODULES="${NV_ROOT}/usr/lib/modules/${KERNEL_VRA}/modules.builtin"
+
+# A driver compiled into the kernel is not listed as a .ko in the initramfs:
+# it is already available before initramfs unpacking. Fedora 43's 7.1.4
+# kernel moved these generic block/optical drivers into that category, so a
+# literal lsinitrd-only check reports a false missing-driver failure.
+module_is_builtin() {
+	local driver="$1"
+	[[ -s "$BUILTIN_MODULES" ]] || return 1
+	grep -qE "(^|/)${driver}\.ko(\.xz|\.zst|\.gz)?$" "$BUILTIN_MODULES"
+}
+
 if [[ ! -s "$INITRAMFS" ]]; then
 	fail "missing or empty initramfs for the installed kernel: /usr/lib/modules/${KERNEL_VRA}/initramfs.img"
 elif ! command -v lsinitrd >/dev/null 2>&1; then
@@ -258,6 +270,8 @@ else
 	for _drv in sr_mod cdrom isofs squashfs virtio_scsi virtio_blk overlay loop; do
 		if grep -qE "/${_drv}\.ko" <<<"$_initrd_list"; then
 			pass "initramfs carries ${_drv}"
+		elif module_is_builtin "${_drv}"; then
+			pass "kernel has built-in ${_drv} (initramfs entry not required)"
 		else
 			fail "initramfs is missing ${_drv} — the live ISO or installed boot cannot mount its root"
 		fi

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -226,6 +226,32 @@ run_verify() {
   [[ "$output" == *"TUNAOS_NVIDIA_CONTRACT_OK"* ]]
 }
 
+@test "verify-nvidia accepts boot drivers compiled into the kernel" {
+  make_stub_tools
+  root="$(make_good_root)"
+  # Fedora 43's 7.1.4 kernel records these as built-ins rather than shipping
+  # standalone .ko files in the initramfs. Keep the other five drivers in the
+  # fake lsinitrd output so this proves the fallback is per-driver.
+  cat > "$root/usr/lib/modules/${KVER}/modules.builtin" <<EOF
+kernel/drivers/scsi/sr_mod.ko
+kernel/drivers/cdrom/cdrom.ko
+kernel/drivers/block/virtio_blk.ko
+EOF
+  cat > "${BATS_TEST_TMPDIR}/bin/lsinitrd" <<STUB
+#!/usr/bin/env bash
+for d in isofs squashfs virtio_scsi overlay loop; do
+  echo "usr/lib/modules/${KVER}/kernel/drivers/misc/\${d}.ko.xz"
+done
+STUB
+  chmod +x "${BATS_TEST_TMPDIR}/bin/lsinitrd"
+  run_verify "$root"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"kernel has built-in sr_mod"* ]]
+  [[ "$output" == *"kernel has built-in cdrom"* ]]
+  [[ "$output" == *"kernel has built-in virtio_blk"* ]]
+  [[ "$output" == *"TUNAOS_NVIDIA_CONTRACT_OK"* ]]
+}
+
 @test "verify-nvidia fails when the kmod is for a different kernel" {
   make_stub_tools
   root="$(make_good_root)"


### PR DESCRIPTION
## Summary

- treat kernel-built-in boot drivers as present during NVIDIA initramfs parity validation
- add a regression test covering FC43-style `modules.builtin` entries

## Root cause

FC43's 7.1.4 kernel can compile `sr_mod`, `cdrom`, and `virtio_blk` into the kernel. Those drivers therefore do not appear as standalone `.ko` files in `lsinitrd`, but they are available before initramfs unpacking. The previous literal `.ko` check reported false failures.

## Validation

- `bash -n build_scripts/checks/verify-nvidia.sh`
- `git diff --check`
- targeted Bats test added; the local `bats` runner was unavailable