### PR TITLE
docs: fix "weekly release cadence" claim in external-facing pitches

### DIFF
--- a/docs/DISTROWATCH-SUBMISSION.md
+++ b/docs/DISTROWATCH-SUBMISSION.md
@@ -28,8 +28,9 @@ verifies every release. For teams already running Kubernetes, the Corral
 project manages desktop and service VMs as declarative resources on the
 same cluster estate, with snapshots and GPU passthrough as code.
 
-TunaOS is free and open source under the Apache-2.0 license, with weekly
-release cadence, verified boot reports, and an active community on Matrix.
+TunaOS is free and open source under the Apache-2.0 license, with a daily
+rolling build cadence (plus weekly and quarterly-LTS stability tiers),
+verified boot reports, and an active community on Matrix.
 
 ## Metadata for the listing
 
@@ -40,7 +41,7 @@ release cadence, verified boot reports, and an active community on Matrix.
 | **Source** | https://github.com/tuna-os/tunaOS |
 | **Download** | https://tunaos.org/download (ISOs for all variants) |
 | **Image registry** | https://github.com/orgs/tuna-os/packages (GHCR) |
-| **Status** | Active (weekly releases) |
+| **Status** | Active (daily rolling builds; weekly/quarterly-LTS stability tiers) |
 | **Origin** | USA / global maintainer community |
 | **Desktop environments** | GNOME, KDE Plasma, COSMIC, Niri, XFCE, Pantheon |
 | **Package management** | bootc image-based (rpm-ostree-style), atomic |

--- a/docs/FEDORA-MAGAZINE-PITCH.md
+++ b/docs/FEDORA-MAGAZINE-PITCH.md
@@ -39,8 +39,10 @@ published on [tunaos.org/blog](https://tunaos.org/blog) and
 [github.com/tuna-os/tunaOS](https://github.com/tuna-os/tunaOS), so we can
 provide a full draft in Magazine house style on request.
 
-**About the author.** TunaOS is an open-source project with weekly release
-cadence and an active community on Matrix. Happy to adapt length, tone, and
+**About the author.** TunaOS is an open-source project with a daily rolling
+build cadence (plus weekly and quarterly-LTS stability tiers for users who
+want less churn) and an active community on Matrix. Happy to adapt length,
+tone, and
 depth to the Magazine's editorial preferences.
 
 Thanks for considering,


### PR DESCRIPTION
## Summary

Issue #1137's Fedora Magazine pitch (`docs/FEDORA-MAGAZINE-PITCH.md`) is submission-ready and about to be emailed to real Fedora Magazine editors, so it warranted a final accuracy pass beyond the COPR correction already made in #1494.

## Found

"TunaOS is an open-source project with weekly release cadence" — checked against `VERSIONING.md` and the actual release workflow (`.github/workflows/generate-changelog-release.yml`, `cron '05 11 * * *'`, daily). `VERSIONING.md` is explicit: "tunaOS images are rebuilt daily ... weekly [is a] snapshot of the most stable daily build" — one of three stability tiers (daily/weekly/LTS), not the project's overall cadence. Describing the whole project as "weekly" to an external Fedora audience understates the actual build frequency.

The same claim appears verbatim in `docs/DISTROWATCH-SUBMISSION.md` (both the prose summary and the metadata table's Status field) — same error, same external-facing risk, fixed the same way.

## Not touched

`COMMUNITY.md`'s "weekly release notes" (a Matrix community-digest cadence, distinct from image build cadence — matches `docs/MATRIX-WEEKLY-DIGEST.md`'s actual weekly-digest-post pattern) — that's a different, accurate claim, not the same error.

Refs #1137
---
🐝 **Hive Agent**: `contributor` | **SHA:** `d4438474`