### PR TITLE
fix(ci): stop piping a remote installer into a root shell, and verify what we download

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -135,27 +135,62 @@ jobs:
 
       - name: Install just and yq
         run: |
+          set -euo pipefail
           # Pinned versions — /latest/download/ redirects trigger 403
-          # rate-limiting on some runner types (e.g. linux/amd64/v2).
+          # rate-limiting on some runner types (e.g. linux/amd64/v2) — AND
+          # pinned SHA-256. A version pin alone still trusts whatever bytes the
+          # CDN hands back, and these land as root-owned binaries in /usr/bin
+          # and /usr/local/bin on a runner holding R2 keys and GHCR push
+          # credentials (tunaOS#1327).
+          #
+          # Hashes verified two ways on 2026-08-14: downloaded and hashed
+          # independently, and compared against each project's own published
+          # checksums (just's SHA256SUMS, yq's checksums + checksums_hashes_order).
           YQ_VERSION="v4.53.3"
           JUST_VERSION="1.55.1"
-          ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-          JUST_ARCH=$(uname -m | sed 's/amd64/x86_64/')
+          case "$(uname -m)" in
+            x86_64)
+              YQ_ARCH="amd64"; JUST_ARCH="x86_64"
+              YQ_SHA256="fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
+              JUST_SHA256="b0ef600f0df20d5ae91ae931627c499fc52b477ffe5f5ea7b7b3ec616b16c778"
+              ;;
+            aarch64)
+              YQ_ARCH="arm64"; JUST_ARCH="aarch64"
+              YQ_SHA256="578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea"
+              JUST_SHA256="b0ee814c9656427408e339893541e30d9027828686839499b2a2a34dd61ad173"
+              ;;
+            *)
+              echo "::error::no pinned yq/just checksum for $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
 
-          # Retry loop — GitHub CDN transient 403s resolve after a short wait
-          for i in 1 2 3; do
-            sudo wget -qO /usr/bin/yq \
-              "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH}" \
-              && break || sleep $((i * 2))
-          done
+          # Retry loop — GitHub CDN transient 403s resolve after a short wait.
+          fetch() { # url dest
+            local i
+            for i in 1 2 3; do
+              curl -fsSL -o "$2" "$1" && return 0
+              sleep $((i * 2))
+            done
+            echo "::error::failed to download $1 after 3 attempts" >&2
+            return 1
+          }
 
-          curl -fsSL \
-            "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz" \
-            -o /tmp/just.tgz 2>/dev/null \
-            || curl -fsSL https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
+          # Downloaded to /tmp and verified BEFORE anything root-owned is
+          # written. The previous version piped straight to /usr/bin/yq under
+          # sudo, so unverified bytes became a system binary before anyone
+          # could object, and fell back to `curl https://just.systems/install.sh
+          # | sudo bash` — an unpinned remote script executed as root, which
+          # fired precisely when the pinned download had already failed.
+          fetch "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH}" /tmp/yq
+          echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
+          sudo install -m 0755 /tmp/yq /usr/bin/yq
 
-          if [ -f /tmp/just.tgz ]; then sudo tar -xzf /tmp/just.tgz -C /usr/local/bin just; fi
-          sudo chmod +x /usr/bin/yq /usr/local/bin/just 2>/dev/null || true
+          fetch "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz" /tmp/just.tgz
+          echo "${JUST_SHA256}  /tmp/just.tgz" | sha256sum -c -
+          sudo tar -xzf /tmp/just.tgz -C /usr/local/bin just
+          sudo chmod 0755 /usr/local/bin/just
+
           just --version && yq --version
 
 

--- a/tests/bats/test_no_curl_pipe_root_shell.bats
+++ b/tests/bats/test_no_curl_pipe_root_shell.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# No workflow pipes a remote script into a root shell (tunaOS#1327).
+#
+# #1327 was filed against tuna-os/tunaos-packages, where 15 workflows ran
+#
+#     curl -fsSL https://rclone.org/install.sh | sudo bash
+#
+# and it was fixed there (tunaos-packages#373). It was filed per-vendor,
+# though, so nothing looked for the same shape elsewhere — and this repo had
+# it too, with a different vendor:
+#
+#     || curl -fsSL https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
+#
+# in reusable-build-image.yml's "Install just and yq" step. Worse than the
+# rclone one in one respect: it was a FALLBACK behind a pinned download, so the
+# unpinned root shell ran exactly when the pinned path had already failed, and
+# the pinned curl's stderr was sent to /dev/null so nobody saw why.
+#
+# The runner holds R2 keys and GHCR push credentials, so root code execution
+# there is not a theoretical grade of bad.
+#
+# This test is the generalisation the issue lacked: the shape, not the vendor.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+
+# Any `curl`/`wget` whose output is piped into a shell. Deliberately matches
+# `| bash`, `| sh`, and the sudo forms — piping into a non-root shell on a
+# runner that has passwordless sudo is barely better.
+PIPE_TO_SHELL='(curl|wget)[^|;&]*\|[[:space:]]*(sudo[[:space:]]+)?(bash|sh)([[:space:]]|$)'
+
+@test "no workflow pipes a downloaded script into a shell" {
+  run grep -rInE "$PIPE_TO_SHELL" "${REPO_ROOT}/.github/workflows"
+  # grep exits 1 on no match, which is the passing case. Print what it found so
+  # a failure names the file and line rather than just going red.
+  if [ "$status" -eq 0 ]; then
+    echo "curl|shell found in workflows:" >&2
+    echo "$output" >&2
+  fi
+  [ "$status" -ne 0 ]
+}
+
+@test "no build or helper script pipes a downloaded script into a shell" {
+  # _upstream-snapshots/ is vendored third-party source, not ours to rewrite.
+  run bash -c "grep -rInE '$PIPE_TO_SHELL' \
+      --include='*.sh' --include='Justfile' --include='Containerfile*' \
+      '${REPO_ROOT}/scripts' '${REPO_ROOT}/build_scripts' '${REPO_ROOT}/Justfile' 2>/dev/null"
+  if [ "$status" -eq 0 ]; then
+    echo "curl|shell found:" >&2
+    echo "$output" >&2
+  fi
+  [ "$status" -ne 0 ]
+}
+
+# ── the replacement is verified, not merely pinned ────────────────────────
+
+@test "the just/yq installer checksums what it downloads" {
+  local wf="${REPO_ROOT}/.github/workflows/reusable-build-image.yml"
+  # A version pin still trusts the bytes the CDN returns. Both downloads must
+  # be checked before install.
+  run grep -c 'sha256sum -c -' "$wf"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 2 ]
+}
+
+@test "the just/yq installer verifies before writing anything root-owned" {
+  # The old step did `sudo wget -qO /usr/bin/yq ...`, so unverified bytes became
+  # a system binary before any check could object. Downloads must land in /tmp.
+  local wf="${REPO_ROOT}/.github/workflows/reusable-build-image.yml"
+  run grep -nE '^\s*sudo (wget|curl)' "$wf"
+  [ "$status" -ne 0 ]
+}
+
+@test "an architecture with no pinned checksum fails instead of guessing" {
+  # Silently continuing on an unknown arch would reintroduce the hole on the
+  # exact runner nobody tested.
+  local wf="${REPO_ROOT}/.github/workflows/reusable-build-image.yml"
+  run grep -F 'no pinned yq/just checksum for' "$wf"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Refs #1327. **Not the rclone fix** — that already landed in the right repo.

## Where the issue actually stands

#1327 is filed against `tuna-os/tunaos-packages`, a different repo. It's been fixed there: **tunaos-packages#373** replaced all 19 occurrences with a shared composite action that downloads a pinned rclone `.deb` and verifies SHA-256, auto-detecting amd64/arm64. Nothing left to do on that.

## What the issue missed

It was filed **per-vendor** — "the rclone installer" — so nothing went looking for the same shape elsewhere. This repo had it, with a different vendor, in `reusable-build-image.yml`'s *"Install just and yq"* step:

```bash
|| curl -fsSL https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
```

Worse than the rclone one in one respect: it was a **fallback** behind a pinned download, so the unpinned root shell ran *precisely when the pinned path had already failed* — and that curl's stderr went to `/dev/null`, so nobody saw why. Same runner, same blast radius: R2 keys and GHCR push credentials.

## Two more holes in the same block

Both survive merely deleting the pipe:

- **Neither download was checksummed.** Versions were pinned, which still trusts whatever bytes the CDN returns.
- **`sudo wget -qO /usr/bin/yq …`** wrote unverified bytes straight to a root-owned system path — there was no moment at which a check *could* have objected.

## The fix

Pinned SHA-256 for both, downloaded to `/tmp`, verified, and only then installed. Unknown architecture is a loud failure instead of a silent continue. The retry loop for the CDN's transient 403s is kept — that was a real documented problem — and now covers both downloads rather than just `yq`.

**Hashes verified two independent ways** on 2026-08-14 — downloaded and hashed here, then compared against each project's own published checksums (`just`'s `SHA256SUMS`; `yq`'s `checksums` + `checksums_hashes_order`, sha256 being column 18). All four agree:

| asset | sha256 |
|---|---|
| `yq_linux_amd64` | `fa52a4e7…eded4` |
| `yq_linux_arm64` | `578648e4…945ea` |
| `just-1.55.1-x86_64-…musl.tar.gz` | `b0ef600f…16c778` |
| `just-1.55.1-aarch64-…musl.tar.gz` | `b0ee814c…1ad173` |

## The regression guard is the generalisation the issue lacked

`tests/bats/test_no_curl_pipe_root_shell.bats` matches the **shape** — `curl`/`wget` piped into `bash`/`sh`, with or without `sudo` — across `.github/workflows`, `scripts/` and `build_scripts/`, rather than one vendor's URL. Plus three assertions that the replacement is genuinely *verified* and not merely *pinned*.

**5/5 on this branch, 1/5 against `upstream/main`** — the shape test catches the `just.systems` pipe.

## Verification

I can't run a build, but I did exercise the parts that are runnable:

```
x86_64   -> YQ_ARCH=amd64 JUST_ARCH=x86_64 YQ_SHA=fa52a4e7
aarch64  -> YQ_ARCH=arm64 JUST_ARCH=aarch64 YQ_SHA=578648e4
riscv64  -> ::error::no pinned yq/just checksum for riscv64
```

YAML parses, and the extracted `run` block passes `bash -n`. (My first attempt at that check selected the wrong YAML path and syntax-checked an empty file — worth saying, since a vacuous green is exactly what this PR is about.)

**Boundary:** the step itself has not run on a real runner. The download URLs and hashes are confirmed against the live releases; that the step executes correctly in Actions is proven by the next build that uses it, not by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
