### PR TITLE
ci: thread per-variant image-desc through build-variant.yml

### DIFF
--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -106,6 +106,7 @@ jobs:
                 image_aliases: (($v.aliases // []) | join(",")),
                 published_tag: (.id + (if ($v.tag_suffix // "") == "" then "" else "-" + $v.tag_suffix end)),
                 variant_emoji: ($v.emoji // "❓"),
+                description:   ($v.description // ""),
                 base_image:    $v.base_image,
                 platforms:     (if $event == "pull_request" then "linux/amd64" else ((.platforms // $v.platforms) | join(",")) end),
                 platforms_json: ((if $event == "pull_request" then ["linux/amd64"] else (.platforms // $v.platforms) end)
@@ -127,6 +128,7 @@ jobs:
                 image_aliases: .image_aliases,
                 published_tag: .published_tag,
                 variant_emoji: .variant_emoji,
+                description:   .description,
                 flavor:        .flavor,
                 platforms:     .platforms,
                 platforms_json: .platforms_json,
@@ -194,6 +196,7 @@ jobs:
       image-name: ${{ matrix.image_name }}
       image-aliases: ${{ matrix.image_aliases }}
       image-variant: ${{ matrix.variant }}
+      image-desc: ${{ matrix.description }}
       flavor: ${{ matrix.flavor }}
       platforms: ${{ matrix.platforms }}
       platforms-json: ${{ matrix.platforms_json }}
@@ -228,6 +231,7 @@ jobs:
       image-name: ${{ matrix.image_name }}
       image-aliases: ${{ matrix.image_aliases }}
       image-variant: ${{ matrix.variant }}
+      image-desc: ${{ matrix.description }}
       flavor: ${{ matrix.flavor }}
       platforms: ${{ matrix.platforms }}
       platforms-json: ${{ matrix.platforms_json }}
@@ -262,6 +266,7 @@ jobs:
       image-name: ${{ matrix.image_name }}
       image-aliases: ${{ matrix.image_aliases }}
       image-variant: ${{ matrix.variant }}
+      image-desc: ${{ matrix.description }}
       flavor: ${{ matrix.flavor }}
       platforms: ${{ matrix.platforms }}
       platforms-json: ${{ matrix.platforms_json }}
@@ -290,6 +295,7 @@ jobs:
       image-name: ${{ matrix.image_name }}
       image-aliases: ${{ matrix.image_aliases }}
       image-variant: ${{ matrix.variant }}
+      image-desc: ${{ matrix.description }}
       flavor: ${{ matrix.flavor }}
       platforms: ${{ matrix.platforms }}
       platforms-json: ${{ matrix.platforms_json }}


### PR DESCRIPTION
## Summary

Fixes the "minor, non-blocking" item noted in #1570's nightly sweep: `build-variant.yml` never passes `image-desc` to `reusable-build-image.yml`, so every variant's published OCI image gets the reusable workflow's hardcoded default (`"Albacore, built on CentOS Stream with bootc"`) — not just skipjack as #1570 spotted, but all 13 variants, each with its own real description already sitting unused in `build-config.yml` (e.g. yellowfin: "Based on AlmaLinux Kitten 10", bonito: "Based on Fedora 44").

## Change

Threads `build-config.yml`'s per-variant `description` field through the existing matrix pipeline the same way `variant_emoji` already is: `FULL_MATRIX` captures `$v.description`, `make_image_matrix()` carries it into each stage's image matrix, and all 4 `reusable-build-image.yml` call sites (stage1-4) now pass `image-desc: ${{ matrix.description }}`.

## Verification

YAML parses; grep confirms all 13 `build-config.yml` variants have a `description` field, so the `// ""` fallback never actually triggers in practice (defensive only, not a behavior change for any current variant).

## Scope

Pure `.github/workflows/` change — per #1557 the hive App can't push workflow files directly, so this needs the maintainer merge path.

Refs #1570
---
🐝 **Hive Agent**: `contributor` | **SHA:** `510f5c7c`