### PR TITLE
fix(nvidia-debian): install version-matched linux-headers for target kernel

### DIFF
--- a/build_scripts/overlay/overrides/nvidia-debian/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia-debian/20-nvidia.sh
@@ -75,13 +75,21 @@ cat /etc/apt/sources.list.d/*.sources /etc/apt/sources.list 2>/dev/null || true
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
 
-# linux-headers-generic is a virtual package resolving to the arch-specific
-# real one (linux-headers-amd64 here) — see header. dkms needs it present
-# under /usr/lib/modules/${KVER}/build before autoinstall below has
-# anything to build against.
+# linux-headers-${KVER} matches the base layer's baked kernel version.
+# On sid / rolling archives where the archive has moved past the cached base
+# layer's kernel (e.g. base kernel 7.1.7 vs archive headers 7.1.8), installing
+# linux-headers-generic pulls headers for a newer kernel that dkms builds for,
+# leaving /usr/lib/modules/${KVER}/build missing. If the exact versioned package
+# has been removed from the archive, fall back to linux-headers-generic.
+HEADERS_PKG="linux-headers-${KVER}"
+if ! apt-cache show "$HEADERS_PKG" >/dev/null 2>&1; then
+	echo "==> ${HEADERS_PKG} not available in apt archive; falling back to linux-headers-generic"
+	HEADERS_PKG="linux-headers-generic"
+fi
+
 apt-get install -y --no-install-recommends \
 	dkms \
-	linux-headers-generic \
+	"${HEADERS_PKG}" \
 	nvidia-kernel-dkms \
 	nvidia-driver-libs \
 	nvidia-vulkan-icd \

--- a/tests/bats/test_nvidia_overlay_arch_debian.bats
+++ b/tests/bats/test_nvidia_overlay_arch_debian.bats
@@ -114,7 +114,7 @@ VERIFY_DEBIAN_SH="${REPO_ROOT}/build_scripts/checks/verify-nvidia-debian.sh"
 @test "nvidia-debian 20-nvidia.sh guards on IS_DEBIAN and asserts the dkms build tree before building" {
   run grep -F 'IS_DEBIAN' "$DEBIAN_INSTALL_SH"
   [ "$status" -eq 0 ]
-  run grep -F 'linux-headers-generic' "$DEBIAN_INSTALL_SH"
+  run grep -F 'HEADERS_PKG' "$DEBIAN_INSTALL_SH"
   [ "$status" -eq 0 ]
   run grep -F 'dkms autoinstall' "$DEBIAN_INSTALL_SH"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes #1565

## Summary
On rolling / sid archives (e.g. `flounder-sid`), the apt archive can advance to a newer kernel (e.g. 7.1.8) while the cached base layer kernel is at a prior version (7.1.7). Installing `linux-headers-generic` pulls headers for the newest kernel in the archive, causing DKMS to build for 7.1.8 while leaving `/usr/lib/modules/7.1.7+deb14-amd64/build` missing.

This PR updates `build_scripts/overlay/overrides/nvidia-debian/20-nvidia.sh` to install `linux-headers-${KVER}` directly if available in the apt archive, falling back to `linux-headers-generic` only if the versioned package is no longer present.

## Verification
- Updated `20-nvidia.sh` logic to probe `apt-cache show linux-headers-${KVER}` before fallback.
- Updated `tests/bats/test_nvidia_overlay_arch_debian.bats` assertions to check for `HEADERS_PKG`.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `4dbef504`