### PR TITLE
ci: close superseded weekly boot reports

### DIFF
--- a/.github/workflows/weekly-boot-report.yml
+++ b/.github/workflows/weekly-boot-report.yml
@@ -129,5 +129,30 @@ jobs:
             --label "boot-report" \
             --body-file "${{ steps.report.outputs.body_file }}")
           echo "==> Report: ${ISSUE_URL}"
+
+          # A weekly report is a snapshot, not a durable work item. Keep the
+          # latest issue open for review and close every older open report so
+          # generated snapshots do not accumulate indefinitely (#660).
+          CURRENT_NUMBER="${ISSUE_URL##*/}"
+          SUPERSEDED_REPORTS=$(mktemp)
+          trap 'rm -f "$SUPERSEDED_REPORTS"' EXIT
+          gh issue list \
+            --repo "$REPO" \
+            --label "boot-report" \
+            --state open \
+            --limit 100 \
+            --json number,title \
+            --jq ".[] | select(.number != ${CURRENT_NUMBER}) | [.number, .title] | @tsv" \
+            > "$SUPERSEDED_REPORTS"
+          CLOSED_REPORTS=$(grep -c . "$SUPERSEDED_REPORTS" || true)
+          while IFS=$'\t' read -r number title; do
+            [[ -z "$number" ]] && continue
+            gh issue close "$number" \
+              --repo "$REPO" \
+              --reason "completed" \
+              --comment "Superseded by the latest weekly boot report: ${ISSUE_URL}."
+            echo "==> Closed superseded boot report #${number}: ${title}"
+          done < "$SUPERSEDED_REPORTS"
           echo "## Boot report" >> "$GITHUB_STEP_SUMMARY"
           echo "- Issue: ${ISSUE_URL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Superseded open reports closed: ${CLOSED_REPORTS}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What changed

Update the weekly boot screenshot report workflow to close older open issues carrying the `boot-report` label after the newest report is created.

## Why

Weekly reports are snapshots for the current validation window. Leaving every historical report open creates an accumulating queue and obscures the current report.

## Behavior

- The newly created report remains open.
- Older open `boot-report` issues are closed as completed.
- Each closed issue receives a comment linking to the newest report.
- The number closed is included in the workflow summary.

## Validation

- Python workflow-content assertions passed.
- `git diff --check` passed.
- `actionlint` was unavailable in the local environment.

Related: #1276, #660