### PR TITLE
docs(outreach): add Fedora 45 Beta testing call for Bonito variant (#1609)

### DIFF
--- a/docs/FEDORA45-TESTING-CALL.md
+++ b/docs/FEDORA45-TESTING-CALL.md
@@ -1,0 +1,68 @@
+# Bonito (Fedora-based) Fedora 45 Beta Testing Call & Community Guide
+
+**Target Audience**: Fedora Atomic / bootc Community, r/Fedora, r/FedoraAtomic, Fedora Discourse Testers  
+**Tracks**: [#1609](https://github.com/tuna-os/tunaOS/issues/1609) (Fedora 45 Beta testing call — Bonito variant)  
+**Supports**: [#1137](https://github.com/tuna-os/tunaOS/issues/1137) (Fedora Magazine Guest Post Pitch) & [#1166](https://github.com/tuna-os/tunaOS/issues/1166) (Q4 Release Calendar)
+
+---
+
+## 🏔️ Background: Bonito on the Fedora Release Cycle
+
+TunaOS's **Bonito** variant brings a container-native, image-mode bootc desktop experience to Fedora users. As the Fedora 45 release cycle advances (Beta ~September 2026, GA October 2026), testing Bonito across diverse hardware architectures and desktop environments gives Fedora testers an immutable desktop trial path while producing real community validation data.
+
+---
+
+## 📋 What to Test (Bonito Test Matrix)
+
+We are calling for community testing across three core Bonito configurations:
+
+| Image / Target | Desktop / Architecture | Key Test Focus |
+|---|---|---|
+| `ghcr.io/tuna-os/bonito:gnome` | GNOME / x86_64, arm64 | Boot, Wayland session, Flatpak preinstall, Extensions |
+| `ghcr.io/tuna-os/bonito:kde` | KDE Plasma / x86_64, arm64 | Wayland login, SDDM/plasmalogin, Dolphin, Konsole |
+| `ghcr.io/tuna-os/bonito:niri` | Niri (Zirconium) / x86_64 | Scrollable tiling compositor, Wayland portals, Greetd |
+
+---
+
+## 🧪 Testing Workflow & Verification Checklist
+
+### 1. Zero-Friction QEMU/KVM VM Trial (20 Minutes)
+Test without touching physical disks:
+```bash
+just vm-run bonito gnome
+```
+Or run directly via QEMU:
+```bash
+qemu-system-x86_64 -m 4096 -smp 4 \
+  -drive file=tunaos-bonito-gnome.qcow2,format=qcow2 \
+  -enable-kvm -cpu host -net nic -net user
+```
+
+### 2. Physical / Bare-Metal Testing (`bootc switch`)
+On an existing Fedora Silverblue / Kinoite / bootc system:
+```bash
+sudo bootc switch ghcr.io/tuna-os/bonito:gnome
+sudo systemctl reboot
+```
+
+### 3. Verification Checklist for Testers
+- [ ] **First Boot**: System reaches graphical login screen (GDM/SDDM/Greetd).
+- [ ] **Desktop Contract**: Desktop session launches smoothly with audio (Pipewire) and portals (`xdg-desktop-portal`).
+- [ ] **Container Image Updates**: Running `sudo bootc update` successfully staging atomic layer updates.
+- [ ] **Atomic Rollback**: Executing `sudo bootc rollback` safely returns to the prior deployment.
+- [ ] **Hardware Acceleration**: GPU rendering active (`glxinfo` / `vulkaninfo` / `nvidia-smi` where applicable).
+
+---
+
+## 📢 Community Engagement & Feedback Channels
+
+- **GitHub Discussion**: Post test logs, hardware specs, and feedback to the [Bonito Fedora 45 Beta Testing Thread](https://github.com/tuna-os/tunaOS/discussions).
+- **Public Community Outlets**: Share testing experiences on `r/Fedora`, `r/FedoraAtomic`, and Fedora Discourse (respecting channel promotion guidelines).
+- **Bug Reporting**: File issue reports tagged `bonito` and `verification-failed` on `tuna-os/tunaOS`.
+
+---
+
+## 🔗 Related Resources
+- [Fedora Magazine Guest Post Pitch](FEDORA-MAGAZINE-PITCH.md)
+- [Variant Selection Decision Guide](choosing-a-variant.md)
+- [ADOPTERS.md Ecosystem & Production Registry](../ADOPTERS.md)

--- a/docs/FEDORA45-TESTING-CALL.md
+++ b/docs/FEDORA45-TESTING-CALL.md
@@ -8,7 +8,36 @@
 
 ## 🏔️ Background: Bonito on the Fedora Release Cycle
 
-TunaOS's **Bonito** variant brings a container-native, image-mode bootc desktop experience to Fedora users. As the Fedora 45 release cycle advances (Beta ~September 2026, GA October 2026), testing Bonito across diverse hardware architectures and desktop environments gives Fedora testers an immutable desktop trial path while producing real community validation data.
+TunaOS's **Bonito** variant brings a container-native, image-mode bootc desktop
+experience to Fedora users.
+
+**Read this before testing: TunaOS does not ship a Fedora 45 image.** Checked
+2026-08-14 against the build config and the upstream base registry:
+
+| what you can install | Fedora stream |
+|---|---|
+| `bonito:<flavor>` | **Fedora 44** — `build-config.yml` pins `quay.io/fedora/fedora-bootc:44` |
+| `bonito:<flavor>-rawhide` | **Rawhide** — which is now Fedora **46** development, since `fedora-bootc` publishes both `45` and `46` |
+
+So neither image is Fedora 45: one is a release behind it, the other a release
+ahead. That is deliberate rather than an oversight —
+[FEDORA-BASE-POLICY.md](FEDORA-BASE-POLICY.md) sequences Fedora 45 base work to
+begin **after** Bonito (Fedora 44) reaches GA
+([#272](https://github.com/tuna-os/tunaOS/issues/272)), specifically so the
+project is not carrying two incomplete Fedora bases at once.
+
+This matters for what the call can honestly ask for. Describing these images as
+"Bonito on Fedora 45" would mislead testers about what they are running, and the
+results feed the Fedora Magazine pitch
+([#1137](https://github.com/tuna-os/tunaOS/issues/1137)) — F44 and Rawhide
+findings labelled as Fedora 45 data is the kind of thing an editor checks.
+
+**What this call actually is**, and is worth doing on its own terms: an
+invitation to Fedora users, who are already testing during the Fedora 45 cycle,
+to try an image-mode bootc desktop built on the Fedora they can run today. Test
+Rawhide if you want to see where the base is heading; test the stable image if
+you want something that should just work. When a Fedora 45 base lands, this
+document gets a fourth row and a re-announcement.
 
 ---
 
@@ -18,9 +47,14 @@ We are calling for community testing across three core Bonito configurations:
 
 | Image / Target | Desktop / Architecture | Key Test Focus |
 |---|---|---|
-| `ghcr.io/tuna-os/bonito:gnome` | GNOME / x86_64, arm64 | Boot, Wayland session, Flatpak preinstall, Extensions |
-| `ghcr.io/tuna-os/bonito:kde` | KDE Plasma / x86_64, arm64 | Wayland login, SDDM/plasmalogin, Dolphin, Konsole |
-| `ghcr.io/tuna-os/bonito:niri` | Niri (Zirconium) / x86_64 | Scrollable tiling compositor, Wayland portals, Greetd |
+| `ghcr.io/tuna-os/bonito:gnome` (F44) | GNOME / x86_64, arm64 | Boot, Wayland session, Flatpak preinstall, Extensions |
+| `ghcr.io/tuna-os/bonito:kde` (F44) | KDE Plasma / x86_64, arm64 | Wayland login, SDDM/plasmalogin, Dolphin, Konsole |
+| `ghcr.io/tuna-os/bonito:niri` (F44) | Niri (Zirconium) / x86_64 | Scrollable tiling compositor, Wayland portals, Greetd |
+| `ghcr.io/tuna-os/bonito:gnome-rawhide` (F46 dev) | GNOME / x86_64, arm64 | The same checks, on the newest base — this is where breakage shows up first |
+
+All four tags verified published in GHCR on 2026-08-14. The Fedora stream is
+stated per row on purpose: a tester who reports "works on Fedora 45" about an
+image that is not Fedora 45 has produced data nobody can use.
 
 ---
 
@@ -29,8 +63,13 @@ We are calling for community testing across three core Bonito configurations:
 ### 1. Zero-Friction QEMU/KVM VM Trial (20 Minutes)
 Test without touching physical disks:
 ```bash
-just vm-run bonito gnome
+# Builds a qcow2 for the flavor and boots it (web console URL is printed).
+scripts/run-vm.sh demo bonito gnome
 ```
+
+> `just vm-run` was in an earlier draft of this guide and is not a recipe in
+> the Justfile — the first command a tester runs has to be one that exists.
+> `just qcow2 bonito gnome` builds the disk image without booting it.
 Or run directly via QEMU:
 ```bash
 qemu-system-x86_64 -m 4096 -smp 4 \

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,8 @@ user-facing site:
 | [DISTROWATCH-SUBMISSION.md](DISTROWATCH-SUBMISSION.md) | DistroWatch project submission draft |
 | [REDDIT-LEMMY-PLAYBOOK.md](REDDIT-LEMMY-PLAYBOOK.md) | Release-announcement playbook for Reddit / Lemmy |
 | [FEDORA-MAGAZINE-PITCH.md](FEDORA-MAGAZINE-PITCH.md) | Guest-post pitch draft for Fedora Magazine |
+| [EDUCATION-PITCH.md](EDUCATION-PITCH.md) | Education & teaching lab adoption brief for CS departments (#1600) |
+| [FEDORA45-TESTING-CALL.md](FEDORA45-TESTING-CALL.md) | Fedora 45 Beta testing call guide for Bonito variant (#1609) |
 | [ELEMENTARY-CROSSPOST.md](ELEMENTARY-CROSSPOST.md) | Gurnard cross-post draft for the elementary OS community |
 | [MATRIX-WEEKLY-DIGEST.md](MATRIX-WEEKLY-DIGEST.md) | Matrix weekly-digest post template |
 | [HACKTOBERFEST-2026.md](HACKTOBERFEST-2026.md) | Hacktoberfest 2026 contributor runbook |

--- a/tests/bats/test_testing_call_claims.bats
+++ b/tests/bats/test_testing_call_claims.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# A testing call names the Fedora stream testers are actually running (#1609).
+#
+# The draft invited Fedora 45 Beta testers to test `bonito:gnome|kde|niri` and
+# report results that feed the Fedora Magazine pitch (#1137). None of those
+# images is Fedora 45:
+#
+#   bonito:<flavor>          → Fedora 44 (build-config pins fedora-bootc:44)
+#   bonito:<flavor>-rawhide  → Rawhide, which is Fedora 46 development now that
+#                              fedora-bootc publishes both 45 and 46
+#
+# One release behind, one ahead. And it is deliberate: FEDORA-BASE-POLICY.md
+# sequences Fedora 45 base work to start only after Bonito (F44) reaches GA
+# (#272). So this is not a missing build — it is outreach promising a base the
+# project has decided not to carry yet, which is the "promotion outruns
+# product" risk #1171 named.
+#
+# The tests assert the doc is HONEST about the stream, not that any particular
+# version is used — the version will change, and a test pinning "44" would be
+# wrong the day the base moves. What must not change is that the reader can
+# tell what they are installing.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+DOC="${REPO_ROOT}/docs/FEDORA45-TESTING-CALL.md"
+CONFIG="${REPO_ROOT}/.github/build-config.yml"
+
+setup() { [ -f "$DOC" ] || skip "testing call not present on this branch"; }
+
+@test "the doc states which Fedora stream each image is" {
+  # The correction that matters: a tester must not think bonito:gnome is F45.
+  run grep -Fi 'does not ship a Fedora 45 image' "$DOC"
+  [ "$status" -eq 0 ]
+}
+
+@test "the image table labels the stream per row" {
+  # Per-row, not one disclaimer at the top — the table is what gets copied into
+  # a forum post.
+  run grep -cE '^\| `ghcr\.io/tuna-os/bonito:[a-z-]+`? \(F[0-9]+' "$DOC"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 3 ]
+}
+
+@test "the stated stable stream matches build-config" {
+  # If someone bumps bonito's base and not this doc, the doc starts lying. Read
+  # the version from the config rather than hardcoding it here.
+  local ver
+  ver="$(awk '/^  - id: bonito$/{f=1} f && /base_image:/{print; exit}' "$CONFIG" | grep -oE 'fedora-bootc:[0-9]+' | cut -d: -f2)"
+  [ -n "$ver" ]
+  run grep -F "Fedora ${ver}" "$DOC"
+  [ "$status" -eq 0 ]
+}
+
+# A phrase blacklist for "bonito is on Fedora 45" was here and has been removed.
+# It failed in both directions: it matched this document's own sentence
+# explaining why that phrasing is wrong, and it missed the original draft, whose
+# claim was never phrased that way — it was implied by inviting Fedora 45 Beta
+# testers to test Bonito with no stream named anywhere. Tests 1-3 assert the
+# positive property instead (the stream is stated per row, and matches
+# build-config), which is what actually protects a reader. Asserting the
+# presence of the truth beats blacklisting one spelling of the falsehood.
+
+@test "every command the guide tells a tester to run exists" {
+  # `just vm-run` was in the draft and is not a recipe. The first command in a
+  # testing guide is the one most likely to be run and least likely to be
+  # checked.
+  local bad=0 r
+  while read -r r; do
+    grep -qE "^${r}( |:)" "${REPO_ROOT}/Justfile" || { echo "NOT A RECIPE: just $r" >&2; bad=$((bad+1)); }
+  done < <(grep -oE '^just [a-z0-9-]+' "$DOC" | awk '{print $2}' | sort -u)
+  [ "$bad" -eq 0 ]
+}
+
+@test "referenced helper scripts exist" {
+  local bad=0 s
+  while read -r s; do
+    [ -f "${REPO_ROOT}/${s}" ] || { echo "MISSING: $s" >&2; bad=$((bad+1)); }
+  done < <(grep -oE 'scripts/[a-z0-9._-]+\.sh' "$DOC" | sort -u)
+  [ "$bad" -eq 0 ]
+}


### PR DESCRIPTION
Fixes #1609.

### Summary
- Authored docs/FEDORA45-TESTING-CALL.md establishing the community testing call and verification guide for the Fedora-based Bonito variant ahead of the Fedora 45 release window (Beta ~Sep, GA Oct 2026).
- Defines explicit test targets across bonito:gnome, bonito:kde, and bonito:niri.
- Outlines evaluation paths via 20-minute QEMU/KVM VM testing and bare-metal bootc switch, complete with a 5-point verification checklist (first boot, desktop session contract, atomic updates, rollback, hardware acceleration).
- Connects community testing data directly into the Fedora Magazine guest post pitch (#1137) and Q4 release calendar (#1166), linking the guide from docs/README.md.