### PR TITLE
test(nvidia): prove the SELinux copy-up on a real overlayfs

### DIFF
--- a/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
@@ -150,6 +150,14 @@ if [[ -f /usr/lib/systemd/system/ublue-nvctk-cdi.service ]]; then
 	systemctl enable ublue-nvctk-cdi.service
 fi
 if [[ -f /usr/share/selinux/packages/nvidia-container.pp ]]; then
+	# Force copy-up of /etc/selinux/targeted into the top layer so libsemanage's
+	# atomic directory renames (tmp -> active) succeed on overlayfs.
+	if [[ -d /etc/selinux/targeted ]]; then
+		rm -rf /etc/selinux/targeted/tmp /etc/selinux/targeted/previous
+		cp -a /etc/selinux/targeted /etc/selinux/targeted.copyup
+		rm -rf /etc/selinux/targeted
+		mv /etc/selinux/targeted.copyup /etc/selinux/targeted
+	fi
 	semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
 fi
 

--- a/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
@@ -154,6 +154,7 @@ if [[ -f /usr/share/selinux/packages/nvidia-container.pp ]]; then
 	# atomic directory renames (tmp -> active) succeed on overlayfs.
 	if [[ -d /etc/selinux/targeted ]]; then
 		rm -rf /etc/selinux/targeted/tmp /etc/selinux/targeted/previous
+		rm -rf /etc/selinux/targeted.copyup
 		cp -a /etc/selinux/targeted /etc/selinux/targeted.copyup
 		rm -rf /etc/selinux/targeted
 		mv /etc/selinux/targeted.copyup /etc/selinux/targeted

--- a/tests/bats/test_selinux_store_copyup.bats
+++ b/tests/bats/test_selinux_store_copyup.bats
@@ -33,8 +33,16 @@ INSTALL_SH="${REPO_ROOT}/build_scripts/overlay/overrides/nvidia/20-nvidia.sh"
 # on GitHub-hosted ubuntu runners; skipped rather than failed anywhere it is
 # not, so a constrained runner reports "skipped", not a fake regression.
 setup() {
-  if ! unshare -Ur --mount true 2>/dev/null; then
-    skip "unprivileged user+mount namespaces unavailable"
+  # Probe the WHOLE capability, not just unshare. A runner where unshare works
+  # but overlay-over-tmpfs does not would otherwise fail every test below on a
+  # mount error — a false regression, and exactly the kind of red that gets
+  # ignored. Either the fixture can be built or the tests skip.
+  if ! unshare -Ur --mount bash -c '
+        mount -t tmpfs tmpfs /mnt &&
+        mkdir -p /mnt/l /mnt/u /mnt/w /mnt/m &&
+        mount -t overlay overlay -o lowerdir=/mnt/l,upperdir=/mnt/u,workdir=/mnt/w /mnt/m
+      ' >/dev/null 2>&1; then
+    skip "unprivileged overlayfs-over-tmpfs unavailable on this runner"
   fi
 }
 

--- a/tests/bats/test_selinux_store_copyup.bats
+++ b/tests/bats/test_selinux_store_copyup.bats
@@ -32,18 +32,28 @@ INSTALL_SH="${REPO_ROOT}/build_scripts/overlay/overrides/nvidia/20-nvidia.sh"
 # Needs unprivileged user+mount namespaces and overlayfs-over-tmpfs. Available
 # on GitHub-hosted ubuntu runners; skipped rather than failed anywhere it is
 # not, so a constrained runner reports "skipped", not a fake regression.
-setup() {
-  # Probe the WHOLE capability, not just unshare. A runner where unshare works
-  # but overlay-over-tmpfs does not would otherwise fail every test below on a
-  # mount error — a false regression, and exactly the kind of red that gets
-  # ignored. Either the fixture can be built or the tests skip.
-  if ! unshare -Ur --mount bash -c '
-        mount -t tmpfs tmpfs /mnt &&
-        mkdir -p /mnt/l /mnt/u /mnt/w /mnt/m &&
-        mount -t overlay overlay -o lowerdir=/mnt/l,upperdir=/mnt/u,workdir=/mnt/w /mnt/m
-      ' >/dev/null 2>&1; then
-    skip "unprivileged overlayfs-over-tmpfs unavailable on this runner"
+# Can this runner build the overlay fixture at all? GitHub-hosted runners turned
+# out NOT to allow unprivileged overlayfs-over-tmpfs — the first version of this
+# file skipped all five tests there, which is a suite that costs CI time and
+# proves nothing. They do have passwordless sudo, so try that too before giving
+# up. Probes the WHOLE capability, not just unshare: a runner with one and not
+# the other would fail on a mount error rather than skipping.
+OVERLAY_RUNNER=""
+probe_overlay() {
+  local fixture='
+    mount -t tmpfs tmpfs /mnt &&
+    mkdir -p /mnt/l /mnt/u /mnt/w /mnt/m &&
+    mount -t overlay overlay -o lowerdir=/mnt/l,upperdir=/mnt/u,workdir=/mnt/w /mnt/m'
+  if unshare -Ur --mount bash -c "$fixture" >/dev/null 2>&1; then
+    OVERLAY_RUNNER="unshare -Ur --mount"
+  elif sudo -n unshare --mount bash -c "$fixture" >/dev/null 2>&1; then
+    OVERLAY_RUNNER="sudo -n unshare --mount"
   fi
+}
+
+require_overlay() {
+  probe_overlay
+  [ -n "$OVERLAY_RUNNER" ] || skip "no way to mount overlayfs-over-tmpfs on this runner"
 }
 
 # Runs a script inside a namespace with an overlay mounted at /mnt/merged,
@@ -51,7 +61,7 @@ setup() {
 # build layer leaves behind.
 in_overlay() {
   local body="$1"
-  unshare -Ur --mount bash -s <<EOF 2>&1
+  ${OVERLAY_RUNNER} bash -s <<EOF 2>&1
 set -u
 mount -t tmpfs tmpfs /mnt || exit 1
 mkdir -p /mnt/lower/selinux/targeted/active/modules /mnt/upper /mnt/work /mnt/merged
@@ -98,6 +108,7 @@ copyup_block() {
 }
 
 @test "without the copy-up, libsemanage's commit reproduces the build failure" {
+  require_overlay
   run in_overlay "$COMMIT_SANDBOX"
   [ "$status" -eq 0 ]
   # Exactly the two messages from the build log, in order: the EXDEV that sends
@@ -107,6 +118,7 @@ copyup_block() {
 }
 
 @test "with the copy-up from 20-nvidia.sh, both renames succeed" {
+  require_overlay
   run in_overlay "$(copyup_block)
 ${COMMIT_SANDBOX}"
   [ "$status" -eq 0 ]
@@ -117,6 +129,7 @@ ${COMMIT_SANDBOX}"
 }
 
 @test "the copy-up preserves the store rather than emptying it" {
+  require_overlay
   # A copy-up that lost the policy would turn a loud build failure into a
   # broken image, which is worse. Assert the payload survives the round trip.
   #

--- a/tests/bats/test_selinux_store_copyup.bats
+++ b/tests/bats/test_selinux_store_copyup.bats
@@ -32,6 +32,15 @@ INSTALL_SH="${REPO_ROOT}/build_scripts/overlay/overrides/nvidia/20-nvidia.sh"
 # Needs unprivileged user+mount namespaces and overlayfs-over-tmpfs. Available
 # on GitHub-hosted ubuntu runners; skipped rather than failed anywhere it is
 # not, so a constrained runner reports "skipped", not a fake regression.
+# redirect_dir=off is load-bearing, not tidiness. With redirect_dir=ON — which
+# some kernels default to for privileged mounts — overlayfs CAN rename a
+# lower-layer directory, the EXDEV never happens, and the bug does not
+# reproduce at all. CI proved that the hard way: the first version of this file
+# ran as root via sudo, got a redirect_dir=on mount, and failed asserting an
+# EXDEV that legitimately did not occur there. buildah's rootful overlay is the
+# environment the failure was observed in, so the fixture pins the option that
+# reproduces it rather than assuming every overlay behaves alike.
+#
 # Can this runner build the overlay fixture at all? GitHub-hosted runners turned
 # out NOT to allow unprivileged overlayfs-over-tmpfs — the first version of this
 # file skipped all five tests there, which is a suite that costs CI time and
@@ -39,21 +48,50 @@ INSTALL_SH="${REPO_ROOT}/build_scripts/overlay/overrides/nvidia/20-nvidia.sh"
 # up. Probes the WHOLE capability, not just unshare: a runner with one and not
 # the other would fail on a mount error rather than skipping.
 OVERLAY_RUNNER=""
+OVERLAY_OPTS=""
+
+# Two axes have to line up, and neither is available on every runner:
+#
+#   * A way to mount overlayfs at all — unprivileged user+mount namespaces, or
+#     passwordless sudo. GitHub-hosted runners refuse the former.
+#   * A mount where a lower-layer directory rename actually fails. With
+#     redirect_dir=ON, which kernels default to for PRIVILEGED mounts,
+#     overlayfs renames it happily and the bug does not exist. But
+#     redirect_dir=off is REJECTED for unprivileged mounts, where the default
+#     already gives the failing behaviour.
+#
+# So: privileged wants the explicit option, unprivileged cannot have it. Try
+# both, then CONFIRM the fixture really reproduces EXDEV before trusting it —
+# an environment that cannot reproduce the bug cannot say anything about the
+# fix, and should skip rather than assert.
 probe_overlay() {
-  local fixture='
-    mount -t tmpfs tmpfs /mnt &&
-    mkdir -p /mnt/l /mnt/u /mnt/w /mnt/m &&
-    mount -t overlay overlay -o lowerdir=/mnt/l,upperdir=/mnt/u,workdir=/mnt/w /mnt/m'
-  if unshare -Ur --mount bash -c "$fixture" >/dev/null 2>&1; then
-    OVERLAY_RUNNER="unshare -Ur --mount"
-  elif sudo -n unshare --mount bash -c "$fixture" >/dev/null 2>&1; then
-    OVERLAY_RUNNER="sudo -n unshare --mount"
-  fi
+  local runner opts
+  for runner in "sudo -n unshare --mount" "unshare -Ur --mount"; do
+    for opts in "redirect_dir=off," ""; do
+      if $runner bash -c "
+            mount -t tmpfs tmpfs /mnt &&
+            mkdir -p /mnt/l /mnt/u /mnt/w /mnt/m &&
+            mount -t overlay overlay -o ${opts}lowerdir=/mnt/l,upperdir=/mnt/u,workdir=/mnt/w /mnt/m
+          " >/dev/null 2>&1; then
+        OVERLAY_RUNNER="$runner"; OVERLAY_OPTS="$opts"
+        # Does a lower-layer directory rename actually fail here?
+        if [[ "$(in_overlay 'python3 -c "
+import os,sys
+try:
+    os.rename(\"$S/active\", \"$S/previous\"); print(\"renamed\")
+except OSError: print(\"failed\")
+"')" == *failed* ]]; then
+          return 0
+        fi
+        OVERLAY_RUNNER=""; OVERLAY_OPTS=""
+      fi
+    done
+  done
+  return 1
 }
 
 require_overlay() {
-  probe_overlay
-  [ -n "$OVERLAY_RUNNER" ] || skip "no way to mount overlayfs-over-tmpfs on this runner"
+  probe_overlay || skip "no overlayfs mount here reproduces a failing lower-layer directory rename"
 }
 
 # Runs a script inside a namespace with an overlay mounted at /mnt/merged,
@@ -66,7 +104,7 @@ set -u
 mount -t tmpfs tmpfs /mnt || exit 1
 mkdir -p /mnt/lower/selinux/targeted/active/modules /mnt/upper /mnt/work /mnt/merged
 echo kern > /mnt/lower/selinux/targeted/active/policy.kern
-mount -t overlay overlay -o lowerdir=/mnt/lower,upperdir=/mnt/upper,workdir=/mnt/work /mnt/merged || exit 1
+mount -t overlay overlay -o ${OVERLAY_OPTS}lowerdir=/mnt/lower,upperdir=/mnt/upper,workdir=/mnt/work /mnt/merged || exit 1
 S=/mnt/merged/selinux/targeted
 ${body}
 EOF

--- a/tests/bats/test_selinux_store_copyup.bats
+++ b/tests/bats/test_selinux_store_copyup.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# The SELinux policy-store copy-up in the nvidia overlay (tunaOS#1562).
+#
+# `semodule --install` died mid-build on 6+ nvidia cells on 2026-08-14 with:
+#
+#   semanage_commit_sandbox: Error while renaming .../tmp to .../active.
+#     (Directory not empty).
+#
+# preceded, in an earlier RPM scriptlet, by:
+#
+#   semanage_rename: WARNING: rename(...active, ...previous) failed:
+#     Invalid cross-device link, fall back to non-atomic semanage_copy_dir_flags()
+#
+# Those two messages are one mechanism, and the second explains the first.
+# libsemanage commits by renaming active -> previous, then tmp -> active. On
+# overlayfs, renaming a directory that lives in a LOWER layer fails EXDEV, so
+# libsemanage falls back to COPYING active -> previous — which leaves active/
+# in place. The next rename then lands on a populated directory and gets
+# ENOTEMPTY. Whether a given flavor hits it depends only on whether that layer
+# was rebuilt or served from --cache-from, which is why it read as random.
+#
+# The fix copies the store into the top layer first. These tests prove the
+# mechanism rather than restating it, by running the overlay for real: the
+# failure is reproduced, then the ACTUAL block from 20-nvidia.sh is extracted
+# and run against the same fixture. So an edit that keeps the lines but breaks
+# their order (dropping the `rm -rf` before the `mv`, say) fails here — a grep
+# for the lines could not tell the difference.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+INSTALL_SH="${REPO_ROOT}/build_scripts/overlay/overrides/nvidia/20-nvidia.sh"
+
+# Needs unprivileged user+mount namespaces and overlayfs-over-tmpfs. Available
+# on GitHub-hosted ubuntu runners; skipped rather than failed anywhere it is
+# not, so a constrained runner reports "skipped", not a fake regression.
+setup() {
+  if ! unshare -Ur --mount true 2>/dev/null; then
+    skip "unprivileged user+mount namespaces unavailable"
+  fi
+}
+
+# Runs a script inside a namespace with an overlay mounted at /mnt/merged,
+# lower layer pre-populated with a policy store — i.e. the state a cached
+# build layer leaves behind.
+in_overlay() {
+  local body="$1"
+  unshare -Ur --mount bash -s <<EOF 2>&1
+set -u
+mount -t tmpfs tmpfs /mnt || exit 1
+mkdir -p /mnt/lower/selinux/targeted/active/modules /mnt/upper /mnt/work /mnt/merged
+echo kern > /mnt/lower/selinux/targeted/active/policy.kern
+mount -t overlay overlay -o lowerdir=/mnt/lower,upperdir=/mnt/upper,workdir=/mnt/work /mnt/merged || exit 1
+S=/mnt/merged/selinux/targeted
+${body}
+EOF
+}
+
+# libsemanage's commit order, with its documented fallback. Prints one line per
+# rename so a failure names which one broke.
+COMMIT_SANDBOX='
+mkdir -p "$S/tmp/modules"; echo new > "$S/tmp/policy.kern"
+python3 - "$S" <<'"'"'PY'"'"'
+import os, sys, errno
+S = sys.argv[1]
+def rename(a, b):
+    try:
+        os.rename(f"{S}/{a}", f"{S}/{b}"); print(f"rename({a}->{b}): OK"); return True
+    except OSError as e:
+        print(f"rename({a}->{b}): {errno.errorcode[e.errno]}"); return False
+if not rename("active", "previous"):
+    print("fallback: non-atomic copy, active/ stays put")
+rename("tmp", "active")
+PY
+'
+
+# The real block, path-substituted onto the fixture. Extracted rather than
+# retyped so the test cannot drift from the script it is defending — the same
+# reason test_registry_ref.bats sed-patches the real _registry.sh.
+copyup_block() {
+  awk '/Force copy-up of \/etc\/selinux\/targeted/{f=1}
+       f{print}
+       f && /^\tfi$/{exit}' "$INSTALL_SH" \
+    | sed 's#/etc/selinux/targeted#"$S"#g'
+}
+
+@test "the extracted copy-up block is not empty (the script still has one)" {
+  run copyup_block
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"cp -a"* ]]
+  [[ "$output" == *'mv "$S".copyup "$S"'* ]]
+}
+
+@test "without the copy-up, libsemanage's commit reproduces the build failure" {
+  run in_overlay "$COMMIT_SANDBOX"
+  [ "$status" -eq 0 ]
+  # Exactly the two messages from the build log, in order: the EXDEV that sends
+  # libsemanage down the copy path, then the ENOTEMPTY that kills semodule.
+  [[ "$output" == *"rename(active->previous): EXDEV"* ]]
+  [[ "$output" == *"rename(tmp->active): ENOTEMPTY"* ]]
+}
+
+@test "with the copy-up from 20-nvidia.sh, both renames succeed" {
+  run in_overlay "$(copyup_block)
+${COMMIT_SANDBOX}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rename(active->previous): OK"* ]]
+  [[ "$output" == *"rename(tmp->active): OK"* ]]
+  [[ "$output" != *"ENOTEMPTY"* ]]
+  [[ "$output" != *"EXDEV"* ]]
+}
+
+@test "the copy-up preserves the store rather than emptying it" {
+  # A copy-up that lost the policy would turn a loud build failure into a
+  # broken image, which is worse. Assert the payload survives the round trip.
+  #
+  # Guarded on the block being non-empty: with no copy-up in the script this
+  # body degrades to a bare `cat`, which passes without proving anything.
+  local block
+  block="$(copyup_block)"
+  [ -n "$block" ]
+  run in_overlay "$block
+cat \"\$S/active/policy.kern\"
+ls \"\$S/active\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"kern"* ]]
+  [[ "$output" == *"modules"* ]]
+}
+
+@test "the copy-up runs before semodule, not after" {
+  # Ordering is the entire fix: after the semodule call it would be a no-op.
+  run awk '/Force copy-up of/{print NR; exit}' "$INSTALL_SH"
+  local copyup_line="$output"
+  run awk '/semodule --verbose --install/{print NR; exit}' "$INSTALL_SH"
+  local semodule_line="$output"
+  [ -n "$copyup_line" ]
+  [ -n "$semodule_line" ]
+  [ "$copyup_line" -lt "$semodule_line" ]
+}


### PR DESCRIPTION
Refs #1562. **Stacked on #1577, which already fixes it** — this doesn't reimplement the fix, it demonstrates it.

## Why not another fix PR

#1577 is open, non-draft, mergeable, and effectively green (its only failing check is the pre-existing `Justfile contains custom recipes`, which fails on `main` too). Its copy-up is correct, and `semodule` has exactly one call site in `build_scripts/`, so it covers the whole surface. A competing fix would be waste.

What it doesn't have is evidence. The fix was reasoned from the log; nobody had run the failure.

## Running it

The test mounts a **real overlayfs** (userns + overlay-over-tmpfs) with the policy store seeded in the **lower** layer — the state a `--cache-from` layer leaves behind — then performs libsemanage's own commit order:

```
rename(active->previous): EXDEV
fallback: non-atomic copy, active/ stays put
rename(tmp->active): ENOTEMPTY
```

Those are the two messages from the build log, in order. Running it is what shows they're **one mechanism, not two problems**: libsemanage can't rename a lower-layer directory (`EXDEV`), falls back to *copying* `active` → `previous` — which leaves `active` in place — so the next rename lands on a populated directory and gets `ENOTEMPTY`. With the copy-up applied, both renames succeed.

That also explains the "cache roulette": nothing is random. A flavor fails iff its `/etc/selinux/targeted` came from a cached lower layer.

## Testing the real code, not a copy of it

The block is **extracted from `20-nvidia.sh`** and path-substituted onto the fixture rather than retyped. So an edit that keeps the lines but breaks their order — dropping the `rm -rf "$S"` before the `mv`, say — fails here, where a grep for the same lines couldn't tell the difference.

**Verified it bites: 5/5 on this branch, 1/5 against `upstream/main`.**

Skips (not fails) where unprivileged user namespaces are unavailable, so a constrained runner reports "skipped" rather than a fake regression.

## Two things I got wrong, both caught by running it

Worth stating, because they're the reason this is worth more than a shape assertion:

1. **My first reproduction wasn't a reproduction.** It renamed `tmp` onto a populated `active` and called the resulting `ENOTEMPTY` the bug. That's plain POSIX — it happens on any filesystem and modelled nothing. The real sequence renames `active` *away* first, and that's the rename overlayfs breaks. Had I stopped there I'd have reported that #1577 doesn't work.

2. **The path substitution emitted a literal `"$S"`** instead of an expansion, so the `[[ -d ... ]]` guard was false and the copy-up silently never ran. The suite still reported 4/5 — one real failure and one test passing for no reason at all. Both fixed; the payload test now refuses to run against an empty block so it can't pass vacuously again.

## Stacking

The first commit here is #1577 unchanged; only the test is new. A fork PR can't target another fork branch, so this necessarily shows both. **If #1577 merges first, this reduces to the single test commit.**

## Boundary

The overlayfs behaviour is genuinely executed here — not shape-tested, not inferred. What is *not* proven is the full `semodule --install` against a real SELinux policy store inside buildah; this models libsemanage's rename sequence, not libsemanage. First real proof of the end-to-end fix is the next nvidia nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
