### PR TITLE
docs: fact-check the press materials before they reach editors

### DIFF
--- a/docs/DISTROWATCH-SUBMISSION.md
+++ b/docs/DISTROWATCH-SUBMISSION.md
@@ -18,9 +18,13 @@ Variants cover the desktop spectrum on a common base: GNOME with backports
 onto Enterprise Linux lifecycles (AlmaLinux 10 and CentOS Stream 10),
 KDE Plasma 6, the Rust-built COSMIC, the scrollable-tiling Niri compositor,
 XFCE 4.20, plus Ubuntu-, Debian-, Gentoo-, Arch-, and Fedora-based flavors.
-All published images are multi-arch (x86_64 and aarch64), with Apple Silicon
-(M1/M2) support via an Asahi-based installer and Snapdragon X Elite laptop
-support documented per variant.
+Published container images are multi-arch (x86_64 and aarch64). Downloadable
+ISOs are x86_64 today — the artifact matrix that builds them is still
+amd64-only (#1378), so an aarch64 listing would promise a download that does
+not exist. Apple Silicon (M1/M2) work is in progress rather than shipped: the
+build config marks the Asahi flavor "EXPERIMENTAL: kernel + glue only; boot
+payloads pending #777", and the macOS installer app has not yet been proven on
+real hardware.
 
 Under the hood, TunaOS is manifest-driven: a YAML file defines a variant,
 the pipeline turns it into a published, signed, multi-arch image, and CI
@@ -39,13 +43,13 @@ verified boot reports, and an active community on Matrix.
 | **Name** | TunaOS |
 | **Homepage** | https://tunaos.org |
 | **Source** | https://github.com/tuna-os/tunaOS |
-| **Download** | https://tunaos.org/download (ISOs for all variants) |
+| **Download** | https://tunaos.org/download (x86_64 ISOs) |
 | **Image registry** | https://github.com/orgs/tuna-os/packages (GHCR) |
 | **Status** | Active (daily rolling builds; weekly/quarterly-LTS stability tiers) |
 | **Origin** | USA / global maintainer community |
 | **Desktop environments** | GNOME, KDE Plasma, COSMIC, Niri, XFCE, Pantheon |
 | **Package management** | bootc image-based (rpm-ostree-style), atomic |
-| **Architectures** | x86_64, aarch64 |
+| **Architectures** | Images: x86_64, aarch64. ISOs: x86_64 (aarch64 ISO builds tracked in #1378) |
 | **License** | Apache-2.0 |
 | **First release** | 2026 |
 | **Based on** | AlmaLinux 10, CentOS Stream 10, Fedora, Ubuntu, Debian, Gentoo, Arch |
@@ -53,29 +57,50 @@ verified boot reports, and an active community on Matrix.
 
 ## Variant matrix (for the listing)
 
-| Variant | Base | Desktop | Status |
-|---|---|---|---|
-| Yellowfin | AlmaLinux Kitten 10 | GNOME | Stable |
-| Albacore | AlmaLinux 10 | GNOME | Stable |
-| Bonito | Fedora | GNOME | Beta |
-| Skipjack | CentOS Stream 10 | KDE Plasma | Beta |
-| Tromsø | BuildStream-based | KDE Plasma 6 | Stable |
-| XFCE Linux | BuildStream-based | XFCE 4.20 | Stable |
-| COSMIC | EL10 cell (Tideforge-built) | COSMIC | Beta |
-| Niri | Fedora | Niri | Beta |
-| Gurnard | Ubuntu 24.04 LTS | Pantheon | Experimental |
-| Marlin | Arch | GNOME | Beta |
+Copied from [ROADMAP.md](../ROADMAP.md)'s variant table, which states that it
+"is the canonical per-variant status; tunaos.org wiki and blog copy must track
+it". An earlier hand-written version of this section had drifted from it:
+Skipjack listed Stable (canonical: Beta), Marlin listed Alpha (Beta), Gurnard
+listed as a headline new variant (Experimental, #1341), five variants missing,
+and COSMIC/Niri/XFCE listed as separate variants when they are desktop flavors
+available across variants — which would have told DistroWatch this project has
+distributions it does not have.
+
+| Variant | Base | Desktops | Status |
+|---------|------|----------|--------|
+| Yellowfin | AlmaLinux Kitten 10 | GNOME, KDE, COSMIC, Niri, XFCE | Stable |
+| Albacore | AlmaLinux 10 | GNOME, KDE, COSMIC, Niri, XFCE | Stable |
+| Skipjack | CentOS Stream 10 | GNOME, KDE, COSMIC, Niri, XFCE | Beta |
+| Bonito / Bonito Rawhide | Fedora 44 / Rawhide | GNOME, KDE, COSMIC, Niri | Beta |
+| Sailfin | openSUSE Tumbleweed (rolling) | GNOME, KDE, Niri, XFCE | Beta |
+| Guppy | Gentoo Linux (source-based) | GNOME, KDE, Niri, XFCE | Beta |
+| Grouper | Ubuntu 26.04 | GNOME, KDE, Niri, XFCE | Beta (RFC 010) |
+| Marlin | Arch Linux (rolling), CachyOS overlay | GNOME, KDE, COSMIC, Niri, XFCE | Beta |
+| Flounder / Flounder Sid | Debian 13 Trixie / Sid | GNOME, KDE, COSMIC, Niri, XFCE | Beta |
+| Hummingbird | Fedora Hummingbird (container-native bootc) | Base, GNOME, KDE, COSMIC, Niri | Experimental (see #1341) |
+| Gurnard | Ubuntu 24.04 Noble | Base, Pantheon | Experimental (see #1341) |
+
+**Status terms** follow [VARIANT-LIFECYCLE.md](../VARIANT-LIFECYCLE.md):
+`Stable` means GA, `Beta` means published for testing. Experimental variants
+predate the admission gate and have no named owner yet — worth saying plainly
+to an editor rather than listing them alongside GA products.
 
 ## Suggested pitch to DistroWatch Weekly editors
 
 > "TunaOS brings the bootable-container model to the enterprise desktop:
 > GNOME and KDE on 10-year Enterprise Linux lifecycles, updated atomically
 > like a container fleet. New this quarter: an Ubuntu 24.04 + Pantheon
-> variant (Gurnard) and Apple Silicon installer support."
+> variant (Gurnard, experimental) and in-progress Apple Silicon support."
+
+Deliberately not "Apple Silicon installer support" — that reads as shipped, and
+a DistroWatch reader would reasonably try to download it. Pitch the experimental
+things as experimental; an editor who finds out otherwise remembers.
 
 ## Submission checklist
 
 - [ ] Maintainer review of description and variant matrix
+- [ ] Re-check the variant matrix against ROADMAP.md's canonical table — it is
+      copied, not authored here, and drifted once already
 - [ ] Confirm current download URLs + image tags before submission
 - [ ] Submit via DistroWatch project submission form
 - [ ] Add tunaos.org/download link to any public project listings

--- a/tests/bats/test_press_claims_match_roadmap.bats
+++ b/tests/bats/test_press_claims_match_roadmap.bats
@@ -39,14 +39,30 @@ press_docs() {
   done
 }
 
-# "| Name | Base | Desktops | Status |" rows from a markdown variant table.
+# "| Variant | Base | Desktops | Status |" rows from a markdown variant table.
+#
+# Scoped to tables whose FIRST column header is literally "Variant", because a
+# press doc may carry other four-column tables. YOUTUBER-REVIEW-KIT.md heads
+# its download table "| Story | Variant | Download | Notes |" — the variant is
+# in column 2, so reading column 1 as a name produced "Enterprise Linux
+# desktop, stable" and three siblings as variants that do not exist in
+# ROADMAP. That is a false positive of exactly the kind this file warns about
+# below ("a false positive is how a guard gets deleted"), so the table is
+# identified by its header rather than by the shape of its rows.
 variant_rows() {
-  awk -F'|' '/^\| *[A-Z][A-Za-z]/ && NF==6 {
-      name=$2; status=$5
-      gsub(/^ +| +$/, "", name); gsub(/^ +| +$/, "", status)
-      if (name == "Variant") next
+  awk -F'|' '
+    /^\|/ {
+      if ($0 ~ /^\| *:?-+/) next            # separator row
+      name=$2; gsub(/^ +| +$/, "", name)
+      if (name == "Variant") { in_table=1; next }   # a real variant table
+      if (!in_table) next                   # some other table: not ours
+      if (NF != 6 || name !~ /^[A-Z]/) next
+      status=$5; gsub(/^ +| +$/, "", status)
       print name "\t" status
-    }' "$1"
+      next
+    }
+    { in_table=0 }                          # any non-table line ends it
+  ' "$1"
 }
 
 # ROADMAP names some rows for a pair — "Bonito / Bonito Rawhide", "Flounder /

--- a/tests/bats/test_press_claims_match_roadmap.bats
+++ b/tests/bats/test_press_claims_match_roadmap.bats
@@ -21,6 +21,24 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
 ROADMAP="${REPO_ROOT}/ROADMAP.md"
 DISTROWATCH="${REPO_ROOT}/docs/DISTROWATCH-SUBMISSION.md"
 
+# Every external-facing doc that publishes a variant table, not just the
+# DistroWatch one. Four more were in flight when this was written — PRESSKIT.md
+# (#1653), TECH-PRESS-PITCHES.md (#1544), YOUTUBER-REVIEW-KIT.md (#1545) — and
+# a guard that only covers the document that happened to be checked first is
+# how the next one ships wrong. Files are matched if present; a doc that does
+# not exist yet simply is not scanned, and starts being scanned the day it
+# lands.
+press_docs() {
+  local f
+  for f in "${REPO_ROOT}"/docs/DISTROWATCH-SUBMISSION.md \
+           "${REPO_ROOT}"/docs/PRESSKIT.md \
+           "${REPO_ROOT}"/docs/TECH-PRESS-PITCHES.md \
+           "${REPO_ROOT}"/docs/YOUTUBER-REVIEW-KIT.md \
+           "${REPO_ROOT}"/docs/FEDORA-MAGAZINE-PITCH.md; do
+    [ -f "$f" ] && grep -qE '^\| *[A-Z][A-Za-z]+ *\|' "$f" && echo "$f"
+  done
+}
+
 # "| Name | Base | Desktops | Status |" rows from a markdown variant table.
 variant_rows() {
   awk -F'|' '/^\| *[A-Z][A-Za-z]/ && NF==6 {
@@ -35,12 +53,29 @@ variant_rows() {
 # Flounder Sid". A listing reasonably says just "Bonito", so match either half
 # rather than forcing press copy to use the compound name.
 canon_status_for() {
+  # Compound names appear on BOTH sides and are not written identically:
+  # ROADMAP says "Flounder / Flounder Sid", a press kit reasonably writes
+  # "Flounder / Sid". Split both and match on any shared part, so the guard
+  # flags variants that do not exist rather than variants spelled shorter. (It
+  # flagged Flounder before this — a false positive is how a guard gets
+  # deleted, so it matters more than the true positives.)
   variant_rows "$ROADMAP" | awk -F'\t' -v want="$1" '
     {
       if ($1 == want) { print $2; exit }
-      n = split($1, parts, / *\/ */)
-      for (i = 1; i <= n; i++) if (parts[i] == want) { print $2; exit }
+      nc = split($1, cparts, / *\/ */)
+      nw = split(want, wparts, / *\/ */)
+      for (i = 1; i <= nc; i++)
+        for (j = 1; j <= nw; j++)
+          if (cparts[i] == wparts[j]) { print $2; exit }
     }'
+}
+
+@test "there is at least one press doc with a variant table to check" {
+  # Without this, renaming a press doc turns every check below into a pass that
+  # inspected nothing.
+  run bash -c "$(declare -f press_docs); REPO_ROOT='$REPO_ROOT'; press_docs | wc -l"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
 }
 
 @test "the canonical table is parseable and non-trivial" {
@@ -51,31 +86,48 @@ canon_status_for() {
   [ "$output" -ge 10 ]
 }
 
-@test "every variant the DistroWatch draft lists exists in ROADMAP's canonical table" {
-  # Catches desktop flavors (COSMIC, Niri, XFCE) and other repos (Tromsø)
-  # being presented to an editor as distributions.
-  local missing=0 name status
-  while IFS=$'\t' read -r name status; do
-    [ -n "$name" ] || continue
-    if [ -z "$(canon_status_for "$name")" ]; then
-      echo "NOT A VARIANT: DistroWatch draft lists '$name', absent from ROADMAP's canonical table" >&2
-      missing=$((missing + 1))
-    fi
-  done < <(variant_rows "$DISTROWATCH")
+@test "every variant any press doc lists exists in ROADMAP's canonical table" {
+  # Catches three things an editor would check and we would not: desktop
+  # flavors (COSMIC, Niri, XFCE) presented as distributions, other repos
+  # (Tromsø, XFCE Linux) presented as variants, and — the expensive one —
+  # variants that are goals rather than builds. PRESSKIT.md's draft listed
+  # "Redfin | RHEL 10" in a table headed "Variant matrix (as of 2026-08-14)";
+  # `redfin` appears zero times in build-config.yml, and ROADMAP tracks it as a
+  # Q3 goal with "zero movement since 08-08". RHEL support is exactly what an
+  # enterprise outlet asks about first.
+  local missing=0 name status doc
+  while read -r doc; do
+    while IFS=$'\t' read -r name status; do
+      [ -n "$name" ] || continue
+      if [ -z "$(canon_status_for "$name")" ]; then
+        echo "NOT A VARIANT: $(basename "$doc") lists '$name', absent from ROADMAP's canonical table" >&2
+        missing=$((missing + 1))
+      fi
+    done < <(variant_rows "$doc")
+  done < <(press_docs)
   [ "$missing" -eq 0 ]
 }
 
-@test "the DistroWatch draft reports each variant's canonical status" {
-  local drift=0 name status canon
-  while IFS=$'\t' read -r name status; do
-    [ -n "$name" ] || continue
-    canon="$(canon_status_for "$name")"
-    [ -n "$canon" ] || continue  # absence is the previous test's job
-    if [ "$status" != "$canon" ]; then
-      echo "STATUS DRIFT: '$name' is '$status' in the DistroWatch draft, '$canon' in ROADMAP" >&2
-      drift=$((drift + 1))
-    fi
-  done < <(variant_rows "$DISTROWATCH")
+@test "press docs report each variant's canonical status" {
+  # Only applies to tables whose 4th column IS a status. A press kit whose
+  # columns are Base/Desktop/Arch has no status to drift, and canon_status_for
+  # returning empty for a non-status string keeps this from firing on it.
+  local drift=0 name status canon doc
+  while read -r doc; do
+    while IFS=$'\t' read -r name status; do
+      [ -n "$name" ] || continue
+      canon="$(canon_status_for "$name")"
+      [ -n "$canon" ] || continue
+      case "$status" in
+        Stable|Beta|Alpha|Experimental*|New*|GA) ;;
+        *) continue ;;   # not a status column
+      esac
+      if [ "$status" != "$canon" ]; then
+        echo "STATUS DRIFT: '$name' is '$status' in $(basename "$doc"), '$canon' in ROADMAP" >&2
+        drift=$((drift + 1))
+      fi
+    done < <(variant_rows "$doc")
+  done < <(press_docs)
   [ "$drift" -eq 0 ]
 }
 

--- a/tests/bats/test_press_claims_match_roadmap.bats
+++ b/tests/bats/test_press_claims_match_roadmap.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# External-facing copy tracks the canonical variant table (tunaOS#1534).
+#
+# ROADMAP.md states the rule itself: its variant table "is the canonical
+# per-variant status; tunaos.org wiki and blog copy must track it." Nothing
+# enforced that, and the press materials drifted — DISTROWATCH-SUBMISSION.md
+# listed Skipjack as Stable (canonical: Beta), Marlin as Alpha (Beta), Gurnard
+# as a headline new variant (Experimental, #1341), omitted five variants, and
+# listed COSMIC/Niri/XFCE as separate variants when they are desktop flavors
+# available across variants.
+#
+# These documents are sent to DistroWatch and to magazine editors, so a wrong
+# status is not an internal inconsistency — it is a public claim about what the
+# project ships, made to people whose job is to check.
+#
+# This is a status check, not a prose check. Wording is left alone on purpose:
+# pinning sentences would fail on every edit and teach people to delete the
+# test.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+ROADMAP="${REPO_ROOT}/ROADMAP.md"
+DISTROWATCH="${REPO_ROOT}/docs/DISTROWATCH-SUBMISSION.md"
+
+# "| Name | Base | Desktops | Status |" rows from a markdown variant table.
+variant_rows() {
+  awk -F'|' '/^\| *[A-Z][A-Za-z]/ && NF==6 {
+      name=$2; status=$5
+      gsub(/^ +| +$/, "", name); gsub(/^ +| +$/, "", status)
+      if (name == "Variant") next
+      print name "\t" status
+    }' "$1"
+}
+
+# ROADMAP names some rows for a pair — "Bonito / Bonito Rawhide", "Flounder /
+# Flounder Sid". A listing reasonably says just "Bonito", so match either half
+# rather than forcing press copy to use the compound name.
+canon_status_for() {
+  variant_rows "$ROADMAP" | awk -F'\t' -v want="$1" '
+    {
+      if ($1 == want) { print $2; exit }
+      n = split($1, parts, / *\/ */)
+      for (i = 1; i <= n; i++) if (parts[i] == want) { print $2; exit }
+    }'
+}
+
+@test "the canonical table is parseable and non-trivial" {
+  # Without this, a table-format change would make every check below pass by
+  # comparing two empty sets.
+  run bash -c "$(declare -f variant_rows); variant_rows '$ROADMAP' | wc -l"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 10 ]
+}
+
+@test "every variant the DistroWatch draft lists exists in ROADMAP's canonical table" {
+  # Catches desktop flavors (COSMIC, Niri, XFCE) and other repos (Tromsø)
+  # being presented to an editor as distributions.
+  local missing=0 name status
+  while IFS=$'\t' read -r name status; do
+    [ -n "$name" ] || continue
+    if [ -z "$(canon_status_for "$name")" ]; then
+      echo "NOT A VARIANT: DistroWatch draft lists '$name', absent from ROADMAP's canonical table" >&2
+      missing=$((missing + 1))
+    fi
+  done < <(variant_rows "$DISTROWATCH")
+  [ "$missing" -eq 0 ]
+}
+
+@test "the DistroWatch draft reports each variant's canonical status" {
+  local drift=0 name status canon
+  while IFS=$'\t' read -r name status; do
+    [ -n "$name" ] || continue
+    canon="$(canon_status_for "$name")"
+    [ -n "$canon" ] || continue  # absence is the previous test's job
+    if [ "$status" != "$canon" ]; then
+      echo "STATUS DRIFT: '$name' is '$status' in the DistroWatch draft, '$canon' in ROADMAP" >&2
+      drift=$((drift + 1))
+    fi
+  done < <(variant_rows "$DISTROWATCH")
+  [ "$drift" -eq 0 ]
+}
+
+@test "press copy does not promise aarch64 ISO downloads" {
+  # The artifact matrix that builds ISOs is amd64-only (#1378), so an aarch64
+  # ISO is a download that does not exist. Images ARE multi-arch, which is why
+  # this is easy to state wrongly.
+  run grep -nE '^\| \*\*Architectures\*\*.*\|' "$DISTROWATCH"
+  [ "$status" -eq 0 ]
+  # Either it scopes the arch claim to images, or it names the gap.
+  [[ "$output" == *"Images:"* || "$output" == *"1378"* ]]
+}


### PR DESCRIPTION
Refs #1534. **Not a fifth press document** — both writable actions already have PRs in flight.

## Where the issue stands

| Action | Status |
|---|---|
| 1. Per-outlet pitches | PR **#1544** (`docs/TECH-PRESS-PITCHES.md`, draft) |
| 2. Media kit | PR **#1653** (`docs/PRESSKIT.md`) |
| 3–4. Send pitches, time follow-ups | maintainer actions on the org's behalf |

Plus #1545 (YouTuber review kit) and #1594 in the same area. Adding another document would be waste.

## What isn't covered: whether the materials are true

There's a pattern. **#1594 exists solely** to remove a "weekly release cadence" claim from these files. The maintainer's review of the Gurnard launch post found `bootc container copy` (not a real subcommand) and a "CKI ARK kernel" claim with zero hits anywhere in the repo. I found "56 stars, 40+ repos" wrong in the FOSDEM CFP earlier today.

These are the documents most likely to embarrass the project, because they go to people whose job is to check.

## The DistroWatch draft contradicted the table ROADMAP calls canonical

ROADMAP states the rule in its own words: its variant table *"is the canonical per-variant status; tunaos.org wiki and blog copy must track it."* The draft had drifted five ways:

- **Skipjack** listed `Stable` — canonical says **Beta**
- **Marlin** listed `Alpha` — canonical says **Beta**
- **Gurnard** listed as a headline new variant — canonical says **Experimental** (#1341: no named owner, staff-vs-descope decided at the Q3 checkpoint)
- **COSMIC, Niri, XFCE listed as separate variants.** They're desktop *flavors* available across variants — this would have told DistroWatch the project ships distributions it does not have. Tromsø is a separate repo.
- **Sailfin, Guppy, Grouper, Flounder, Hummingbird** missing entirely

The matrix is now *copied* from ROADMAP rather than hand-authored, since hand-authoring is how it drifted.

## Two capability claims were ahead of the code

**aarch64 ISOs don't exist.** The draft said "All published images are multi-arch (x86_64 and aarch64)" beside "Download: ISOs for all variants" and "Architectures: x86_64, aarch64". Images *are* multi-arch; ISOs aren't — `build-variant.yml`'s artifact matrix hardcodes `platform: "linux/amd64"` (#1378, fix open as #1592). An aarch64 listing promises a download that doesn't exist.

**Apple Silicon isn't shipped.** "Support via an Asahi-based installer" reads as done. `build-config.yml`'s own comment on the asahi flavor says *"EXPERIMENTAL: kernel + glue only; boot payloads pending #777"*, and the macOS installer app's README says it still needs real hardware to prove it launches, drives a backend, or partitions a disk.

I left the release-cadence lines alone — **#1594 owns those**, no point conflicting.

## The guard

`tests/bats/test_press_claims_match_roadmap.bats` enforces the rule ROADMAP already states: every variant press copy names must exist in the canonical table, with the canonical status, and the arch claim must not promise aarch64 ISOs.

**Statuses only — wording is deliberately not pinned.** A test that fails on every prose edit gets deleted, and then it protects nothing.

**4/4 here, 1/4 against `upstream/main`**, naming all eight drifts individually rather than just going red.

One thing running it caught: my first matcher flagged **Bonito** as a nonexistent variant, because ROADMAP names that row "Bonito / Bonito Rawhide". It now accepts either half, so a listing can say "Bonito" without the test forcing compound names into press copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
