### PR TITLE
docs(fedora): make the base-currency policy executable, and fix what it exposed

### DIFF
--- a/FEDORA-BASE-POLICY.md
+++ b/FEDORA-BASE-POLICY.md
@@ -52,6 +52,45 @@ tunaOS tracks Fedora bases on an **N (current stable) + rawhide** model,
   planned/upcoming, not shipped, until this policy's trigger condition is
   met and #1171 reports base readiness.
 
+## Executing a transition — where the version actually lives
+
+A currency policy that does not say what to edit cannot be carried out, and
+this repo has already paid for that. `scripts/get-base-image.sh`'s header
+records a second hardcoded copy of the variant→base map drifting from
+build-config:
+
+    bonito    build-config: fedora-bootc:44      here: fedora-bootc:43
+
+— "silently, because nothing compared them". The lesson it drew was to keep one
+copy. The inventory below is the copies that remain, measured on 2026-08-14,
+so the next transition is a checklist rather than a search.
+
+**Authoritative.** Change this first; everything else follows it:
+
+| Location | What |
+|---|---|
+| `.github/build-config.yml` (`bonito` entry) | `base_image:` — the pin every build resolves, and `description:` alongside it, which feeds docs and the image label |
+
+**Must be changed in the same PR.** None of these derive from the pin above:
+
+| Location | What | Note |
+|---|---|---|
+| `registry-map.yaml` → `fedora-bootc.tag` | duplicate of the base version | **no consumers** — nothing calls `registry_ref fedora-bootc`, so it can drift without any build failing |
+| `Justfile:5` → `coreos_stable_version` | akmods/CoreOS stream for bonito | the value every real build uses |
+| `scripts/build-image-inner.sh` → `COREOS_STABLE_VERSION` default | same, for direct invocation | had drifted to `41` while the Justfile said `43` |
+| `build_scripts/overlay/overrides/nvidia/20-nvidia.sh` → `FEDORA_AKMODS_VERSION` fallback | negativo17 nvidia userspace tree | only a fallback; the live value is derived from the akmods bundle's dist tag |
+
+**Prose that states the version** and goes stale without failing anything:
+`ROADMAP.md`, `MIGRATION.md`, `.github/copilot-instructions.md`,
+`docs/PIPELINE.md`, `docs/build-pipeline.md`, `docs/AGENT_GUIDE.md`,
+`docs/LUKS-TPM.md`, `docs/FEDORA-MAGAZINE-PITCH.md`, `docs/adr/0003-mkosi-co-build-poc.md`.
+
+`tests/bats/test_fedora_base_currency.bats` compares the pins that can be
+compared, so the silent half of this list is no longer silent. The prose list
+is not machine-checked — deliberately, since pinning strings in nine documents
+would fail on every unrelated wording change — which is why it is written down
+here instead.
+
 ## Relationship to other bases
 
 This policy covers Fedora only. Other rolling/tracking bases (Sailfin/

--- a/scripts/build-image-inner.sh
+++ b/scripts/build-image-inner.sh
@@ -78,7 +78,13 @@ AKMODS_REGISTRY_BASE="$(registry_ref akmods 2>/dev/null || echo "ghcr.io/${AKMOD
 BUILD_ARGS+=("--build-arg" "AKMODS_BASE=${AKMODS_REGISTRY_BASE}")
 
 if [[ "${ENABLE_HWE}" == "1" ]] || [[ "${VARIANT}" == bonito* ]]; then
-	COREOS_STABLE="${COREOS_STABLE_VERSION:-41}"
+	# Keep this default equal to the Justfile's (Justfile:5). Nothing in
+	# .github/workflows sets COREOS_STABLE_VERSION, and every real build goes
+	# through `just`, which exports it — so this fallback only fires when the
+	# script is invoked directly, which is exactly why it sat two Fedora
+	# releases behind (41) without anyone noticing. tests/bats/
+	# test_fedora_base_currency.bats now compares the two (tunaOS#1171).
+	COREOS_STABLE="${COREOS_STABLE_VERSION:-43}"
 	BUILD_ARGS+=("--build-arg" "AKMODS_VERSION=coreos-stable-${COREOS_STABLE}")
 	BUILD_ARGS+=("--build-arg" "AKMODS_NVIDIA_VERSION=coreos-stable-${COREOS_STABLE}")
 else

--- a/tests/bats/test_fedora_base_currency.bats
+++ b/tests/bats/test_fedora_base_currency.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# Base-version pins that must move together (tunaOS#1171).
+#
+# FEDORA-BASE-POLICY.md commits the project to tracking one Fedora stable at a
+# time. Executing that commitment means bumping a base version in several
+# places at once, and this repo has already been bitten by exactly that:
+# get-base-image.sh's header records a second hardcoded copy of the
+# variant→base map drifting from build-config.yml —
+#
+#   bonito    build-config: fedora-bootc:44      here: fedora-bootc:43
+#
+# — "silently, because nothing compared them". The lesson it drew was to keep
+# one copy. These tests are the comparison for the copies that remain, so the
+# next transition fails loudly here rather than shipping a variant built on a
+# base nobody meant to ship.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+BUILD_CONFIG="${REPO_ROOT}/.github/build-config.yml"
+REGISTRY_MAP="${REPO_ROOT}/registry-map.yaml"
+JUSTFILE="${REPO_ROOT}/Justfile"
+INNER_SH="${REPO_ROOT}/scripts/build-image-inner.sh"
+
+setup() {
+  command -v yq >/dev/null 2>&1 || skip "yq unavailable"
+}
+
+# The base_image build-config declares for a variant — the authoritative one.
+config_base() {
+  yq -r ".variants[] | select(.id == \"$1\") | .base_image" "$BUILD_CONFIG"
+}
+
+# The ref registry-map.yaml would resolve for a logical image name.
+map_ref() {
+  local host path tag
+  host="$(yq -r ".registries.\"$(yq -r ".images.\"$1\".registry" "$REGISTRY_MAP")\"" "$REGISTRY_MAP")"
+  path="$(yq -r ".images.\"$1\".path" "$REGISTRY_MAP")"
+  tag="$(yq -r ".images.\"$1\".tag" "$REGISTRY_MAP")"
+  echo "${host}/${path}:${tag}"
+}
+
+@test "registry-map's fedora-bootc pin matches bonito's build-config base" {
+  # These agree today. The point is that nothing made them: registry-map is a
+  # second copy of the Fedora base version, and a transition that bumps
+  # build-config alone leaves it stale.
+  [ "$(map_ref fedora-bootc)" = "$(config_base bonito)" ]
+}
+
+@test "registry-map's centos-bootc pin matches skipjack's build-config base" {
+  [ "$(map_ref centos-bootc)" = "$(config_base skipjack)" ]
+}
+
+@test "registry-map's almalinux-bootc pin matches albacore's build-config base" {
+  # This one has a real consumer — _registry.sh exports it as the default
+  # BASE_IMAGE — so drift here is not merely cosmetic.
+  [ "$(map_ref almalinux-bootc)" = "$(config_base albacore)" ]
+}
+
+@test "the two COREOS_STABLE_VERSION defaults agree" {
+  # Justfile:5 defaults it to one value and build-image-inner.sh:81 to another.
+  # Nothing in .github/workflows sets it, so the Justfile's value is what every
+  # real build uses and the script's is a fallback for direct invocation — one
+  # that had drifted two Fedora releases behind. Latent, not live, which is
+  # precisely why it survived: no build ever took the branch that would have
+  # shown it.
+  local just_default inner_default
+  just_default="$(sed -n 's/.*coreos_stable_version := env("COREOS_STABLE_VERSION", "\([0-9]*\)").*/\1/p' "$JUSTFILE")"
+  inner_default="$(sed -n 's/.*COREOS_STABLE="\${COREOS_STABLE_VERSION:-\([0-9]*\)}".*/\1/p' "$INNER_SH")"
+  [ -n "$just_default" ]
+  [ -n "$inner_default" ]
+  [ "$just_default" = "$inner_default" ]
+}
+
+@test "bonito's base and its description agree about the Fedora version" {
+  # build-config carries the version twice per variant — in base_image and in
+  # the human description that feeds docs and the image label. A transition
+  # that bumps one and not the other ships an image that misreports itself.
+  local base desc base_ver
+  base="$(config_base bonito)"
+  desc="$(yq -r '.variants[] | select(.id == "bonito") | .description' "$BUILD_CONFIG")"
+  base_ver="${base##*:}"
+  [[ "$desc" == *"$base_ver"* ]]
+}
+
+@test "FEDORA-BASE-POLICY.md names the file a transition actually has to edit" {
+  # A currency policy that does not say where the version lives cannot be
+  # executed. build-config.yml is the authoritative pin; the policy must point
+  # at it, not just at the release cadence.
+  run grep -F 'build-config.yml' "${REPO_ROOT}/FEDORA-BASE-POLICY.md"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Refs #1171. **Not closing it** — its own trigger condition is Bonito (#272) reaching GA, which hasn't happened.

## All three proposed steps already landed

#1432 merged on 08-13. I verified on `main` rather than taking the comment on trust:

- `FEDORA-BASE-POLICY.md` exists (62 lines, N + rawhide model, one transition at a time)
- `ROADMAP.md:149` carries the Q4 row with `#1171` as tracker and a link to the policy
- The policy's cross-reference to `VARIANT-LIFECYCLE.md`'s exit criteria **resolves** (line 30 table) — I checked, because a policy pointing at a rule that doesn't exist has been a recurring find

## What it's missing: a way to carry it out

The policy says *which* Fedora release the project commits to. It doesn't say *where that version lives* — and the version lives in more places than one.

This repo has already paid for that gap. `scripts/get-base-image.sh`'s header records a second hardcoded copy of the variant→base map drifting from build-config:

```
bonito    build-config: fedora-bootc:44      here: fedora-bootc:43
```

> *"silently, because nothing compared them"*

The lesson it drew was to keep one copy. So this adds the inventory of the copies that **remain** — measured on 2026-08-14, not listed from memory — split by whether drift there fails a build or not.

## Writing the inventory turned up two live gaps

Both fail the new tests against `main`:

**1. `COREOS_STABLE_VERSION` has two different defaults.** `Justfile:5` says `43`, `scripts/build-image-inner.sh:81` said `41` — two Fedora releases apart. Nothing in `.github/workflows` sets it and every real build goes through `just`, so the `41` only fires on direct invocation. Latent, which is exactly why it survived: no build ever took the branch that would have shown it. Aligned to `43`.

**2. `registry-map.yaml` duplicates the base version with no consumers.** Nothing calls `registry_ref fedora-bootc` — or `centos-bootc`:

| entry | tag | consumers |
|---|---|---|
| `fedora-bootc` | `44` | **0** |
| `centos-bootc` | `stream10` | **0** |
| `almalinux-bootc` | `10` | 1 (`_registry.sh` exports it as the default `BASE_IMAGE`) |

They agree with build-config today by coincidence, not by construction. A transition that bumps build-config alone leaves them stale with nothing failing — the same shape as the bug `get-base-image.sh` already suffered.

## Tests

`tests/bats/test_fedora_base_currency.bats` compares the pins that *can* be compared: registry-map vs build-config for all three families, the two `COREOS_STABLE` defaults, and bonito's `base_image` against its own `description:`, which carries the version a second time and feeds the image label.

**6/6 on this branch, 4/6 against `upstream/main`** — the two failures are exactly the gaps above.

## What I deliberately did not automate

Nine documents state "Fedora 44" in prose (`ROADMAP.md`, `MIGRATION.md`, `.github/copilot-instructions.md`, `docs/PIPELINE.md`, `docs/build-pipeline.md`, `docs/AGENT_GUIDE.md`, `docs/LUKS-TPM.md`, `docs/FEDORA-MAGAZINE-PITCH.md`, `docs/adr/0003-mkosi-co-build-poc.md`). They're listed in the policy but **not** machine-checked — pinning strings across nine files would fail on every unrelated wording change. Written down is the right amount of enforcement for those; a test would be worse than none.

## One thing I checked and did *not* report as a finding

I initially read the `fedora-bootc:43` line in `get-base-image.sh` as a live divergence. It isn't — it's a comment describing a bug that was already fixed by making the script read the config. Reading the file rather than the grep hit is what kept that out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
