### PR TITLE
fix(flounder): install the packages that actually ship the Wayland GBM path

### DIFF
--- a/build_scripts/checks/verify-nvidia-debian.sh
+++ b/build_scripts/checks/verify-nvidia-debian.sh
@@ -148,6 +148,19 @@ if compgen -G "${NVLIB}/nvidia-drm_gbm.so" >/dev/null; then
 else
 	fail "missing /usr/lib/x86_64-linux-gnu/nvidia/current/nvidia-drm_gbm.so — Wayland compositors cannot use the driver"
 fi
+# The backend above is loaded THROUGH the EGL external-platform registration,
+# not directly: without 15_nvidia_gbm.json, EGL never looks for the GBM
+# platform and nvidia-drm_gbm.so sits on disk doing nothing. Checking only the
+# .so made "Wayland compositors can use the driver" provable in a state where
+# they still could not — and, unlike the .so, nothing in the nvidia-driver
+# dependency chain pulls this in even with Recommends enabled, so it can only
+# ever arrive by being named in the install list (tunaOS#1564). Path read from
+# libnvidia-egl-gbm1's file list (trixie 1.1.2.1-1; same version in unstable).
+if compgen -G "${NV_ROOT}/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json" >/dev/null; then
+	pass "EGL GBM external platform registered"
+else
+	fail "missing /usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json (libnvidia-egl-gbm1) — EGL will not load the GBM backend"
+fi
 
 echo "== initramfs policy =="
 DRACUT_CONF="${NV_ROOT}/usr/lib/dracut/dracut.conf.d/99-nvidia.conf"

--- a/build_scripts/overlay/overrides/nvidia-debian/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia-debian/20-nvidia.sh
@@ -87,6 +87,40 @@ if ! apt-cache show "$HEADERS_PKG" >/dev/null 2>&1; then
 	HEADERS_PKG="linux-headers-generic"
 fi
 
+# linux-headers-generic is a virtual package resolving to the arch-specific
+# real one (linux-headers-amd64 here) — see header. dkms needs it present
+# under /usr/lib/modules/${KVER}/build before autoinstall below has
+# anything to build against.
+#
+# --no-install-recommends is deliberate, but it means every Recommends this
+# stack needs has to be named here. nvidia-driver-libs Recommends
+# libnvidia-allocator1 (verified on packages.debian.org, trixie 550.163.01-2),
+# and that is the package shipping
+# /usr/lib/x86_64-linux-gnu/nvidia/current/nvidia-drm_gbm.so — read straight
+# off its file list, not inferred. Dropping the Recommends dropped the file,
+# and verify-nvidia-debian.sh failed every flounder nvidia build on it
+# (tunaOS#1564).
+#
+# The two egl-* packages are separate source packages that nothing in the
+# nvidia-driver chain depends on OR recommends, so they were never going to
+# arrive on their own. They are what makes the GBM backend reachable rather
+# than merely present:
+#
+#   libnvidia-egl-gbm1     libnvidia-egl-gbm.so.1
+#                          /usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
+#   libnvidia-egl-wayland1 libnvidia-egl-wayland.so.1
+#
+# Without that JSON, EGL never loads the GBM external platform and
+# nvidia-drm_gbm.so sits on disk unused — the contract check would pass while
+# the thing it exists to guarantee still did not work. egl-wayland is the same
+# component the Arch sibling installs as `egl-wayland`
+# (overrides/nvidia-arch/20-nvidia.sh), so this also brings the two families
+# to parity.
+#
+# All three are in stable AND unstable for amd64/arm64 (madison, 2026-08-14),
+# so this is safe for flounder (trixie) and flounder-sid alike;
+# libnvidia-egl-gbm1 is in contrib and the rest in non-free/main, all of which
+# the component-enabling block above turns on.
 apt-get install -y --no-install-recommends \
 	dkms \
 	"${HEADERS_PKG}" \
@@ -94,7 +128,10 @@ apt-get install -y --no-install-recommends \
 	nvidia-driver-libs \
 	nvidia-vulkan-icd \
 	nvidia-settings \
-	libgl1-nvidia-glvnd-glx
+	libgl1-nvidia-glvnd-glx \
+	libnvidia-allocator1 \
+	libnvidia-egl-gbm1 \
+	libnvidia-egl-wayland1
 
 if [[ ! -e "/usr/lib/modules/${KVER}/build" ]]; then
 	echo "ERROR: /usr/lib/modules/${KVER}/build is missing after installing linux-headers-generic —" >&2

--- a/tests/bats/test_nvidia_overlay_arch_debian.bats
+++ b/tests/bats/test_nvidia_overlay_arch_debian.bats
@@ -267,6 +267,7 @@ make_good_debian_root() {
     "$r/usr/lib/bootc/kargs.d" \
     "$r/usr/share/glvnd/egl_vendor.d" \
     "$r/usr/share/vulkan/icd.d" \
+    "$r/usr/share/egl/egl_external_platform.d" \
     "$r/usr/lib/dracut/dracut.conf.d" \
     "$nvlib"
   # nvidia-current.ko.xz is what Debian's alternatives-managed
@@ -285,6 +286,10 @@ make_good_debian_root() {
   echo '{}' >"$r/usr/share/glvnd/egl_vendor.d/10_nvidia.json"
   echo '{}' >"$r/usr/share/vulkan/icd.d/nvidia_icd.json"
   touch "$nvlib/libEGL_nvidia.so.0" "$nvlib/libGLX_nvidia.so.0" "$nvlib/nvidia-drm_gbm.so"
+  # nvidia-drm_gbm.so is only reachable through this registration — the file
+  # alone is not a working GBM path (tunaOS#1564). From libnvidia-egl-gbm1's
+  # file list; libnvidia-allocator1 ships the .so above.
+  echo '{}' >"$r/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json"
   echo 'force_drivers+=" i915 amdgpu nvidia nvidia_modeset nvidia_uvm nvidia_drm "' \
     >"$r/usr/lib/dracut/dracut.conf.d/99-nvidia.conf"
   echo "$r"
@@ -354,6 +359,56 @@ run_verify_debian() {
   run_verify_debian "$root"
   [ "$status" -ne 0 ]
   [[ "$output" == *"nvidia-drm_gbm.so"* ]]
+}
+
+@test "verify-nvidia-debian fails when the EGL GBM external platform is unregistered" {
+  # The .so present but its platform JSON absent is the state that would let a
+  # driver look complete to the old check while EGL never loaded the GBM
+  # backend at all (tunaOS#1564).
+  make_debian_stub_tools
+  root="$(make_good_debian_root)"
+  rm "$root/usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json"
+  run_verify_debian "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"15_nvidia_gbm.json"* ]]
+  [[ "$output" == *"libnvidia-egl-gbm1"* ]]
+}
+
+# ── the packages that ship the Wayland path (tunaOS#1564) ──────────────────
+#
+# --no-install-recommends means every Recommends has to be named. The overlay
+# installed nvidia-driver-libs but not libnvidia-allocator1, which is where
+# .../nvidia/current/nvidia-drm_gbm.so actually comes from — so every flounder
+# nvidia build failed the contract on a file no listed package shipped.
+
+@test "nvidia-debian 20-nvidia.sh installs libnvidia-allocator1 for nvidia-drm_gbm.so" {
+  # Must be an installed package, not just a name in a comment.
+  run grep -nE '^[[:space:]]*libnvidia-allocator1[[:space:]]*\\?[[:space:]]*$' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "nvidia-debian 20-nvidia.sh installs the EGL external platform packages" {
+  # Neither is a dependency OR a recommendation of anything else in the list,
+  # so they can only arrive by being named. libnvidia-egl-gbm1 is what makes
+  # the GBM backend loadable; egl-wayland matches what the Arch sibling
+  # installs as `egl-wayland`.
+  run grep -nE '^[[:space:]]*libnvidia-egl-gbm1[[:space:]]*\\?[[:space:]]*$' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -nE '^[[:space:]]*libnvidia-egl-wayland1[[:space:]]*\\?[[:space:]]*$' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'egl-wayland' "$ARCH_INSTALL_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "the contract check and the install list agree about the GBM path" {
+  # The pairing that broke: a check asserting a file, and an install list that
+  # ships no package providing it. Both halves must move together.
+  run grep -F 'nvidia-drm_gbm.so' "$VERIFY_DEBIAN_SH"
+  [ "$status" -eq 0 ]
+  run grep -F '15_nvidia_gbm.json' "$VERIFY_DEBIAN_SH"
+  [ "$status" -eq 0 ]
+  run grep -nE '^[[:space:]]*libnvidia-(allocator1|egl-gbm1)[[:space:]]*\\?[[:space:]]*$' "$DEBIAN_INSTALL_SH"
+  [ "$status" -eq 0 ]
 }
 
 @test "verify-nvidia-debian fails when the modeset karg is absent" {


### PR DESCRIPTION
Closes #1564.

## Confirmed from the archive, not inferred

The contract demands `/usr/lib/x86_64-linux-gnu/nvidia/current/nvidia-drm_gbm.so` and no package in the install list ships it. It comes from `libnvidia-allocator1`, which `nvidia-driver-libs` only **Recommends** — and `--no-install-recommends` drops it:

```
libnvidia-allocator1 (trixie 550.163.01-2) file list:
  /usr/lib/x86_64-linux-gnu/nvidia/current/libnvidia-allocator.so.1
  /usr/lib/x86_64-linux-gnu/nvidia/current/nvidia-drm_gbm.so

nvidia-driver-libs:  rec: libnvidia-allocator1 (= 550.163.01-2)
```

`--no-install-recommends` is deliberate and stays, so the Recommends has to be named.

## Why this isn't a one-line list edit

`nvidia-drm_gbm.so` is loaded **through** an EGL external-platform registration, and that registration is in a different package entirely:

```
libnvidia-egl-gbm1:
  /usr/lib/x86_64-linux-gnu/libnvidia-egl-gbm.so.1
  /usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json
```

Nothing in the nvidia chain depends on **or** recommends it — I checked `nvidia-driver` and `nvidia-driver-libs` directly — so it was never going to arrive on its own, even with Recommends enabled.

That matters: adding `libnvidia-allocator1` alone would have turned the check green while EGL still never looked for the GBM platform. The contract would have certified *"Wayland compositors can use the driver"* in a state where they could not. So the check is extended to assert `15_nvidia_gbm.json` alongside the `.so` — a check that guards half a mechanism is how this stayed scoped to one filename for as long as it did.

`libnvidia-egl-wayland1` is the same component the Arch sibling already installs as `egl-wayland` (`overrides/nvidia-arch/20-nvidia.sh`), so this also brings the two families level. It's worth noting it does **not** have the same split problem — it ships its own registration, so no fourth package is hiding behind it:

```
libnvidia-egl-wayland1 (trixie 1:1.1.18-1) file list:
  /usr/lib/x86_64-linux-gnu/libnvidia-egl-wayland.so.1
  /usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json
```

The allocator/egl-gbm split is the unusual one, which is exactly why it went unnoticed.

## Suite safety

All three are in **stable and unstable**, amd64 and arm64 (`madison`, 2026-08-14), so this is safe for flounder (trixie) and flounder-sid alike. `libnvidia-egl-gbm1` is in contrib, the rest non-free/main — all enabled by the component block already in this script.

These are Debian package names, and this overlay dispatches on `IS_DEBIAN`, so I checked whether Ubuntu-based Grouper/Gurnard could hit them: `.github/build-config.yml` declares no `grouper`/`gurnard` nvidia flavor, so nothing else reaches this code path.

## Verification

**30/30 on this branch, 26/30 against `upstream/main`**, with exactly the 4 new tests failing there. The good-root fixture gains the platform JSON, which is why the pre-existing "passes on a complete driver install" test still passes — the fixture and the contract moved together.

`bats` isn't installed in my environment, so I ran the real `.bats` file through a shim; CI is the real runner.

**Boundary:** verified against the live Debian archive and fixture-tested — not built. First real proof is the next flounder nightly.

## Note for whoever merges

This touches the same `apt-get install` block as **#1642** (flounder-sid header pinning, issue #1565). Both are based on `main`, so they'll conflict textually. The resolution for that block is to keep #1642's split (exact-ABI `linux-headers-${KVER}` in its own transaction first) and add this PR's three packages to the driver transaction.

They also both touch `tests/bats/test_nvidia_overlay_arch_debian.bats` — #1642 adds 5 tests and rewrites `guards on IS_DEBIAN`; this one adds 4 and edits `make_good_debian_root`. Different regions, but expect a second conflict there, not just the one in the install list. They're independent fixes for different variants and neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
