### PR TITLE
fix(cachyos): build initramfs for deterministic kernel trees

### DIFF
--- a/Containerfile.arch
+++ b/Containerfile.arch
@@ -168,7 +168,11 @@ RUN --mount=type=bind,from=context,source=/,target=/run/context \
 # nowhere shared to live.
 RUN --mount=type=bind,from=context,source=/,target=/run/context \
     /run/context/build_scripts/bootc/dracut-config.sh && \
-    dracut --force "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v '\.img' | tail -1)/initramfs.img"
+    for kernel_dir in /usr/lib/modules/*; do \
+        [ -d "${kernel_dir}" ] || continue; \
+        case "${kernel_dir##*/}" in *.img) continue ;; esac; \
+        dracut --force "${kernel_dir}/initramfs.img"; \
+    done
 
 # systemd-firstboot asks the CONSOLE for a timezone and blocks there forever.
 #

--- a/build_scripts/overlay/cachyos.sh
+++ b/build_scripts/overlay/cachyos.sh
@@ -38,14 +38,38 @@ Include = /etc/pacman.d/cachyos-mirrorlist
 EOF
 fi
 
-pacman -Syu --noconfirm --needed \
+# Install the CachyOS kernel without upgrading the entire base mid-overlay.
+# A full -Syu can update the stock kernel as a side effect, leaving multiple
+# module trees for the bootc/BLS generator to choose between.
+pacman -S --noconfirm --needed \
 	cachyos-keyring cachyos-mirrorlist cachyos-settings \
 	linux-cachyos linux-cachyos-headers tpm2-tss
+
+# The Arch base's stock linux package is not a usable fallback here: keeping
+# it alongside linux-cachyos gives bootc two kernels but only one reliably
+# prepared initramfs. Remove it before generating the CachyOS initramfs.
+if pacman -Qq linux >/dev/null 2>&1; then
+	pacman -Rdd --noconfirm linux
+fi
 
 # Mark as CachyOS-augmented for install-desktop.sh detection
 install -D /dev/null /etc/cachyos-release
 printf 'CachyOS\n' >/etc/cachyos-release
 
-# Rebuild initramfs via dracut
-dracut --force --omit "tpm2-tss" "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v '\.img' | tail -1)/initramfs.img"
+# Rebuild an initramfs for every remaining kernel tree. Never select one with
+# find | tail: directory enumeration order is not stable, and bootc may select
+# a different BLS kernel than the one that happened to receive the initramfs.
+kernel_dirs=()
+for kernel_dir in /usr/lib/modules/*; do
+	[[ -d "$kernel_dir" ]] || continue
+	[[ "${kernel_dir##*/}" == *.img ]] && continue
+	kernel_dirs+=("$kernel_dir")
+done
+if ((${#kernel_dirs[@]} == 0)); then
+	echo "ERROR: no kernel module directories remain after installing linux-cachyos" >&2
+	exit 1
+fi
+for kernel_dir in "${kernel_dirs[@]}"; do
+	dracut --force --omit "tpm2-tss" "${kernel_dir}/initramfs.img"
+done
 pacman -Scc --noconfirm || true

--- a/tests/bats/test_cachyos_initramfs.bats
+++ b/tests/bats/test_cachyos_initramfs.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+
+@test "CachyOS overlay removes the stock kernel" {
+  run grep -F 'pacman -Rdd --noconfirm linux' \
+    "${REPO_ROOT}/build_scripts/overlay/cachyos.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "CachyOS overlay builds initramfs for every kernel tree" {
+  run grep -F 'for kernel_dir in /usr/lib/modules/*' \
+    "${REPO_ROOT}/build_scripts/overlay/cachyos.sh"
+  [ "$status" -eq 0 ]
+  run grep -F 'for kernel_dir in "${kernel_dirs[@]}"' \
+    "${REPO_ROOT}/build_scripts/overlay/cachyos.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "CachyOS and Arch image builds do not choose a kernel with find tail" {
+  run grep -nE 'find .*\/usr/lib/modules.*tail -1' \
+    "${REPO_ROOT}/build_scripts/overlay/cachyos.sh"
+  [ "$status" -ne 0 ]
+  run grep -nE 'find .*\/usr/lib/modules.*tail -1' \
+    "${REPO_ROOT}/Containerfile.arch"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

Fixes #1563 by making CachyOS kernel/initramfs preparation deterministic.

- Install `linux-cachyos` without a mid-overlay full `pacman -Syu`.
- Remove the stock `linux` package when present, so bootc does not see competing kernel trees.
- Generate an initramfs for every remaining `/usr/lib/modules/<kver>` directory instead of selecting one through unstable `find | tail -1` ordering.
- Apply the same all-kernel initramfs rule to the Arch base Containerfile.
- Add focused Bats coverage for stock-kernel removal and the eliminated selection gamble.

## Root cause

The CachyOS overlay retained the Arch stock kernel while installing `linux-cachyos`, then generated one initramfs into whichever module directory happened to be returned last by unsorted `find`. Bootc/BLS could select a different kernel tree, producing either `initramfs not found` during installation or a guest that never reached the desktop contract.

## Validation

- `git diff --check`
- `bash -n build_scripts/overlay/cachyos.sh`
- Static checks confirm neither affected path contains the old `find | tail -1` selection.
- Focused Bats tests added; full Bats execution is delegated to CI.