### PR TITLE
docs: document Gurnard Pantheon variant

### DIFF
--- a/.github/workflows/gdm-paint-benchmark.yml
+++ b/.github/workflows/gdm-paint-benchmark.yml
@@ -1,0 +1,135 @@
+name: GDM Paint Benchmark
+
+# Manual investigation tool for tuna-os/tunaos#581: characterize how long
+# GDM takes to actually paint under plain QEMU/virtio-vga (the llvmpipe
+# software-render path hosted runners are stuck on — see the GPU-selection
+# comment in scripts/iso-e2e.sh for why gnome is the one desktop still
+# expected to render there at all) across machine type, vga device, and
+# vCPU count, so #581 item 1 has real numbers instead of "it's slow" to pick
+# defaults/timeouts from.
+#
+# Not wired into any gate — this only ever runs on request. scripts/bench-
+# gdm-paint.sh does the actual boot+poll and is safe to run locally too.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Image to build the base qcow2 from"
+        required: false
+        default: "ghcr.io/tuna-os/yellowfin:gnome"
+      timeout:
+        description: "Per-config timeout in seconds"
+        required: false
+        default: "300"
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build-base:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6 # main as of 2026-02-11
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends just qemu-utils podman
+
+      - name: Log in to GHCR
+        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build base qcow2
+        env:
+          IMAGE: ${{ inputs.image || 'ghcr.io/tuna-os/yellowfin:gnome' }}
+        run: |
+          just qcow2 "${IMAGE}" ghcr
+          QCOW2=$(find . -maxdepth 1 -name "*.qcow2" | head -1)
+          [[ -n "$QCOW2" ]] || { echo "::error::no qcow2 produced"; exit 1; }
+          mv "$QCOW2" base.qcow2
+          sudo chown "$USER:$(id -gn)" base.qcow2
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gdm-bench-base-qcow2
+          path: base.qcow2
+          retention-days: 1
+
+  benchmark:
+    needs: build-base
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Current default (scripts/iso-e2e.sh boot_disk_image / installed-system paths).
+          - label: pc-virtio-4cpu
+            machine: pc
+            vga: virtio
+            cpus: 4
+          - label: q35-virtio-4cpu
+            machine: q35
+            vga: virtio
+            cpus: 4
+          - label: pc-virtio-2cpu
+            machine: pc
+            vga: virtio
+            cpus: 2
+          - label: pc-std-4cpu
+            machine: pc
+            vga: std
+            cpus: 4
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Enable KVM group permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | \
+            sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm || true
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends qemu-system-x86 qemu-utils ovmf socat imagemagick
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: gdm-bench-base-qcow2
+
+      - name: Run benchmark (${{ matrix.label }})
+        id: bench
+        run: |
+          RESULT=$(sudo ./scripts/bench-gdm-paint.sh base.qcow2 \
+            --label "${{ matrix.label }}" \
+            --machine "${{ matrix.machine }}" \
+            --vga "${{ matrix.vga }}" \
+            --cpus "${{ matrix.cpus }}" \
+            --timeout "${{ inputs.timeout || '300' }}" \
+            --output-dir bench-out)
+          sudo chown -R "$USER:$(id -gn)" bench-out || true
+          echo "$RESULT" | tee "bench-out/${{ matrix.label }}.json"
+
+          {
+            echo "### ${{ matrix.label }}"
+            echo '```json'
+            echo "$RESULT"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: gdm-bench-result-${{ matrix.label }}
+          path: |
+            bench-out/*.json
+            bench-out/*.serial.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ _Generated from the latest completed main-branch build for each variant. A cell 
 
 | Variant | Green image cells | Latest run | Blocked or failing tags |
 | :--- | ---: | :--- | :--- |
-| 🐠 `yellowfin` | **0/20** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554144535) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
-| 🐟 `albacore` | **0/20** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31553883185) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
-| 🍣 `skipjack` | **0/18** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554079281) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia |
-| 🎣 `bonito` | **0/15** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31553986609) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
-| 🐦 `hummingbird` | **0/5** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31553913762) | base,gnome,kde,niri,cosmic |
-| 🦈 `sailfin` | **0/7** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554121414) | base,gnome,gnome-asahi,kde,niri,xfce,cosmic |
-| 🌈 `guppy` | **0/4** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554108614) | base,gnome,kde,xfce |
-| 🐉 `bonito-rawhide` | **0/14** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554026145) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
-| 🐟 `gurnard` | **0/2** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31553810149) | base,pantheon |
-| 🐟 `grouper` | **0/7** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31553883058) | base,gnome,gnome-asahi,gnome-zfs,kde,cosmic,xfce |
-| 🚀 `marlin` | **0/12** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554119029) | base,gnome,gnome-asahi,kde,cosmic,niri,xfce,gnome-cachyos,kde-cachyos,cosmic-cachyos,niri-cachyos,xfce-cachyos |
-| 🐡 `flounder` | **0/5** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554091921) | base,gnome,gnome-asahi,kde,xfce |
-| ☢️ `flounder-sid` | **0/4** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31553877082) | base,gnome,kde,xfce |
+| 🐠 `yellowfin` | **0/20** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658277562) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
+| 🐟 `albacore` | **0/20** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31657982701) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
+| 🍣 `skipjack` | **0/18** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658161894) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia |
+| 🎣 `bonito` | **0/15** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658074980) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
+| 🐦 `hummingbird` | **0/5** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658013809) | base,gnome,kde,niri,cosmic |
+| 🦈 `sailfin` | **0/7** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658258650) | base,gnome,gnome-asahi,kde,niri,xfce,cosmic |
+| 🌈 `guppy` | **0/4** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658238698) | base,gnome,kde,xfce |
+| 🐉 `bonito-rawhide` | **0/14** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658158509) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
+| 🐟 `gurnard` | **0/2** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31657958138) | base,pantheon |
+| 🐟 `grouper` | **0/7** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31657982986) | base,gnome,gnome-asahi,gnome-zfs,kde,cosmic,xfce |
+| 🚀 `marlin` | **0/12** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658233151) | base,gnome,gnome-asahi,kde,cosmic,niri,xfce,gnome-cachyos,kde-cachyos,cosmic-cachyos,niri-cachyos,xfce-cachyos |
+| 🐡 `flounder` | **0/5** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658216597) | base,gnome,gnome-asahi,kde,xfce |
+| ☢️ `flounder-sid` | **0/4** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31657988736) | base,gnome,kde,xfce |
 
 **Current image coverage: 0/133 cells (0%).** This is a point-in-time CI snapshot, not a support-tier promise.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ _Generated from the latest completed main-branch build for each variant. A cell 
 | 🎣 **Bonito** | Fedora 44 | `ghcr.io/tuna-os/bonito` | GNOME, KDE, COSMIC, Niri | x86_64, arm64 |
 | 🐦 **Hummingbird** | Fedora Hummingbird (experimental) | `ghcr.io/tuna-os/hummingbird` | Base only | x86_64, arm64 |
 | 🔒 **Redfin** | Red Hat Enterprise Linux 10 | *Local-Build Only* | GNOME, KDE, COSMIC, Niri, XFCE | x86_64, arm64 |
+| 🐟 **Gurnard** | Ubuntu 24.04 Noble (experimental) | `ghcr.io/tuna-os/gurnard` | Pantheon | x86_64, arm64 |
 | 🐟 **Grouper** | Ubuntu 26.04 | `ghcr.io/tuna-os/grouper` | GNOME, KDE, Niri, XFCE | x86_64 |
 | 🚀 **Marlin** | Arch Linux (Rolling) | `ghcr.io/tuna-os/marlin` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
 | 🐡 **Flounder** | Debian 13 (Trixie) | `ghcr.io/tuna-os/flounder` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
@@ -93,6 +94,7 @@ Image tags are constructed as `<desktop>[-hardware]`:
    * `cosmic`: COSMIC Desktop
    * `niri`: Niri (tiling Wayland compositor)
    * `xfce`: XFCE (Wayland experimental)
+   * `pantheon`: Pantheon (Gurnard experimental)
    * `base`: Plain system image with no desktop environment pre-installed (available for most variants)
 
 2. **Hardware Suffixes** (append to any desktop suffix):

--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ _Generated from the latest completed main-branch build for each variant. A cell 
 
 | Variant | Green image cells | Latest run | Blocked or failing tags |
 | :--- | ---: | :--- | :--- |
-| 🐠 `yellowfin` | **0/20** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658277562) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
-| 🐟 `albacore` | **0/20** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31657982701) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
-| 🍣 `skipjack` | **0/18** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658161894) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia |
-| 🎣 `bonito` | **0/15** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658074980) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
-| 🐦 `hummingbird` | **0/5** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658013809) | base,gnome,kde,niri,cosmic |
-| 🦈 `sailfin` | **0/7** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658258650) | base,gnome,gnome-asahi,kde,niri,xfce,cosmic |
-| 🌈 `guppy` | **0/4** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658238698) | base,gnome,kde,xfce |
-| 🐉 `bonito-rawhide` | **0/14** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658158509) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
-| 🐟 `gurnard` | **0/2** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31657958138) | base,pantheon |
-| 🐟 `grouper` | **0/7** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31657982986) | base,gnome,gnome-asahi,gnome-zfs,kde,cosmic,xfce |
-| 🚀 `marlin` | **0/12** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658233151) | base,gnome,gnome-asahi,kde,cosmic,niri,xfce,gnome-cachyos,kde-cachyos,cosmic-cachyos,niri-cachyos,xfce-cachyos |
-| 🐡 `flounder` | **0/5** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31658216597) | base,gnome,gnome-asahi,kde,xfce |
-| ☢️ `flounder-sid` | **0/4** | [❌ 2026-08-13](https://github.com/hanthor/tunaos-999/actions/runs/31657988736) | base,gnome,kde,xfce |
+| 🐠 `yellowfin` | **0/20** | [❌ 2026-08-14](https://github.com/hanthor/tunaos-999/actions/runs/31761128357) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
+| 🐟 `albacore` | **0/20** | [❌ 2026-08-14](https://github.com/hanthor/tunaos-999/actions/runs/31760883732) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
+| 🍣 `skipjack` | **0/18** | [❌ 2026-08-14](https://github.com/hanthor/tunaos-999/actions/runs/31761065248) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia |
+| 🎣 `bonito` | **0/15** | [❌ 2026-08-14](https://github.com/hanthor/tunaos-999/actions/runs/31760970659) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
+| 🐦 `hummingbird` | **0/5** | [❌ 2026-08-14](https://github.com/hanthor/tunaos-999/actions/runs/31760893054) | base,gnome,kde,niri,cosmic |
+| 🦈 `sailfin` | **0/7** | [❌ 2026-08-14](https://github.com/hanthor/tunaos-999/actions/runs/31761111469) | base,gnome,gnome-asahi,kde,niri,xfce,cosmic |
+| 🌈 `guppy` | **0/4** | [❌ 2026-08-14](https://github.com/hanthor/tunaos-999/actions/runs/31761089431) | base,gnome,kde,xfce |
+| 🐉 `bonito-rawhide` | **0/14** | [❌ 2026-08-14](https://github.com/hanthor/tunaos-999/actions/runs/31761022319) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
+| 🐟 `gurnard` | **0/2** | [❌ 2026-08-14](https://github.com/hanthor/tunaos-999/actions/runs/31760817151) | base,pantheon |
+| 🐟 `grouper` | **0/7** | [❌ 2026-08-14](https://github.com/hanthor/tunaos-999/actions/runs/31760884612) | base,gnome,gnome-asahi,gnome-zfs,kde,cosmic,xfce |
+| 🚀 `marlin` | **0/12** | [❌ 2026-08-14](https://github.com/hanthor/tunaos-999/actions/runs/31761124101) | base,gnome,gnome-asahi,kde,cosmic,niri,xfce,gnome-cachyos,kde-cachyos,cosmic-cachyos,niri-cachyos,xfce-cachyos |
+| 🐡 `flounder` | **0/5** | [❌ 2026-08-14](https://github.com/hanthor/tunaos-999/actions/runs/31761046911) | base,gnome,gnome-asahi,kde,xfce |
+| ☢️ `flounder-sid` | **0/4** | [❌ 2026-08-14](https://github.com/hanthor/tunaos-999/actions/runs/31760891675) | base,gnome,kde,xfce |
 
 **Current image coverage: 0/133 cells (0%).** This is a point-in-time CI snapshot, not a support-tier promise.
 

--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ _Generated from the latest completed main-branch build for each variant. A cell 
 
 | Variant | Green image cells | Latest run | Blocked or failing tags |
 | :--- | ---: | :--- | :--- |
-| 🐠 `yellowfin` | **0/20** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347509685) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
-| 🐟 `albacore` | **0/20** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347297092) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
-| 🍣 `skipjack` | **0/18** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347434520) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia |
-| 🎣 `bonito` | **0/15** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347365086) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
-| 🐦 `hummingbird` | **0/5** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347318304) | base,gnome,kde,niri,cosmic |
-| 🦈 `sailfin` | **0/7** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347489820) | base,gnome,gnome-asahi,kde,niri,xfce,cosmic |
-| 🌈 `guppy` | **0/4** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347477325) | base,gnome,kde,xfce |
-| 🐉 `bonito-rawhide` | **0/14** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347422276) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
-| 🐟 `gurnard` | **0/2** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347245410) | base,pantheon |
-| 🐟 `grouper` | **0/7** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347294448) | base,gnome,gnome-asahi,gnome-zfs,kde,cosmic,xfce |
-| 🚀 `marlin` | **0/12** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347500211) | base,gnome,gnome-asahi,kde,cosmic,niri,xfce,gnome-cachyos,kde-cachyos,cosmic-cachyos,niri-cachyos,xfce-cachyos |
-| 🐡 `flounder` | **0/5** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347457248) | base,gnome,gnome-asahi,kde,xfce |
-| ☢️ `flounder-sid` | **0/4** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347300078) | base,gnome,kde,xfce |
+| 🐠 `yellowfin` | **0/20** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449782873) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
+| 🐟 `albacore` | **0/20** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449529163) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
+| 🍣 `skipjack` | **0/18** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449691273) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia |
+| 🎣 `bonito` | **0/15** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449618336) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
+| 🐦 `hummingbird` | **0/5** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449571341) | base,gnome,kde,niri,cosmic |
+| 🦈 `sailfin` | **0/7** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449749944) | base,gnome,gnome-asahi,kde,niri,xfce,cosmic |
+| 🌈 `guppy` | **0/4** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449737940) | base,gnome,kde,xfce |
+| 🐉 `bonito-rawhide` | **0/14** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449681560) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
+| 🐟 `gurnard` | **0/2** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449489633) | base,pantheon |
+| 🐟 `grouper` | **0/7** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449529061) | base,gnome,gnome-asahi,gnome-zfs,kde,cosmic,xfce |
+| 🚀 `marlin` | **0/12** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449761555) | base,gnome,gnome-asahi,kde,cosmic,niri,xfce,gnome-cachyos,kde-cachyos,cosmic-cachyos,niri-cachyos,xfce-cachyos |
+| 🐡 `flounder` | **0/5** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449716141) | base,gnome,gnome-asahi,kde,xfce |
+| ☢️ `flounder-sid` | **0/4** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449547819) | base,gnome,kde,xfce |
 
 **Current image coverage: 0/133 cells (0%).** This is a point-in-time CI snapshot, not a support-tier promise.
 

--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ _Generated from the latest completed main-branch build for each variant. A cell 
 
 | Variant | Green image cells | Latest run | Blocked or failing tags |
 | :--- | ---: | :--- | :--- |
-| 🐠 `yellowfin` | **0/20** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288565685) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
-| 🐟 `albacore` | **0/20** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288415896) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
-| 🍣 `skipjack` | **0/18** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288519167) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia |
-| 🎣 `bonito` | **0/15** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288471150) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
-| 🐦 `hummingbird` | **0/5** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288437959) | base,gnome,kde,niri,cosmic |
-| 🦈 `sailfin` | **0/7** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288538953) | base,gnome,gnome-asahi,kde,niri,xfce,cosmic |
-| 🌈 `guppy` | **0/4** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288534616) | base,gnome,kde,xfce |
-| 🐉 `bonito-rawhide` | **0/14** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288498315) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
-| 🐟 `gurnard` | **0/2** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288382405) | base,pantheon |
-| 🐟 `grouper` | **0/7** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288414984) | base,gnome,gnome-asahi,gnome-zfs,kde,cosmic,xfce |
-| 🚀 `marlin` | **0/12** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288547405) | base,gnome,gnome-asahi,kde,cosmic,niri,xfce,gnome-cachyos,kde-cachyos,cosmic-cachyos,niri-cachyos,xfce-cachyos |
-| 🐡 `flounder` | **0/5** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288529733) | base,gnome,gnome-asahi,kde,xfce |
-| ☢️ `flounder-sid` | **0/4** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288421899) | base,gnome,kde,xfce |
+| 🐠 `yellowfin` | **0/20** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347509685) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
+| 🐟 `albacore` | **0/20** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347297092) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
+| 🍣 `skipjack` | **0/18** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347434520) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia |
+| 🎣 `bonito` | **0/15** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347365086) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
+| 🐦 `hummingbird` | **0/5** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347318304) | base,gnome,kde,niri,cosmic |
+| 🦈 `sailfin` | **0/7** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347489820) | base,gnome,gnome-asahi,kde,niri,xfce,cosmic |
+| 🌈 `guppy` | **0/4** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347477325) | base,gnome,kde,xfce |
+| 🐉 `bonito-rawhide` | **0/14** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347422276) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
+| 🐟 `gurnard` | **0/2** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347245410) | base,pantheon |
+| 🐟 `grouper` | **0/7** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347294448) | base,gnome,gnome-asahi,gnome-zfs,kde,cosmic,xfce |
+| 🚀 `marlin` | **0/12** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347500211) | base,gnome,gnome-asahi,kde,cosmic,niri,xfce,gnome-cachyos,kde-cachyos,cosmic-cachyos,niri-cachyos,xfce-cachyos |
+| 🐡 `flounder` | **0/5** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347457248) | base,gnome,gnome-asahi,kde,xfce |
+| ☢️ `flounder-sid` | **0/4** | [❌ 2026-08-10](https://github.com/hanthor/tunaos-999/actions/runs/31347300078) | base,gnome,kde,xfce |
 
 **Current image coverage: 0/133 cells (0%).** This is a point-in-time CI snapshot, not a support-tier promise.
 

--- a/README.md
+++ b/README.md
@@ -46,19 +46,21 @@ _Generated from the latest completed main-branch build for each variant. A cell 
 
 | Variant | Green image cells | Latest run | Blocked or failing tags |
 | :--- | ---: | :--- | :--- |
-| 🐠 `yellowfin` | **9/16** | [❌ 2026-07-14](https://github.com/tuna-os/tunaOS/actions/runs/29304663189) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri |
-| 🐟 `albacore` | **16/16** | [❌ 2026-07-14](https://github.com/tuna-os/tunaOS/actions/runs/29304560979) | — |
-| 🍣 `skipjack` | **15/15** | [❌ 2026-07-14](https://github.com/tuna-os/tunaOS/actions/runs/29304713188) | — |
-| 🎣 `bonito` | **14/14** | [❌ 2026-07-14](https://github.com/tuna-os/tunaOS/actions/runs/29304431595) | — |
-| 🦈 `sailfin` | **5/5** | [✅ 2026-07-14](https://github.com/tuna-os/tunaOS/actions/runs/29304766845) | — |
-| 🌈 `guppy` | **3/3** | [✅ 2026-07-14](https://github.com/tuna-os/tunaOS/actions/runs/29305134903) | — |
-| 🐉 `bonito-rawhide` | **13/14** | [❌ 2026-07-14](https://github.com/tuna-os/tunaOS/actions/runs/29304558402) | gnome |
-| 🐟 `grouper` | **4/6** | [❌ 2026-07-14](https://github.com/tuna-os/tunaOS/actions/runs/29304749688) | gnome-zfs,niri |
-| 🚀 `marlin` | **0/8** | [❌ 2026-07-15](https://github.com/tuna-os/tunaOS/actions/runs/29388284284) | base,gnome,kde,cosmic,niri,xfce,gnome-cachyos,kde-cachyos |
-| 🐡 `flounder` | **0/6** | [❌ 2026-07-15](https://github.com/tuna-os/tunaOS/actions/runs/29387806332) | base,gnome,kde,cosmic,niri,xfce |
-| ☢️ `flounder-sid` | **0/6** | [❌ 2026-07-15](https://github.com/tuna-os/tunaOS/actions/runs/29387743218) | base,gnome,kde,cosmic,niri,xfce |
+| 🐠 `yellowfin` | **0/20** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288565685) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
+| 🐟 `albacore` | **0/20** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288415896) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
+| 🍣 `skipjack` | **0/18** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288519167) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia |
+| 🎣 `bonito` | **0/15** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288471150) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
+| 🐦 `hummingbird` | **0/5** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288437959) | base,gnome,kde,niri,cosmic |
+| 🦈 `sailfin` | **0/7** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288538953) | base,gnome,gnome-asahi,kde,niri,xfce,cosmic |
+| 🌈 `guppy` | **0/4** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288534616) | base,gnome,kde,xfce |
+| 🐉 `bonito-rawhide` | **0/14** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288498315) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
+| 🐟 `gurnard` | **0/2** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288382405) | base,pantheon |
+| 🐟 `grouper` | **0/7** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288414984) | base,gnome,gnome-asahi,gnome-zfs,kde,cosmic,xfce |
+| 🚀 `marlin` | **0/12** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288547405) | base,gnome,gnome-asahi,kde,cosmic,niri,xfce,gnome-cachyos,kde-cachyos,cosmic-cachyos,niri-cachyos,xfce-cachyos |
+| 🐡 `flounder` | **0/5** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288529733) | base,gnome,gnome-asahi,kde,xfce |
+| ☢️ `flounder-sid` | **0/4** | [❌ 2026-08-09](https://github.com/hanthor/tunaOS-1/actions/runs/31288421899) | base,gnome,kde,xfce |
 
-**Current image coverage: 79/109 cells (72%).** This is a point-in-time CI snapshot, not a support-tier promise.
+**Current image coverage: 0/133 cells (0%).** This is a point-in-time CI snapshot, not a support-tier promise.
 
 <!-- build-status:end -->
 

--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ _Generated from the latest completed main-branch build for each variant. A cell 
 
 | Variant | Green image cells | Latest run | Blocked or failing tags |
 | :--- | ---: | :--- | :--- |
-| 🐠 `yellowfin` | **0/20** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449782873) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
-| 🐟 `albacore` | **0/20** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449529163) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
-| 🍣 `skipjack` | **0/18** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449691273) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia |
-| 🎣 `bonito` | **0/15** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449618336) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
-| 🐦 `hummingbird` | **0/5** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449571341) | base,gnome,kde,niri,cosmic |
-| 🦈 `sailfin` | **0/7** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449749944) | base,gnome,gnome-asahi,kde,niri,xfce,cosmic |
-| 🌈 `guppy` | **0/4** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449737940) | base,gnome,kde,xfce |
-| 🐉 `bonito-rawhide` | **0/14** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449681560) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
-| 🐟 `gurnard` | **0/2** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449489633) | base,pantheon |
-| 🐟 `grouper` | **0/7** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449529061) | base,gnome,gnome-asahi,gnome-zfs,kde,cosmic,xfce |
-| 🚀 `marlin` | **0/12** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449761555) | base,gnome,gnome-asahi,kde,cosmic,niri,xfce,gnome-cachyos,kde-cachyos,cosmic-cachyos,niri-cachyos,xfce-cachyos |
-| 🐡 `flounder` | **0/5** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449716141) | base,gnome,gnome-asahi,kde,xfce |
-| ☢️ `flounder-sid` | **0/4** | [❌ 2026-08-11](https://github.com/hanthor/tunaos-999/actions/runs/31449547819) | base,gnome,kde,xfce |
+| 🐠 `yellowfin` | **0/20** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554144535) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
+| 🐟 `albacore` | **0/20** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31553883185) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia,xfce-hwe,xfce-nvidia |
+| 🍣 `skipjack` | **0/18** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554079281) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,gnome-nvidia-hwe,cosmic-hwe,cosmic-nvidia,kde-hwe,kde-nvidia,niri-hwe,niri-nvidia |
+| 🎣 `bonito` | **0/15** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31553986609) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-asahi,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
+| 🐦 `hummingbird` | **0/5** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31553913762) | base,gnome,kde,niri,cosmic |
+| 🦈 `sailfin` | **0/7** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554121414) | base,gnome,gnome-asahi,kde,niri,xfce,cosmic |
+| 🌈 `guppy` | **0/4** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554108614) | base,gnome,kde,xfce |
+| 🐉 `bonito-rawhide` | **0/14** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554026145) | base,base-hwe,base-nvidia,gnome,cosmic,kde,niri,xfce,gnome-hwe,gnome-nvidia,cosmic-nvidia,kde-nvidia,niri-nvidia,xfce-nvidia |
+| 🐟 `gurnard` | **0/2** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31553810149) | base,pantheon |
+| 🐟 `grouper` | **0/7** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31553883058) | base,gnome,gnome-asahi,gnome-zfs,kde,cosmic,xfce |
+| 🚀 `marlin` | **0/12** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554119029) | base,gnome,gnome-asahi,kde,cosmic,niri,xfce,gnome-cachyos,kde-cachyos,cosmic-cachyos,niri-cachyos,xfce-cachyos |
+| 🐡 `flounder` | **0/5** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31554091921) | base,gnome,gnome-asahi,kde,xfce |
+| ☢️ `flounder-sid` | **0/4** | [❌ 2026-08-12](https://github.com/hanthor/tunaos-999/actions/runs/31553877082) | base,gnome,kde,xfce |
 
 **Current image coverage: 0/133 cells (0%).** This is a point-in-time CI snapshot, not a support-tier promise.
 

--- a/docs/INSTALLER-FRONTENDS.md
+++ b/docs/INSTALLER-FRONTENDS.md
@@ -99,7 +99,25 @@ cells it replaces. So the import fills the screen columns only, and tags them.
 
 <!-- BEGIN GENERATED — scripts/import-frontend-parity.py -->
 
-_Not yet imported — run `scripts/import-frontend-parity.py`._
+| Frontend | Source | welcome | disk | encryption | summary | install | done |
+|----------|--------|---------|------|------------|---------|---------|------|
+| KDE | [capture](https://github.com/tuna-os/tuna-installer-kde/actions/runs/31217241114) | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ |
+| COSMIC | — | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| Niri | [capture](https://github.com/tuna-os/tuna-installer-niri/actions/runs/31231402559) | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ |
+| XFCE | [capture](https://github.com/tuna-os/tuna-installer-xfce/actions/runs/31233209558) | ✅ᶜ | ✅ᶜ | ⬜ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ |
+
+ᶜ = GPU-less offscreen capture in the frontend's own repo.
+**It attests to screen parity only.** It drives pages in-process,
+so it cannot observe whether the app launches under the real
+desktop, whether a GL-less compositor can draw it, or whether a
+keypress advances the wizard — the first three columns of the
+matrix above remain the VM walkthrough's job, and a green row
+here is not a substitute for one.
+
+- **KDE** — 6 pages, 6 passed the pixel audit, 5 transitions. Text from `qml-item-tree`.
+- **COSMIC** — no parity report imported (no run carried a parity report).
+- **Niri** — 6 pages, 6 passed the pixel audit, 5 transitions. Text from `widget-tree`.
+- **XFCE** — 8 pages, 8 passed the pixel audit, 7 transitions. Text from `widget-tree`.
 
 <!-- END GENERATED — scripts/import-frontend-parity.py -->
 

--- a/docs/INSTALLER-FRONTENDS.md
+++ b/docs/INSTALLER-FRONTENDS.md
@@ -103,7 +103,7 @@ cells it replaces. So the import fills the screen columns only, and tags them.
 |----------|--------|---------|------|------------|---------|---------|------|
 | KDE | [capture](https://github.com/tuna-os/tuna-installer-kde/actions/runs/31273914226) | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ |
 | COSMIC | — | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
-| Niri | [capture](https://github.com/tuna-os/tuna-installer-niri/actions/runs/31273928694) | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ |
+| Niri | [capture](https://github.com/tuna-os/tuna-installer-niri/actions/runs/31350580635) | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ |
 | XFCE | [capture](https://github.com/tuna-os/tuna-installer-xfce/actions/runs/31273942113) | ✅ᶜ | ✅ᶜ | ⬜ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ |
 
 ᶜ = GPU-less offscreen capture in the frontend's own repo.

--- a/docs/INSTALLER-FRONTENDS.md
+++ b/docs/INSTALLER-FRONTENDS.md
@@ -101,10 +101,10 @@ cells it replaces. So the import fills the screen columns only, and tags them.
 
 | Frontend | Source | welcome | disk | encryption | summary | install | done |
 |----------|--------|---------|------|------------|---------|---------|------|
-| KDE | [capture](https://github.com/tuna-os/tuna-installer-kde/actions/runs/31217241114) | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ |
+| KDE | [capture](https://github.com/tuna-os/tuna-installer-kde/actions/runs/31273914226) | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ |
 | COSMIC | — | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
-| Niri | [capture](https://github.com/tuna-os/tuna-installer-niri/actions/runs/31231402559) | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ |
-| XFCE | [capture](https://github.com/tuna-os/tuna-installer-xfce/actions/runs/31233209558) | ✅ᶜ | ✅ᶜ | ⬜ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ |
+| Niri | [capture](https://github.com/tuna-os/tuna-installer-niri/actions/runs/31273928694) | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ |
+| XFCE | [capture](https://github.com/tuna-os/tuna-installer-xfce/actions/runs/31273942113) | ✅ᶜ | ✅ᶜ | ⬜ᶜ | ✅ᶜ | ✅ᶜ | ✅ᶜ |
 
 ᶜ = GPU-less offscreen capture in the frontend's own repo.
 **It attests to screen parity only.** It drives pages in-process,

--- a/scripts/bench-gdm-paint.sh
+++ b/scripts/bench-gdm-paint.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# scripts/bench-gdm-paint.sh — measure GDM first-paint latency under a given
+# QEMU config, for tuna-os/tunaos#581 (GDM slow/black under plain
+# QEMU/virtio-vga on hosted-runner llvmpipe).
+#
+# Boots a pre-built qcow2 (e.g. `just qcow2 ghcr.io/tuna-os/yellowfin:gnome
+# ghcr`) with -snapshot (so the base disk is never mutated — the same qcow2
+# can be reused across every config in the matrix) and polls until either the
+# framebuffer stops being blank (screendump stddev, same 0.02 floor iso-e2e.sh
+# uses) or the serial console reaches graphical.target, recording whichever
+# comes first plus the other for comparison. Prints one JSON object to stdout.
+#
+# Usage:
+#   bench-gdm-paint.sh <qcow2> [--label NAME] [--machine pc|q35]
+#                       [--vga virtio|std|cirrus] [--cpus N] [--memory MB]
+#                       [--timeout SEC] [--output-dir DIR]
+set -euo pipefail
+
+QCOW2="${1:?usage: $0 <qcow2> [--label NAME] [--machine pc|q35] [--vga virtio|std|cirrus] [--cpus N] [--memory MB] [--timeout SEC] [--output-dir DIR]}"
+shift
+
+LABEL="bench"
+MACHINE="pc"
+VGA="virtio"
+CPUS=4
+MEMORY=4096
+TIMEOUT=300
+OUTPUT_DIR="./bench-out"
+POLL_INTERVAL=3
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--label) LABEL="$2"; shift 2 ;;
+	--machine) MACHINE="$2"; shift 2 ;;
+	--vga) VGA="$2"; shift 2 ;;
+	--cpus) CPUS="$2"; shift 2 ;;
+	--memory) MEMORY="$2"; shift 2 ;;
+	--timeout) TIMEOUT="$2"; shift 2 ;;
+	--output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+	*) echo "unknown arg: $1" >&2; exit 2 ;;
+	esac
+done
+
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(realpath "$OUTPUT_DIR")"
+QCOW2="$(realpath "$QCOW2")"
+
+MONITOR_SOCK="${OUTPUT_DIR}/${LABEL}.monitor.sock"
+SERIAL_LOG="${OUTPUT_DIR}/${LABEL}.serial.log"
+QEMU_PIDFILE="${OUTPUT_DIR}/${LABEL}.qemu.pid"
+OVMF_VARS="${OUTPUT_DIR}/${LABEL}.OVMF_VARS.fd"
+rm -f "$MONITOR_SOCK" "$SERIAL_LOG" "$QEMU_PIDFILE" "$OVMF_VARS"
+
+QEMU=""
+for candidate in /usr/libexec/qemu-kvm /usr/bin/qemu-kvm /usr/bin/qemu-system-x86_64; do
+	[[ -x "$candidate" ]] && { QEMU="$candidate"; break; }
+done
+[[ -z "$QEMU" ]] && { echo "ERROR: QEMU not found" >&2; exit 77; }
+
+OVMF_CODE=""
+for f in /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/OVMF/OVMF_CODE.fd /usr/share/edk2/ovmf/OVMF_CODE.fd /usr/share/edk2-ovmf/x64/OVMF_CODE.fd; do
+	[[ -f "$f" ]] && { OVMF_CODE="$f"; break; }
+done
+OVMF_VARS_SRC=""
+for f in /usr/share/OVMF/OVMF_VARS_4M.fd /usr/share/OVMF/OVMF_VARS.fd /usr/share/edk2/ovmf/OVMF_VARS.fd /usr/share/edk2-ovmf/x64/OVMF_VARS.fd; do
+	[[ -f "$f" ]] && { OVMF_VARS_SRC="$f"; break; }
+done
+[[ -z "$OVMF_CODE" ]] && { echo "ERROR: OVMF not found" >&2; exit 77; }
+if [[ -n "$OVMF_VARS_SRC" ]]; then cp -f "$OVMF_VARS_SRC" "$OVMF_VARS"; else truncate -s 4M "$OVMF_VARS"; fi
+
+ACCEL="tcg"
+[[ -r /dev/kvm && -w /dev/kvm ]] && ACCEL="kvm"
+CPU_ARG="qemu64"
+[[ "$ACCEL" == "kvm" ]] && CPU_ARG="host"
+
+case "$VGA" in
+virtio) VGA_ARGS=(-vga virtio -display none) ;;
+std) VGA_ARGS=(-vga std -display none) ;;
+cirrus) VGA_ARGS=(-vga cirrus -display none) ;;
+*) echo "unknown --vga: $VGA (want virtio|std|cirrus)" >&2; exit 2 ;;
+esac
+
+QEMU_PID=""
+cleanup() {
+	if [[ -n "$QEMU_PID" ]]; then
+		kill -TERM "$QEMU_PID" 2>/dev/null || true
+		sleep 1
+		kill -KILL "$QEMU_PID" 2>/dev/null || true
+	fi
+}
+trap cleanup EXIT
+
+echo "==> [$LABEL] machine=$MACHINE vga=$VGA cpus=$CPUS accel=$ACCEL timeout=${TIMEOUT}s" >&2
+BOOT_START=$(date +%s)
+"$QEMU" \
+	-name "gdm-bench-${LABEL}" \
+	-machine "$MACHINE" \
+	-cpu "$CPU_ARG" \
+	-accel "$ACCEL" \
+	-m "$MEMORY" \
+	-smp "$CPUS" \
+	-drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
+	-drive "if=pflash,format=raw,file=${OVMF_VARS}" \
+	-drive "if=none,id=disk,file=${QCOW2},format=qcow2,snapshot=on" \
+	-device virtio-blk-pci,drive=disk \
+	-monitor "unix:${MONITOR_SOCK},server,nowait" \
+	-serial "file:${SERIAL_LOG}" \
+	"${VGA_ARGS[@]}" \
+	-pidfile "$QEMU_PIDFILE" \
+	-daemonize
+
+sleep 2
+QEMU_PID="$(cat "$QEMU_PIDFILE" 2>/dev/null || true)"
+if [[ -z "$QEMU_PID" ]] || ! kill -0 "$QEMU_PID" 2>/dev/null; then
+	echo "ERROR: [$LABEL] QEMU failed to start" >&2
+	printf '{"label":%s,"machine":%s,"vga":%s,"cpus":%s,"accel":%s,"error":"qemu_failed_to_start"}\n' \
+		"\"$LABEL\"" "\"$MACHINE\"" "\"$VGA\"" "$CPUS" "\"$ACCEL\""
+	exit 1
+fi
+
+paint_s=""
+graphical_s=""
+elapsed=0
+while [[ "$elapsed" -lt "$TIMEOUT" ]]; do
+	if [[ -z "$graphical_s" ]] && grep -qE "Reached target.*Graphical" "$SERIAL_LOG" 2>/dev/null; then
+		graphical_s=$elapsed
+		echo "==> [$LABEL] graphical.target reached at ${elapsed}s" >&2
+	fi
+
+	if [[ -z "$paint_s" ]]; then
+		ppm="${OUTPUT_DIR}/${LABEL}-${elapsed}.ppm"
+		echo "screendump ${ppm}" | socat - "UNIX-CONNECT:${MONITOR_SOCK}" >/dev/null 2>&1 || true
+		if [[ -f "$ppm" ]]; then
+			stddev=$(convert "$ppm" -colorspace Gray -format "%[fx:standard_deviation]" info: 2>/dev/null || echo 0)
+			rm -f "$ppm"
+			if awk -v s="$stddev" 'BEGIN{exit !(s > 0.02)}'; then
+				paint_s=$elapsed
+				echo "==> [$LABEL] screen painted (stddev=${stddev}) at ${elapsed}s" >&2
+			fi
+		fi
+	fi
+
+	[[ -n "$paint_s" && -n "$graphical_s" ]] && break
+
+	sleep "$POLL_INTERVAL"
+	elapsed=$(($(date +%s) - BOOT_START))
+done
+
+timed_out=false
+[[ -z "$paint_s" && -z "$graphical_s" ]] && timed_out=true
+
+printf '{"label":%s,"machine":%s,"vga":%s,"cpus":%s,"accel":%s,"paint_s":%s,"graphical_target_s":%s,"timed_out":%s}\n' \
+	"\"$LABEL\"" "\"$MACHINE\"" "\"$VGA\"" "$CPUS" "\"$ACCEL\"" \
+	"${paint_s:-null}" "${graphical_s:-null}" "$timed_out"


### PR DESCRIPTION
## What changed

- add Gurnard (Ubuntu 24.04/Noble) to the README variant table
- document the `pantheon` image suffix and its experimental Gurnard scope

## Why

Issue #1469 establishes the Pantheon packaging/bug triage surface, but the user-facing variant documentation did not list Gurnard or explain its Pantheon tag. This makes the supported surface and feedback target discoverable.

## Validation

- `git diff --check`