### PR TITLE
fix(hummingbird): stop asking tailscale for a repo keyed on a datestamp

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -48,16 +48,46 @@ else
 fi
 
 # Tailscale — fetch repo file directly into /etc/yum.repos.d/
-local_ts_ver="${MAJOR_VERSION_NUMBER:-10}"
-if [[ ! "$local_ts_ver" =~ ^[0-9]+$ ]]; then local_ts_ver=10; fi
-
-if [[ $IS_FEDORA == true ]]; then
-	curl -fsSL -o /etc/yum.repos.d/tailscale.repo "https://pkgs.tailscale.com/stable/fedora/tailscale.repo" || true
+#
+# Tailscale publishes ONE version-independent repo file for Fedora and one per
+# EL major for CentOS. The EL branch interpolates MAJOR_VERSION_NUMBER, which
+# comes from os-release VERSION_ID — and that is not always an EL major.
+# Hummingbird versions by datestamp, so this built
+#
+#   https://pkgs.tailscale.com/stable/centos/20251124/tailscale.repo   → 404
+#
+# (tunaOS#1555's evidence list). The old guard only asked "is it digits", which
+# a datestamp satisfies. Nothing failed the build — every step here ends in
+# `|| true` — so tailscale was simply absent from Hummingbird images, silently.
+#
+# Hummingbird is Fedora-derived and IS_FEDORA is deliberately false for it
+# (lib.sh excludes it so the Bonito-specific Fedora paths don't fire), so it
+# needs naming here rather than folding into IS_FEDORA. The fedora repo file is
+# correct for it — verified 200 against pkgs.tailscale.com on 2026-08-14, as
+# were centos/9 and centos/10.
+ts_repo_url=""
+local_ts_ver="${MAJOR_VERSION_NUMBER:-}"
+if [[ $IS_FEDORA == true || ${IS_HUMMINGBIRD:-false} == true ]]; then
+	ts_repo_url="https://pkgs.tailscale.com/stable/fedora/tailscale.repo"
+elif [[ "$local_ts_ver" =~ ^[0-9]{1,2}$ ]]; then
+	# An EL major is one or two digits. A datestamp is not.
+	ts_repo_url="https://pkgs.tailscale.com/stable/centos/${local_ts_ver}/tailscale.repo"
 else
-	curl -fsSL -o /etc/yum.repos.d/tailscale.repo "https://pkgs.tailscale.com/stable/centos/${local_ts_ver}/tailscale.repo" || true
+	echo "WARNING: no tailscale repo for VERSION_ID-derived major '${local_ts_ver:-unset}'" >&2
+	echo "         on this base; skipping tailscale rather than fetching a URL that 404s." >&2
 fi
-sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/tailscale.repo 2>/dev/null || true
-dnf -y --enablerepo "tailscale-stable" install tailscale || true
+
+if [[ -n "$ts_repo_url" ]]; then
+	if curl -fsSL -o /etc/yum.repos.d/tailscale.repo "$ts_repo_url"; then
+		sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/tailscale.repo 2>/dev/null || true
+		dnf -y --enablerepo "tailscale-stable" install tailscale || true
+	else
+		# curl -f leaves no file behind on an HTTP error, so there is nothing
+		# to clean up — but say so, because the previous version's silence is
+		# what let this sit unnoticed across ten red nightlies.
+		echo "WARNING: could not fetch ${ts_repo_url}; tailscale not installed." >&2
+	fi
+fi
 
 # Upstream ublue-os-signing bug: the package used /usr/etc for container
 # signing; bootc rejects non-/etc paths. Fixed upstream (ublue-os/packages#245

--- a/tests/bats/test_tailscale_repo_selection.bats
+++ b/tests/bats/test_tailscale_repo_selection.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# Which tailscale repo file a base image asks for (tunaOS#1555).
+#
+# Tailscale publishes one version-independent repo file for Fedora and one per
+# EL major for CentOS. 20-packages.sh picked between them using
+# MAJOR_VERSION_NUMBER, which is `${VERSION_ID%.*}` from os-release — not
+# always an EL major. Hummingbird versions by datestamp, so this asked for
+#
+#   https://pkgs.tailscale.com/stable/centos/20251124/tailscale.repo
+#
+# which 404s (verbatim in #1555's evidence). The old guard only asked "is it
+# digits", and a datestamp is digits.
+#
+# Nothing failed: every step in that block ends in `|| true`, so tailscale was
+# simply absent from Hummingbird images with no signal. That is the part worth
+# testing — a build that goes green while dropping a package is harder to
+# notice than one that goes red.
+#
+# The selection is pure string logic, so these run it for real rather than
+# grepping for it. Extracted from the script so the test cannot drift from it.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+PKGS_SH="${REPO_ROOT}/build_scripts/20-packages.sh"
+
+# Run the selection block with the inputs a given base would supply, and print
+# the URL it chose (empty = deliberately skipped).
+select_url() { # IS_FEDORA IS_HUMMINGBIRD MAJOR_VERSION_NUMBER
+  local block
+  block="$(awk '/^ts_repo_url=""$/{f=1} f{print} f && /^fi$/{exit}' "$PKGS_SH")"
+  [ -n "$block" ] || { echo "COULD-NOT-EXTRACT"; return 1; }
+  IS_FEDORA="$1" IS_HUMMINGBIRD="$2" MAJOR_VERSION_NUMBER="$3" \
+    bash -c "$block"'; printf "%s" "$ts_repo_url"' 2>/dev/null
+}
+
+@test "the selection block is extractable (guards against a silent no-op test)" {
+  run select_url false false 10
+  [ "$output" != "COULD-NOT-EXTRACT" ]
+  [ -n "$output" ]
+}
+
+@test "an EL major picks that major's centos repo" {
+  run select_url false false 10
+  [ "$output" = "https://pkgs.tailscale.com/stable/centos/10/tailscale.repo" ]
+  run select_url false false 9
+  [ "$output" = "https://pkgs.tailscale.com/stable/centos/9/tailscale.repo" ]
+}
+
+@test "Fedora picks the version-independent fedora repo" {
+  run select_url true false 44
+  [ "$output" = "https://pkgs.tailscale.com/stable/fedora/tailscale.repo" ]
+}
+
+@test "Hummingbird picks the fedora repo, not a centos one built from its datestamp" {
+  # The regression. IS_FEDORA is deliberately false for Hummingbird (lib.sh
+  # excludes it so Bonito's Fedora-specific paths don't fire), so it has to be
+  # named here — folding it into IS_FEDORA would change unrelated behaviour.
+  run select_url false true 20251124
+  [ "$output" = "https://pkgs.tailscale.com/stable/fedora/tailscale.repo" ]
+}
+
+@test "a datestamp on a non-Fedora base skips rather than requesting a 404" {
+  # Belt and braces for a future base that versions by date and is not
+  # Hummingbird: ask for nothing rather than a URL known not to exist.
+  run select_url false false 20251124
+  [ -z "$output" ]
+}
+
+@test "an unset or non-numeric version skips rather than guessing a major" {
+  # The previous code defaulted to 10 here, which is a guess that happens to
+  # 200 for EL bases and silently installs the wrong repo for anything else.
+  run select_url false false ""
+  [ -z "$output" ]
+  run select_url false false "rawhide"
+  [ -z "$output" ]
+}
+
+@test "the fetch is conditional on having chosen a URL" {
+  # Without this the old unconditional `curl … || true` shape could come back
+  # and re-hide the failure.
+  run grep -F 'if [[ -n "$ts_repo_url" ]]; then' "$PKGS_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "a failed fetch says so instead of failing silently" {
+  run grep -F 'could not fetch' "$PKGS_SH"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Refs #1555. **One signature, not the whole issue** — the others are claimed.

## Division of labour

| Signature | Status |
|---|---|
| dnf resolver failures retried 3× | **#1575** — skip doomed retries |
| `libjsoncpp.so.26` / `librhash.so.1`, kf6/qt6 `-devel` | **#1622** — `kcm-ublue.sh`'s `BUILD_DEPS` probe now degrades instead of killing the image |
| arm64 `libpod_lock` | runner-level, out of repo |
| niri verify (`missing required command: niri`) | reads as *downstream* of the dnf failures — if packages can't install, niri isn't there. Not claimed. |
| **`curl: (22) 404` on tailscale.repo** | **this PR** |

## The bug

Tailscale publishes **one version-independent** repo file for Fedora and **one per EL major** for CentOS. `20-packages.sh` chose between them using `MAJOR_VERSION_NUMBER` — which is `${VERSION_ID%.*}` out of os-release, and is not always an EL major.

Hummingbird versions by **datestamp**, so the EL branch built:

```
https://pkgs.tailscale.com/stable/centos/20251124/tailscale.repo   → 404
```

The old guard asked only *"is it digits"*. A datestamp is digits.

## Why it survived ten red nightlies

**It never failed a build.** Every step in that block ends in `|| true`, so the actual result is that **tailscale is absent from Hummingbird images**, with no signal — one line of noise in logs that were red for other reasons.

A build that goes green while quietly dropping a package is harder to notice than one that goes red. That's the part worth fixing, and the part the tests target.

## The fix

Hummingbird is Fedora-derived and the fedora repo file is correct for it — but `IS_FEDORA` is *deliberately* false for Hummingbird (`lib.sh:97` excludes it so Bonito's Fedora-specific paths don't fire). So it's named explicitly rather than folded into `IS_FEDORA`, which would change unrelated behaviour.

Non-EL-major versions on a non-Hummingbird base now **skip with a warning** rather than defaulting to `10`. That default was a guess that happens to 200 for EL bases and silently installs the wrong repo for anything else.

## Verified live, 2026-08-14

```
fedora/tailscale.repo            200
centos/10/tailscale.repo         200
centos/9/tailscale.repo          200
centos/20251124/tailscale.repo   404   ← the log line from the issue
```

I also checked what `curl -f` leaves behind on a 404: **nothing**. Worth knowing before writing cleanup code for a problem that doesn't exist.

And each URL the new logic picks, confirmed live:

```
EL major 10        -> centos/10/tailscale.repo   [200]
Fedora 44          -> fedora/tailscale.repo      [200]
Hummingbird datestamp -> fedora/tailscale.repo   [200]   ← previously 404
```

## Tests

The selection is pure string logic, so the tests **execute** it rather than grepping for it. The block is extracted from the script so the test can't drift from the code, with a guard that fails if extraction ever returns nothing — a suite that passes by inspecting nothing is the same class of bug as the silent `|| true` above.

**8/8 here, 0/8 against `upstream/main`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
