### PR TITLE
ci: expand ISO/QCOW2 artifact matrix to arm64, not amd64-only

### DIFF
--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -148,21 +148,34 @@ jobs:
           # Per-stage artifact matrices — each stage's ISOs/QCOW2s depend
           # only on that stage's image builds, avoiding the stage-4 artifact
           # jail where a gnome-nvidia-hwe failure blocked ALL ISOs (F10).
+          # One row per architecture platform (#1378): this used to hardcode
+          # platform: "linux/amd64" unconditionally, so flavors that publish
+          # arm64 images (per build-config.yml's platforms/global_platforms)
+          # never got arm64 ISO/QCOW2 artifacts — the same gap #230 closed
+          # without the fix landing. platforms_json (built above, per entry)
+          # already carries every {platform, safeplatform} pair the image
+          # matrix published; expand each artifact-eligible entry into one
+          # row per amd64/arm64 platform instead of one fixed amd64 row.
+          # /v2 (a CPU-feature variant, not a real target arch) is excluded.
           make_artifact_matrix() {
             local STAGE=$1
             echo "$FULL_MATRIX" | jq -c --argjson stage "$STAGE" '{
               include: map(
                 select(.stage == $stage and (.build_iso == true or .build_qcow2 == true))
+                | . as $e
+                | ($e.platforms_json | fromjson)[]
+                | select(.platform == "linux/amd64" or .platform == "linux/arm64")
                 | {
-                    variant:       .variant,
-                    image_name:    .image_name,
-                    published_tag: .published_tag,
-                    variant_emoji: .variant_emoji,
-                    flavor:        .flavor,
-                    build_iso:     .build_iso,
-                    build_qcow2:   .build_qcow2,
-                    base_image:    .base_image,
-                    platform:      "linux/amd64"
+                    variant:       $e.variant,
+                    image_name:    $e.image_name,
+                    published_tag: $e.published_tag,
+                    variant_emoji: $e.variant_emoji,
+                    flavor:        $e.flavor,
+                    build_iso:     $e.build_iso,
+                    build_qcow2:   $e.build_qcow2,
+                    base_image:    $e.base_image,
+                    platform:      .platform,
+                    safeplatform:  .safeplatform
                   }
               )
             }'
@@ -304,7 +317,7 @@ jobs:
   # ISOs pull the already-published GHCR image for their stage.
 
   build_artifacts_s2:
-    name: "iso:${{ matrix.flavor }}"
+    name: "iso:${{ matrix.flavor }} (${{ matrix.safeplatform }})"
     needs: [generate_matrix, build_stage2]
     if: github.event_name != 'pull_request' && needs.generate_matrix.outputs.artifact_s2_count != '0'
     strategy:
@@ -318,7 +331,9 @@ jobs:
     with:
       variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
-      image-tag: ${{ matrix.published_tag }}-linux-amd64
+      platform: ${{ matrix.platform }}
+      safeplatform: ${{ matrix.safeplatform }}
+      image-tag: ${{ matrix.published_tag }}-${{ matrix.safeplatform }}
       build-iso: ${{ matrix.build_iso }}
     secrets:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -329,7 +344,7 @@ jobs:
   # Same cell logic for stage-3 ISOs (gnome-nvidia etc.). `!cancelled()` so a
   # single stage-3 image failure doesn't skip the artifacts that DID build.
   build_artifacts_s3:
-    name: "iso:${{ matrix.flavor }}"
+    name: "iso:${{ matrix.flavor }} (${{ matrix.safeplatform }})"
     needs: [generate_matrix, build_stage3]
     if: >-
       !cancelled() && needs.generate_matrix.result == 'success' &&
@@ -347,7 +362,9 @@ jobs:
     with:
       variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
-      image-tag: ${{ matrix.published_tag }}-linux-amd64
+      platform: ${{ matrix.platform }}
+      safeplatform: ${{ matrix.safeplatform }}
+      image-tag: ${{ matrix.published_tag }}-${{ matrix.safeplatform }}
       build-iso: ${{ matrix.build_iso }}
     secrets:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -356,7 +373,7 @@ jobs:
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
 
   build_artifacts_s4:
-    name: "iso:${{ matrix.flavor }}"
+    name: "iso:${{ matrix.flavor }} (${{ matrix.safeplatform }})"
     needs: [generate_matrix, build_stage4]
     if: >-
       !cancelled() && needs.generate_matrix.result == 'success' &&
@@ -374,7 +391,9 @@ jobs:
     with:
       variant: ${{ matrix.variant }}
       flavor: ${{ matrix.flavor }}
-      image-tag: ${{ matrix.published_tag }}-linux-amd64
+      platform: ${{ matrix.platform }}
+      safeplatform: ${{ matrix.safeplatform }}
+      image-tag: ${{ matrix.published_tag }}-${{ matrix.safeplatform }}
       build-iso: ${{ matrix.build_iso }}
     secrets:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/.github/workflows/reusable-build-artifacts.yml
+++ b/.github/workflows/reusable-build-artifacts.yml
@@ -17,6 +17,24 @@ on:
         description: "Flavor (gnome, kde, niri, xfce, gnome-nvidia, ...)"
         required: true
         type: string
+      platform:
+        description: >-
+          Target platform (linux/amd64 or linux/arm64). Selects the runner
+          arch (#1378) — this job builds and boots the ISO natively, no
+          cross-arch emulation, so it must run on a host matching the image
+          it's building.
+        required: false
+        type: string
+        default: "linux/amd64"
+      safeplatform:
+        description: >-
+          Filesystem/artifact-name-safe form of platform (e.g. linux-amd64).
+          GitHub Actions expressions have no string-replace function, so this
+          is computed by the caller (build-variant.yml already has it from
+          its own matrix) rather than derived here.
+        required: false
+        type: string
+        default: "linux-amd64"
       image-tag:
         description: "GHCR tag to build the ISO from (defaults to <flavor>-linux-amd64)"
         required: false
@@ -56,7 +74,7 @@ jobs:
   iso:
     name: "ISO ${{ inputs.variant }}:${{ inputs.flavor }}"
     if: inputs.build-iso
-    runs-on: ubuntu-latest
+    runs-on: ${{ contains(inputs.platform, 'arm64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 90
     # No explicit permissions: inherit the caller's grant. publish-isos.yml
     # grants contents:write (release attach); build-variant.yml grants only
@@ -108,6 +126,15 @@ jobs:
           sudo -E bash ./scripts/build-iso-tacklebox.sh \
             "${VARIANT}" "${FLAVOR}" ghcr "${TAG}"
 
+      # KNOWN GAP (#1378): qemu-system-x86 + ovmf are x86_64-specific, and
+      # scripts/iso-e2e.sh itself only looks for qemu-system-x86_64 + OVMF
+      # firmware — it has no qemu-system-aarch64/AAVMF path. This job now
+      # runs on an arm64 runner for arm64 platforms (ISO build + tacklebox
+      # need a native host, no cross-arch emulation), so the ISO build step
+      # above should work — but THIS step and iso-e2e.sh's boot gate will
+      # still fail on arm64 until they're taught the aarch64 QEMU/firmware
+      # equivalents. Filed as a follow-up rather than guessed at here: real
+      # aarch64 KVM boot behavior needs verifying on real CI, not assumed.
       - name: Install QEMU for boot verification
         run: |
           sudo apt-get install -y qemu-system-x86 ovmf socat imagemagick qemu-utils sshpass python3-pip
@@ -162,7 +189,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: iso-${{ inputs.variant }}-${{ inputs.flavor }}
+          name: iso-${{ inputs.variant }}-${{ inputs.flavor }}-${{ inputs.safeplatform }}
           path: |
             *.iso
             *.iso.sha256
@@ -200,7 +227,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: e2e-${{ inputs.variant }}-${{ inputs.flavor }}
+          name: e2e-${{ inputs.variant }}-${{ inputs.flavor }}-${{ inputs.safeplatform }}
           path: |
             iso-e2e-out/serial.log
             iso-e2e-out/*.png
@@ -220,6 +247,7 @@ jobs:
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
           VARIANT: ${{ inputs.variant }}
           FLAVOR: ${{ inputs.flavor }}
+          PLATFORM: ${{ inputs.platform }}
         run: |
           if [[ -z "${R2_BUCKET}" ]]; then
             echo "R2 secrets not configured — skipping publish"
@@ -233,7 +261,16 @@ jobs:
             rclone copy --log-level INFO --checksum --s3-no-check-bucket \
               "$artifact" "R2:${R2_BUCKET}/live-isos/"
           done
-          LATEST="${VARIANT}-${FLAVOR}-latest.iso"
+          # amd64 keeps the bare <variant>-<flavor>-latest.iso name — that's a
+          # documented download URL (docs/TESTING.md) users already `wget`,
+          # so it must not move out from under them. Other platforms
+          # (#1378) get an arch-suffixed pointer instead of clobbering it.
+          if [[ "${PLATFORM}" == "linux/amd64" ]]; then
+            LATEST="${VARIANT}-${FLAVOR}-latest.iso"
+          else
+            ARCH_SUFFIX="${PLATFORM##*/}"
+            LATEST="${VARIANT}-${FLAVOR}-latest-${ARCH_SUFFIX}.iso"
+          fi
           rclone copyto --log-level INFO --s3-no-check-bucket \
             "$ISO" "R2:${R2_BUCKET}/live-isos/${LATEST}"
           DIGEST=$(sha256sum "$ISO" | awk '{print $1}')


### PR DESCRIPTION
## Summary

`build-variant.yml`'s `make_artifact_matrix()` hardcoded `platform: "linux/amd64"` for every stage's artifact matrix, so flavors that publish arm64 images (per `build-config.yml`'s `platforms`/`global_platforms`) never got arm64 ISO/QCOW2 artifacts at all — the same gap #230 closed without the fix landing.

## Changes

1. **`make_artifact_matrix()`** now expands each artifact-eligible entry into one row per platform (amd64/arm64) using `platforms_json`, which the image matrix already computes per entry. `linux/amd64/v2` (a CPU-feature variant, not a real target arch) is excluded. Verified against the real `build-config.yml`: the 37 existing amd64 rows for stage 2 are byte-identical to before, plus 32 new arm64 rows for multi-arch flavors; stage 3 (nvidia-only flavors, genuinely amd64-only in `build-config.yml`) correctly produces zero new rows.
2. The three artifact jobs' `image-tag` now uses `matrix.safeplatform` instead of a hardcoded `-linux-amd64` suffix.

Fixing the matrix alone would schedule arm64 jobs that couldn't actually succeed, so `reusable-build-artifacts.yml` also gets:

3. A new `platform` input selecting the runner arch (`ubuntu-24.04-arm` for arm64), mirroring the existing pattern in `reusable-build-image.yml`. ISO building (tacklebox/podman) needs a native host — no cross-arch emulation here.
4. Artifact upload names (`iso-*`, `e2e-*`) now include `safeplatform`. Without this, an amd64 and arm64 cell for the same variant+flavor running in one workflow run would collide on `actions/upload-artifact`'s per-run name-uniqueness requirement.
5. The R2 "latest" pointer is arch-suffixed for non-amd64 platforms only. `<variant>-<flavor>-latest.iso` is a documented download URL (`docs/TESTING.md` tells users to `wget` it directly) — changing it for amd64 would break that. arm64 gets its own `<variant>-<flavor>-latest-arm64.iso` instead of silently overwriting the amd64 pointer on every run.

## Known gap (flagged, not fixed here)

`scripts/iso-e2e.sh` and the "Install QEMU for boot verification" step are x86_64-only (`qemu-system-x86_64` binary, OVMF/x86 UEFI firmware, no aarch64/AAVMF path). Runner selection now puts arm64 jobs on an arm64 host, so the ISO build itself should work, but the boot-verification gate will still need aarch64 QEMU support to actually pass. I'm not attempting that here — real aarch64 KVM boot behavior needs verifying on actual CI, not guessed at in a sandbox with no ARM hardware. Inline comment added at the relevant step pointing back to this issue.

## Verification

- Both workflow files parse as valid YAML.
- The artifact-matrix jq logic tested standalone against the real `build-config.yml` (exact old/new amd64-row diff — identical — plus new arm64-row counts, per-stage correctness for stages 2/3/4).
- `publish-isos.yml` (the other caller of `reusable-build-artifacts.yml`) is unaffected — `platform`/`safeplatform` default to the amd64 values matching its current behavior exactly.

## Scope

Per #1557 the hive App can't push `.github/workflows/` changes directly — this needs the maintainer merge path.

Refs #1378, #230
---
🐝 **Hive Agent**: `contributor` | **SHA:** `5339b128`