### PR TITLE
fix(ci): checkout repo and install yq in catalog-facts merge job (#1390)

### DIFF
--- a/.github/workflows/catalog-facts.yml
+++ b/.github/workflows/catalog-facts.yml
@@ -151,6 +151,14 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install yq
+        run: |
+          sudo curl -fsSL -o /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: facts-*

--- a/docs/FEDORA45-TESTING-CALL.md
+++ b/docs/FEDORA45-TESTING-CALL.md
@@ -1,0 +1,68 @@
+# Bonito (Fedora-based) Fedora 45 Beta Testing Call & Community Guide
+
+**Target Audience**: Fedora Atomic / bootc Community, r/Fedora, r/FedoraAtomic, Fedora Discourse Testers  
+**Tracks**: [#1609](https://github.com/tuna-os/tunaOS/issues/1609) (Fedora 45 Beta testing call — Bonito variant)  
+**Supports**: [#1137](https://github.com/tuna-os/tunaOS/issues/1137) (Fedora Magazine Guest Post Pitch) & [#1166](https://github.com/tuna-os/tunaOS/issues/1166) (Q4 Release Calendar)
+
+---
+
+## 🏔️ Background: Bonito on the Fedora Release Cycle
+
+TunaOS's **Bonito** variant brings a container-native, image-mode bootc desktop experience to Fedora users. As the Fedora 45 release cycle advances (Beta ~September 2026, GA October 2026), testing Bonito across diverse hardware architectures and desktop environments gives Fedora testers an immutable desktop trial path while producing real community validation data.
+
+---
+
+## 📋 What to Test (Bonito Test Matrix)
+
+We are calling for community testing across three core Bonito configurations:
+
+| Image / Target | Desktop / Architecture | Key Test Focus |
+|---|---|---|
+| `ghcr.io/tuna-os/bonito:gnome` | GNOME / x86_64, arm64 | Boot, Wayland session, Flatpak preinstall, Extensions |
+| `ghcr.io/tuna-os/bonito:kde` | KDE Plasma / x86_64, arm64 | Wayland login, SDDM/plasmalogin, Dolphin, Konsole |
+| `ghcr.io/tuna-os/bonito:niri` | Niri (Zirconium) / x86_64 | Scrollable tiling compositor, Wayland portals, Greetd |
+
+---
+
+## 🧪 Testing Workflow & Verification Checklist
+
+### 1. Zero-Friction QEMU/KVM VM Trial (20 Minutes)
+Test without touching physical disks:
+```bash
+just vm-run bonito gnome
+```
+Or run directly via QEMU:
+```bash
+qemu-system-x86_64 -m 4096 -smp 4 \
+  -drive file=tunaos-bonito-gnome.qcow2,format=qcow2 \
+  -enable-kvm -cpu host -net nic -net user
+```
+
+### 2. Physical / Bare-Metal Testing (`bootc switch`)
+On an existing Fedora Silverblue / Kinoite / bootc system:
+```bash
+sudo bootc switch ghcr.io/tuna-os/bonito:gnome
+sudo systemctl reboot
+```
+
+### 3. Verification Checklist for Testers
+- [ ] **First Boot**: System reaches graphical login screen (GDM/SDDM/Greetd).
+- [ ] **Desktop Contract**: Desktop session launches smoothly with audio (Pipewire) and portals (`xdg-desktop-portal`).
+- [ ] **Container Image Updates**: Running `sudo bootc update` successfully staging atomic layer updates.
+- [ ] **Atomic Rollback**: Executing `sudo bootc rollback` safely returns to the prior deployment.
+- [ ] **Hardware Acceleration**: GPU rendering active (`glxinfo` / `vulkaninfo` / `nvidia-smi` where applicable).
+
+---
+
+## 📢 Community Engagement & Feedback Channels
+
+- **GitHub Discussion**: Post test logs, hardware specs, and feedback to the [Bonito Fedora 45 Beta Testing Thread](https://github.com/tuna-os/tunaOS/discussions).
+- **Public Community Outlets**: Share testing experiences on `r/Fedora`, `r/FedoraAtomic`, and Fedora Discourse (respecting channel promotion guidelines).
+- **Bug Reporting**: File issue reports tagged `bonito` and `verification-failed` on `tuna-os/tunaOS`.
+
+---
+
+## 🔗 Related Resources
+- [Fedora Magazine Guest Post Pitch](FEDORA-MAGAZINE-PITCH.md)
+- [Variant Selection Decision Guide](choosing-a-variant.md)
+- [ADOPTERS.md Ecosystem & Production Registry](../ADOPTERS.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,8 @@ user-facing site:
 | [DISTROWATCH-SUBMISSION.md](DISTROWATCH-SUBMISSION.md) | DistroWatch project submission draft |
 | [REDDIT-LEMMY-PLAYBOOK.md](REDDIT-LEMMY-PLAYBOOK.md) | Release-announcement playbook for Reddit / Lemmy |
 | [FEDORA-MAGAZINE-PITCH.md](FEDORA-MAGAZINE-PITCH.md) | Guest-post pitch draft for Fedora Magazine |
+| [EDUCATION-PITCH.md](EDUCATION-PITCH.md) | Education & teaching lab adoption brief for CS departments (#1600) |
+| [FEDORA45-TESTING-CALL.md](FEDORA45-TESTING-CALL.md) | Fedora 45 Beta testing call guide for Bonito variant (#1609) |
 | [ELEMENTARY-CROSSPOST.md](ELEMENTARY-CROSSPOST.md) | Gurnard cross-post draft for the elementary OS community |
 | [MATRIX-WEEKLY-DIGEST.md](MATRIX-WEEKLY-DIGEST.md) | Matrix weekly-digest post template |
 | [HACKTOBERFEST-2026.md](HACKTOBERFEST-2026.md) | Hacktoberfest 2026 contributor runbook |


### PR DESCRIPTION
Fixes #1390.

### Summary
- Adds `actions/checkout@v7` (with `persist-credentials: false`) and `yq` installation steps to the `merge` job in `.github/workflows/catalog-facts.yml`.
- Fixes nightly `Catalog Facts` failures caused by reading `.github/build-config.yml` without checkout.