### PR TITLE
fix(flounder-sid): pin nvidia dkms headers to the baked kernel's ABI

### DIFF
--- a/build_scripts/overlay/overrides/nvidia-debian/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia-debian/20-nvidia.sh
@@ -20,8 +20,25 @@
 # is a virtual package resolving to linux-image-amd64 (verified via
 # packages.debian.org, 2026-08-08), and linux-headers-generic resolves to
 # the matching linux-headers-amd64 the SAME way — both are kept in lockstep
-# by the linux source package, so installing them together always pairs a
+# by the linux source package, so installing them TOGETHER always pairs a
 # kernel with its own headers, no exact-EVR juggling required.
+#
+# That lockstep is real, and it is why Containerfile.debian's base stage needs
+# no version pinning. It does NOT carry over to this stage, and assuming it did
+# is tunaOS#1565. Here the kernel is already baked into the base layer — served
+# from --cache-from ghcr.io/tuna-os/tunaos-buildcache — while only the headers
+# are installed, resolved against whatever the archive holds TODAY. The two
+# lockstep with each other, not with the cached layer. On sid they diverge
+# constantly (madison, 2026-08-14):
+#
+#   linux-headers-amd64 | 7.1.7-1 | testing
+#   linux-headers-amd64 | 7.1.8-1 | unstable
+#
+# so `linux-headers-generic` on a base layer holding 7.1.7 installed the 7.1.8
+# headers, upgraded linux-image-amd64 from 7.1.7-1 "over" to 7.1.8-1, created a
+# second /usr/lib/modules tree, and dkms built nvidia-current.ko.xz for
+# 7.1.8+deb14-amd64 while every KVER-keyed step below still pointed at 7.1.7.
+# Headers are therefore pinned to the baked kernel, not taken from the meta.
 #
 # The exact dkms module name nvidia-kernel-dkms registers is NOT assumed:
 # the Debian Contents index (2026-08-08) shows
@@ -75,13 +92,48 @@ cat /etc/apt/sources.list.d/*.sources /etc/apt/sources.list 2>/dev/null || true
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
 
-# linux-headers-generic is a virtual package resolving to the arch-specific
-# real one (linux-headers-amd64 here) — see header. dkms needs it present
-# under /usr/lib/modules/${KVER}/build before autoinstall below has
-# anything to build against.
+# Headers for the kernel THIS IMAGE ACTUALLY CARRIES, by exact ABI name, in
+# their own transaction ahead of the driver — see the header for why
+# linux-headers-generic (-> linux-headers-amd64 -> whatever the archive serves
+# today) is the wrong package here.
+#
+# Debian keeps the ABI-versioned binaries in the archive across a transition
+# while the meta moves on, which is what makes pinning work (madison,
+# 2026-08-14):
+#
+#   linux-headers-7.1.7+deb14-amd64 | 7.1.7-1 | testing, unstable
+#   linux-headers-7.1.8+deb14-amd64 | 7.1.8-1 | unstable
+#
+# and linux-headers-<abi>-amd64 depends only on gcc-*-for-host, linux-base,
+# linux-base-<abi>, linux-headers-<abi>-common and linux-kbuild-<abi> — no
+# linux-image — so this cannot drag a second kernel in the way the meta did.
+#
+# Separate transaction, before the driver: nvidia-kernel-dkms's postinst
+# autobuilds against whatever headers are installed at that moment, so the
+# only way to guarantee it builds for ${KVER} is for ${KVER}'s headers to be
+# the only ones present when it is unpacked. (apt would satisfy dkms itself
+# either way — nvidia-kernel-dkms Depends on it.)
+HEADERS_PKG="linux-headers-${KVER}"
+echo "==> installing headers for the baked kernel: ${HEADERS_PKG}"
+if ! apt-get install -y --no-install-recommends "$HEADERS_PKG"; then
+	echo "ERROR: ${HEADERS_PKG} is not installable from this archive." >&2
+	echo "       This image's baked kernel is ${KVER}, but the Debian archive no" >&2
+	echo "       longer carries headers for that ABI — i.e. the base layer (usually" >&2
+	echo "       served from --cache-from ghcr.io/tuna-os/tunaos-buildcache) is older" >&2
+	echo "       than the archive by more than one kernel transition." >&2
+	echo "" >&2
+	echo "       This is NOT fixable by installing linux-headers-generic instead:" >&2
+	echo "       that resolves to the current ABI, and dkms would build the driver" >&2
+	echo "       for a kernel this image does not ship (tunaOS#1565)." >&2
+	echo "       Rebuild the base layer so its kernel is current, then retry." >&2
+	echo "" >&2
+	echo "       what the archive offers now:" >&2
+	apt-cache policy linux-headers-amd64 "$HEADERS_PKG" >&2 || true
+	exit 1
+fi
+
 apt-get install -y --no-install-recommends \
 	dkms \
-	linux-headers-generic \
 	nvidia-kernel-dkms \
 	nvidia-driver-libs \
 	nvidia-vulkan-icd \
@@ -89,8 +141,10 @@ apt-get install -y --no-install-recommends \
 	libgl1-nvidia-glvnd-glx
 
 if [[ ! -e "/usr/lib/modules/${KVER}/build" ]]; then
-	echo "ERROR: /usr/lib/modules/${KVER}/build is missing after installing linux-headers-generic —" >&2
+	echo "ERROR: /usr/lib/modules/${KVER}/build is missing after installing ${HEADERS_PKG} —" >&2
 	echo "       dkms has no headers to build the nvidia module against for ${KVER}." >&2
+	echo "       The package installed cleanly, so this is a packaging-layout change" >&2
+	echo "       rather than the archive skew in tunaOS#1565 — that path exits above." >&2
 	exit 1
 fi
 

--- a/tests/bats/test_nvidia_overlay_arch_debian.bats
+++ b/tests/bats/test_nvidia_overlay_arch_debian.bats
@@ -114,10 +114,85 @@ VERIFY_DEBIAN_SH="${REPO_ROOT}/build_scripts/checks/verify-nvidia-debian.sh"
 @test "nvidia-debian 20-nvidia.sh guards on IS_DEBIAN and asserts the dkms build tree before building" {
   run grep -F 'IS_DEBIAN' "$DEBIAN_INSTALL_SH"
   [ "$status" -eq 0 ]
-  run grep -F 'linux-headers-generic' "$DEBIAN_INSTALL_SH"
+  # This used to assert linux-headers-generic was installed. That package is
+  # the defect (tunaOS#1565), not the contract — see the headers tests below.
+  run grep -F '/usr/lib/modules/${KVER}/build' "$DEBIAN_INSTALL_SH"
   [ "$status" -eq 0 ]
   run grep -F 'dkms autoinstall' "$DEBIAN_INSTALL_SH"
   [ "$status" -eq 0 ]
+}
+
+# ── headers must match the BAKED kernel, not today's archive (tunaOS#1565) ──
+#
+# KVER is read from the kernel already in the base layer, which is normally
+# served from --cache-from. Installing linux-headers-generic resolved to
+# linux-headers-amd64 at whatever version the archive held at build time. On
+# sid those diverge constantly:
+#
+#   linux-headers-amd64 | 7.1.7-1 | testing
+#   linux-headers-amd64 | 7.1.8-1 | unstable
+#
+# so on a 7.1.7 base layer the overlay installed 7.1.8 headers, upgraded
+# linux-image-amd64 "over" 7.1.7-1, made a second /usr/lib/modules tree, and
+# dkms built for 7.1.8 while every KVER-keyed step still meant 7.1.7.
+
+@test "nvidia-debian 20-nvidia.sh does not install linux-headers-generic" {
+  # Target the package-list usage specifically. The name still appears in the
+  # header (explaining the defect) and in the not-installable error (telling
+  # the reader why falling back to it is not the fix) — a test that matched any
+  # mention would fail on the fix's own documentation. What must never come
+  # back is the package being handed to apt.
+  run grep -nE '^[[:space:]]*linux-headers-generic[[:space:]]*\\?[[:space:]]*$' "$DEBIAN_INSTALL_SH"
+  [ "$status" -ne 0 ]
+  run grep -nE 'apt-get install[^|&;]*linux-headers-generic' "$DEBIAN_INSTALL_SH"
+  [ "$status" -ne 0 ]
+}
+
+@test "nvidia-debian 20-nvidia.sh installs headers for the exact baked ABI" {
+  run grep -F 'HEADERS_PKG="linux-headers-${KVER}"' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'apt-get install -y --no-install-recommends "$HEADERS_PKG"' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "nvidia-debian 20-nvidia.sh installs the headers before the dkms driver" {
+  # nvidia-kernel-dkms's postinst autobuilds against whatever headers are
+  # installed when it is unpacked, so ${KVER}'s headers must be the only ones
+  # present by then. Same transaction is not enough — order is the contract.
+  run awk '/HEADERS_PKG="linux-headers-\$\{KVER\}"/{print NR; exit}' "$DEBIAN_INSTALL_SH"
+  local headers_line="$output"
+  # Anchor to the package-list line, not the first mention anywhere: the file
+  # header discusses nvidia-kernel-dkms long before either is installed.
+  run awk '/^[[:space:]]+nvidia-kernel-dkms[[:space:]]*\\?[[:space:]]*$/{print NR; exit}' "$DEBIAN_INSTALL_SH"
+  local dkms_line="$output"
+  [ -n "$headers_line" ]
+  [ -n "$dkms_line" ]
+  [ "$headers_line" -lt "$dkms_line" ]
+}
+
+@test "nvidia-debian 20-nvidia.sh fails loudly when the baked kernel's headers are gone from the archive" {
+  # Deliberately NOT the fallback the issue suggested. Falling back to
+  # linux-headers-generic reproduces the failure exactly, so it recovers
+  # nothing — it just moves the error later and makes it harder to read.
+  run grep -F 'is not installable from this archive' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  # The message must name the real cause (a base layer older than the archive)
+  # rather than leaving the reader at a missing build directory.
+  run grep -F 'cache-from' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  # And it must exit, not warn.
+  run awk '/is not installable from this archive/{f=1} f&&/^\texit 1/{print "found"; exit}' "$DEBIAN_INSTALL_SH"
+  [ "$output" = "found" ]
+}
+
+@test "nvidia-debian keeps the single-kernel-tree contract satisfiable" {
+  # verify-nvidia-debian.sh requires exactly one tree under /usr/lib/modules.
+  # The old headers path created a second one, so that contract could not hold
+  # on flounder-sid regardless of what the overlay did afterwards.
+  run grep -F 'kernel module trees under /usr/lib/modules' "$VERIFY_DEBIAN_SH"
+  [ "$status" -eq 0 ]
+  run grep -nE '^[^#]*linux-image-generic' "$DEBIAN_INSTALL_SH"
+  [ "$status" -ne 0 ]
 }
 
 @test "nvidia-debian 20-nvidia.sh proves the module by finding it on disk, not by trusting dkms status text" {


### PR DESCRIPTION
Closes #1565.

## Root cause, confirmed against the live archive

`KVER` comes from the kernel already baked into the base layer — normally served from `--cache-from`. The overlay then asked for `linux-headers-generic`, a virtual package resolving to `linux-headers-amd64`, i.e. to whatever the archive holds **at build time**. On sid those are not the same thing (`madison`, 2026-08-14):

```
linux-headers-amd64 | 7.1.7-1 | testing
linux-headers-amd64 | 7.1.8-1 | unstable
```

The file header assumed image and headers move in lockstep. They do — *with each other*. That's sound in `Containerfile.debian`'s base stage, where both are installed together. It doesn't survive into this stage, where only headers are installed against an archive that moved after the base layer was cached. I corrected the comment in place rather than deleting it; it's still right about the base stage.

## It was worse than wrong headers

The failing transaction also did this:

```
Unpacking linux-image-amd64 (7.1.8-1) over (7.1.7-1) ...
Setting up linux-image-7.1.8+deb14-amd64 (7.1.8-1) ...
```

So the overlay was dragging the image's kernel meta forward and creating a **second** `/usr/lib/modules` tree — which `verify-nvidia-debian.sh:71` rejects outright ("expected exactly 1"). That contract could not hold on flounder-sid regardless of what happened downstream.

## The fix

Ask for the ABI-versioned package by name — `linux-headers-${KVER}` — in its own transaction ahead of the driver.

Debian keeps ABI-versioned binaries in the archive across a transition while the meta moves on, which is exactly what makes pinning work:

```
linux-headers-7.1.7+deb14-amd64 | 7.1.7-1 | testing, unstable
linux-headers-7.1.8+deb14-amd64 | 7.1.8-1 | unstable
```

and `linux-headers-<abi>-amd64` depends only on `gcc-*-for-host`, `linux-base`, `linux-base-<abi>`, `linux-headers-<abi>-common`, `linux-kbuild-<abi>` — **no `linux-image`** — so it can't drag a kernel in the way the meta did.

Separate transaction, *before* the driver: `nvidia-kernel-dkms`'s postinst autobuilds against whatever headers are installed when it's unpacked, so `${KVER}`'s headers must be the only ones present by then.

## I did not implement the suggested fallback

The issue proposes falling back to `linux-headers-generic` if the exact package is gone. **That fallback is the defect** — it resolves to the current ABI and reproduces this exact failure, so it recovers nothing; it just moves the error later and makes it harder to read.

Instead, when the baked kernel's ABI has aged out of the archive the build stops and names the real cause:

```
ERROR: linux-headers-7.1.7+deb14-amd64 is not installable from this archive.
       This image's baked kernel is 7.1.7+deb14-amd64, but the Debian archive no
       longer carries headers for that ABI — i.e. the base layer (usually
       served from --cache-from ghcr.io/tuna-os/tunaos-buildcache) is older
       than the archive by more than one kernel transition.
       ...
       Rebuild the base layer so its kernel is current, then retry.
```

Net effect: in the common window (old ABI still in the archive — the case today) builds that used to fail now succeed. In the rare window they still fail, but with a one-line diagnosis instead of a confusing missing-`build` error. `snapshot.debian.org` would be the way to stay green through that window; that's a bigger change than this issue.

## Why `sort -V` is still fine on line 41

Worth pre-empting, since #1640 argues the opposite idiom is a deterministic wrong answer on Arch. `KVER` here is still `find … | sort -V | tail -1`, and that's correct in this file for two reasons: Debian ABI strings version-sort the way you'd want (`7.1.7+deb14-amd64` < `7.1.8+deb14-amd64`), unlike Arch's `6.17.1-2-cachyos` vs `6.17.1-arch1-1`; and at that point in the overlay only the base layer's single tree exists. This PR is what keeps that second condition true.

## Verification

**31/31 on this branch, 27/31 against `upstream/main`.** Five tests added (the suite went 26 → 31); four of them fail against `upstream/main`. The fifth, *keeps the single-kernel-tree contract satisfiable*, passes on both trees by design — it documents the link to `verify-nvidia-debian.sh`'s existing single-tree assertion rather than testing this change, so it's a regression guard, not evidence for the fix. `bats` isn't installed in my environment, so I ran the real `.bats` file through a shim; CI is the real runner.

I also had to fix the shim itself, and it's worth flagging because it affected how much my earlier local runs were actually proving: `set -e` is suppressed inside a subshell used as an `if` condition, so **only the last assertion in each test counted** — a failing assertion mid-test passed silently. And `run` must tolerate non-zero exits (they're data), which plain `output="$(...)"` under errexit does not. With both fixed I re-ran #1563's suite: still 15/15 vs 3/15, so nothing was masked there.

One thing that fix caught in my own work: the existing `guards on IS_DEBIAN` test asserted `linux-headers-generic` **was** installed — it was pinning the defect, so it would have gone green on the broken code forever. Replaced with the `${KVER}/build` assertion it was presumably reaching for.

**Boundary:** verified against the live Debian archive and shape-tested — not built. First real proof is the next flounder-sid nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
