### PR TITLE
fix(nvidia): count kernel builtins as initramfs boot-driver parity

### DIFF
--- a/build_scripts/checks/verify-nvidia.sh
+++ b/build_scripts/checks/verify-nvidia.sh
@@ -248,7 +248,29 @@ echo "== initramfs boot-driver parity =="
 # present in the nvidia image's swapped-kernel initramfs (720 modules) —
 # this is a parity floor, not a wish list; dm_crypt is deliberately absent
 # because the parent's initramfs does not carry it either.
+#
+# A driver satisfies the floor two ways, and the check must accept BOTH: as a
+# .ko in the initramfs, or built into the kernel image. Requiring only the
+# first made the floor a property of the kernel's build config rather than of
+# the boot path, and that broke the moment the kernel changed (#1561). The
+# floor was measured on EL10, where the CentOS Stream 10 config has
+# CONFIG_BLK_DEV_SR=m and CONFIG_VIRTIO_BLK=m. Fedora 43 sets both to =y, so
+# on fc43 sr_mod, cdrom (selected by BLK_DEV_SR) and virtio_blk are vmlinuz
+# builtins with no .ko for dracut to install or lsinitrd to list — and every
+# bonito/bonito-rawhide nvidia flavor plus gnome-nvidia-hwe on three EL
+# variants failed on drivers that were present all along. gnome-hwe on the
+# same kernel passed the full qcow2 boot gate in those same runs, which is
+# what a virtio_blk boot working looks like.
+#
+# modules.builtin is the kernel's own record of that, shipped per-kernel-tree,
+# so this stays a measurement rather than a hardcoded fc43 exemption: a driver
+# that is neither in the initramfs nor builtin is still a real failure.
 INITRAMFS="${NV_ROOT}/usr/lib/modules/${KERNEL_VRA}/initramfs.img"
+BUILTIN="${NV_ROOT}/usr/lib/modules/${KERNEL_VRA}/modules.builtin"
+_builtin_list=""
+if [[ -s "$BUILTIN" ]]; then
+	_builtin_list="$(<"$BUILTIN")"
+fi
 if [[ ! -s "$INITRAMFS" ]]; then
 	fail "missing or empty initramfs for the installed kernel: /usr/lib/modules/${KERNEL_VRA}/initramfs.img"
 elif ! command -v lsinitrd >/dev/null 2>&1; then
@@ -256,10 +278,17 @@ elif ! command -v lsinitrd >/dev/null 2>&1; then
 else
 	_initrd_list="$(lsinitrd "$INITRAMFS" 2>/dev/null || true)"
 	for _drv in sr_mod cdrom isofs squashfs virtio_scsi virtio_blk overlay loop; do
+		# modules.builtin records bare relative paths (kernel/drivers/scsi/
+		# sr_mod.ko), never a compression suffix — anchor the end so cdrom
+		# cannot be satisfied by some other module that merely contains it.
 		if grep -qE "/${_drv}\.ko" <<<"$_initrd_list"; then
 			pass "initramfs carries ${_drv}"
+		elif [[ -n "$_builtin_list" ]] && grep -qE "(^|/)${_drv}\.ko$" <<<"$_builtin_list"; then
+			pass "${_drv} is built into the kernel (modules.builtin) — no .ko to carry"
+		elif [[ ! -s "$BUILTIN" ]]; then
+			fail "initramfs is missing ${_drv}, and /usr/lib/modules/${KERNEL_VRA}/modules.builtin is missing or empty so it cannot be shown to be builtin either — the live ISO or installed boot cannot mount its root"
 		else
-			fail "initramfs is missing ${_drv} — the live ISO or installed boot cannot mount its root"
+			fail "initramfs is missing ${_drv} and it is not built into the kernel — the live ISO or installed boot cannot mount its root"
 		fi
 	done
 fi

--- a/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
@@ -178,15 +178,24 @@ fi
 sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
 # As we need forced load, also must pre-load intel/amd iGPU else chromium web
 # browsers fail to use hardware acceleration. tunaos#1499: also force
-# sr_mod/cdrom/virtio_blk — --no-hostonly alone stopped being enough to
-# guarantee these on the live ISO / installed-disk boot path on this
-# negativo17 conf; they started coming up missing from the rebuilt
-# initramfs on every *-nvidia nightly (10/10 red 08-03..08-13) while present
-# in the parent (non-nvidia) image's initramfs and in this image's own
-# initramfs before this 99-nvidia.conf edit. virtio_scsi/isofs/squashfs/
-# overlay/loop were unaffected, so this isn't a wholesale hostonly-detection
-# failure — just these three. Same mechanism as i915/amdgpu: force them in
-# explicitly rather than trust generic-mode autodetection to include them.
+# sr_mod/cdrom/virtio_blk for the live ISO / installed-disk boot path.
+#
+# CORRECTION (tunaos#1561). #1499 read the 10/10 red *-nvidia nightlies
+# (08-03..08-13) as generic-mode autodetection failing to pick these three up,
+# and forced them here to compensate. That diagnosis was wrong, and forcing
+# them never could have fixed it: the images had swapped to Fedora 43's
+# kernel, whose config sets CONFIG_BLK_DEV_SR=y and CONFIG_VIRTIO_BLK=y (EL10
+# has both =m). sr_mod, cdrom and virtio_blk are therefore compiled into
+# vmlinuz on fc43 — there is no .ko for dracut to install, so no amount of
+# force_drivers puts one in the initramfs. What was actually red was
+# verify-nvidia.sh's parity check, which demanded a .ko; it now accepts a
+# modules.builtin entry as equally good.
+#
+# The line stays because it is NOT dead: yellowfin/albacore/skipjack's
+# non-HWE nvidia flavors build on the EL10 kernel, where these three ARE
+# modular and forcing them is load-bearing exactly as #1499 intended. On fc43
+# dracut skips them harmlessly. virtio_scsi/isofs/squashfs/overlay/loop are
+# =m on both, which is why they were never part of the failure.
 sed -i 's@ nvidia @ i915 amdgpu nvidia sr_mod cdrom virtio_blk @g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
 
 # Make sure initramfs is rebuilt after nvidia drivers or kernel replacement

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -278,6 +278,91 @@ STUB
   [[ "$output" == *"nvidia-drm.modeset=1"* ]]
 }
 
+# ── initramfs parity: builtin drivers count (tunaos#1561) ─────────────────
+#
+# The floor list was measured on EL10, where CONFIG_BLK_DEV_SR=m and
+# CONFIG_VIRTIO_BLK=m so every driver in it is a .ko. Fedora 43 sets both =y,
+# making sr_mod, cdrom (selected by BLK_DEV_SR) and virtio_blk vmlinuz
+# builtins with no .ko anywhere — and the check that demanded a .ko turned
+# that into a deterministic FAIL on every bonito/bonito-rawhide nvidia flavor
+# and gnome-nvidia-hwe on three EL variants, while gnome-hwe on the same
+# kernel passed the qcow2 boot gate. These tests pin the fc43 *shape* — which
+# drivers are .ko and which are builtin — so a future kernel that really does
+# drop a boot driver still fails. The fixture keeps the EL10 $KVER string
+# because nothing in the check branches on the version; only the shape counts,
+# and hardcoding an fc43 exemption is precisely what the fix avoids.
+
+# lsinitrd stub carrying only the drivers that are =m on BOTH configs.
+stub_lsinitrd_modular_only() {
+  cat > "${BATS_TEST_TMPDIR}/bin/lsinitrd" <<STUB
+#!/usr/bin/env bash
+for d in isofs squashfs virtio_scsi overlay loop; do
+  echo "usr/lib/modules/${KVER}/kernel/fs/\${d}.ko.xz"
+done
+STUB
+  chmod +x "${BATS_TEST_TMPDIR}/bin/lsinitrd"
+}
+
+# modules.builtin as the kernel ships it: relative paths, no compression
+# suffix, one per line.
+write_modules_builtin() {
+  local root="$1"; shift
+  local d
+  : > "$root/usr/lib/modules/${KVER}/modules.builtin"
+  for d in "$@"; do
+    echo "kernel/drivers/${d}.ko" >> "$root/usr/lib/modules/${KVER}/modules.builtin"
+  done
+}
+
+@test "verify-nvidia passes when the missing boot drivers are kernel builtins" {
+  make_stub_tools
+  root="$(make_good_root)"
+  stub_lsinitrd_modular_only
+  write_modules_builtin "$root" scsi/sr_mod cdrom/cdrom block/virtio_blk
+  run_verify "$root"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TUNAOS_NVIDIA_CONTRACT_OK"* ]]
+  [[ "$output" == *"sr_mod is built into the kernel"* ]]
+}
+
+@test "verify-nvidia still fails a boot driver that is neither packed nor builtin" {
+  make_stub_tools
+  root="$(make_good_root)"
+  stub_lsinitrd_modular_only
+  # virtio_blk deliberately absent from both — an installed disk cannot boot.
+  write_modules_builtin "$root" scsi/sr_mod cdrom/cdrom
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"TUNAOS_NVIDIA_CONTRACT_FAIL"* ]]
+  [[ "$output" == *"virtio_blk"* ]]
+  [[ "$output" == *"not built into the kernel"* ]]
+}
+
+@test "verify-nvidia says so when modules.builtin cannot be read at all" {
+  make_stub_tools
+  root="$(make_good_root)"
+  stub_lsinitrd_modular_only
+  # No modules.builtin: builtin status is unprovable. That is still a FAIL,
+  # but it must not be reported as "not builtin" — a missing record and a
+  # measured absence are different diagnoses.
+  rm -f "$root/usr/lib/modules/${KVER}/modules.builtin"
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"modules.builtin is missing or empty"* ]]
+}
+
+@test "a builtin entry cannot be satisfied by a different module that contains its name" {
+  make_stub_tools
+  root="$(make_good_root)"
+  stub_lsinitrd_modular_only
+  # pktcdvd.ko must not satisfy cdrom; sr_mod/virtio_blk are real so cdrom is
+  # the only driver left to fail.
+  write_modules_builtin "$root" scsi/sr_mod block/virtio_blk block/pktcdvd
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"initramfs is missing cdrom"* ]]
+}
+
 @test "verify-nvidia fails when a shipped suspend unit is disabled" {
   make_stub_tools
   root="$(make_good_root)"


### PR DESCRIPTION
Closes #1561.

The three "missing" drivers were never missing. They are compiled into the kernel.

## Root cause, from the kernel configs

The floor list was measured with `lsinitrd` on an EL10 parent, where every driver in it is a `.ko` — so "is there a `.ko`?" was a sound proxy. Fedora 43 changed the answer:

| | `kernel-x86_64-fedora.config` (f43 **and** rawhide) | `kernel-x86_64-rhel.config` (c10s) |
|---|---|---|
| `CONFIG_BLK_DEV_SR` | **`y`** | `m` |
| `CONFIG_VIRTIO_BLK` | **`y`** | `m` |
| `CONFIG_ISO9660_FS` / `SQUASHFS` / `SCSI_VIRTIO` / `OVERLAY_FS` / `BLK_DEV_LOOP` | `m` | `m` |

On fc43 `sr_mod` and `virtio_blk` are vmlinuz builtins — there is no `.ko` for dracut to install or `lsinitrd` to list. `cdrom` follows `sr_mod`: it has no standalone entry in either curated config because `BLK_DEV_SR` **selects** it, and a tristate selected by a `=y` symbol is itself `=y`. *(That last one is inference from Kconfig semantics, not a direct reading — no `rpm2cpio`/`zstd` here to crack open `kernel-core` and read the shipped `modules.builtin`. It doesn't affect the fix, which consults the real file at runtime.)*

The bottom row is the confirmation: those five are `=m` on **both** configs, and those five are exactly the ones that kept passing. The config split predicts the observed failure set precisely. And in the same runs, `gnome-hwe` on the same kernel passed the full qcow2 boot gate — which is what a working `virtio_blk` boot looks like.

## The fix

`verify-nvidia.sh` now accepts either proof: a `.ko` in the initramfs, **or** an entry in the kernel's own `/usr/lib/modules/$KERNEL_VRA/modules.builtin`.

That keeps this a measurement rather than an fc43 exemption — a driver in neither place is still a real FAIL. The messages also distinguish "not built into the kernel" from "`modules.builtin` is missing or empty", because a missing record and a measured absence are different diagnoses and this script's job is to not blur them.

## The dracut suggestion is already implemented — and could never have worked

The issue proposes optionally adding `sr_mod cdrom virtio_blk` to the dracut invocation. **#1499 already did that**, which is why this is worth explaining rather than just patching: you cannot force a builtin driver into an initramfs, because there is no `.ko` to force.

`20-nvidia.sh`'s comment attributes the 10/10 red nightlies to `--no-hostonly` autodetection failing to pick these up. That diagnosis is wrong and would send the next reader down the same path, so I corrected it in place. **The line itself stays** — `yellowfin`/`albacore`/`skipjack`'s non-HWE nvidia flavors build on the EL10 kernel, where these three *are* modular and forcing them is load-bearing exactly as #1499 intended. On fc43 dracut skips them harmlessly.

## Verification

Four cases added to the existing fixture-root harness in `test_nvidia_overlay.bats`. `bats` isn't installed in my environment, so I also drove the **real** `verify-nvidia.sh` against the same fixture tree from a plain bash script — before and after the change:

```
=== upstream/main (pre-fix) ===         === this branch ===
1. EL10 shape, all .ko      PASS        1. EL10 shape, all .ko      PASS
2. fc43 shape (3 builtin)   FAIL   ->   2. fc43 shape (3 builtin)   PASS
3. virtio_blk truly absent  PASS        3. virtio_blk truly absent  PASS
4. modules.builtin absent   PASS        4. modules.builtin absent   PASS
5. pktcdvd vs cdrom         PASS        5. pktcdvd vs cdrom         PASS
```

Case 2 on the pre-fix script reproduces the issue's log byte-for-byte:

```
== initramfs boot-driver parity ==
  FAIL: initramfs is missing sr_mod — the live ISO or installed boot cannot mount its root
  FAIL: initramfs is missing cdrom — ...
```

Case 1 is the regression guard (EL10 must keep passing), case 3 is the one that matters most — a driver that really is absent still fails the build.

**The bats suite itself has only been run by CI, not locally.**

## Scope

This fixes the false-FAIL. It doesn't claim the nine matrix cells go green — the `bonito-rawhide gnome-nvidia` semodule bug is filed separately and is out of scope per the issue. Parent #1570 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
