### PR TITLE
docs(policy): add branch hygiene policy and stale branch triage rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ Related Communities:
 - [Versioning](VERSIONING.md) — tag scheme and stability tiers
 - [Migration Guide](MIGRATION.md) — switching from other distros
 - [Security Policy](SECURITY.md) — vulnerability reporting and supported versions
+- [Branch Protection](docs/BRANCH-PROTECTION.md) — rulesets and required CI audit (#1167)
+- [Branch Hygiene](docs/BRANCH-HYGIENE.md) — branch lifecycle, naming rules, and stale branch triage (#1530)
 - [Adopters](ADOPTERS.md) — organizations using TunaOS
 - [Adoption Metrics](ADOPTION-METRICS.md) — how adoption is measured and reported (#1174)
 - [Code of Conduct](CODE_OF_CONDUCT.md) — community standards

--- a/RFC-PROCESS.md
+++ b/RFC-PROCESS.md
@@ -51,7 +51,7 @@ An RFC branch may merge only when **all** of the following hold:
    The decision record may be brief (context + decision + consequences).
 
 Branches that cannot meet the gate within **30 days** of the last commit are
-flagged for triage (stage → Merged, Abandoned, or folded into a successor).
+flagged for triage (stage → Merged, Abandoned, or folded into a successor) per [BRANCH-HYGIENE.md](docs/BRANCH-HYGIENE.md).
 
 ## Numbering and branch conventions
 

--- a/docs/BRANCH-HYGIENE.md
+++ b/docs/BRANCH-HYGIENE.md
@@ -1,0 +1,60 @@
+# Branch Hygiene Policy
+
+**Status**: PROPOSED — 2026-08-14
+**Owner**: tuna-os (hanthor) / strategist
+**Tracks**: #1530 (Branch hygiene policy), #1174 (Adoption metrics snapshot), #1363 (RFC disposition pass)
+
+---
+
+## Purpose
+
+Define branch naming, lifecycle, staleness rules, and automated/manual cleanup procedures for the `tuna-os/tunaos` repository.
+
+Unmanaged branch accumulation (97+ branches across RFCs, agent runs, and feature experiments) creates contributor friction, obscures active work, and clutters PR targeting. This policy establishes a predictable branch lifecycle so that only active, owned branches remain in the repository.
+
+---
+
+## Branch Naming & Classification
+
+All branches pushed to `tuna-os/tunaos` must follow a recognized prefix convention and carry clear ownership:
+
+| Branch Type | Prefix / Pattern | Max Lifetime | Owner / Responsibility | Disposition |
+|---|---|---|---|---|
+| **Default Branch** | `main` | Permanent | Maintainers (`tuna-os`) | Protected by GitHub Rulesets ([BRANCH-PROTECTION.md](BRANCH-PROTECTION.md)) |
+| **RFC Proposals** | `rfcNNN-<slug>` | 30 days post-commit | Author / Strategist | Governed by [RFC-PROCESS.md](../RFC-PROCESS.md). Merged, abandoned, or deleted after disposition pass. |
+| **Feature / Fix** | `feat/<name>`, `fix/<name>`, `docs/<name>`, `ci/<name>`, `arch/<name>` | 30 days post-commit | PR Author | Merged via PR (deleted on merge) or deleted when stale/abandoned. |
+| **Agent / Automation** | `agent/<name>`, `claude/<name>`, `codex/<name>`, `auto/<name>` | 14 days post-commit | Agent / Initiator | Transient build or experiment branches. Deleted automatically on PR merge or purged when stale. |
+| **Release / Stable** | `release/<version>`, `stable/<version>` | Permanent / Lifecycle | Maintainers | Long-term maintenance refs for stable releases. |
+
+> **Fork-First Policy**: External contributors and agent runs without push access build on their personal forks. Direct upstream branches are reserved for core maintainer workflows, release tags, and tracked RFC proposals.
+
+---
+
+## Staleness Rules & Triage Cadence
+
+A branch is considered **stale** if it has no new commits for **30 days** (14 days for agent/automation branches) and has no open, active Pull Request.
+
+### Triage & Cleanup Rules
+
+1. **Delete-on-Merge (Automated)**:
+   GitHub's `delete-branch-on-merge` setting is enabled. Merging a Pull Request automatically deletes the head branch from `tuna-os/tunaos`.
+
+2. **RFC Branch Disposition Pass**:
+   RFC branches (`rfcNNN-*`) are triaged in accordance with [RFC-PROCESS.md](../RFC-PROCESS.md) during quarterly checkpoints (e.g. 2026-08-22 Q3 checkpoint #1299 / #1363). Branches whose ideas are merged/absorbed, superseded, or abandoned are deleted from upstream.
+
+3. **Monthly Stale Branch Audit**:
+   As part of the monthly [ADOPTION-METRICS.md](../ADOPTION-METRICS.md) and hygiene reporting cycle (#1174), the active branch count across `tuna-os` authorized repositories is audited:
+   - Stale unmerged feature/fix/agent branches (>30 days inactive) without an open PR are flagged for deletion.
+   - Maintainers or agents run a cleanup pass deleting obsolete tracking branches:
+     ```bash
+     git push upstream --delete <stale-branch-name>
+     ```
+
+---
+
+## Hygiene Metrics & Reporting
+
+Branch count and stale-branch count are tracked in the monthly maintainer hygiene snapshot alongside release and adoption metrics:
+
+- **Target**: Maintain ≤ 15 active upstream branches at any given time (excluding permanent release tags/branches).
+- **Metric Linkage**: Reported in the monthly ROADMAP Community & Governance updates (#1174).


### PR DESCRIPTION
Fixes #1530

## Summary
Establishes a formal Branch Hygiene Policy in `docs/BRANCH-HYGIENE.md` to prevent branch sprawl and manage branch lifecycles across `tuna-os/tunaos`:

1. **Branch Classification & Lifetime**:
   - RFC branches (`rfcNNN-*`): 30-day post-commit lifetime, governed by `RFC-PROCESS.md`.
   - Feature / Fix / Docs / CI branches (`feat/*`, `fix/*`, `docs/*`, etc.): 30-day limit, deleted upon PR merge or when abandoned.
   - Agent / Automation branches (`agent/*`, `claude/*`, `codex/*`, `auto/*`): 14-day limit, transient build/test branches deleted automatically on PR merge or purged during triage.

2. **Fork-First Directive**:
   - Mandates that external contributors and AI agents build on personal forks rather than cluttering the upstream repository with transient feature branches.

3. **Stale Branch Cleanup Cadence**:
   - Integrates monthly stale branch triage into the maintainer hygiene cycle (`ADOPTION-METRICS.md` #1174) with a target limit of ≤ 15 active upstream branches.
   - Links `BRANCH-HYGIENE.md` in `RFC-PROCESS.md` and `README.md` under Policies & Planning.

## Verification
- Validated markdown formatting and cross-links in `docs/BRANCH-HYGIENE.md`, `RFC-PROCESS.md`, and `README.md`.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `8815be38`