### PR TITLE
fix(rawhide): exclude openh264 on Fedora rawhide during branch window

### DIFF
--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -169,7 +169,14 @@ elif [[ $IS_FEDORA == true ]]; then
 	# what gives GStreamer apps H.264/H.265 decode. gstreamer1-plugins-ugly
 	# is the RPM Fusion build. The build contract asserts the result
 	# (verify-desktop-experience.sh codec baseline).
-	dnf -y install \
+	# Note: On Rawhide (Fedora 46+), exclude openh264* until fedora-cisco-openh264
+	# updates its openh264 RPMs signed with the F46 key (currently fc45 signed with F45 key).
+	# Remove this exclude once openh264-*.fc46 appears in fedora-cisco-openh264.
+	local dnf_opts=()
+	if [[ "${FEDORA_VER}" == "rawhide" ]]; then
+		dnf_opts+=(--exclude='openh264*')
+	fi
+	dnf -y install "${dnf_opts[@]}" \
 		gstreamer1-plugins-good \
 		gstreamer1-plugins-ugly \
 		gstreamer1-plugin-libav \

--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -172,7 +172,7 @@ elif [[ $IS_FEDORA == true ]]; then
 	# Note: On Rawhide (Fedora 46+), exclude openh264* until fedora-cisco-openh264
 	# updates its openh264 RPMs signed with the F46 key (currently fc45 signed with F45 key).
 	# Remove this exclude once openh264-*.fc46 appears in fedora-cisco-openh264.
-	local dnf_opts=()
+	dnf_opts=()
 	if [[ "${FEDORA_VER}" == "rawhide" ]]; then
 		dnf_opts+=(--exclude='openh264*')
 	fi

--- a/tests/bats/test_10_base_packages.bats
+++ b/tests/bats/test_10_base_packages.bats
@@ -162,7 +162,7 @@
     FEDORA_VER="rawhide"
     dnf_opts=()
     if [[ "${FEDORA_VER}" == "rawhide" ]]; then
-      dnf_opts+=(--exclude=\'openh264*\')
+      dnf_opts+=(--exclude="openh264*")
     fi
     echo "dnf -y install ${dnf_opts[*]}"
   '

--- a/tests/bats/test_10_base_packages.bats
+++ b/tests/bats/test_10_base_packages.bats
@@ -156,6 +156,20 @@
   [[ ! "$output" == *"epel"* ]]
 }
 
+@test "Fedora rawhide excludes openh264 during transaction" {
+  run bash -c '
+    IS_FEDORA=true
+    FEDORA_VER="rawhide"
+    dnf_opts=()
+    if [[ "${FEDORA_VER}" == "rawhide" ]]; then
+      dnf_opts+=(--exclude=\'openh264*\')
+    fi
+    echo "dnf -y install ${dnf_opts[*]}"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--exclude=openh264*"* ]]
+}
+
 # ── RHEL: EPEL URL-based install vs AlmaLinux: EPEL via epel-release ──────
 
 @test "RHEL installs EPEL from URL" {


### PR DESCRIPTION
Fixes #1566

### Description
On Fedora rawhide (now branched to Fedora 46), `fedora-cisco-openh264` repository still serves `openh264` RPMs built for `fc45` signed with the F45 key while rawhide GPG verification expects the F46 key. This causes signature verification failures during the base package transaction (`build_scripts/10-base-packages.sh`).

This change adds `--exclude='openh264*'` to the `dnf install` invocation in `10-base-packages.sh` when `FEDORA_VER == rawhide`. A comment note was added indicating that this exclude should be dropped once `openh264-*.fc46` RPMs land in `fedora-cisco-openh264`.
