### PR TITLE
fix(security): remove unpinned just.systems install.sh fallback in reusable-build-image.yml

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -149,12 +149,14 @@ jobs:
               && break || sleep $((i * 2))
           done
 
-          curl -fsSL \
-            "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz" \
-            -o /tmp/just.tgz 2>/dev/null \
-            || curl -fsSL https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
+          for i in 1 2 3; do
+            sudo curl -fsSL \
+              "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz" \
+              -o /tmp/just.tgz \
+              && break || sleep $((i * 2))
+          done
 
-          if [ -f /tmp/just.tgz ]; then sudo tar -xzf /tmp/just.tgz -C /usr/local/bin just; fi
+          sudo tar -xzf /tmp/just.tgz -C /usr/local/bin just
           sudo chmod +x /usr/bin/yq /usr/local/bin/just 2>/dev/null || true
           just --version && yq --version
 


### PR DESCRIPTION
Fixes #1357

## Summary
In `.github/workflows/reusable-build-image.yml`, the "Install just and yq" step previously fell back to downloading and running an unpinned installer (`curl -fsSL https://just.systems/install.sh | sudo bash`) whenever downloading the pinned `just` release tarball failed.

This PR replaces the unpinned remote installer fallback with a 3-attempt retry loop against the pinned GitHub release URL for `just` (matching the existing `yq` retry pattern in the same step). If the download fails after 3 attempts, the step now fails closed instead of running arbitrary unpinned scripts as root.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `63d913d1`