### PR TITLE
fix(chunkah): use the digest pin that already existed, prune /sysroot/, validate before load

### DIFF
--- a/registry-map.yaml
+++ b/registry-map.yaml
@@ -68,7 +68,16 @@ images:
     path: coreos/chunkah
     # SECURITY: Pinned to digest to prevent supply-chain attacks via tag mutation.
     # tag: latest is retained as fallback for setups without the pinned image.
-    digest: sha256:33ab77f29c90fb3ec7a3a6b6c84ee2f2bcff1846b3c34a3231092aebd39e673b
+    #
+    # Refreshed 2026-08-14 (tunaOS#1568). The previous pin
+    # (sha256:33ab77f2…) had been garbage-collected upstream — quay returns
+    # 404 for it — so anything resolving this entry would have fallen through
+    # to building chunkah from source on every build. Nothing noticed because
+    # registry_ref could not read this entry at all (see scripts/_registry.sh)
+    # and the only consumer hardcoded :latest. A pin that nothing bumps and
+    # nothing reads rots; renovate.json now has a manager for this file.
+    # Verified a manifest list covering amd64 + arm64, the two arches built here.
+    digest: sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708
     tag: latest
 
   # --- Tool images (build infra) ---

--- a/renovate.json
+++ b/renovate.json
@@ -1,23 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
-
+  "extends": [
+    "config:best-practices"
+  ],
   "platformAutomerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "automerge": true,
-
   "rebaseWhen": "conflicted",
-
   "git-submodules": {
     "enabled": true
   },
-
   "customManagers": [
     {
       "customType": "regex",
       "description": "Update image digests in image-versions.yaml",
-      "managerFilePatterns": ["/^image-versions\\.yaml$/"],
+      "managerFilePatterns": [
+        "/^image-versions\\.yaml$/"
+      ],
       "matchStrings": [
         "- name: (?<depName>[\\w-]+)\\n\\s+image: (?<packageName>[^\\n]+)\\n\\s+tag: (?<currentValue>[^\\n]+)\\n\\s+digest: (?<currentDigest>sha256:[a-f0-9]+)"
       ],
@@ -27,7 +27,9 @@
     {
       "customType": "regex",
       "description": "Update pinned downloads in image-versions.yaml (GitHub releases)",
-      "managerFilePatterns": ["/^image-versions\\.yaml$/"],
+      "managerFilePatterns": [
+        "/^image-versions\\.yaml$/"
+      ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)\\n\\s+[\\w-]+:\\s*\"(?<currentValue>[^\"]+)\""
       ]
@@ -35,7 +37,9 @@
     {
       "customType": "regex",
       "description": "Update GitHub Actions pinned SHAs",
-      "managerFilePatterns": ["/\\.github/workflows/.+\\.ya?ml$/"],
+      "managerFilePatterns": [
+        "/\\.github/workflows/.+\\.ya?ml$/"
+      ],
       "matchStrings": [
         "uses:\\s+(?<depName>[\\w-]+/[\\w-]+)@(?<currentDigest>[a-f0-9]{40})\\s*#\\s*(?<currentValue>v?\\d[^\\s]*)"
       ],
@@ -44,34 +48,62 @@
     {
       "customType": "regex",
       "description": "Update font/binary version pins in build scripts",
-      "managerFilePatterns": ["/^build_scripts/.+\\.sh$/", "/^scripts/.+\\.sh$/"],
+      "managerFilePatterns": [
+        "/^build_scripts/.+\\.sh$/",
+        "/^scripts/.+\\.sh$/"
+      ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)\\n.*?(?<currentValue>v?\\d+\\.\\d+[^\\s/\"]*)"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update quay.io image digests in registry-map.yaml. tunaOS#1568: this file carried a digest pin for supply-chain safety that nothing bumped, and the pin was garbage-collected upstream (quay 404) before anyone noticed. Scoped to `registry: quay` entries so registryUrlTemplate is correct by construction; a ghcr entry that gains a digest needs its own block rather than silently resolving against the wrong registry.",
+      "managerFilePatterns": [
+        "/^registry-map\\.yaml$/"
+      ],
+      "matchStrings": [
+        "registry: quay\\n\\s+path: (?<packageName>[^\\n]+)\\n(?:\\s+#[^\\n]*\\n)*\\s+digest: (?<currentDigest>sha256:[a-f0-9]+)\\n\\s+tag: (?<currentValue>[^\\n]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "registryUrlTemplate": "https://quay.io",
+      "depNameTemplate": "{{{packageName}}}"
     }
   ],
-
   "packageRules": [
     {
       "description": "Automerge everything",
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "pinDigest", "digest"],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest"
+      ],
       "automerge": true
     },
     {
       "description": "Group all GitHub Actions updates into a single PR",
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "groupName": "github-actions",
       "automerge": true
     },
     {
       "description": "Group git-submodule updates into a single PR",
-      "matchManagers": ["git-submodules"],
+      "matchManagers": [
+        "git-submodules"
+      ],
       "groupName": "submodules",
       "automerge": true
     },
     {
-      "description": "ghcr.io/projectbluefin/common:latest moves upstream multiple times a day, and digest-tracking PRs get superseded rather than updated in place — three separate PRs (each a full CI run) landed in ~33 hours (tunaOS#753). Debounce: wait for a digest to sit still for a few days before opening a PR, so rapid upstream churn coalesces into one PR instead of several.",
-      "matchPackageNames": ["ghcr.io/projectbluefin/common"],
+      "description": "ghcr.io/projectbluefin/common:latest moves upstream multiple times a day, and digest-tracking PRs get superseded rather than updated in place \u2014 three separate PRs (each a full CI run) landed in ~33 hours (tunaOS#753). Debounce: wait for a digest to sit still for a few days before opening a PR, so rapid upstream churn coalesces into one PR instead of several.",
+      "matchPackageNames": [
+        "ghcr.io/projectbluefin/common"
+      ],
       "minimumReleaseAge": "3 days"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,23 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices"
-  ],
+  "extends": ["config:best-practices"],
+
   "platformAutomerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "automerge": true,
+
   "rebaseWhen": "conflicted",
+
   "git-submodules": {
     "enabled": true
   },
+
   "customManagers": [
     {
       "customType": "regex",
       "description": "Update image digests in image-versions.yaml",
-      "managerFilePatterns": [
-        "/^image-versions\\.yaml$/"
-      ],
+      "managerFilePatterns": ["/^image-versions\\.yaml$/"],
       "matchStrings": [
         "- name: (?<depName>[\\w-]+)\\n\\s+image: (?<packageName>[^\\n]+)\\n\\s+tag: (?<currentValue>[^\\n]+)\\n\\s+digest: (?<currentDigest>sha256:[a-f0-9]+)"
       ],
@@ -27,9 +27,7 @@
     {
       "customType": "regex",
       "description": "Update pinned downloads in image-versions.yaml (GitHub releases)",
-      "managerFilePatterns": [
-        "/^image-versions\\.yaml$/"
-      ],
+      "managerFilePatterns": ["/^image-versions\\.yaml$/"],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)\\n\\s+[\\w-]+:\\s*\"(?<currentValue>[^\"]+)\""
       ]
@@ -37,9 +35,7 @@
     {
       "customType": "regex",
       "description": "Update GitHub Actions pinned SHAs",
-      "managerFilePatterns": [
-        "/\\.github/workflows/.+\\.ya?ml$/"
-      ],
+      "managerFilePatterns": ["/\\.github/workflows/.+\\.ya?ml$/"],
       "matchStrings": [
         "uses:\\s+(?<depName>[\\w-]+/[\\w-]+)@(?<currentDigest>[a-f0-9]{40})\\s*#\\s*(?<currentValue>v?\\d[^\\s]*)"
       ],
@@ -48,10 +44,7 @@
     {
       "customType": "regex",
       "description": "Update font/binary version pins in build scripts",
-      "managerFilePatterns": [
-        "/^build_scripts/.+\\.sh$/",
-        "/^scripts/.+\\.sh$/"
-      ],
+      "managerFilePatterns": ["/^build_scripts/.+\\.sh$/", "/^scripts/.+\\.sh$/"],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)\\n.*?(?<currentValue>v?\\d+\\.\\d+[^\\s/\"]*)"
       ]
@@ -59,9 +52,7 @@
     {
       "customType": "regex",
       "description": "Update quay.io image digests in registry-map.yaml. tunaOS#1568: this file carried a digest pin for supply-chain safety that nothing bumped, and the pin was garbage-collected upstream (quay 404) before anyone noticed. Scoped to `registry: quay` entries so registryUrlTemplate is correct by construction; a ghcr entry that gains a digest needs its own block rather than silently resolving against the wrong registry.",
-      "managerFilePatterns": [
-        "/^registry-map\\.yaml$/"
-      ],
+      "managerFilePatterns": ["/^registry-map\\.yaml$/"],
       "matchStrings": [
         "registry: quay\\n\\s+path: (?<packageName>[^\\n]+)\\n(?:\\s+#[^\\n]*\\n)*\\s+digest: (?<currentDigest>sha256:[a-f0-9]+)\\n\\s+tag: (?<currentValue>[^\\n]+)"
       ],
@@ -70,40 +61,28 @@
       "depNameTemplate": "{{{packageName}}}"
     }
   ],
+
   "packageRules": [
     {
       "description": "Automerge everything",
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "pin",
-        "pinDigest",
-        "digest"
-      ],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "pinDigest", "digest"],
       "automerge": true
     },
     {
       "description": "Group all GitHub Actions updates into a single PR",
-      "matchManagers": [
-        "github-actions"
-      ],
+      "matchManagers": ["github-actions"],
       "groupName": "github-actions",
       "automerge": true
     },
     {
       "description": "Group git-submodule updates into a single PR",
-      "matchManagers": [
-        "git-submodules"
-      ],
+      "matchManagers": ["git-submodules"],
       "groupName": "submodules",
       "automerge": true
     },
     {
-      "description": "ghcr.io/projectbluefin/common:latest moves upstream multiple times a day, and digest-tracking PRs get superseded rather than updated in place \u2014 three separate PRs (each a full CI run) landed in ~33 hours (tunaOS#753). Debounce: wait for a digest to sit still for a few days before opening a PR, so rapid upstream churn coalesces into one PR instead of several.",
-      "matchPackageNames": [
-        "ghcr.io/projectbluefin/common"
-      ],
+      "description": "ghcr.io/projectbluefin/common:latest moves upstream multiple times a day, and digest-tracking PRs get superseded rather than updated in place — three separate PRs (each a full CI run) landed in ~33 hours (tunaOS#753). Debounce: wait for a digest to sit still for a few days before opening a PR, so rapid upstream churn coalesces into one PR instead of several.",
+      "matchPackageNames": ["ghcr.io/projectbluefin/common"],
       "minimumReleaseAge": "3 days"
     }
   ]

--- a/scripts/_registry.sh
+++ b/scripts/_registry.sh
@@ -94,7 +94,21 @@ registry_ref() {
 		ref="${ref}${tag_spec}"
 	elif [[ -n "${default_digest}" && "${default_digest}" != "null" ]]; then
 		# Digest takes precedence over tag (security: immutable reference)
-		local digest_override_var="TUNA_IMAGE_DIGEST_${name}"
+		#
+		# ${name//-/_} like the path and tag overrides above, not a bare
+		# ${name}. A hyphen is not legal in a shell identifier, so for any
+		# hyphenated image name `${!var}` did not merely fail to find an
+		# override — bash aborted with "invalid variable name", and under this
+		# file's `set -euo pipefail` that took registry_ref down with it.
+		# coreos-chunkah is the only hyphenated image in registry-map.yaml that
+		# carries a digest, so `registry_ref coreos-chunkah` has never
+		# returned: the digest pin added there "to prevent supply-chain attacks
+		# via tag mutation" was unreachable by every caller, and
+		# build-image-inner.sh hardcoded quay.io/coreos/chunkah:latest instead
+		# (tunaOS#1568). The tests missed it because the digest case used a
+		# name without a hyphen and the hyphen case used a name without a
+		# digest — neither covered the intersection.
+		local digest_override_var="TUNA_IMAGE_DIGEST_${name//-/_}"
 		local digest="${!digest_override_var:-${default_digest}}"
 		ref="${ref}@${digest}"
 	elif [[ -n "${default_tag}" && "${default_tag}" != "null" ]]; then

--- a/scripts/build-image-inner.sh
+++ b/scripts/build-image-inner.sh
@@ -192,9 +192,18 @@ fi
 # ── Pass 2: Rechunk ──────────────────────────────────────────────────────────
 echo "==> Running chunkah on ${PRE_CHUNK_TAG}..."
 
+# Resolve through registry-map.yaml rather than hardcoding a ref, so chunkah
+# comes in digest-pinned like every other build input. registry-map.yaml has
+# carried a coreos-chunkah digest (with a "prevent supply-chain attacks via tag
+# mutation" comment) the whole time; registry_ref just could not read it —
+# see the digest-override note in scripts/_registry.sh (tunaOS#1568). An
+# unpinned :latest meant an upstream chunkah regression landed in our builds
+# the hour it was published, unreviewed, which is one of the two candidate
+# causes for the corrupt archive this block now also detects.
 if [[ -z "${CHUNKAH_IMAGE:-}" ]]; then
-	CHUNKAH_IMAGE="quay.io/coreos/chunkah:latest"
+	CHUNKAH_IMAGE="$(registry_ref coreos-chunkah)"
 fi
+echo "==> chunkah image: ${CHUNKAH_IMAGE}"
 if ! podman image inspect "${CHUNKAH_IMAGE}" &>/dev/null; then
 	if ! podman pull "${CHUNKAH_IMAGE}" 2>/dev/null; then
 		echo "==> chunkah image not pullable, building from source..."
@@ -208,32 +217,125 @@ fi
 # by copying the rootfs into container-local workspace, creating a temporary
 # /var/lib/rpm directory so chunkah's rpmdb component loader succeeds, and
 # passing `--prune /var/lib/rpm` so the dummy directory is never packed into the OCI archive.
-CHUNK_OUT=$(mktemp -d)
+# `--prune /sysroot/` — note the TRAILING SLASH. chunkah's scanner documents
+# it as load-bearing:
+#
+#   "Paths must be absolute. A trailing `/` means prune children only,
+#    keeping the directory itself."               (chunkah src/scan.rs)
+#
+# so `--prune /sysroot` (no slash) would drop the /sysroot directory itself,
+# which a bootc image needs as the real sysroot's mountpoint. Upstream's own
+# warning — the one bonito's log printed — spells it with the slash:
+# "Use --prune /sysroot/ to exclude it". Chunking an ostree object store
+# "produces poor results" per that warning, and packs bytes no deployment
+# reads. `prune` is a Vec, so it can be passed more than once.
+#
+# It goes on BOTH branches. The rpmdb branch — the one every RPM variant takes,
+# bonito included — passed no --prune at all, so the sysroot has been packed
+# into every rechunked RPM image.
+chunkah_attempt() {
+	local out_dir="$1"
+	podman run --rm \
+		--security-opt label=disable \
+		--network host \
+		--entrypoint="" \
+		-v "${out_dir}:/run/out:Z" \
+		--mount "type=image,source=${PRE_CHUNK_TAG},target=/chunkah" \
+		-v "${CHUNK_EMPTY_DEV}:/chunkah/dev:Z" \
+		"${CHUNKAH_IMAGE}" \
+		sh -c '
+			HAS_RPMDB=0
+			if [ -n "$(ls -A /chunkah/usr/lib/sysimage/rpm 2>/dev/null)" ] || [ -n "$(ls -A /chunkah/var/lib/rpm 2>/dev/null)" ]; then
+				HAS_RPMDB=1
+			fi
+			if [ "$HAS_RPMDB" = "1" ]; then
+				chunkah build --rootfs /chunkah --prune /sysroot/ --skip-special-files -o /run/out/out.ociarchive
+			else
+				echo "==> Image has no rpmdb — preparing rootfs copy with dummy rpmdb & pruning it in chunkah build..."
+				mkdir -p /tmp/rootfs
+				cp -a /chunkah/. /tmp/rootfs/
+				mkdir -p /tmp/rootfs/var/lib/rpm
+				chunkah build --rootfs /tmp/rootfs --prune /var/lib/rpm --prune /sysroot/ --skip-special-files -o /run/out/out.ociarchive
+				rm -rf /tmp/rootfs
+			fi
+		'
+}
+
+# chunkah reported "build complete" and still produced an archive that podman
+# could not read ("archive/tar: invalid tar header" mid-blob, bonito base
+# 2026-08-14). A zero exit from the builder is therefore not evidence the
+# archive is loadable — check the container that podman is about to consume
+# before consuming it, so a truncated write is named where it happens rather
+# than surfacing as an opaque `podman load` error two steps later.
+validate_ociarchive() {
+	local f="$1" listing
+	if [[ ! -s "$f" ]]; then
+		echo "==> archive is missing or empty" >&2
+		return 1
+	fi
+	# oci-archive is a plain (uncompressed) tar, so listing it walks every
+	# header — exactly the read that failed. Capture the listing instead of
+	# piping it: `tar tf ... | grep -q` lets grep exit at the first match, tar
+	# takes SIGPIPE, and under this script's `set -o pipefail` the pipeline
+	# then reports failure for a perfectly good archive. The listing is
+	# filenames only (an oci-archive has a handful of entries), not content.
+	if ! listing="$(tar tf "$f" 2>&1)"; then
+		echo "==> archive does not read as a valid tar:" >&2
+		printf '%s\n' "$listing" | tail -3 >&2
+		return 1
+	fi
+	# The whole "./" is optional, not just its slash: `tar cf x -C d .` lists
+	# entries as ./oci-layout while `tar cf x -C d oci-layout ...` lists them
+	# bare, and both are valid OCI archives. `^\./?oci-layout$` would demand
+	# the dot and reject the second form — verified against real tarballs of
+	# each shape rather than reasoned about.
+	if ! grep -qE '^(\./)?oci-layout$' <<<"$listing"; then
+		echo "==> archive is a valid tar but has no oci-layout — not an OCI archive" >&2
+		return 1
+	fi
+	return 0
+}
+
+# Disk pressure is the other candidate cause: the uncompressed archive is
+# several GiB and is written before the prune below frees space. Report it
+# rather than guess — one line that either confirms or kills that hypothesis
+# the next time this fails.
+echo "==> free space before rechunk:"
+df -Ph "${TMPDIR:-/tmp}" . 2>/dev/null || true
+
 CHUNK_EMPTY_DEV=$(mktemp -d)
-podman run --rm \
-	--security-opt label=disable \
-	--network host \
-	--entrypoint="" \
-	-v "${CHUNK_OUT}:/run/out:Z" \
-	--mount "type=image,source=${PRE_CHUNK_TAG},target=/chunkah" \
-	-v "${CHUNK_EMPTY_DEV}:/chunkah/dev:Z" \
-	"${CHUNKAH_IMAGE}" \
-	sh -c '
-		HAS_RPMDB=0
-		if [ -n "$(ls -A /chunkah/usr/lib/sysimage/rpm 2>/dev/null)" ] || [ -n "$(ls -A /chunkah/var/lib/rpm 2>/dev/null)" ]; then
-			HAS_RPMDB=1
-		fi
-		if [ "$HAS_RPMDB" = "1" ]; then
-			chunkah build --rootfs /chunkah --skip-special-files -o /run/out/out.ociarchive
-		else
-			echo "==> Image has no rpmdb — preparing rootfs copy with dummy rpmdb & pruning it in chunkah build..."
-			mkdir -p /tmp/rootfs
-			cp -a /chunkah/. /tmp/rootfs/
-			mkdir -p /tmp/rootfs/var/lib/rpm
-			chunkah build --rootfs /tmp/rootfs --prune /var/lib/rpm --skip-special-files -o /run/out/out.ociarchive
-			rm -rf /tmp/rootfs
-		fi
-	'
+CHUNK_OUT=""
+rechunk_ok=0
+for attempt in 1 2; do
+	# CHUNK_OUT is empty on the first pass, so this is a no-op then and a
+	# cleanup of the previous attempt's partial archive on the second —
+	# attempt 2 must not end up validating attempt 1's corpse.
+	#
+	# Spelled as `if` rather than `[[ -n ... ]] && rm`: under `set -e` the &&
+	# form is exempt here only because another statement follows it, and it
+	# would start failing the build if it were ever moved to the end of a
+	# function or loop body. Not worth leaving that dependency on line order.
+	if [[ -n "${CHUNK_OUT}" ]]; then
+		rm -rf "${CHUNK_OUT}"
+	fi
+	CHUNK_OUT=$(mktemp -d)
+	echo "==> chunkah build (attempt ${attempt}/2)"
+	if chunkah_attempt "${CHUNK_OUT}" && validate_ociarchive "${CHUNK_OUT}/out.ociarchive"; then
+		rechunk_ok=1
+		break
+	fi
+	echo "::warning::chunkah attempt ${attempt} produced no usable oci-archive" >&2
+	df -Ph "${TMPDIR:-/tmp}" . 2>/dev/null || true
+done
+if [[ "${rechunk_ok}" -ne 1 ]]; then
+	echo "ERROR: chunkah produced an unreadable oci-archive twice — not loading it." >&2
+	echo "       A corrupt archive here is a truncated/interrupted write, not a" >&2
+	echo "       recoverable image; loading it fails later with a far less" >&2
+	echo "       obvious 'invalid tar header' (tunaOS#1568)." >&2
+	rm -rf "${CHUNK_OUT}" "${CHUNK_EMPTY_DEV}"
+	exit 1
+fi
+
 mv "${CHUNK_OUT}/out.ociarchive" out.ociarchive
 rm -rf "${CHUNK_OUT}" "${CHUNK_EMPTY_DEV}"
 

--- a/tests/bats/test_chunkah_rechunk.bats
+++ b/tests/bats/test_chunkah_rechunk.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# The rechunk→load handoff in scripts/build-image-inner.sh.
+#
+# tunaOS#1568: bonito's base build died at `podman load` with
+#
+#   archive/tar: invalid tar header
+#
+# after chunkah had printed "build complete". Three things were wrong around
+# that, independent of whatever truncated the write:
+#
+#   1. CHUNKAH_IMAGE was hardcoded to quay.io/coreos/chunkah:latest, so an
+#      upstream regression reached our builds unreviewed — while
+#      registry-map.yaml had carried a digest pin for this image all along
+#      that no caller could read (see test_registry_ref.bats).
+#   2. The rpmdb branch — every RPM variant, bonito included — passed no
+#      --prune, so chunkah packed the ostree object store into every image and
+#      warned about it on every run.
+#   3. Nothing looked at the archive before handing it to podman, so a
+#      truncated write surfaced two steps later as an opaque tar error.
+#
+# These are shape assertions: the script drives podman against multi-GiB
+# images and cannot be executed here.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+INNER_SH="${REPO_ROOT}/scripts/build-image-inner.sh"
+REGISTRY_MAP="${REPO_ROOT}/registry-map.yaml"
+
+@test "build-image-inner.sh is valid bash" {
+  run bash -n "$INNER_SH"
+  [ "$status" -eq 0 ]
+}
+
+# ── the chunkah image is pinned, not :latest ───────────────────────────────
+
+@test "CHUNKAH_IMAGE resolves through registry-map.yaml, not a hardcoded tag" {
+  run grep -F 'CHUNKAH_IMAGE="$(registry_ref coreos-chunkah)"' "$INNER_SH"
+  [ "$status" -eq 0 ]
+  # ^[^#]* so the comment explaining what was wrong doesn't satisfy the check.
+  run grep -nE '^[^#]*CHUNKAH_IMAGE="quay\.io/coreos/chunkah:latest"' "$INNER_SH"
+  [ "$status" -ne 0 ]
+}
+
+@test "registry-map.yaml pins coreos-chunkah to a digest" {
+  # Extract the block by indentation rather than a fixed -A window, so adding
+  # comment lines to the entry cannot silently stop the assertion from
+  # reaching the digest.
+  run awk '/^  coreos-chunkah:/{f=1;next} f&&/^  [a-z]/{exit} f' "$REGISTRY_MAP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"digest: sha256:"* ]]
+}
+
+@test "renovate has a manager for registry-map.yaml digests" {
+  # The previous pin was garbage-collected upstream (quay 404) because nothing
+  # bumped it. A pin nothing maintains is a slow-motion build break.
+  run grep -F 'registry-map' "${REPO_ROOT}/renovate.json"
+  [ "$status" -eq 0 ]
+}
+
+# ── /sysroot pruning, with the slash that decides what it means ────────────
+
+@test "chunkah prunes the ostree sysroot on BOTH rootfs branches" {
+  # The rpmdb branch had no --prune at all, which is the branch bonito takes.
+  # Code lines only: the comment above the block quotes the flag while
+  # explaining it, and a count that included prose would pass on a file where
+  # neither branch actually prunes.
+  local n
+  n="$(grep -cE '^[^#]*--prune /sysroot/' "$INNER_SH")"
+  [ "$n" -eq 2 ]
+}
+
+@test "the sysroot prune keeps the directory itself (trailing slash)" {
+  # chunkah src/scan.rs: "A trailing `/` means prune children only, keeping
+  # the directory itself." Without the slash chunkah drops /sysroot itself —
+  # the mountpoint a bootc image needs — so this is not cosmetic. Upstream's
+  # own warning spells it "--prune /sysroot/".
+  run grep -nE '^[^#]*--prune /sysroot([^/]|$)' "$INNER_SH"
+  [ "$status" -ne 0 ]
+}
+
+@test "the existing rpmdb prune is preserved on the non-rpmdb branch" {
+  # /var/lib/rpm is the dummy dir that branch creates so chunkah's rpmdb
+  # loader succeeds; dropping it would pack the dummy into the image.
+  run grep -F -- '--prune /var/lib/rpm' "$INNER_SH"
+  [ "$status" -eq 0 ]
+}
+
+# ── the archive is checked before podman is asked to read it ───────────────
+
+@test "the oci-archive is validated before podman load" {
+  run grep -F 'validate_ociarchive' "$INNER_SH"
+  [ "$status" -eq 0 ]
+  # A zero exit from chunkah is not evidence: it printed "build complete" and
+  # still produced the corrupt archive. The validator must actually walk the
+  # tar headers, which is the read that failed.
+  run grep -F 'tar tf' "$INNER_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "validation runs before podman load, not after" {
+  run awk '/^\tif chunkah_attempt .* && validate_ociarchive/{print NR; exit}' "$INNER_SH"
+  local validate_line="$output"
+  run awk '/podman load --input out\.ociarchive/{print NR; exit}' "$INNER_SH"
+  local load_line="$output"
+  [ -n "$validate_line" ]
+  [ -n "$load_line" ]
+  [ "$validate_line" -lt "$load_line" ]
+}
+
+@test "a corrupt archive fails the build instead of being loaded" {
+  run awk '/rechunk_ok.*-ne 1/{f=1} f&&/^\texit 1/{print "found"; exit}' "$INNER_SH"
+  [ "$output" = "found" ]
+}
+
+@test "the rechunk is retried once, on a fresh output directory" {
+  run grep -F 'for attempt in 1 2; do' "$INNER_SH"
+  [ "$status" -eq 0 ]
+  # Attempt 2 must not validate attempt 1's corpse: the previous output dir is
+  # removed and a new one made inside the loop.
+  run awk '/for attempt in 1 2; do/{f=1} f&&/CHUNK_OUT=\$\(mktemp -d\)/{print "found"; exit}' "$INNER_SH"
+  [ "$output" = "found" ]
+  run awk '/for attempt in 1 2; do/{f=1} f&&/rm -rf "\$\{CHUNK_OUT\}"/{print "found"; exit}' "$INNER_SH"
+  [ "$output" = "found" ]
+}
+
+@test "free space is reported around the rechunk" {
+  # Disk pressure is the other candidate cause for a truncated write; one df
+  # line either confirms or kills it the next time this fails.
+  run grep -F 'df -Ph' "$INNER_SH"
+  [ "$status" -eq 0 ]
+}

--- a/tests/bats/test_registry_ref.bats
+++ b/tests/bats/test_registry_ref.bats
@@ -47,6 +47,16 @@ images:
     registry: docker
     path: library/ubuntu
     tag: "22.04"
+  # Hyphenated name AND a digest — the intersection the two fixtures above
+  # each miss (`pinned` has a digest but no hyphen; `multi-override` has a
+  # hyphen but no digest). registry-map.yaml's real coreos-chunkah entry is
+  # exactly this shape, and resolving it aborted registry_ref outright
+  # (tunaOS#1568).
+  pinned-tool:
+    registry: quay
+    path: coreos/sometool
+    digest: "sha256:deadbeef1234"
+    tag: latest
 YAML
 
   # Patch _registry.sh: point REGISTRY_MAP at the test map and replace
@@ -203,6 +213,49 @@ teardown() {
   '
   [ "$status" -eq 0 ]
   [[ "$output" == "ghcr.io/tuna-os/tools@sha256:ffffff999999" ]]
+}
+
+@test "registry_ref: resolves a digest-pinned image whose name contains a hyphen" {
+  # A hyphen is not a legal shell identifier character, so building the
+  # override variable name as TUNA_IMAGE_DIGEST_${name} made bash abort with
+  # "invalid variable name" — under _registry.sh's own `set -euo pipefail`
+  # that took the whole call down. Not "the override was ignored": no ref came
+  # back at all, which is why registry-map.yaml's coreos-chunkah digest pin
+  # was unreachable and build-image-inner.sh hardcoded :latest instead.
+  run bash -c '
+    source "${TEST_ROOT}/scripts/_registry.sh" 2>/dev/null
+    registry_ref pinned-tool
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "quay.io/coreos/sometool@sha256:deadbeef1234" ]]
+}
+
+@test "registry_ref: TUNA_IMAGE_DIGEST_ override works on a hyphenated name" {
+  # Hyphens become underscores in the variable name, matching the
+  # TUNA_IMAGE_PATH_/TUNA_IMAGE_TAG_ convention and _registry.sh's own header,
+  # which documents TUNA_IMAGE_DIGEST_coreos_chunkah.
+  run bash -c '
+    export TUNA_IMAGE_DIGEST_pinned_tool=sha256:cafe5678
+    source "${TEST_ROOT}/scripts/_registry.sh" 2>/dev/null
+    registry_ref pinned-tool
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == "quay.io/coreos/sometool@sha256:cafe5678" ]]
+}
+
+@test "registry_ref: the real coreos-chunkah entry resolves against the shipped map" {
+  # The regression that mattered, against registry-map.yaml itself rather than
+  # a fixture: build-image-inner.sh calls registry_ref coreos-chunkah, and it
+  # must return a digest ref instead of aborting.
+  # Double-quoted so REPO_ROOT expands HERE: setup() exports TEST_ROOT, but
+  # REPO_ROOT is a plain file-scope assignment, so a single-quoted body would
+  # reach the child shell as an empty path and source nothing.
+  run bash -c "
+    source '${REPO_ROOT}/scripts/_registry.sh' 2>/dev/null
+    registry_ref coreos-chunkah
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == quay.io/coreos/chunkah@sha256:* ]]
 }
 
 @test "registry_ref: multiple overrides combined (registry + path + tag)" {


### PR DESCRIPTION
Closes #1568.

The corruption itself is one occurrence and unreproduced. This eliminates both candidate causes and — more usefully — makes the next occurrence say what happened instead of surfacing as an opaque tar error two steps downstream.

## The pin already existed, and had never worked

The issue asks for `CHUNKAH_IMAGE` to be digest-pinned. `registry-map.yaml` has carried a `coreos-chunkah` digest all along, under the comment *"SECURITY: Pinned to digest to prevent supply-chain attacks via tag mutation"*. **No caller could use it:**

```bash
local digest_override_var="TUNA_IMAGE_DIGEST_${name}"
```

A hyphen isn't a legal shell identifier character, so for `coreos-chunkah` this didn't merely miss an override — bash raised `invalid variable name`, and under `_registry.sh`'s own `set -euo pipefail` that took `registry_ref` down with it. Not a wrong answer: **no answer**.

```
$ bash -c 'v="TUNA_IMAGE_DIGEST_coreos-chunkah"; echo "${!v:-FALLBACK}"'
bash: TUNA_IMAGE_DIGEST_coreos-chunkah: invalid variable name   (rc=1)
```

The path and tag overrides two lines above already do `${name//-/_}`, and the file header documents `TUNA_IMAGE_DIGEST_coreos_chunkah` with underscores. The tests missed it because the digest fixture had no hyphen and the hyphen fixture had no digest — neither covered the intersection, which is exactly what `coreos-chunkah` is.

So `build-image-inner.sh` hardcoded `:latest`, and an upstream chunkah regression reached our builds the hour it was published.

**The pinned digest was also gone.** Quay returns 404 for `sha256:33ab77f2…` — garbage-collected upstream while nothing bumped it. Refreshed to `sha256:ff8b8b46…` (verified: manifest list covering amd64 + arm64), and added a `renovate.json` manager for `registry-map.yaml`, scoped to `registry: quay` entries so `registryUrlTemplate` is correct by construction. A pin nothing maintains is a slow-motion build break — this one already broke.

## `--prune /sysroot/` — the trailing slash is not cosmetic

The issue suggests `--prune /sysroot`. From chunkah's scanner:

> Paths must be absolute. A trailing `/` means prune children only, keeping the directory itself. — `src/scan.rs`

Without the slash, chunkah drops `/sysroot` **itself** — the mountpoint a bootc image needs. Upstream's own warning, the one bonito logged, spells it `--prune /sysroot/`.

Applied to **both** branches (`prune` is a `Vec`, so it's repeatable). The rpmdb branch — every RPM variant, bonito included — passed no `--prune` at all, so the ostree object store has been packed into every rechunked RPM image.

## Validation before `podman load`

A zero exit from chunkah is not evidence the archive is loadable; that's the whole lesson here. `validate_ociarchive` walks every tar header (the read that failed) and confirms an `oci-layout` entry; the rechunk retries once on a fresh output directory; a corrupt archive fails *here*. Plus `df` around the rechunk, so the disk-pressure hypothesis gets confirmed or killed next time rather than re-argued.

## Two bugs found by running the validator, not reviewing it

I built real tarballs and ran the actual function against them. Both of these would have broken every build:

| Bug | Effect |
|---|---|
| `tar tf … \| grep -q` | `grep -q` exits at first match → tar takes SIGPIPE → under `set -o pipefail` the pipeline fails → **a valid archive is rejected** |
| `^\./?oci-layout$` | makes the *slash* optional, not the `./` → **rejects archives written without the `./` prefix** |

Final behavior, against real files:

```
valid.ociarchive      (./ prefix)   VALID
valid2.ociarchive     (bare)        VALID
truncated.ociarchive                REJECTED
empty.ociarchive                    REJECTED
notoci.tar                          REJECTED
missing.ociarchive                  REJECTED
script survived set -euxo pipefail
```

I also had a third "bug" in a draft comment claiming `[[ -n "$X" ]] && rm` would abort under `set -e`. It doesn't — errexit exempts it when another statement follows. I kept the `if` form (it's only safe by line order) but corrected the comment rather than shipping a confident wrong explanation.

## Verification

| Suite | This branch | `upstream/main` |
|---|---|---|
| `test_chunkah_rechunk.bats` (new, 12) | 12/12 | 4/12 |
| `test_registry_ref.bats` (+3) | 21/21 | 18/21 |
| `test_registry.bats` (untouched) | 15/15 | 15/15 |

`bats` isn't installed here, so I ran the real `.bats` files through a shim; CI is the real runner.

## One observation, deliberately not fixed

`.github/workflows/validate-renovate.yaml` watches `.github/renovate.json5`, which doesn't exist — the live config is `renovate.json` at the repo root. So renovate config changes, including this one, get **no CI validation**. I mitigated by modelling the new manager on the existing `image-versions.yaml` one, checking the JSON parses, and running the regex against the real file (1 match, correct captures). Fixing the workflow path is a separate change and a workflow file.

## Two things a reviewer will reasonably ask

**Does `registry_ref` add a new dependency to the build path?** No. `build-image-inner.sh` already sources `_registry.sh` at line 40, whose export block calls `registry_ref common` at source time — so `yq` has always been a hard requirement of this script, and the build job installs it (`reusable-build-image.yml`, "Install just and yq", verified with `yq --version`). Unlike the existing `registry_ref akmods` call, mine is unprotected, which is correct: a chunkah ref that can't be resolved should stop the build rather than silently fall back to an unpinned tag.

**Does CI green here prove the new call works?** No — and this is worth being blunt about. The rechunk path only runs when `SKIP_RECHUNK != 1`, and PR builds skip it. Lint and Unit Tests passing on this PR tell you nothing about the `registry_ref coreos-chunkah` line itself; only a real variant build exercises it. That's what the resolver tests are for — including one that resolves the actual shipped `registry-map.yaml` rather than a fixture.

**Boundary:** the `registry_ref` fix and the validator are behaviorally tested; the chunkah invocation itself is shape-tested and read from upstream source — not built. First real proof is the next bonito nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
