### PR TITLE
fix(hummingbird): guard dconf database verification check for experimental hummingbird variant (#1559)

### DIFF
--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -644,7 +644,9 @@ else
 			_dcf_name="${_dcf_name##*/}"
 			if [[ ! -s "/etc/dconf/db/${_dcf_name}" ]]; then
 				echo "missing compiled dconf database: keyfiles in ${_dcf_dir} but /etc/dconf/db/${_dcf_name} is missing or empty (run dconf update)" >&2
-				exit 1
+				if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
+					exit 1
+				fi
 			fi
 		fi
 	done

--- a/tests/bats/test_custom_overlay.bats
+++ b/tests/bats/test_custom_overlay.bats
@@ -32,12 +32,16 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
 }
 
 @test "Justfile contains custom recipes" {
-  run grep "build-custom" "${REPO_ROOT}/Justfile"
-  [ "$status" -eq 0 ]
-  run grep "check-custom" "${REPO_ROOT}/Justfile"
-  [ "$status" -eq 0 ]
-  run grep "run-custom-vm" "${REPO_ROOT}/Justfile"
-  [ "$status" -eq 0 ]
-  run grep "custom-iso" "${REPO_ROOT}/Justfile"
-  [ "$status" -eq 0 ]
+  local recipe_file="${REPO_ROOT}/Justfile"
+  if ! grep -q "build-custom" "$recipe_file" ||
+    ! grep -q "check-custom" "$recipe_file" ||
+    ! grep -q "run-custom-vm" "$recipe_file" ||
+    ! grep -q "custom-iso" "$recipe_file"; then
+    recipe_file="${REPO_ROOT}/just/custom-overlay.just"
+  fi
+
+  for recipe in build-custom check-custom run-custom-vm custom-iso; do
+    run grep -q "$recipe" "$recipe_file"
+    [ "$status" -eq 0 ]
+  done
 }

--- a/tests/bats/test_custom_overlay.bats
+++ b/tests/bats/test_custom_overlay.bats
@@ -31,17 +31,20 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
   [ "$status" -eq 0 ]
 }
 
-@test "Justfile contains custom recipes" {
-  local recipe_file="${REPO_ROOT}/Justfile"
-  if ! grep -q "build-custom" "$recipe_file" ||
-    ! grep -q "check-custom" "$recipe_file" ||
-    ! grep -q "run-custom-vm" "$recipe_file" ||
-    ! grep -q "custom-iso" "$recipe_file"; then
-    recipe_file="${REPO_ROOT}/just/custom-overlay.just"
-  fi
+@test "Justfile imports the custom-overlay recipe module" {
+  run grep "^import 'just/custom-overlay.just'" "${REPO_ROOT}/Justfile"
+  [ "$status" -eq 0 ]
+}
 
-  for recipe in build-custom check-custom run-custom-vm custom-iso; do
-    run grep -q "$recipe" "$recipe_file"
-    [ "$status" -eq 0 ]
-  done
+@test "just/custom-overlay.just contains custom recipes" {
+  run test -f "${REPO_ROOT}/just/custom-overlay.just"
+  [ "$status" -eq 0 ]
+  run grep "build-custom" "${REPO_ROOT}/just/custom-overlay.just"
+  [ "$status" -eq 0 ]
+  run grep "check-custom" "${REPO_ROOT}/just/custom-overlay.just"
+  [ "$status" -eq 0 ]
+  run grep "run-custom-vm" "${REPO_ROOT}/just/custom-overlay.just"
+  [ "$status" -eq 0 ]
+  run grep "custom-iso" "${REPO_ROOT}/just/custom-overlay.just"
+  [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Fixes #1559.

### Summary
- Guarded the trailing compiled `dconf` database assertion in `build_scripts/checks/verify-desktop-experience.sh` with an `${IS_HUMMINGBIRD:-false} != "true"` check.
- Prevents experimental Fedora Hummingbird container-native OS desktop builds (`hummingbird:gnome`, `hummingbird:kde`, etc.) from failing build-time contract verification when optional `dconf` databases are missing or uncompiled, matching the non-fatal contract handling used across the rest of `verify-desktop-experience.sh`.
