### PR TITLE
ci: publish scheduled releases for kde/xfce/cosmic/niri, not gnome only

### DIFF
--- a/.github/workflows/generate-changelog-release.yml
+++ b/.github/workflows/generate-changelog-release.yml
@@ -53,7 +53,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stream: ${{ github.event_name == 'workflow_dispatch' && fromJson(format('[\"{0}\"]', inputs.stream)) || fromJson('["gnome"]') }}
+        # Scheduled runs cover every stable desktop flavor (#1254): the
+        # matrix used to default to gnome-only on cron, so kde/xfce/cosmic/
+        # niri assets on tunaos.org only ever moved on a manual dispatch —
+        # kde had exactly one release ever (kde-20260705) despite being a
+        # first-class ROADMAP desktop, and the other three sat 36 days
+        # stale. Adoption-metrics work (#1174) needs GitHub Release
+        # download counts across all flavors users can actually get from
+        # tunaos.org, not gnome alone.
+        stream: ${{ github.event_name == 'workflow_dispatch' && fromJson(format('[\"{0}\"]', inputs.stream)) || fromJson('["gnome", "kde", "xfce", "cosmic", "niri"]') }}
 
     steps:
       - name: Checkout repository
@@ -341,10 +349,22 @@ jobs:
               ;;
             no-build)
               OUTCOME="no ${VARIANT} build ran in the lookback window — nothing to release"
-              LATEST=$(gh api "repos/${REPO}/releases?per_page=1" \
-                --jq '.[0].published_at // ""' 2>/dev/null || echo "")
+              # Filtered by this stream's tag prefix (#1254): now that the
+              # scheduled matrix covers 5 streams, ".releases?per_page=1"
+              # would return whichever stream shipped most recently
+              # repo-wide -- gnome ships daily, so it would permanently mask
+              # staleness on every other stream and this gate would never
+              # fire again for them. per_page=100 bounds the same way the
+              # SBOM lookback above does; a stream that hasn't shipped in
+              # over ~100 releases-worth of history reads the same as "no
+              # published release" below, which is the correct fail-loud
+              # outcome for a stream that stale.
+              LATEST=$(gh api "repos/${REPO}/releases?per_page=100" 2>/dev/null \
+                | jq -r --arg prefix "${STREAM}-" \
+                  '[.[] | select(.tag_name | startswith($prefix))][0].published_at // ""' \
+                2>/dev/null || echo "")
               if [[ -z "${LATEST}" ]]; then
-                OUTCOME="${OUTCOME}; and no published release exists at all"
+                OUTCOME="${OUTCOME}; and no published release exists for ${STREAM} at all"
                 STATUS="fail"
               else
                 AGE_DAYS=$(( ( $(date -u +%s) - $(date -u -d "${LATEST}" +%s) ) / 86400 ))

--- a/ADOPTION-METRICS.md
+++ b/ADOPTION-METRICS.md
@@ -36,7 +36,10 @@ publish, and *how* the snapshot feeds roadmap decisions.
 **Instrumentation order** (cheapest first):
 
 1. **GitHub Releases download counts** — free API counter; requires non-gnome
-   flavors to publish assets too (#1254 parity gap).
+   flavors to publish assets too (#1254 parity gap — scheduled matrix now
+   covers gnome/kde/xfce/cosmic/niri, PR pending; watch the next few
+   scheduled runs to confirm kde/xfce/cosmic/niri actually publish before
+   counting this instrumentation step done).
 2. **R2/Cloudflare access-log analytics** on tunaos.org/download — R2 already
    serves the ISOs; enable access logs + a dashboard (owner: ci-maintainer).
 3. **Docs analytics** — Cloudflare Web Analytics on the Docusaurus site


### PR DESCRIPTION
## Summary

Advances #1174 (adoption metrics have no data source yet — GitHub Release download counts are step 1 of ADOPTION-METRICS.md's "cheapest first" instrumentation order) by fixing the parity gap that blocked it, #1254: the scheduled release pipeline's matrix hard-coded `["gnome"]` for cron runs, so kde/xfce/cosmic/niri assets on tunaos.org only ever moved on a manual `workflow_dispatch`. kde had exactly one release ever (`kde-20260705`) despite being a first-class ROADMAP desktop; the other three sat 36+ days stale. Adoption metrics can't measure downloads for flavors whose Release assets don't exist.

## Changes

Both in `.github/workflows/generate-changelog-release.yml`:

1. **Scheduled (cron) runs now cover all 5 stable desktop streams** (gnome, kde, xfce, cosmic, niri) instead of gnome only. `workflow_dispatch` is unaffected — still single-stream, as before.

2. **Fixed a real bug this exposed in the release-cadence health gate** (#1147): its "how old is the newest release" check queried `releases?per_page=1` repo-wide, not scoped to the stream being checked. That's silently broken once more than one stream is active on a schedule — gnome ships daily, so the repo-wide "latest release" query always returns a fresh gnome release and would mask staleness on every other stream forever, defeating the exact cadence backstop #1147 built. Verified live against the real Releases API: gnome's latest is 2026-08-13, kde's is still 2026-07-05 — the old unfiltered query returns only the former. Fixed by filtering on the stream's own tag prefix before taking the newest match.

`ADOPTION-METRICS.md`'s instrumentation-order note updated to reflect this PR is pending and that the next few scheduled runs should be watched to confirm the new streams actually publish before marking that step done.

## Verification

- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- The per-stream jq filter tested live against the real Releases API for kde (returns 2026-07-05), gnome (returns 2026-08-13), and a nonexistent stream (returns empty, correctly falls through to the "no published release" branch).

## Scope

Pure `.github/workflows/` + docs change — per #1557 the hive App can't push workflow files directly, so this needs the maintainer merge path.

Refs #1174, #1254
---
🐝 **Hive Agent**: `contributor` | **SHA:** `fa868982`