### PR TITLE
docs: make adoption evidence auditable

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -3,11 +3,12 @@
 > A list of organizations and projects that use TunaOS in production, development, or evaluation.
 >
 > If you or your organization is using TunaOS, we'd love to add you to this list!
-> Please submit a PR adding your name or open an issue.
+> See the [adoption call](docs/ADOPTION-CALL.md) to self-identify in the public
+> Show-and-tell Discussion, or submit a PR with the same consent details.
 
 ## Production Users
 
-_(None listed yet — be the first!)_
+_(None listed yet — see the [adoption call](docs/ADOPTION-CALL.md) and be the first!)_
 
 ## Development & Evaluation
 

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -6,6 +6,11 @@
 > See the [adoption call](docs/ADOPTION-CALL.md) to self-identify in the public
 > Show-and-tell Discussion, or submit a PR with the same consent details.
 
+**Evidence baseline (2026-08-14):** 0 named production users and 2 named
+development/evaluation entries. The ecosystem table below records projects
+that TunaOS depends on, integrates with, or is inspired by; it is not evidence
+that those projects use TunaOS.
+
 ## Production Users
 
 _(None listed yet — see the [adoption call](docs/ADOPTION-CALL.md) and be the first!)_

--- a/ADOPTION-METRICS.md
+++ b/ADOPTION-METRICS.md
@@ -58,6 +58,14 @@ publish, and *how* the snapshot feeds roadmap decisions.
 - Ownership: **strategist** compiles; **ci-maintainer** supplies R2/Releases
   exports; **guide** publishes on tunaos.org/blog.
 
+## Outreach evidence
+
+The current outreach record is kept in
+[docs/ADOPTION-OUTREACH-STATUS.md](docs/ADOPTION-OUTREACH-STATUS.md). A draft,
+an intended recipient, or an ecosystem relationship is not an outreach result;
+the monthly snapshot must record a sent date, public URL, response, or an
+explicitly unattempted status.
+
 ## Decision linkage
 
 Each snapshot must answer two questions for the roadmap:

--- a/ADOPTION-METRICS.md
+++ b/ADOPTION-METRICS.md
@@ -32,6 +32,7 @@ publish, and *how* the snapshot feeds roadmap decisions.
 | Community | Open PRs from external contributors | GitHub API | 0 external contributors | ≥2 external contributor PRs merged |
 | Community | Discussion posts, `good first issue` pickups | GitHub API | 0 starter issues (dead label, #1308) | ≥5 starter issues picked up |
 | Community | Public adopters (production or evaluation), [ADOPTERS.md](./ADOPTERS.md) | Manual — PR from the adopting org, or outreach asking permission to list | 0 production entries (#1348) | ≥2–3 public evaluator/production entries |
+| Community | Adoption-call conversion | GitHub Discussion + follow-up PRs | **not measured** | Record responses, consent-confirmed named entries, anonymous reports, and ADOPTERS.md PRs |
 
 **Instrumentation order** (cheapest first):
 
@@ -51,8 +52,9 @@ publish, and *how* the snapshot feeds roadmap decisions.
   **2026-11-01**, covering October — aligns with Q4 "Mature" opening).
 - Snapshot format: downloads by variant × desktop (top 10), stars/forks,
   external-contributor PRs, release-asset presence per flavor,
-  [ADOPTERS.md](./ADOPTERS.md) production/evaluation entry count, and a
-  one-line "variant ranking" that flags under-/over-performing editions.
+  [ADOPTERS.md](./ADOPTERS.md) production/evaluation entry count, adoption-call
+  responses/conversion, and a one-line "variant ranking" that flags
+  under-/over-performing editions.
 - Ownership: **strategist** compiles; **ci-maintainer** supplies R2/Releases
   exports; **guide** publishes on tunaos.org/blog.
 

--- a/Q3_CHECKPOINT-2026-08-22.md
+++ b/Q3_CHECKPOINT-2026-08-22.md
@@ -1,7 +1,7 @@
 # Q3 2026 Checkpoint — Decision Sheet (2026-08-22)
 
 **Milestone**: Q3 2026 "Expand Coverage" (closes 2026-09-30)
-**Tracker**: #1299 | **Prepared**: 2026-08-11 | **Last refreshed**: 2026-08-14 (T-8) | **Decision authority**: maintainer
+**Tracker**: #1299 | **Prepared**: 2026-08-11 | **Last refreshed**: 2026-08-12 (T-10) | **Decision authority**: maintainer
 
 > **Correction (2026-08-13, #1317)**: every "shimonenator" reference below assumed a
 > human external contributor. The maintainer confirmed the account is a Google
@@ -10,20 +10,6 @@
 > contributor to retain or convert into capacity; treat the "external
 > capacity" framing for #1123 Redfin below as unavailable until a real human
 > contributor appears.
-
-## T-8 refresh (2026-08-14) — what changed since T-10
-
-| Input | T-10 (08-12) | T-8 (08-14) | Source |
-|-------|--------------|-------------|--------|
-| ADR coverage (#1094) staff test | 2 ADR PRs open | ✅ **Met** — ADR 0003 (#1369) + ADR 0004 (#1370) merged 08-13 | PR states |
-| RFC disposition (#1363) | 11 branches undetermined | 11 RFC branches still undetermined; 97 total branches on tunaos; disposition pass due **at** this checkpoint | branch list |
-| GFI pool (#1362) | ZERO usable | **~6 usable seeds** — tunaos #1496/#1351, docs #204/#158/#157, protota #193 (verified 08-14) | label search |
-| External capacity | shimonenator (agent, misattributed) | **None** — retraction confirmed; no human contributor exists | #1317, ROADMAP |
-| Release parity (#1254) | gnome daily to 08-11; others 30–37d stale | gnome daily through 08-13; kde/xfce/niri/cosmic/gnome50 stale 40d (since 07-05), gnome-nvidia 33d (since 07-12) | Releases API |
-| NVIDIA (#1383) | overlay builds regressed 08-12 | **Worse** — initramfs regression #1499 (5 variants, 10/10 nightlies red); fixes #1503/#1523 in flight | #1499 |
-| Q4 milestone fidelity (#1307) | 7/9 trackers unattached | ✅ **Fixed** — all trackers attached (verified 08-13); milestone #3 = 10 open / 1 closed | #1307, milestone |
-| Docs adoption surface | 3 P0s open | ✅ **Recovered** — #103 pagination, #115 flatpak deploy, #135 404 links all closed 08-13 | docs issues |
-| wootc planning (#1358) | no ROADMAP/LICENSE | ROADMAP (wootc#116) + LICENSE-GPL-2.0/LICENSE-MIT landed; **CONTRIBUTING still missing** | wootc tree |
 
 ## Purpose
 
@@ -35,56 +21,48 @@ Make Q3 carryover an explicit decision, not a discovery. For every open Q3 goal,
 | **DESCOPE → Q4** | Explicitly moved to Q4 milestone with named owner | Q3 closes clean; Q4 load acknowledged |
 | **DROP** | Goal no longer pursued; close issue | Removes noise; revisit at Q5 planning |
 
-## Decision inputs (T-8 refresh, 2026-08-14)
+## Decision inputs (T-10 refresh, 2026-08-12)
 
-### Original four Q3 goals — status change since 08-12
+### Original four Q3 goals — status change since 08-11
 
-| Goal | Issue | Owner | Staff test (first PR by 09-01) | Status 08-14 |
+| Goal | Issue | Owner | Staff test (first PR by 09-01) | Status 08-12 |
 |------|-------|-------|--------------------------------|--------------|
-| Bonito (Fedora 44) GA | #272 | ci-maintainer | T2 bootc profile PR #1256 merged + Beta→Stable exit per VARIANT-LIFECYCLE.md | 🔴 zero movement since 07-19; #1256 still draft (T-8); Fedora 44 superseded by #1171 |
-| Redfin (RHEL 10) alpha | #1123 | ci-maintainer | EL10/OBS package-gap work (#777) starts landing packages | 🔴 zero movement; external-capacity framing void post-retraction (#1317) |
-| RFC lifecycle governance | #1093 | strategist | RFC merge policy doc merged; 11 unmerged branches triaged | 🟢 RFC-PROCESS.md merged 08-11 (#1352); **branch disposition pass is due at this checkpoint** (#1363) |
-| ADR coverage | #1094 | strategist | 2 new ADRs merged (e.g., RFC-010 Grouper, image factory completion gate) | ✅ **staff test met** — ADR 0003 (#1369) + ADR 0004 (#1370) merged 08-13 |
+| Bonito (Fedora 44) GA | #272 | ci-maintainer | T2 bootc profile PR #1256 merged + Beta→Stable exit per VARIANT-LIFECYCLE.md | 🔴 zero movement; #1256 still draft |
+| Redfin (RHEL 10) alpha | #1123 | ci-maintainer | EL10/OBS package-gap work (#777, shimonenator docs) starts landing packages | 🔴 zero movement |
+| RFC lifecycle governance | #1093 | strategist | RFC merge policy doc merged; 11 unmerged branches triaged | 🟢 RFC-PROCESS.md merged 08-11 (#1352); branch disposition pass due 08-22 (#1363) |
+| ADR coverage | #1094 | strategist | 2 new ADRs merged (e.g., RFC-010 Grouper, image factory completion gate) | 🟢 ADR 0003 + ADR 0004 PRs open (#1369/#1370) — merge by 09-01 |
 
 ### New directives added since checkpoint scheduling (must also be framed)
 
 | Directive | Issue | Status | Decision needed |
 |-----------|-------|--------|-----------------|
-| Flavor equality | #1315 / #1316 | Catalog parity gate merged 08-11 (#1322, closes #1281); scheduled cadence parity still pending (#1254) — gnome-only releases through 08-13 | STAFF cadence parity in Q3, or descope to Q4 with owner |
-| Package sourcing | #1319 / #1323 | PACKAGE-SOURCING.md merged (#1330); DNF/COPR audit landed 08-13 — niri desktop depends on 6 unsanctioned COPRs (`yalter/niri-git` ships niri itself); Q2 "COPR eliminated" regression (`ublue-os/packages` → krunner-bazaar). apt/AUR/OBS bases (marlin/flounder/sailfin/guppy) not yet audited | STAFF — allowlist sign-off + migration plan for the niri COPR cluster at this checkpoint |
+| Flavor equality | #1315 / #1316 | Catalog parity gate merged 08-11 (#1322, closes #1281); scheduled cadence parity pending (#1254) | STAFF cadence parity in Q3, or descope to Q4 with owner |
+| Package sourcing | #1319 / #1323 | PACKAGE-SOURCING.md merged (#1330); DNF/COPR audit landed 08-13 — found the niri desktop depends on 6 distinct unsanctioned COPRs (largest single gap: `yalter/niri-git` ships niri itself), plus a Q2 "COPR eliminated" regression (`ublue-os/packages` still feeds krunner-bazaar). apt/AUR/OBS bases (marlin/flounder/sailfin/guppy) not yet audited | STAFF — allowlist sign-off + migration plan for the niri COPR cluster at the 08-22 checkpoint |
 
 ### Supporting items for the checkpoint
 
-- **Release reliability is the top new risk since T-10**: 08-13 nightly failed across the variant matrix (Yellowfin, Bonito…); NVIDIA initramfs regression #1499 has 5 variants on 10/10 red nightlies (fixes #1503/#1523 in flight); Asahi manifest gate red nightly (#1411); live-overlay artifacts red for guppy/grouper/bonito-rawhide (#1397). Every one of these blocks the flavor-equality mandate (#1316) and the parity decision above.
-- **GFI pool improved but below target**: ~6 usable seeds verified 08-14 (tunaos #1496/#1351, docs #204/#158/#157, protota #193) vs ZERO at 08-12 — but the 09-15 seeding deadline for Hacktoberfest (10-01) needs 15–20 (#1362, #1347). CONTRIBUTING's good-first-issue link fixed; the meta-tracker #1308 itself carries the label and is not a task.
-- **No external capacity — Q3 staff tests are maintainer-only**: post-retraction (#1317) the only human is hanthor. #272 and #1123 staff tests have no borrowed-capacity path; **DESCOPE is the realistic outcome for both unless concrete PRs land by 08-22**.
-- **Q4 dependency risk**: Q4 milestone #3 = 10 open / 1 closed; trackers now attached (fidelity fixed, #1307). Bonito GA and Redfin GA already appear as Q4 rows — every Q3 descope adds Q4 load before Q4 starts. Q4 also carries adoption metrics snapshot (#1174, first 11-01), governance (#1168), branch protection (#1167), Fedora 45 planning (#1171).
-- **Release parity**: GNOME daily through 08-13 (gnome-20260813). kde/xfce/niri/cosmic/gnome50 stale **40 days** (since 07-05); gnome-nvidia stale 33 days (since 07-12). Browser-catalog parity gate (#1322) fixed the on-demand path; scheduled GitHub Releases pipeline remains GNOME-only.
-- **Planning debt (mid-cycle)**: wootc ROADMAP + LICENSE landed but CONTRIBUTING missing (#1358); gtk-office-suite planning gap open (#1359); tromso stable release untracked — zero releases, zero milestones (#1371).
-- **Enterprise posture**: ADOPTERS.md empty vs Q4 "Mature" claim (#1348); Redfin alpha dropped from Q3 (#1123); branch protection unverified (#1167).
-- **Docs adoption surface recovered**: all three docs P0s closed 08-13 (#103 pagination, #115 flatpak deploy, #135 404 links) — next step is Cloudflare Web Analytics instrumentation per ADOPTION-METRICS.md (#1174).
+- **Adoption call (#1367)**: before using Q4 “Mature” language, publish the
+  [warm-channel adoption call](docs/ADOPTION-CALL.md) in a Show-and-tell
+  Discussion and record the link here. Count only consent-confirmed named
+  entries as public adoption evidence; downloads, stars, pulls, CI, and
+  anonymous reports do not populate `ADOPTERS.md` Production Users.
+- **Contributor retention → capacity**: shimonenator is ACTIVE (8 commits 08-10/11 across tunaOS + xfce-linux; last 08-11 20:26Z). 14-day window closes ~08-24 — 2 days AFTER this checkpoint. Recommend converting retention into capacity: seed GFI-scoped Bonito/Redfin packaging subtasks for the contributor **at** the checkpoint, so #272/#1123 staff tests can borrow external capacity instead of maintainer-only time.
+- **GFI pool is ZERO usable (#1362)**: the #1308 seeds never landed (letters#8 is on an archived repo); CONTRIBUTING's good-first-issue link is dead. No seeds → no external capacity → the retention-window opportunity above is moot. Seed 20+ GFIs by 09-15 (#1362; outreach #1354 tracks 3→8).
+- **Q4 dependency risk**: Q4 is 0/13 items closed (was 0/9); Bonito GA and Redfin GA already appear as Q4 rows — every Q3 descope adds Q4 load before Q4 starts. #1159/#1307 track Q4 goal fidelity.
+- **Release parity**: GNOME releases are now daily (08-09 → 08-11, 3 assets each). kde/xfce/niri/gnome-nvidia still stale 30–37 days (#1254). Browser-catalog parity gate (#1322) fixed the on-demand path; the scheduled GitHub Releases pipeline remains GNOME-only.
+- **New planning debt (mid-cycle)**: wootc ROADMAP merged (wootc#116) but CONTRIBUTING/LICENSE still missing (#1358); gtk-office-suite planning gap open (#1359); tromso stable release untracked (no releases, no milestones — core build tooling; filed as new tracker this cycle).
+- **Enterprise posture**: ADOPTERS.md empty vs Q4 "Mature" claim (#1348); RHEL10/AlmaLinux topics on repo but Redfin alpha dropped (#1123); branch protection unverified (#1167).
 
 ## Strategist recommendation (input — decision authority stays with maintainer)
 
 | Goal | Recommended | Rationale |
 |------|-------------|-----------|
-| #272 Bonito GA | **DESCOPE → Q4** unless #1256 exits draft by 08-22 | Zero movement since 07-19; T2 profile still draft; Fedora 44 superseded by Fedora 45 planning (#1171); no external capacity |
-| #1123 Redfin alpha | **DESCOPE → Q4** with named owner | Enterprise flagship, but external-capacity framing is void (#1317) and no package-gap PRs have landed; descope explicitly rather than silently |
-| #1093 RFC governance | **STAFF (close-out)** | Policy merged (#1352); finish the 11-branch disposition pass **at** this checkpoint (#1363); then close the goal |
-| #1094 ADR coverage | ✅ **Met — close out** | ADR 0003 + ADR 0004 merged 08-13; mark completed at checkpoint |
-| #1316 Flavor equality | **STAFF cadence parity** | Catalog parity done (#1322); scheduled Releases parity (#1254) is the remaining deliverable — but blocked by #1499 NVIDIA + nightly matrix failures |
-| #1323 Package sourcing | **STAFF** | Draft exists (#1330); merge + allowlist by 08-22 keeps the audit on schedule |
-
-## Decision calendar
-
-| Date | Event | Owner |
-|------|-------|-------|
-| 2026-08-22 | **Checkpoint decision sheet filled** (table below) | maintainer (strategist prepares) |
-| 2026-08-24 | shimonenator 14-day window closes (moot — retracted) | — |
-| 2026-09-01 | Staff-test deadline: first PR for any STAFF goal | goal owners |
-| 2026-09-15 | Hacktoberfest GFI seeding deadline (15–20 seeds) | outreach + strategist (#1362/#1347) |
-| 2026-09-30 | Q3 milestone closes | all |
-| 2026-10-01 | Hacktoberfest 2026 opens | all |
+| #272 Bonito GA | **DESCOPE → Q4** unless #1256 exits draft by 08-22 | Zero movement since 07-19; T2 profile in draft; Fedora 44 is now superseded by Fedora 45 planning (#1171) — carryover should be explicit, not silent |
+| #1123 Redfin alpha | **STAFF with external capacity** or **DESCOPE → Q4** | Enterprise flagship; seed EL10 package-gap GFIs for shimonenator before window closes 08-24; if no seeds, descope with named owner |
+| #1093 RFC governance | **STAFF** | Policy merged (#1352); finish branch disposition pass by 08-22 (#1363) |
+| #1094 ADR coverage | **STAFF** | Merge ADR 0003/0004 (#1369/#1370) by 09-01; RFC backlog governance (#1093) is the long pole |
+| #1316 Flavor equality | **STAFF cadence parity** | Catalog parity done (#1322); scheduled Releases parity (#1254) is the remaining deliverable |
+| #1323 Package sourcing | **STAFF** | Draft exists (#1330); merge + allowlist by 08-22 keeps the 08-22 audit on schedule |
 
 ## Decision record (fill at 2026-08-22)
 
@@ -100,6 +78,16 @@ Make Q3 carryover an explicit decision, not a discovery. For every open Q3 goal,
 ## Outcome recording
 
 After the checkpoint, update the ROADMAP.md Q3 status table (per #1299 step 3) so carryover is a decision, not a discovery.
+
+### Adoption-call record
+
+| Discussion URL | Responses | Confirmed named entries | Anonymous reports | ADOPTERS.md PRs |
+|---|---:|---:|---:|---:|
+| `[DISCUSSION_URL]` | [N] | [N] | [N] | [#PRs] |
+
+Replace the placeholder only after the maintainer publishes the Discussion.
+Keep the counts separate and do not promote the Q4 “Mature” claim from this
+call unless the evidence target is met.
 
 ---
 *Prepared by strategist agent (ACMM L6 — full mode). Signed-off-by: hanthor-hive-agent[bot] <290068839+hanthor-hive-agent[bot]@users.noreply.github.com>*

--- a/Q3_CHECKPOINT-2026-08-22.md
+++ b/Q3_CHECKPOINT-2026-08-22.md
@@ -1,7 +1,7 @@
 # Q3 2026 Checkpoint — Decision Sheet (2026-08-22)
 
 **Milestone**: Q3 2026 "Expand Coverage" (closes 2026-09-30)
-**Tracker**: #1299 | **Prepared**: 2026-08-11 | **Last refreshed**: 2026-08-12 (T-10) | **Decision authority**: maintainer
+**Tracker**: #1299 | **Prepared**: 2026-08-11 | **Last refreshed**: 2026-08-14 (T-8) | **Decision authority**: maintainer
 
 > **Correction (2026-08-13, #1317)**: every "shimonenator" reference below assumed a
 > human external contributor. The maintainer confirmed the account is a Google
@@ -10,6 +10,20 @@
 > contributor to retain or convert into capacity; treat the "external
 > capacity" framing for #1123 Redfin below as unavailable until a real human
 > contributor appears.
+
+## T-8 refresh (2026-08-14) — what changed since T-10
+
+| Input | T-10 (08-12) | T-8 (08-14) | Source |
+|-------|--------------|-------------|--------|
+| ADR coverage (#1094) staff test | 2 ADR PRs open | ✅ **Met** — ADR 0003 (#1369) + ADR 0004 (#1370) merged 08-13 | PR states |
+| RFC disposition (#1363) | 11 branches undetermined | 11 RFC branches still undetermined; 97 total branches on tunaos; disposition pass due **at** this checkpoint | branch list |
+| GFI pool (#1362) | ZERO usable | **~6 usable seeds** — tunaos #1496/#1351, docs #204/#158/#157, protota #193 (verified 08-14) | label search |
+| External capacity | shimonenator (agent, misattributed) | **None** — retraction confirmed; no human contributor exists | #1317, ROADMAP |
+| Release parity (#1254) | gnome daily to 08-11; others 30–37d stale | gnome daily through 08-13; kde/xfce/niri/cosmic/gnome50 stale 40d (since 07-05), gnome-nvidia 33d (since 07-12) | Releases API |
+| NVIDIA (#1383) | overlay builds regressed 08-12 | **Worse** — initramfs regression #1499 (5 variants, 10/10 nightlies red); fixes #1503/#1523 in flight | #1499 |
+| Q4 milestone fidelity (#1307) | 7/9 trackers unattached | ✅ **Fixed** — all trackers attached (verified 08-13); milestone #3 = 10 open / 1 closed | #1307, milestone |
+| Docs adoption surface | 3 P0s open | ✅ **Recovered** — #103 pagination, #115 flatpak deploy, #135 404 links all closed 08-13 | docs issues |
+| wootc planning (#1358) | no ROADMAP/LICENSE | ROADMAP (wootc#116) + LICENSE-GPL-2.0/LICENSE-MIT landed; **CONTRIBUTING still missing** | wootc tree |
 
 ## Purpose
 
@@ -21,48 +35,56 @@ Make Q3 carryover an explicit decision, not a discovery. For every open Q3 goal,
 | **DESCOPE → Q4** | Explicitly moved to Q4 milestone with named owner | Q3 closes clean; Q4 load acknowledged |
 | **DROP** | Goal no longer pursued; close issue | Removes noise; revisit at Q5 planning |
 
-## Decision inputs (T-10 refresh, 2026-08-12)
+## Decision inputs (T-8 refresh, 2026-08-14)
 
-### Original four Q3 goals — status change since 08-11
+### Original four Q3 goals — status change since 08-12
 
-| Goal | Issue | Owner | Staff test (first PR by 09-01) | Status 08-12 |
+| Goal | Issue | Owner | Staff test (first PR by 09-01) | Status 08-14 |
 |------|-------|-------|--------------------------------|--------------|
-| Bonito (Fedora 44) GA | #272 | ci-maintainer | T2 bootc profile PR #1256 merged + Beta→Stable exit per VARIANT-LIFECYCLE.md | 🔴 zero movement; #1256 still draft |
-| Redfin (RHEL 10) alpha | #1123 | ci-maintainer | EL10/OBS package-gap work (#777, shimonenator docs) starts landing packages | 🔴 zero movement |
-| RFC lifecycle governance | #1093 | strategist | RFC merge policy doc merged; 11 unmerged branches triaged | 🟢 RFC-PROCESS.md merged 08-11 (#1352); branch disposition pass due 08-22 (#1363) |
-| ADR coverage | #1094 | strategist | 2 new ADRs merged (e.g., RFC-010 Grouper, image factory completion gate) | 🟢 ADR 0003 + ADR 0004 PRs open (#1369/#1370) — merge by 09-01 |
+| Bonito (Fedora 44) GA | #272 | ci-maintainer | T2 bootc profile PR #1256 merged + Beta→Stable exit per VARIANT-LIFECYCLE.md | 🔴 zero movement since 07-19; #1256 still draft (T-8); Fedora 44 superseded by #1171 |
+| Redfin (RHEL 10) alpha | #1123 | ci-maintainer | EL10/OBS package-gap work (#777) starts landing packages | 🔴 zero movement; external-capacity framing void post-retraction (#1317) |
+| RFC lifecycle governance | #1093 | strategist | RFC merge policy doc merged; 11 unmerged branches triaged | 🟢 RFC-PROCESS.md merged 08-11 (#1352); **branch disposition pass is due at this checkpoint** (#1363) |
+| ADR coverage | #1094 | strategist | 2 new ADRs merged (e.g., RFC-010 Grouper, image factory completion gate) | ✅ **staff test met** — ADR 0003 (#1369) + ADR 0004 (#1370) merged 08-13 |
 
 ### New directives added since checkpoint scheduling (must also be framed)
 
 | Directive | Issue | Status | Decision needed |
 |-----------|-------|--------|-----------------|
-| Flavor equality | #1315 / #1316 | Catalog parity gate merged 08-11 (#1322, closes #1281); scheduled cadence parity pending (#1254) | STAFF cadence parity in Q3, or descope to Q4 with owner |
-| Package sourcing | #1319 / #1323 | PACKAGE-SOURCING.md merged (#1330); DNF/COPR audit landed 08-13 — found the niri desktop depends on 6 distinct unsanctioned COPRs (largest single gap: `yalter/niri-git` ships niri itself), plus a Q2 "COPR eliminated" regression (`ublue-os/packages` still feeds krunner-bazaar). apt/AUR/OBS bases (marlin/flounder/sailfin/guppy) not yet audited | STAFF — allowlist sign-off + migration plan for the niri COPR cluster at the 08-22 checkpoint |
+| Flavor equality | #1315 / #1316 | Catalog parity gate merged 08-11 (#1322, closes #1281); scheduled cadence parity still pending (#1254) — gnome-only releases through 08-13 | STAFF cadence parity in Q3, or descope to Q4 with owner |
+| Package sourcing | #1319 / #1323 | PACKAGE-SOURCING.md merged (#1330); DNF/COPR audit landed 08-13 — niri desktop depends on 6 unsanctioned COPRs (`yalter/niri-git` ships niri itself); Q2 "COPR eliminated" regression (`ublue-os/packages` → krunner-bazaar). apt/AUR/OBS bases (marlin/flounder/sailfin/guppy) not yet audited | STAFF — allowlist sign-off + migration plan for the niri COPR cluster at this checkpoint |
 
 ### Supporting items for the checkpoint
 
-- **Adoption call (#1367)**: before using Q4 “Mature” language, publish the
-  [warm-channel adoption call](docs/ADOPTION-CALL.md) in a Show-and-tell
-  Discussion and record the link here. Count only consent-confirmed named
-  entries as public adoption evidence; downloads, stars, pulls, CI, and
-  anonymous reports do not populate `ADOPTERS.md` Production Users.
-- **Contributor retention → capacity**: shimonenator is ACTIVE (8 commits 08-10/11 across tunaOS + xfce-linux; last 08-11 20:26Z). 14-day window closes ~08-24 — 2 days AFTER this checkpoint. Recommend converting retention into capacity: seed GFI-scoped Bonito/Redfin packaging subtasks for the contributor **at** the checkpoint, so #272/#1123 staff tests can borrow external capacity instead of maintainer-only time.
-- **GFI pool is ZERO usable (#1362)**: the #1308 seeds never landed (letters#8 is on an archived repo); CONTRIBUTING's good-first-issue link is dead. No seeds → no external capacity → the retention-window opportunity above is moot. Seed 20+ GFIs by 09-15 (#1362; outreach #1354 tracks 3→8).
-- **Q4 dependency risk**: Q4 is 0/13 items closed (was 0/9); Bonito GA and Redfin GA already appear as Q4 rows — every Q3 descope adds Q4 load before Q4 starts. #1159/#1307 track Q4 goal fidelity.
-- **Release parity**: GNOME releases are now daily (08-09 → 08-11, 3 assets each). kde/xfce/niri/gnome-nvidia still stale 30–37 days (#1254). Browser-catalog parity gate (#1322) fixed the on-demand path; the scheduled GitHub Releases pipeline remains GNOME-only.
-- **New planning debt (mid-cycle)**: wootc ROADMAP merged (wootc#116) but CONTRIBUTING/LICENSE still missing (#1358); gtk-office-suite planning gap open (#1359); tromso stable release untracked (no releases, no milestones — core build tooling; filed as new tracker this cycle).
-- **Enterprise posture**: ADOPTERS.md empty vs Q4 "Mature" claim (#1348); RHEL10/AlmaLinux topics on repo but Redfin alpha dropped (#1123); branch protection unverified (#1167).
+- **Release reliability is the top new risk since T-10**: 08-13 nightly failed across the variant matrix (Yellowfin, Bonito…); NVIDIA initramfs regression #1499 has 5 variants on 10/10 red nightlies (fixes #1503/#1523 in flight); Asahi manifest gate red nightly (#1411); live-overlay artifacts red for guppy/grouper/bonito-rawhide (#1397). Every one of these blocks the flavor-equality mandate (#1316) and the parity decision above.
+- **GFI pool improved but below target**: ~6 usable seeds verified 08-14 (tunaos #1496/#1351, docs #204/#158/#157, protota #193) vs ZERO at 08-12 — but the 09-15 seeding deadline for Hacktoberfest (10-01) needs 15–20 (#1362, #1347). CONTRIBUTING's good-first-issue link fixed; the meta-tracker #1308 itself carries the label and is not a task.
+- **No external capacity — Q3 staff tests are maintainer-only**: post-retraction (#1317) the only human is hanthor. #272 and #1123 staff tests have no borrowed-capacity path; **DESCOPE is the realistic outcome for both unless concrete PRs land by 08-22**.
+- **Q4 dependency risk**: Q4 milestone #3 = 10 open / 1 closed; trackers now attached (fidelity fixed, #1307). Bonito GA and Redfin GA already appear as Q4 rows — every Q3 descope adds Q4 load before Q4 starts. Q4 also carries adoption metrics snapshot (#1174, first 11-01), governance (#1168), branch protection (#1167), Fedora 45 planning (#1171).
+- **Release parity**: GNOME daily through 08-13 (gnome-20260813). kde/xfce/niri/cosmic/gnome50 stale **40 days** (since 07-05); gnome-nvidia stale 33 days (since 07-12). Browser-catalog parity gate (#1322) fixed the on-demand path; scheduled GitHub Releases pipeline remains GNOME-only.
+- **Planning debt (mid-cycle)**: wootc ROADMAP + LICENSE landed but CONTRIBUTING missing (#1358); gtk-office-suite planning gap open (#1359); tromso stable release untracked — zero releases, zero milestones (#1371).
+- **Enterprise posture**: ADOPTERS.md empty vs Q4 "Mature" claim (#1348); Redfin alpha dropped from Q3 (#1123); branch protection unverified (#1167).
+- **Docs adoption surface recovered**: all three docs P0s closed 08-13 (#103 pagination, #115 flatpak deploy, #135 404 links) — next step is Cloudflare Web Analytics instrumentation per ADOPTION-METRICS.md (#1174).
 
 ## Strategist recommendation (input — decision authority stays with maintainer)
 
 | Goal | Recommended | Rationale |
 |------|-------------|-----------|
-| #272 Bonito GA | **DESCOPE → Q4** unless #1256 exits draft by 08-22 | Zero movement since 07-19; T2 profile in draft; Fedora 44 is now superseded by Fedora 45 planning (#1171) — carryover should be explicit, not silent |
-| #1123 Redfin alpha | **STAFF with external capacity** or **DESCOPE → Q4** | Enterprise flagship; seed EL10 package-gap GFIs for shimonenator before window closes 08-24; if no seeds, descope with named owner |
-| #1093 RFC governance | **STAFF** | Policy merged (#1352); finish branch disposition pass by 08-22 (#1363) |
-| #1094 ADR coverage | **STAFF** | Merge ADR 0003/0004 (#1369/#1370) by 09-01; RFC backlog governance (#1093) is the long pole |
-| #1316 Flavor equality | **STAFF cadence parity** | Catalog parity done (#1322); scheduled Releases parity (#1254) is the remaining deliverable |
-| #1323 Package sourcing | **STAFF** | Draft exists (#1330); merge + allowlist by 08-22 keeps the 08-22 audit on schedule |
+| #272 Bonito GA | **DESCOPE → Q4** unless #1256 exits draft by 08-22 | Zero movement since 07-19; T2 profile still draft; Fedora 44 superseded by Fedora 45 planning (#1171); no external capacity |
+| #1123 Redfin alpha | **DESCOPE → Q4** with named owner | Enterprise flagship, but external-capacity framing is void (#1317) and no package-gap PRs have landed; descope explicitly rather than silently |
+| #1093 RFC governance | **STAFF (close-out)** | Policy merged (#1352); finish the 11-branch disposition pass **at** this checkpoint (#1363); then close the goal |
+| #1094 ADR coverage | ✅ **Met — close out** | ADR 0003 + ADR 0004 merged 08-13; mark completed at checkpoint |
+| #1316 Flavor equality | **STAFF cadence parity** | Catalog parity done (#1322); scheduled Releases parity (#1254) is the remaining deliverable — but blocked by #1499 NVIDIA + nightly matrix failures |
+| #1323 Package sourcing | **STAFF** | Draft exists (#1330); merge + allowlist by 08-22 keeps the audit on schedule |
+
+## Decision calendar
+
+| Date | Event | Owner |
+|------|-------|-------|
+| 2026-08-22 | **Checkpoint decision sheet filled** (table below) | maintainer (strategist prepares) |
+| 2026-08-24 | shimonenator 14-day window closes (moot — retracted) | — |
+| 2026-09-01 | Staff-test deadline: first PR for any STAFF goal | goal owners |
+| 2026-09-15 | Hacktoberfest GFI seeding deadline (15–20 seeds) | outreach + strategist (#1362/#1347) |
+| 2026-09-30 | Q3 milestone closes | all |
+| 2026-10-01 | Hacktoberfest 2026 opens | all |
 
 ## Decision record (fill at 2026-08-22)
 
@@ -78,16 +100,6 @@ Make Q3 carryover an explicit decision, not a discovery. For every open Q3 goal,
 ## Outcome recording
 
 After the checkpoint, update the ROADMAP.md Q3 status table (per #1299 step 3) so carryover is a decision, not a discovery.
-
-### Adoption-call record
-
-| Discussion URL | Responses | Confirmed named entries | Anonymous reports | ADOPTERS.md PRs |
-|---|---:|---:|---:|---:|
-| `[DISCUSSION_URL]` | [N] | [N] | [N] | [#PRs] |
-
-Replace the placeholder only after the maintainer publishes the Discussion.
-Keep the counts separate and do not promote the Q4 “Mature” claim from this
-call unless the evidence target is met.
 
 ---
 *Prepared by strategist agent (ACMM L6 — full mode). Signed-off-by: hanthor-hive-agent[bot] <290068839+hanthor-hive-agent[bot]@users.noreply.github.com>*

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![License](https://img.shields.io/github/license/tuna-os/tunaOS?style=for-the-badge)](https://github.com/tuna-os/tunaOS/blob/main/LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/tuna-os/tunaOS?style=for-the-badge)](https://github.com/tuna-os/tunaOS/stargazers)
 [![Issues](https://img.shields.io/github/issues/tuna-os/tunaOS?style=for-the-badge)](https://github.com/tuna-os/tunaOS/issues)
-[![Adopters](https://img.shields.io/badge/adopters-15_entries-2ea44f?style=for-the-badge)](ADOPTERS.md)
+[![Adoption evidence](https://img.shields.io/badge/adoption-0_production%2C_2_evaluation-2ea44f?style=for-the-badge)](ADOPTERS.md)
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/MXSTqB8Nv)
 
 </div>

--- a/docs/ADOPTION-CALL.md
+++ b/docs/ADOPTION-CALL.md
@@ -1,0 +1,103 @@
+# Adoption call: who is running TunaOS?
+
+**Status**: ready for maintainer publication
+**Tracking**: [tunaOS#1367](https://github.com/tuna-os/tunaos/issues/1367)
+
+This is a warm-channel call for organizations and teams already running or
+evaluating TunaOS. It supports the Q4 “Mature” evidence review without
+inventing adopters or treating a download as proof of production use.
+
+## Where and when to publish
+
+Publish as a GitHub Discussion in the **Show-and-tell** category, then share
+the Discussion link in the TunaOS Matrix room and the next community or
+release post. Use existing community relationships and public channels only;
+do not cold-DM people or claim that a named organization uses TunaOS without
+their permission.
+
+The call should run for at least two weeks before the Q4 checkpoint. Keep it
+open afterward so new adopters have a stable path to self-identify. The
+Discussion is the source of truth for responses; comments and Matrix replies
+should link back to it.
+
+## Discussion title and body
+
+Use this copy, replacing the date and links before publishing:
+
+```markdown
+# Who's running TunaOS? Add yourself to ADOPTERS.md
+
+Are you or your organization running TunaOS in production, development, or
+evaluation? We are collecting voluntary, public adopter reports before the Q4
+“Mature” checkpoint.
+
+If you would like to be listed, reply with this template:
+
+Organization or public name:
+Use case (production, development, or evaluation):
+Variant(s) and desktop(s):
+Since (YYYY-MM):
+Public link (optional):
+What is working well or what should we improve? (optional):
+
+Please share only information you are authorized to publish. A maintainer will
+confirm the wording with you before opening a small follow-up PR to
+[ADOPTERS.md](https://github.com/tuna-os/tunaos/blob/main/ADOPTERS.md). You can
+also open that PR yourself. We will not add a person or organization from a
+private message, telemetry, registry pull, or an unverified claim.
+
+If you prefer not to be named, a maintainer can record an anonymous count in
+the monthly adoption snapshot; anonymous use will not be presented as a named
+Production User.
+```
+
+## Matrix and release-note CTA
+
+Use a short pointer in Matrix `#tunaos:reilly.asia` or a release/community
+post:
+
+> Are you already running or evaluating TunaOS? Tell us what you use and
+> whether we may list it publicly in [the “Who’s running TunaOS?” Discussion]
+> ([DISCUSSION_URL]). We will confirm the wording with you before updating
+> [ADOPTERS.md](https://github.com/tuna-os/tunaos/blob/main/ADOPTERS.md).
+
+The Q3 checkpoint recap or release notes should use the same CTA and link to
+the Discussion. Do not duplicate a response template in several posts, since
+that fragments the record.
+
+## Consent and verification rules
+
+1. A maintainer acknowledges each response and asks the respondent to confirm
+   the exact public name, category, variants, and start month.
+2. A named Production User requires explicit confirmation from an authorized
+   representative. A GitHub username alone is not evidence of organizational
+   production use.
+3. Development and evaluation reports are welcome and should stay in those
+   sections unless the respondent later confirms production use.
+4. Never infer an adopter from downloads, stars, container pulls, CI jobs, or
+   an organization appearing in the ecosystem table.
+5. If a respondent withdraws consent, remove or amend the entry in a follow-up
+   PR and note the change in the next snapshot without retaining private
+   details.
+
+## Follow-up workflow
+
+- [ ] Create the Discussion in **Show-and-tell** and record its URL in issue
+      #1367.
+- [ ] Share the URL in Matrix and the next community/release post.
+- [ ] Acknowledge responses and request confirmation of the proposed wording.
+- [ ] Open one small PR per confirmed adopter, linking the Discussion comment
+      and issue #1367; do not bundle unconfirmed entries.
+- [ ] Record response count, confirmed named entries, anonymous responses, and
+      conversion to ADOPTERS.md in the next monthly adoption snapshot.
+- [ ] Refresh the Q4 “Mature” claim only after comparing the evidence against
+      the documented target; otherwise state the gap and re-baseline it.
+
+## Tracking record
+
+| Date | Channel / Discussion URL | Responses | Confirmed named entries | Anonymous reports | ADOPTERS.md PRs | Notes |
+|---|---|---:|---:|---:|---:|---|
+| [YYYY-MM-DD] | [URL] | [N] | [N] | [N] | [#PRs] | [follow-up] |
+
+The count measures participation in the call, not adoption itself. Keep named
+entries and anonymous responses separate in every report.

--- a/docs/ADOPTION-OUTREACH-STATUS.md
+++ b/docs/ADOPTION-OUTREACH-STATUS.md
@@ -1,6 +1,6 @@
 # Adoption outreach status
 
-**As of:** 2026-08-14  
+**As of:** 2026-08-14
 **Owner:** strategist, with maintainer approval for external contact
 
 This is an evidence ledger, not a prospect list. It deliberately separates

--- a/docs/ADOPTION-OUTREACH-STATUS.md
+++ b/docs/ADOPTION-OUTREACH-STATUS.md
@@ -1,0 +1,25 @@
+# Adoption outreach status
+
+**As of:** 2026-08-14  
+**Owner:** strategist, with maintainer approval for external contact
+
+This is an evidence ledger, not a prospect list. It deliberately separates
+prepared material from outreach that was actually sent. No organization is
+listed as a TunaOS adopter without consent-confirmed public evidence in
+[ADOPTERS.md](../ADOPTERS.md).
+
+| Channel | Prepared material | Sent? | Evidence / next action |
+|---|---|---|---|
+| DistroWatch | [Submission draft](DISTROWATCH-SUBMISSION.md), tracked by [#1333](https://github.com/tuna-os/tunaOS/issues/1333) | No — draft only | Maintainer review and submission date are still required; record the submission URL and first referral snapshot here. |
+| CNCF / bootc showcase | [FOSDEM/CNCF section](CFP-FOSDEM-2027.md), tracked by [#1340](https://github.com/tuna-os/tunaOS/issues/1340) | No — pitch explicitly not sent | A maintainer must approve the recipient/channel, send the pitch, and record the public thread or response. A bootc dependency is not an adoption reference. |
+| Public adopter call | [Consent workflow](ADOPTION-CALL.md), tracked by [#1367](https://github.com/tuna-os/tunaOS/issues/1367) | No Discussion URL yet | Create the Show-and-tell Discussion, then record response and consent-confirmed-entry counts in the call and monthly snapshot. |
+
+## Update rules
+
+- Replace **No** only with a date and a durable public evidence link.
+- Record no-response and declined outreach without converting it into an
+  adopter count.
+- Keep production, development/evaluation, and anonymous reports as separate
+  measures.
+- Do not use stars, downloads, image pulls, CI jobs, or ecosystem rows as
+  evidence of organizational adoption.

--- a/docs/MATRIX-WEEKLY-DIGEST.md
+++ b/docs/MATRIX-WEEKLY-DIGEST.md
@@ -29,6 +29,9 @@
 - New good-first-issue tasks: [#NNNN](https://github.com/tuna-os/tunaOS/issues/NNNN) — _one-line scope_
 - Discussion thread worth reading: [title](link) — _one-line why_
 - New contributor shout-out (if any): @handle merged _x_ PR(s)
+- Adoption call (once published): [Who's running TunaOS?](DISCUSSION_URL) —
+  _voluntary, consent-confirmed reports for ADOPTERS.md; do not infer use from
+  downloads or image pulls_
 
 ### 🔗 Links
 
@@ -46,7 +49,8 @@
 - **Ad hoc** only for: variant launches, conference talks, Hacktoberfest
   start, release-week events (e.g., GNOME 51, Fedora 45)
 - Always end with one **call to action** (try the ISO, pick up a GFI,
-  join office hours) — a digest without an ask does not grow the room
+  join office hours, or self-identify through the [adoption call](ADOPTION-CALL.md))
+  — a digest without an ask does not grow the room
 
 ## First post candidates
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,6 @@ user-facing site:
 | [ci-troubleshooting.md](ci-troubleshooting.md) | Diagnosing and fixing common CI failures |
 | [mkosi-investigation.md](mkosi-investigation.md) | Notes from the mkosi-based image build investigation |
 | [PIPELINE.md](PIPELINE.md) | Build pipeline reference: stages, workflows, artifact flow |
-| [BRANCH-PROTECTION.md](BRANCH-PROTECTION.md) | Current-state audit + proposal for main-branch protection & required CI (#1167) |
 | [CI_SPEC.md](CI_SPEC.md) | CI behavior specification |
 | [TESTING.md](TESTING.md) | ISO end-to-end test harness |
 | [MATRIX-STATUS.md](MATRIX-STATUS.md) | Which variant×desktop combinations are actually verified — and which have never been tested |
@@ -38,14 +37,9 @@ user-facing site:
 | [SCREENSHOTS.md](SCREENSHOTS.md) | TunaOS screenshot gallery |
 | [IMAGE-FACTORY-GATE.md](IMAGE-FACTORY-GATE.md) | Image factory completion gate & definition of done (#1283) |
 | [IMAGE-FACTORY-LIFECYCLE-GATE.md](IMAGE-FACTORY-LIFECYCLE-GATE.md) | Image factory lifecycle coverage & required gate (#1278) |
-| [../VARIANT-LIFECYCLE.md](../VARIANT-LIFECYCLE.md) | Variant/flavor admission, capacity, promotion, and deprecation policy (#1196, #1175) |
 | [CFP-FOSDEM-2027.md](CFP-FOSDEM-2027.md) | FOSDEM 2027 CFP draft |
 | [DISTROWATCH-SUBMISSION.md](DISTROWATCH-SUBMISSION.md) | DistroWatch project submission draft |
-| [REDDIT-LEMMY-PLAYBOOK.md](REDDIT-LEMMY-PLAYBOOK.md) | Release-announcement playbook for Reddit / Lemmy |
-| [FEDORA-MAGAZINE-PITCH.md](FEDORA-MAGAZINE-PITCH.md) | Guest-post pitch draft for Fedora Magazine |
-| [ELEMENTARY-CROSSPOST.md](ELEMENTARY-CROSSPOST.md) | Gurnard cross-post draft for the elementary OS community |
-| [MATRIX-WEEKLY-DIGEST.md](MATRIX-WEEKLY-DIGEST.md) | Matrix weekly-digest post template |
-| [HACKTOBERFEST-2026.md](HACKTOBERFEST-2026.md) | Hacktoberfest 2026 contributor runbook |
+| [ADOPTION-CALL.md](ADOPTION-CALL.md) | Warm-channel call and consent workflow for public TunaOS adopter reports |
 | [IMPROVEMENT_PLAN.md](IMPROVEMENT_PLAN.md) | Historical record of the May 2026 sprint + remaining roadmap items |
 | [agents/](agents/) | Hive agent guides (issue-tracker, triage-labels, domain) |
 | [adr/](adr/) | Architecture Decision Records |

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ user-facing site:
 | [../VARIANT-LIFECYCLE.md](../VARIANT-LIFECYCLE.md) | Variant/flavor admission, capacity, promotion, and deprecation policy (#1196, #1175) |
 | [CFP-FOSDEM-2027.md](CFP-FOSDEM-2027.md) | FOSDEM 2027 CFP draft |
 | [DISTROWATCH-SUBMISSION.md](DISTROWATCH-SUBMISSION.md) | DistroWatch project submission draft |
+| [ADOPTION-OUTREACH-STATUS.md](ADOPTION-OUTREACH-STATUS.md) | Evidence ledger for DistroWatch, CNCF, and adopter outreach |
 | [REDDIT-LEMMY-PLAYBOOK.md](REDDIT-LEMMY-PLAYBOOK.md) | Release-announcement playbook for Reddit / Lemmy |
 | [FEDORA-MAGAZINE-PITCH.md](FEDORA-MAGAZINE-PITCH.md) | Guest-post pitch draft for Fedora Magazine |
 | [ELEMENTARY-CROSSPOST.md](ELEMENTARY-CROSSPOST.md) | Gurnard cross-post draft for the elementary OS community |

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ user-facing site:
 | [ci-troubleshooting.md](ci-troubleshooting.md) | Diagnosing and fixing common CI failures |
 | [mkosi-investigation.md](mkosi-investigation.md) | Notes from the mkosi-based image build investigation |
 | [PIPELINE.md](PIPELINE.md) | Build pipeline reference: stages, workflows, artifact flow |
+| [BRANCH-PROTECTION.md](BRANCH-PROTECTION.md) | Current-state audit + proposal for main-branch protection & required CI (#1167) |
 | [CI_SPEC.md](CI_SPEC.md) | CI behavior specification |
 | [TESTING.md](TESTING.md) | ISO end-to-end test harness |
 | [MATRIX-STATUS.md](MATRIX-STATUS.md) | Which variant×desktop combinations are actually verified — and which have never been tested |
@@ -37,9 +38,14 @@ user-facing site:
 | [SCREENSHOTS.md](SCREENSHOTS.md) | TunaOS screenshot gallery |
 | [IMAGE-FACTORY-GATE.md](IMAGE-FACTORY-GATE.md) | Image factory completion gate & definition of done (#1283) |
 | [IMAGE-FACTORY-LIFECYCLE-GATE.md](IMAGE-FACTORY-LIFECYCLE-GATE.md) | Image factory lifecycle coverage & required gate (#1278) |
+| [../VARIANT-LIFECYCLE.md](../VARIANT-LIFECYCLE.md) | Variant/flavor admission, capacity, promotion, and deprecation policy (#1196, #1175) |
 | [CFP-FOSDEM-2027.md](CFP-FOSDEM-2027.md) | FOSDEM 2027 CFP draft |
 | [DISTROWATCH-SUBMISSION.md](DISTROWATCH-SUBMISSION.md) | DistroWatch project submission draft |
-| [ADOPTION-CALL.md](ADOPTION-CALL.md) | Warm-channel call and consent workflow for public TunaOS adopter reports |
+| [REDDIT-LEMMY-PLAYBOOK.md](REDDIT-LEMMY-PLAYBOOK.md) | Release-announcement playbook for Reddit / Lemmy |
+| [FEDORA-MAGAZINE-PITCH.md](FEDORA-MAGAZINE-PITCH.md) | Guest-post pitch draft for Fedora Magazine |
+| [ELEMENTARY-CROSSPOST.md](ELEMENTARY-CROSSPOST.md) | Gurnard cross-post draft for the elementary OS community |
+| [MATRIX-WEEKLY-DIGEST.md](MATRIX-WEEKLY-DIGEST.md) | Matrix weekly-digest post template |
+| [HACKTOBERFEST-2026.md](HACKTOBERFEST-2026.md) | Hacktoberfest 2026 contributor runbook |
 | [IMPROVEMENT_PLAN.md](IMPROVEMENT_PLAN.md) | Historical record of the May 2026 sprint + remaining roadmap items |
 | [agents/](agents/) | Hive agent guides (issue-tracker, triage-labels, domain) |
 | [adr/](adr/) | Architecture Decision Records |


### PR DESCRIPTION
## Summary

- document the 2026-08-14 evidence baseline: 0 named production adopters and 2 named development/evaluation entries
- replace the misleading README adopter-count badge with the production/evaluation evidence counts
- add an outreach evidence ledger covering DistroWatch, CNCF/bootc, and the public adopter call
- track adoption-call conversion in the adoption metrics and link the ledger from the docs index
- make the consent and evidence rules explicit so ecosystem relationships and draft outreach are not presented as adoption

Closes #1348

## Verification

- `git diff --check`
