### PR TITLE
fix: bootc-lifecycle matrix jq bug + gpgcheck/privacy security fixes + CI fixes

### DIFF
--- a/.github/workflows/bootc-lifecycle.yml
+++ b/.github/workflows/bootc-lifecycle.yml
@@ -62,11 +62,11 @@ jobs:
             '{include: [ .variants[] | . as $variant | .id as $v | .aliases as $aliases
                | .flavors[] | select(.build_image == true) | select(.id != "base") | select(.id | startswith("base-") | not)
                | . as $flavor
-               | ("rawhide" | test($v)) or ("sid" | test($v)) or ($v == "guppy") or (.id | contains("asahi")) or (.id | contains("zfs")) as $is_beta
+               | (("rawhide" | test($v)) or ("sid" | test($v)) or ($v == "guppy") or (.id | contains("asahi")) or (.id | contains("zfs"))) as $is_beta
                | select($is_beta == false)
                | ("amd64", "arm64") as $arch
                | select((.platforms // $variant.platforms // []) | index("linux/" + $arch))
-               | {variant: $v, flavor: .id, arch: $arch, aliases: ($aliases // []), is_beta: false}
+               | {variant: $v, flavor: .id, arch: $arch, aliases: ($aliases // [])}
                | select($fv == "all" or .variant == $fv)
                | select($ff == "all" or .flavor == $ff)
                | select($fa == "all" or .arch == $fa) ]}')"
@@ -76,11 +76,11 @@ jobs:
             '{include: [ .variants[] | . as $variant | .id as $v | .aliases as $aliases
                | .flavors[] | select(.build_image == true) | select(.id != "base") | select(.id | startswith("base-") | not)
                | . as $flavor
-               | ("rawhide" | test($v)) or ("sid" | test($v)) or ($v == "guppy") or (.id | contains("asahi")) or (.id | contains("zfs")) as $is_beta
+               | (("rawhide" | test($v)) or ("sid" | test($v)) or ($v == "guppy") or (.id | contains("asahi")) or (.id | contains("zfs"))) as $is_beta
                | select($is_beta == true)
                | ("amd64", "arm64") as $arch
                | select((.platforms // $variant.platforms // []) | index("linux/" + $arch))
-               | {variant: $v, flavor: .id, arch: $arch, aliases: ($aliases // []), is_beta: true}
+               | {variant: $v, flavor: .id, arch: $arch, aliases: ($aliases // [])}
                | select($fv == "all" or .variant == $fv)
                | select($ff == "all" or .flavor == $ff)
                | select($fa == "all" or .arch == $fa) ]}')"

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -641,7 +641,7 @@ jobs:
             io.artifacthub.package.keywords=bootc,tunaos
             io.artifacthub.package.license=Apache-2.0
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/223733964?s=200&v=4
-            io.artifacthub.package.maintainers=[{\"name\":\"hanthor\",\"email\":\"jreilly1821@gmail.com\"}]
+            io.artifacthub.package.maintainers=[{\"name\":\"${{ vars.MAINTAINER_NAME || github.repository_owner }}\",\"email\":\"${{ vars.MAINTAINER_EMAIL }}\"}]
             io.artifacthub.package.prerelease=true
             containers.bootc=1
 

--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -426,7 +426,16 @@ if [[ "${_TD_OS}" == "el10" || "${_TD_OS}" == "fedora" || "${_TD_OS}" == "hummin
 			echo "name=${_TD_RN}"
 			echo "baseurl=${_TD_RB}"
 			echo "enabled=1"
-			echo "gpgcheck=0"
+			# gpgcheck=1 verifies each RPM against the tuna-os signing key
+			# (every repo.tunaos.org publish pipeline runs `rpmsign --addsign`
+			# before upload — see tuna-os/tunaos-packages#394). repo_gpgcheck
+			# stays 0: repomd.xml isn't detached-signed yet (no repomd.xml.asc
+			# published), so turning that on would hard-fail every dnf
+			# transaction against these repos, not just add a check. Matches
+			# the already-working contrib/install-gnome49.sh pattern rather
+			# than tuna-os/tunaOS#1655's literal ask of both =1.
+			echo "gpgcheck=1"
+			echo "gpgkey=https://repo.tunaos.org/public.gpg"
 			echo "repo_gpgcheck=0"
 			echo "skip_if_unavailable=False"
 			[[ -n "${_TD_RP}" && "${_TD_RP}" != "null" ]] && echo "priority=${_TD_RP}"

--- a/build_scripts/desktop/kcm-ublue.sh
+++ b/build_scripts/desktop/kcm-ublue.sh
@@ -72,9 +72,18 @@ if ((${#missing_deps[@]} > 0)); then
 	printf '::warning title=kcm_ublue skipped (%s)::build deps unavailable in the active repos: %s\n' \
 		"${IMAGE_NAME:-?}" "${missing_deps[*]}"
 	echo "Skipping kcm_ublue source build."
+elif ! dnf_retry -y install "${BUILD_DEPS[@]}"; then
+	# The repoquery probe above only checks that a package NAME resolves in
+	# the active repos — it can't see a broken *dependency* of that package.
+	# tuna-os/tunaOS#1555: cmake existed in the Hummingbird repo index (probe
+	# passed), but its own libjsoncpp.so.26/librhash.so.1 providers didn't,
+	# so this install still failed and — before this branch existed — took
+	# the whole image down under `set -e`. Same "nice to have, not
+	# essential" call as the missing-package case above.
+	printf '::warning title=kcm_ublue skipped (%s)::dnf install of build deps failed despite passing the repoquery probe — an unresolvable transitive dependency in the active repos.\n' \
+		"${IMAGE_NAME:-?}"
+	echo "Skipping kcm_ublue source build."
 else
-	dnf_retry -y install "${BUILD_DEPS[@]}"
-
 	BUILD_DIR=$(mktemp -d)
 	trap 'rm -rf "$BUILD_DIR"' EXIT
 

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -1424,3 +1424,24 @@ STUB
   done
   grep -qE '^d /var/lib/lightdm 0750 lightdm lightdm' "$runtime"
 }
+
+@test "install-desktop.sh signature-verifies manifest-declared yum repos" {
+  # tuna-os/tunaOS#1655: this block used to write gpgcheck=0/repo_gpgcheck=0
+  # unconditionally for every repo the manifest declares (the xfce-wayland,
+  # hummingbird, and fprintd repos), so packages installed on real systems
+  # with no authenticity check at all. Every repo.tunaos.org publish pipeline
+  # signs its RPMs (tuna-os/tunaos-packages#394's `rpmsign --addsign` step),
+  # so gpgcheck=1 + the matching gpgkey= is real protection. repo_gpgcheck
+  # stays 0 on purpose: repomd.xml isn't detached-signed (no repomd.xml.asc
+  # published), so =1 there would hard-fail every dnf transaction rather than
+  # add a check — same tradeoff contrib/install-gnome49.sh already makes in
+  # tunaos-packages.
+  local script="${REPO_ROOT}/build_scripts/desktop/install-desktop.sh"
+  local block
+  block="$(awk '/for \(\(i = 0; i < _TD_REPO_COUNT/,/^\tdone$/' "$script")"
+  [ -n "$block" ]
+  grep -qF 'echo "gpgcheck=1"' <<<"$block"
+  grep -qF 'echo "gpgkey=https://repo.tunaos.org/public.gpg"' <<<"$block"
+  grep -qF 'echo "repo_gpgcheck=0"' <<<"$block"
+  ! grep -qF 'echo "gpgcheck=0"' <<<"$block"
+}

--- a/tests/bats/test_custom_overlay.bats
+++ b/tests/bats/test_custom_overlay.bats
@@ -31,10 +31,13 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
   [ "$status" -eq 0 ]
 }
 
-@test "Justfile contains custom recipes" {
-  # Custom overlay recipes live in just/custom-overlay.just, imported from
-  # the root Justfile (#508 Justfile modularization, PR #1417).
+@test "Justfile imports the custom-overlay recipe module" {
   run grep "^import 'just/custom-overlay.just'" "${REPO_ROOT}/Justfile"
+  [ "$status" -eq 0 ]
+}
+
+@test "just/custom-overlay.just contains custom recipes" {
+  run test -f "${REPO_ROOT}/just/custom-overlay.just"
   [ "$status" -eq 0 ]
   run grep "build-custom" "${REPO_ROOT}/just/custom-overlay.just"
   [ "$status" -eq 0 ]

--- a/tests/bats/test_oci_metadata_no_personal_identity.bats
+++ b/tests/bats/test_oci_metadata_no_personal_identity.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+# tunaOS#1649: the io.artifacthub.package.maintainers OCI label baked into
+# every published image hardcoded a maintainer's personal email
+# (jreilly1821@gmail.com). Unlike a build-time convenience, this is a shipped
+# artifact -- it leaks personal data into every published container's
+# metadata in perpetuity, and cannot be fixed after the fact for images
+# already published. Replaced with vars.MAINTAINER_NAME/vars.MAINTAINER_EMAIL
+# (empty by default) so it can be set centrally without touching the
+# workflow, same pattern this file already uses for vars.IMAGE_REGISTRY.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+
+@test "reusable-build-image.yml does not hardcode a personal email in OCI metadata" {
+  workflow="${REPO_ROOT}/.github/workflows/reusable-build-image.yml"
+  ! grep -q '@gmail\.com\|@[a-zA-Z0-9.-]\+\.[a-zA-Z]\{2,\}"' "$workflow"
+}
+
+@test "reusable-build-image.yml sources the ArtifactHub maintainer identity from repo/org vars" {
+  workflow="${REPO_ROOT}/.github/workflows/reusable-build-image.yml"
+  grep -q 'io.artifacthub.package.maintainers=.*vars.MAINTAINER_NAME' "$workflow"
+  grep -q 'io.artifacthub.package.maintainers=.*vars.MAINTAINER_EMAIL' "$workflow"
+}


### PR DESCRIPTION
## Summary

Fixes #1430 (primary). Also bundles two security/privacy fixes (#1655, #1649) and CI-hygiene fixes found while working this branch — flagging that up front since the title now covers more than the original jq bug.

The `Bootc Lifecycle` workflow's `generate-matrix` job succeeded (printed a plausible cell count) but the downstream `lifecycle`/`lifecycle-beta` matrix jobs never spawned — the run failed in 9s with no job-level error visible via the API.

The issue as filed diagnosed this as GitHub's strategy evaluator rejecting the unused `is_beta: true/false` key inside each matrix-cell object. That's a reasonable read of the "Unexpected value 'true'" error, but it's not the actual mechanism.

## Root cause (#1430)

Both matrix-generation jq filters had this shape:

```
| ("rawhide" | test($v)) or (...) or (...) as $is_beta
| select($is_beta == false)
| ...
| {variant: $v, flavor: .id, arch: $arch, ..., is_beta: false}
```

jq's `as` binds tighter than an unparenthesized `or` chain reads. Without parens around the whole OR expression, `as $is_beta | select(...) | ... | {...}` parses as the **last operand of the `or`** — and jq's `or` always coerces its result to a bare boolean. So every element of both `matrix.include` and `beta_matrix.include` was actually just `true`/`false`, never the object the filter appears to build.

## What changed

- **#1430**: Parenthesized the full `or` chain so it binds as a single operand to `as`. Also dropped the now-pointless `is_beta:` key from both object literals.
- **#1655 (security, medium severity)**: `build_scripts/desktop/install-desktop.sh`'s manifest-repo-writing block wrote `gpgcheck=0`/`repo_gpgcheck=0` unconditionally for every repo a desktop manifest declares (xfce-wayland, hummingbird, fprintd), with no `gpgkey` ever written. Verified every `repo.tunaos.org` publish pipeline signs its RPMs before enabling `gpgcheck=1`; confirmed `repomd.xml.asc` does **not** exist on the live repo before leaving `repo_gpgcheck=0`, rather than hard-failing every dnf transaction. Sibling fix: tuna-os/tunaos-packages#394.
- **#1649 (privacy)**: `.github/workflows/reusable-build-image.yml`'s `io.artifacthub.package.maintainers` OCI label — baked into every published image — hardcoded a maintainer's personal email. Replaced with `vars.MAINTAINER_NAME`/`vars.MAINTAINER_EMAIL` (empty by default), the same `vars.X`-with-fallback pattern this file already uses for `vars.IMAGE_REGISTRY`.
- `tests/bats/test_custom_overlay.bats`: fixed a test left stale by an earlier Justfile-extraction refactor (#508), failing on every run including `main` itself since it merged.
- `build_scripts/desktop/kcm-ublue.sh` (#1555, one of two failure signatures): guarded an unchecked `dnf_retry -y install` that could take the whole image build down under `set -e` when a dependency probe passed on name but the package still failed to actually install.

## Verification

- `jq '[.include[] | type] | unique'` on either matrix: `["boolean"]` before, `["object"]` after. Cell counts: 156 stable + 11 beta.
- `bats tests/bats/test_custom_overlay.bats` — 6/6 passing.
- `bats tests/bats/test_build_scripts_remaining.bats` — new gpgcheck test passing.
- `bats tests/bats/test_oci_metadata_no_personal_identity.bats tests/bats/test_signing_trust_boundary.bats` — 6/6 passing.
- `python3 -c "import yaml; yaml.safe_load(...)"` on both touched workflow files.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/bootc-lifecycle.yml'))"` — YAML parses cleanly
- [x] Reproduced the exact `jq` filter locally, confirmed `boolean` → `object` element type before/after
- [x] `bats tests/bats/test_custom_overlay.bats` — 6/6 passing
- [x] `bats tests/bats/test_build_scripts_remaining.bats` — new gpgcheck test passing
- [x] `bats tests/bats/test_oci_metadata_no_personal_identity.bats tests/bats/test_signing_trust_boundary.bats` — 6/6 passing
- [ ] CI — will confirm the scheduled `Bootc Lifecycle` run actually spawns matrix cells once this merges

---
_Generated by [Claude Code](https://claude.ai/code/session_014mkpNM2ZMGG78bAiYM1osn)_