### PR TITLE
fix(cachyos): keep one kernel and build its initramfs by name, not by readdir order

### DIFF
--- a/Containerfile.arch
+++ b/Containerfile.arch
@@ -166,9 +166,19 @@ RUN --mount=type=bind,from=context,source=/,target=/run/context \
 # It used to be a printf here. That is how five composefs variants ended up with
 # one erofs driver between them: the fix was made while chasing marlin and had
 # nowhere shared to live.
+#
+# The kernel is named once and passed to both dracut-config.sh (which probes
+# drivers against that kernel's module tree) and dracut itself, rather than
+# each rediscovering it. This step only ever sees one kernel, so the old
+# `find ... | tail -1` output path was correct here by luck; the same idiom in
+# build_scripts/overlay/cachyos.sh ran with two kernel trees and picked a
+# different one per flavor, failing 5/5 cachyos Gates (tunaOS#1563). It is not
+# worth leaving a second copy of that around to be inherited.
 RUN --mount=type=bind,from=context,source=/,target=/run/context \
-    /run/context/build_scripts/bootc/dracut-config.sh && \
-    dracut --force "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v '\.img' | tail -1)/initramfs.img"
+    KVER="$(basename "$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d ! -name '*.img' | sort -V | tail -1)")" && \
+    if [ -z "$KVER" ]; then echo "ERROR: no kernel module directory under /usr/lib/modules" >&2; exit 1; fi && \
+    /run/context/build_scripts/bootc/dracut-config.sh "$KVER" && \
+    dracut --force "/usr/lib/modules/${KVER}/initramfs.img" "${KVER}"
 
 # systemd-firstboot asks the CONSOLE for a timezone and blocks there forever.
 #

--- a/build_scripts/overlay/cachyos.sh
+++ b/build_scripts/overlay/cachyos.sh
@@ -38,7 +38,14 @@ Include = /etc/pacman.d/cachyos-mirrorlist
 EOF
 fi
 
-pacman -Syu --noconfirm --needed \
+# -Sy + -S, not -Syu: this runs mid-overlay on a published parent image, and a
+# full upgrade here can bump the stock kernel too — a second moving kernel in a
+# script whose whole job is to end up with exactly one. (Not what broke run
+# 31766586852: `installing linux-cachyos` with no `upgrading linux` shows the
+# parent's kernel was untouched there. This closes the latent version, not the
+# observed one.) Same shape as overrides/nvidia-arch/20-nvidia.sh.
+pacman -Sy --noconfirm
+pacman -S --noconfirm --needed \
 	cachyos-keyring cachyos-mirrorlist cachyos-settings \
 	linux-cachyos linux-cachyos-headers tpm2-tss
 
@@ -46,6 +53,72 @@ pacman -Syu --noconfirm --needed \
 install -D /dev/null /etc/cachyos-release
 printf 'CachyOS\n' >/etc/cachyos-release
 
-# Rebuild initramfs via dracut
-dracut --force --omit "tpm2-tss" "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v '\.img' | tail -1)/initramfs.img"
+# ── one kernel, one initramfs, both named explicitly (tunaOS#1563) ───────────
+#
+# The parent image already ships the stock `linux` kernel (Containerfile.arch
+# installs ${KERNEL_PKG}/${KERNEL_PKG}-headers), so installing linux-cachyos
+# above leaves TWO module trees. This block used to end in:
+#
+#   dracut --force --omit tpm2-tss \
+#     "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v '\.img' | tail -1)/initramfs.img"
+#
+# `find` without `sort` returns readdir order, so which tree got the initramfs
+# was a per-image coin flip. Run 31766586852 flipped it both ways in a single
+# nightly — same script, same commit, five flavors:
+#
+#   gnome/kde/cosmic-cachyos -> /usr/lib/modules/7.1.8-arch1-3/initramfs.img
+#   xfce/niri-cachyos        -> /usr/lib/modules/7.1.8-1-cachyos/initramfs.img
+#
+# and that split is exactly the split in the Gate failures: the three that
+# wrote to the stock tree died in `bootc install` with "Computing boot digest:
+# initramfs not found", the two that wrote to the cachyos tree installed but
+# booted a kernel whose module tree disagreed and never reached
+# graphical.target. Both presentations, one cause.
+#
+# Note `sort -V` would NOT have fixed it and must not be used here:
+#
+#   $ printf '6.17.1-arch1-1\n6.17.1-2-cachyos\n' | sort -V | tail -1
+#   6.17.1-arch1-1
+#
+# version-sort puts the stock kernel last, so `sort -V | tail -1` is a
+# deterministic wrong answer rather than a coin flip. The package is literally
+# linux-cachyos and its module directory carries `cachyos`, so select by name.
+KVER="$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d -name '*cachyos*' -printf '%f\n' 2>/dev/null | sort -V | tail -1)"
+if [ -z "$KVER" ]; then
+	echo "ERROR: linux-cachyos installed but no *cachyos* module directory exists" >&2
+	echo "       under /usr/lib/modules — the kernel package layout changed." >&2
+	find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d -printf '  %f\n' >&2 || true
+	exit 1
+fi
+echo "==> target kernel: ${KVER}"
+
+# Drop the stock kernel now that cachyos is in — the asahi.sh:179 pattern.
+# -Rdd skips dep checks (nothing here needs a cascade) and this runs AFTER the
+# install, so a failed linux-cachyos transaction leaves a bootable image rather
+# than no kernel at all. Both the x86_64 and ARM stock names are tried because
+# Containerfile.arch picks between them by $(uname -m).
+for _stock in linux linux-headers linux-aarch64 linux-aarch64-headers; do
+	pacman -Rdd --noconfirm "$_stock" 2>/dev/null || true
+done
+
+# Package removal is not enough: initramfs.img is generated, not packaged, so
+# pacman leaves the stock tree behind with a stale initramfs in it. Delete any
+# tree that is not the selected kernel, then PROVE only one remains — tunaOS#912
+# is this exact cleanup silently not happening and an ambiguous-boot image
+# getting published. A loud build failure beats a silently-wrong image.
+find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d ! -name "$KVER" -exec rm -rf {} +
+REMAINING_KVERS="$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d -printf '%f\n')"
+REMAINING_COUNT="$(printf '%s\n' "$REMAINING_KVERS" | grep -c .)"
+if [ "$REMAINING_COUNT" -ne 1 ] || [ "$REMAINING_KVERS" != "$KVER" ]; then
+	echo "ERROR: expected exactly 1 kernel in /usr/lib/modules (${KVER}) after cleanup, found ${REMAINING_COUNT}:" >&2
+	printf '%s\n' "$REMAINING_KVERS" >&2
+	echo "ERROR: a stock kernel survived removal; bootc would pick between two trees (tunaOS#912, tunaOS#1563)." >&2
+	exit 1
+fi
+
+# Rebuild initramfs via dracut. Path AND kernel version passed positionally —
+# the same form overrides/nvidia-arch/20-nvidia.sh uses, which is the sibling
+# Arch overlay whose five flavors passed their Gate in the run above. Naming
+# the kernel means the output path can never disagree with what was built.
+dracut --force --omit "tpm2-tss" "/usr/lib/modules/${KVER}/initramfs.img" "${KVER}"
 pacman -Scc --noconfirm || true

--- a/tests/bats/test_cachyos_overlay.bats
+++ b/tests/bats/test_cachyos_overlay.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+# The cachyos overlay must end with exactly one kernel and an initramfs built
+# for that kernel, named explicitly.
+#
+# Failure mode these tests pin (tunaOS#1563): cachyos.sh installed
+# linux-cachyos on a parent that already ships stock `linux`, leaving two
+# module trees, then wrote ONE initramfs to
+#
+#   "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v '\.img' | tail -1)/initramfs.img"
+#
+# `find` without `sort` is readdir order, so the target was a per-image coin
+# flip. Run 31766586852 flipped it both ways in one nightly — gnome/kde/cosmic
+# wrote to /usr/lib/modules/7.1.8-arch1-3 (stock) and died in `bootc install`
+# with "initramfs not found"; xfce/niri wrote to 7.1.8-1-cachyos and booted a
+# kernel whose module tree disagreed, never reaching graphical.target. All five
+# cachyos Gates failed while all five nvidia Gates passed, and the nvidia-arch
+# overlay is the sibling that names its kernel explicitly.
+#
+# These are shape assertions on scripts that cannot be executed here (they run
+# pacman against a live Arch root), matching the convention in
+# test_nvidia_overlay.bats.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+CACHYOS_SH="${REPO_ROOT}/build_scripts/overlay/cachyos.sh"
+ARCH_CF="${REPO_ROOT}/Containerfile.arch"
+NVIDIA_ARCH_SH="${REPO_ROOT}/build_scripts/overlay/overrides/nvidia-arch/20-nvidia.sh"
+
+@test "cachyos.sh exists and is valid bash" {
+  run bash -n "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+}
+
+# ── the readdir gamble is gone ─────────────────────────────────────────────
+
+@test "no find|tail -1 feeds an initramfs path in cachyos.sh" {
+  # The precise defect: a command substitution whose result becomes the dracut
+  # output path. Any reappearance is the bug coming back.
+  #
+  # ^[^#]* matches code only — cachyos.sh's own header quotes the old line
+  # verbatim to explain what went wrong, and a test that cannot tell the
+  # documentation from the defect would fail on the fix's own comment. Same
+  # reason test_nvidia_overlay.bats anchors its dnf-config-manager check.
+  run grep -nE '^[^#]*\$\(find /usr/lib/modules[^)]*\)/initramfs\.img' "$CACHYOS_SH"
+  [ "$status" -ne 0 ]
+  run grep -nE '^[^#]*find /usr/lib/modules.*tail -1.*initramfs' "$CACHYOS_SH"
+  [ "$status" -ne 0 ]
+  # The KVER selection line is allowed to end in `sort -V | tail -1`: it has
+  # already filtered to *cachyos* dirs, so it is picking among candidates
+  # rather than gambling across kernels. Only an initramfs PATH built that way
+  # is the defect, which is why both patterns above require /initramfs.img.
+}
+
+@test "no find|tail -1 feeds an initramfs path in Containerfile.arch" {
+  run grep -nE '^[^#]*\$\(find /usr/lib/modules[^)]*\)/initramfs\.img' "$ARCH_CF"
+  [ "$status" -ne 0 ]
+}
+
+@test "the cachyos kernel is selected by name, not by version sort" {
+  # sort -V puts the stock kernel LAST, so `sort -V | tail -1` would be a
+  # deterministic wrong answer rather than a coin flip:
+  #   $ printf '6.17.1-arch1-1\n6.17.1-2-cachyos\n' | sort -V | tail -1
+  #   6.17.1-arch1-1
+  # Prove that here rather than asserting it in a comment, so a future
+  # "cleanup" to sort -V fails this test instead of the nightly.
+  run bash -c "printf '6.17.1-arch1-1\n6.17.1-2-cachyos\n' | sort -V | tail -1"
+  [ "$output" = "6.17.1-arch1-1" ]
+  # Hence: -name '*cachyos*'. The `--` is required: the pattern starts with a
+  # dash, so grep would otherwise parse it as options.
+  run grep -F -- "-name '*cachyos*'" "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "an empty kernel selection is a hard failure, not an empty path" {
+  # KVER="" would silently produce /usr/lib/modules//initramfs.img.
+  run grep -A1 -E '^if \[ -z "\$KVER" \]' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ERROR"* ]]
+  run grep -E '^\s*exit 1' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+}
+
+# ── exactly one kernel survives ────────────────────────────────────────────
+
+@test "cachyos.sh removes the stock kernel it was layered on top of" {
+  # Containerfile.arch installs ${KERNEL_PKG} and ${KERNEL_PKG}-headers, which
+  # is linux/linux-headers on x86_64. Same -Rdd mechanism as asahi.sh.
+  run grep -F 'pacman -Rdd --noconfirm' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+  run grep -E 'linux-headers' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "leftover module trees are deleted, because initramfs.img is not packaged" {
+  # pacman -Rdd removes packaged files; the generated initramfs.img in the
+  # stock tree survives and keeps the tree alive.
+  run grep -F 'find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d ! -name "$KVER" -exec rm -rf {} +' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "exactly one remaining kernel is proven, not hoped for" {
+  # tunaOS#912: the same rm -rf silently not working shipped a two-kernel
+  # image. The count must be asserted and must exit non-zero.
+  run grep -F 'REMAINING_COUNT' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+  run grep -E 'REMAINING_COUNT.*-ne 1' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+  # The assertion block must terminate the build.
+  run awk '/REMAINING_COUNT.*-ne 1/{f=1} f&&/exit 1/{print "found"; exit}' "$CACHYOS_SH"
+  [ "$output" = "found" ]
+}
+
+@test "the single-kernel assertion runs BEFORE the initramfs is built" {
+  run awk '/REMAINING_COUNT.*-ne 1/{print NR; exit}' "$CACHYOS_SH"
+  local assert_line="$output"
+  run awk '/^dracut --force/{print NR; exit}' "$CACHYOS_SH"
+  local dracut_line="$output"
+  [ -n "$assert_line" ]
+  [ -n "$dracut_line" ]
+  [ "$assert_line" -lt "$dracut_line" ]
+}
+
+# ── dracut names its kernel ────────────────────────────────────────────────
+
+@test "cachyos.sh passes both the output path and the kernel version to dracut" {
+  # dracut's second positional is the kernel version. Passing the path alone is
+  # what let the path and the built kernel disagree.
+  run grep -F 'dracut --force --omit "tpm2-tss" "/usr/lib/modules/${KVER}/initramfs.img" "${KVER}"' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "the --omit tpm2-tss behaviour is preserved" {
+  # tpm2-tss is in the installed package set; dropping the omit while
+  # rewriting the line would be a silent behaviour change.
+  run grep -F -- '--omit "tpm2-tss"' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "Containerfile.arch passes the kernel version to dracut and dracut-config" {
+  run grep -F 'dracut --force "/usr/lib/modules/${KVER}/initramfs.img" "${KVER}"' "$ARCH_CF"
+  [ "$status" -eq 0 ]
+  # dracut-config.sh probes drivers against a kernel's module tree; it takes
+  # the kver positionally and otherwise guesses with a plain (non -V) sort.
+  run grep -F '/run/context/build_scripts/bootc/dracut-config.sh "$KVER"' "$ARCH_CF"
+  [ "$status" -eq 0 ]
+}
+
+@test "cachyos.sh matches the nvidia-arch overlay's positional path+kver form" {
+  # nvidia-arch is the sibling Arch overlay whose five flavors passed the Gate
+  # in the run that failed all five cachyos flavors. Both must name the kernel.
+  run grep -E 'dracut .*"/usr/lib/modules/\$\{KVER\}/initramfs\.img" "\$\{KVER\}"' "$NVIDIA_ARCH_SH"
+  [ "$status" -eq 0 ]
+  run grep -E 'dracut .*"/usr/lib/modules/\$\{KVER\}/initramfs\.img" "\$\{KVER\}"' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+}
+
+# ── no full upgrade mid-overlay ────────────────────────────────────────────
+
+@test "cachyos.sh does not run a full -Syu mid-overlay" {
+  # A full upgrade on a published parent can bump the stock kernel too, adding
+  # a second moving kernel to a script whose job is to end with one. Not what
+  # broke run 31766586852 (no `upgrading linux` in its log) — a latent one.
+  run grep -E '^[^#]*pacman -Syu' "$CACHYOS_SH"
+  [ "$status" -ne 0 ]
+  run grep -E '^pacman -Sy --noconfirm$' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+  run grep -E '^pacman -S --noconfirm --needed' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "linux-cachyos is still what gets installed" {
+  run grep -F 'linux-cachyos linux-cachyos-headers' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+}

--- a/tests/bats/test_cachyos_overlay.bats
+++ b/tests/bats/test_cachyos_overlay.bats
@@ -147,9 +147,14 @@ NVIDIA_ARCH_SH="${REPO_ROOT}/build_scripts/overlay/overrides/nvidia-arch/20-nvid
 @test "cachyos.sh matches the nvidia-arch overlay's positional path+kver form" {
   # nvidia-arch is the sibling Arch overlay whose five flavors passed the Gate
   # in the run that failed all five cachyos flavors. Both must name the kernel.
-  run grep -E 'dracut .*"/usr/lib/modules/\$\{KVER\}/initramfs\.img" "\$\{KVER\}"' "$NVIDIA_ARCH_SH"
+  #
+  # Match the positional pair alone, without a `dracut .*` prefix: nvidia-arch
+  # wraps its invocation across two lines (the args are on the continuation),
+  # and grep is line-oriented, so requiring both on one line asserts a line
+  # layout rather than the thing that matters.
+  run grep -E '"/usr/lib/modules/\$\{KVER\}/initramfs\.img" "\$\{KVER\}"' "$NVIDIA_ARCH_SH"
   [ "$status" -eq 0 ]
-  run grep -E 'dracut .*"/usr/lib/modules/\$\{KVER\}/initramfs\.img" "\$\{KVER\}"' "$CACHYOS_SH"
+  run grep -E '"/usr/lib/modules/\$\{KVER\}/initramfs\.img" "\$\{KVER\}"' "$CACHYOS_SH"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
Closes #1563.

The build logs settle the diagnosis, and they settle it twice.

## The gamble, caught in the act

`cachyos.sh` installs `linux-cachyos` onto a parent that already ships stock `linux` (`Containerfile.arch:85-98` installs `${KERNEL_PKG}` and `${KERNEL_PKG}-headers`), leaving two module trees. It then wrote exactly one initramfs to a `find | tail -1` path — readdir order.

Same script, same commit, one nightly, five flavors, **two answers**, straight from run [31766586852](https://github.com/tuna-os/tunaOS/actions/runs/31766586852):

| Flavor | dracut output path | Gate failure |
|---|---|---|
| gnome / kde / cosmic-cachyos | `/usr/lib/modules/7.1.8-arch1-3/initramfs.img` ← **stock** | `bootc install`: "Computing boot digest: initramfs not found" |
| xfce / niri-cachyos | `/usr/lib/modules/7.1.8-1-cachyos/initramfs.img` ← cachyos | installs, never reaches `graphical.target` |

That split is exactly the split in the issue's two failure presentations. Two symptoms, one cause, no inference required.

## `sort -V` would have made it worse

The obvious fix is to copy the sibling `nvidia-arch` overlay's selector. Don't — it's wrong for this kernel pair:

```
$ printf '6.17.1-arch1-1\n6.17.1-2-cachyos\n' | sort -V | tail -1
6.17.1-arch1-1
```

Version-sort puts the **stock** kernel last, so `sort -V | tail -1` converts a coin flip into a deterministic wrong answer. The package is literally `linux-cachyos` and its module dir carries `cachyos`, so selection is by name — and a test pins the `sort -V` ordering directly, so a future "cleanup" fails CI instead of the nightly.

## What changed

Every step now names the kernel:

- **Select by name** (`-name '*cachyos*'`); empty is a hard failure, not an empty path.
- **Remove the stock kernel** — `asahi.sh:179`'s `-Rdd` pattern, placed *after* the install so a failed `linux-cachyos` transaction leaves a bootable image rather than none.
- **Delete leftover trees and prove one remains.** Package removal alone isn't enough: `initramfs.img` is generated, not packaged, so pacman leaves the stock tree standing. #912 is this same cleanup silently not working and publishing a two-kernel image.
- **Pass dracut the path *and* the kernel version positionally** — the form `overrides/nvidia-arch/20-nvidia.sh` uses, i.e. the sibling Arch overlay whose five flavors passed the Gate in the very run where these five failed.
- `-Sy` + `-S` instead of `-Syu`. **This one is latent, not the observed cause** — the failing log shows `installing linux-cachyos` with no `upgrading linux`, so the parent's kernel was untouched. I'd rather not have a second moving kernel in a script whose job is to end with one.

`Containerfile.arch:171` carried the same idiom. It only ever sees one kernel, so it was correct by luck; it now names the kernel once and hands it to both `dracut-config.sh` (which otherwise re-guesses with a plain, non-version sort) and `dracut`.

## Verification

15 shape assertions in `tests/bats/test_cachyos_overlay.bats`, in the style of `test_nvidia_overlay.bats`. `bats-core` isn't installed in my environment, so I ran the real `.bats` file through a shim and against both trees:

```
this branch      15/15 passed
upstream/main     3/15 passed
```

The 3 that pass on both are the behaviour-preservation guards — `--omit tpm2-tss` still present, `linux-cachyos` still installed — which is what they're for. Every substantive assertion fails pre-fix.

Two of those tests were wrong when I first wrote them and the shim caught it: one matched `cachyos.sh`'s own explanatory comment quoting the old line (now anchored `^[^#]*`, same as `test_nvidia_overlay.bats:108`), and one used `grep -F "-name ..."` without `--`, so grep parsed the pattern as options.

**Boundary:** this is shape-tested and argued from the sibling overlay that passes — not built. The first real proof is the next nightly.

## Follow-ups, deliberately out of scope

`Containerfile.debian:204` and `:258`, and `dracut-config.sh`'s plain-`sort` default, carry the same latent idiom. The issue names only `Containerfile.arch`, so I left them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
