### PR TITLE
docs(adopters): update TunaOS Hive Agents link to point to hive.tunaos.org

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -14,7 +14,7 @@ _(None listed yet — be the first!)_
 | Organization | Use Case | Variant(s) | Since |
 |---|---|---|---|
 | [@hanthor](https://github.com/hanthor) (Project Maintainer) | Personal daily driver — development, testing, and dogfooding all variants | Yellowfin GNOME, Albacore GNOME, Skipjack KDE | 2026-04 |
-| [TunaOS Hive Agents](https://github.com/tuna-os) | Automated CI/CD — build, test, and release pipeline runs on TunaOS infrastructure | Yellowfin GNOME, Albacore GNOME | 2026-05 |
+| [TunaOS Hive Agents](https://hive.tunaos.org) | Automated CI/CD — build, test, and release pipeline runs on TunaOS infrastructure | Yellowfin GNOME, Albacore GNOME | 2026-05 |
 
 ## Ecosystem & Downstream Projects
 


### PR DESCRIPTION
Fixes #1620

## Summary
Updates the **TunaOS Hive Agents** entry in `ADOPTERS.md` to point directly to `https://hive.tunaos.org` instead of the generic GitHub org URL.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `d5a56f01`