### PR TITLE
ci: gate installer smoke on GPU capability

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -38,7 +38,29 @@ permissions:
   packages: read
 
 jobs:
+  # Hosted Ubuntu runners do not expose a DRM render node.  The Smithay
+  # frontends (KDE, COSMIC, Niri and XFCE) need EGL_EXT_device_drm, so
+  # launching those legs on plain virtio only produces the misleading
+  # "process is alive, no readiness stamp" failure.  Detect the capability
+  # before expanding the matrix and keep the weekly hosted run honest.
+  host-capabilities:
+    runs-on: ubuntu-latest
+    outputs:
+      gpu_available: ${{ steps.detect.outputs.gpu_available }}
+    steps:
+      - id: detect
+        run: |
+          if [[ -e /dev/dri/renderD128 ]]; then
+            echo "gpu_available=true" >> "$GITHUB_OUTPUT"
+            echo "DRM render node detected; GPU-dependent installer legs enabled"
+          else
+            echo "gpu_available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No DRM render node; GPU-dependent installer legs will be omitted"
+            echo "Explicit manual flavor selections remain available for targeted diagnosis."
+          fi
+
   generate-matrix:
+    needs: host-capabilities
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
@@ -56,6 +78,7 @@ jobs:
         env:
           FILTER_VARIANT: ${{ inputs.variant || '' }}
           FILTER_FLAVORS: ${{ inputs.flavors || '' }}
+          GPU_AVAILABLE: ${{ needs.host-capabilities.outputs.gpu_available }}
         run: |
           set -euo pipefail
           json="$(yq -o=json '.' .github/build-config.yml)"
@@ -71,6 +94,16 @@ jobs:
                  | select(.build_iso == true)
                  | select((.platforms // $variant.platforms // []) | index("linux/amd64"))
                  | {variant: $v, flavor: .id} ]}')
+          fi
+
+          # A plain hosted runner cannot provide the EGL/DRM surface required
+          # by the four non-GNOME frontends.  Keep GNOME as a useful weekly
+          # smoke signal, and reserve the other legs for a GPU-capable manual
+          # run instead of reporting a deterministic infrastructure failure
+          # as an installer regression.
+          if [[ "$GPU_AVAILABLE" != "true" && -z "$FILTER_FLAVORS" ]]; then
+            echo "::notice::Filtering GPU-dependent installer flavors (no DRM render node)"
+            M=$(echo "$M" | jq -c '{include: [.include[] | select(.flavor == "gnome")]}' )
           fi
           echo "matrix=$M" >> "$GITHUB_OUTPUT"
           echo "$M" | jq .

--- a/tests/bats/test_live_installer_launch.bats
+++ b/tests/bats/test_live_installer_launch.bats
@@ -95,6 +95,14 @@ launcher_app() {
   grep -Fq 'grep -Fx' "$WORKFLOW"
 }
 
+@test "installer smoke gates GPU-dependent flavors on runner capability" {
+  [ -f "$WORKFLOW" ]
+  grep -Fq 'host-capabilities:' "$WORKFLOW"
+  grep -Fq 'gpu_available' "$WORKFLOW"
+  grep -Fq 'No DRM render node' "$WORKFLOW"
+  grep -Fq 'select(.flavor == "gnome")' "$WORKFLOW"
+}
+
 
 @test "installer recipe backend does not need an executable source mount" {
   # Tacklebox bind-mounts live-customize read-only. Git may retain this helper


### PR DESCRIPTION
## Summary

- detect whether the runner exposes the DRM render node required by EGL-dependent desktop frontends
- keep GNOME coverage in automatic hosted runs while filtering deterministic GPU-dependent failures from the generated matrix
- preserve explicit manual flavor selections for targeted diagnosis
- add a regression assertion for the capability gate

## Root cause

The installer smoke harness falls back to plain `-vga virtio` when `/dev/dri/renderD128` is unavailable. KDE, COSMIC, Niri, and XFCE require `EGL_EXT_device_drm`; they can remain alive without producing a readiness stamp, yielding the issue's misleading failure.

## Validation

- `git diff --check`
- matrix filter smoke test with `jq`
- focused installer-smoke assertions
- YAML parse was not run because PyYAML is unavailable in the checkout environment

Closes #1396