### PR TITLE
docs(adopters): stop the file reading as evidence it does not have

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -17,14 +17,35 @@ _(None listed yet — see the [adoption call](docs/ADOPTION-CALL.md) and be the 
 
 ## Development & Evaluation
 
+> Both current entries are the project itself — the maintainer, and TunaOS's own
+> CI. They are honest as dogfooding records and are **not** external adoption
+> evidence; the adopters KPI in
+> [ADOPTION-METRICS.md](./ADOPTION-METRICS.md) counts external entries only, so
+> these do not move it.
+
 | Organization | Use Case | Variant(s) | Since |
 |---|---|---|---|
 | [@hanthor](https://github.com/hanthor) (Project Maintainer) | Personal daily driver — development, testing, and dogfooding all variants | Yellowfin GNOME, Albacore GNOME, Skipjack KDE | 2026-04 |
 | [TunaOS Hive Agents](https://hive.tunaos.org) | Automated CI/CD — build, test, and release pipeline runs on TunaOS infrastructure | Yellowfin GNOME, Albacore GNOME | 2026-05 |
 
-## Ecosystem & Downstream Projects
+## Upstream & Ecosystem Dependencies
 
-| Project | Relationship | Link |
+**These are not adopters.** Every entry below is a project TunaOS *builds on* or
+*consumes* — base operating systems, desktop environments it packages, build
+services, registries. None of them are downstream of TunaOS, and none have a
+partnership with it; being listed here says only that TunaOS uses their work.
+
+The section was previously headed "Ecosystem & Downstream Projects", which in a
+file that opens "organizations and projects that use TunaOS" reads as 24
+adopters. That matters because this file is cited as adoption evidence in the
+DistroWatch (#1333) and CNCF (#1340) pitches — a reader checking it would find
+Debian, Fedora, KDE and elementary OS apparently listed as TunaOS adopters, and
+none of them have said any such thing.
+
+Kept because the dependency map is genuinely useful; relabelled so it cannot be
+read as, or counted as, adoption.
+
+| Project | What TunaOS uses it for | Link |
 |---|---|---|
 | [Universal Blue](https://universal-blue.org/) | Upstream inspiration — TunaOS is a fork of Bluefin LTS | [github.com/ublue-os](https://github.com/ublue-os) |
 | [Bluefin](https://projectbluefin.io) | Direct upstream — bootc-based desktop foundation | [github.com/ublue-os/bluefin-lts](https://github.com/ublue-os/bluefin-lts) |

--- a/ADOPTION-METRICS.md
+++ b/ADOPTION-METRICS.md
@@ -31,7 +31,7 @@ publish, and *how* the snapshot feeds roadmap decisions.
 | Install | Installs / successful boots | opt-in telemetry or boot-report gating | **not measured** | Q4 design decision (#577 GUI gate, #763) |
 | Community | Open PRs from external contributors | GitHub API | 0 external contributors | ≥2 external contributor PRs merged |
 | Community | Discussion posts, `good first issue` pickups | GitHub API | 0 starter issues (dead label, #1308) | ≥5 starter issues picked up |
-| Community | Public adopters (production or evaluation), [ADOPTERS.md](./ADOPTERS.md) | Manual — PR from the adopting org, or outreach asking permission to list | 0 production entries (#1348) | ≥2–3 public evaluator/production entries |
+| Community | **External** public adopters (production or evaluation), [ADOPTERS.md](./ADOPTERS.md) — excludes the maintainer and TunaOS's own infrastructure | Manual — PR from the adopting org, or outreach asking permission to list | 0 external entries (#1348) | ≥2–3 external evaluator/production entries |
 | Community | Adoption-call conversion | GitHub Discussion + follow-up PRs | **not measured** | Record responses, consent-confirmed named entries, anonymous reports, and ADOPTERS.md PRs |
 
 **Instrumentation order** (cheapest first):
@@ -52,9 +52,11 @@ publish, and *how* the snapshot feeds roadmap decisions.
   **2026-11-01**, covering October — aligns with Q4 "Mature" opening).
 - Snapshot format: downloads by variant × desktop (top 10), stars/forks,
   external-contributor PRs, release-asset presence per flavor,
-  [ADOPTERS.md](./ADOPTERS.md) production/evaluation entry count, adoption-call
-  responses/conversion, and a one-line "variant ranking" that flags
-  under-/over-performing editions.
+  [ADOPTERS.md](./ADOPTERS.md) EXTERNAL production/evaluation entry count
+  (the two self-entries — maintainer and TunaOS CI — are excluded; counting
+  them would have met the >=2 target on the day it was written, #1348),
+  adoption-call responses/conversion, and a one-line "variant ranking" that
+  flags under-/over-performing editions.
 - Ownership: **strategist** compiles; **ci-maintainer** supplies R2/Releases
   exports; **guide** publishes on tunaos.org/blog.
 

--- a/tests/bats/test_adopters_evidence.bats
+++ b/tests/bats/test_adopters_evidence.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# ADOPTERS.md says only what it can back up (tunaOS#1348).
+#
+# #1348's point is that the adopters list carries zero external adopters while
+# Q4 positions the project as "Mature", and that the file is cited as evidence
+# in the DistroWatch (#1333) and CNCF (#1340) pitches. Collecting real adopters
+# is outreach work no agent can originate. What IS checkable is that the file
+# does not appear to have adopters it does not have.
+#
+# Two ways it did:
+#
+#  1. A 24-row table headed "Ecosystem & Downstream Projects" in a file that
+#     opens "organizations and projects that use TunaOS". Every one of those 24
+#     is an UPSTREAM or a service TunaOS consumes — 7 base OSes, 5 desktop
+#     environments it packages, registries, build services. None is downstream.
+#     A reader checking the evidence would find Debian, Fedora, KDE and
+#     elementary OS apparently listed as adopters.
+#
+#  2. The adopters KPI (#1463) counts "production/evaluation entry count", and
+#     the two Development & Evaluation entries are the maintainer and TunaOS's
+#     own CI — so the >=2 target was met by self-reference on the day it was
+#     written, with zero external adopters.
+#
+# These tests pin the labelling and the KPI scope. They deliberately do NOT
+# assert an adopter count: going from zero to one is the outreach work this
+# issue is actually about, and a test demanding it would just be red until
+# someone else did it.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+ADOPTERS="${REPO_ROOT}/ADOPTERS.md"
+METRICS="${REPO_ROOT}/ADOPTION-METRICS.md"
+
+@test "the dependency table is not labelled downstream" {
+  # "Downstream" is the specific word that turns a dependency list into
+  # apparent adoption.
+  run grep -nE '^## .*Downstream' "$ADOPTERS"
+  [ "$status" -ne 0 ]
+}
+
+@test "the dependency table says plainly that its entries are not adopters" {
+  # A reader who lands mid-file, or an editor skimming for evidence, has to hit
+  # the disclaimer before the 24 rows.
+  run grep -F 'These are not adopters' "$ADOPTERS"
+  [ "$status" -eq 0 ]
+}
+
+@test "the disclaimer comes before the dependency rows, not after them" {
+  local dis rows
+  dis="$(grep -n 'These are not adopters' "$ADOPTERS" | head -1 | cut -d: -f1)"
+  rows="$(grep -nE '^\| \[' "$ADOPTERS" | awk -F: -v d="$dis" '$1 > d {print $1; exit}')"
+  [ -n "$dis" ]
+  [ -n "$rows" ]
+  [ "$dis" -lt "$rows" ]
+}
+
+@test "the adopters KPI counts external entries only" {
+  # Without the word, the metric is satisfiable by the project listing itself.
+  run grep -nE '^\| Community \|.*adopters.*ADOPTERS\.md' "$METRICS"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"xternal"* ]]
+}
+
+@test "the KPI's baseline and target measure the same unit" {
+  # The original read baseline "0 production entries" against target ">=2-3
+  # public evaluator/production entries" — different units, which is the gap
+  # the self-entries slipped through.
+  local row
+  row="$(grep -E '^\| Community \|.*adopters.*ADOPTERS\.md' "$METRICS" | head -1)"
+  [ -n "$row" ]
+  local baseline target
+  baseline="$(echo "$row" | awk -F'|' '{print $5}')"
+  target="$(echo "$row" | awk -F'|' '{print $6}')"
+  [[ "$baseline" == *"xternal"* ]]
+  [[ "$target" == *"xternal"* ]]
+}
+
+@test "the self-entries are marked as not counting toward adoption" {
+  # The maintainer and the CI are legitimate dogfooding records. The problem is
+  # only that they were countable.
+  # Matched on one line: the sentence wraps, and grep is line-oriented.
+  run grep -F '**not** external adoption' "$ADOPTERS"
+  [ "$status" -eq 0 ]
+}
+
+@test "no production adopter is claimed while the section is empty" {
+  # Guards the direction that actually matters for credibility: if someone adds
+  # a Production Users row, the "None listed yet" placeholder must go with it,
+  # so the file can never both claim and disclaim at once.
+  if grep -qF '(None listed yet' "$ADOPTERS"; then
+    local after
+    after="$(awk '/^## Production Users/{f=1;next} /^## /{f=0} f' "$ADOPTERS" | grep -cE '^\| \[' || true)"
+    [ "$after" -eq 0 ]
+  fi
+}


### PR DESCRIPTION
Refs #1348. **Adds no adopters** — deliberately.

## Where the issue stands

Recommendations 1 and 3 landed in **#1463** (merged): the adopters KPI is a tracked metric tier and its count is in the monthly snapshot. Recommendation 2 — asking real evaluators for permission to list — is outreach nobody should fabricate, as the maintainer already noted.

So there is nothing legitimate to add to the adopter count, and this PR doesn't try. What *is* checkable is whether the file claims adopters it doesn't have. **It did, two ways** — and both matter precisely because #1348's own argument is that this file is cited as evidence in the DistroWatch (#1333) and CNCF (#1340) pitches.

## 1. A 24-row table headed "Ecosystem & Downstream Projects"

…in a file that opens *"organizations and projects that use TunaOS"*.

I classified every row by its own `Relationship` text:

| kind | count |
|---|---|
| Base OS | 7 |
| Desktop environment TunaOS packages | 5 |
| Upstream / reference | 3 |
| Registry, build service, package manager, app distribution, hardware enablement | 9 |

**24 of 24 are things TunaOS consumes. Not one is downstream of it.** An editor checking the evidence would find Debian, Fedora, KDE and elementary OS apparently listed as TunaOS adopters — none of whom have said any such thing.

elementary OS is especially awkward: #1344's own text records *"ADOPTERS.md cross-check: elementary OS / Pantheon is NOT listed as an adopter or downstream — no conflict; engagement is appropriate."* It was added afterwards, so the cross-check that authorised the outreach is now false.

Renamed to **"Upstream & Ecosystem Dependencies"**, with the disclaimer placed *above* the rows rather than below. The table stays — the dependency map is genuinely useful — it just can't be read as adoption.

## 2. The KPI was already met by self-reference

#1463 defines the metric as *"production/evaluation entry count"*. The two Development & Evaluation entries are **the maintainer** and **TunaOS's own CI**. So the ≥2–3 target was satisfied on the day it was written, with zero external adopters.

The row's baseline and target also measured different units:

```
baseline: "0 production entries"
target:   "≥2–3 public evaluator/production entries"
```

That mismatch is the seam the self-entries fit through. Both now say **external**, and the snapshot format says so too.

The self-entries stay. They're honest dogfooding records; the problem was only that they were countable.

## What the tests deliberately don't do

They do **not** assert an adopter count. Going from zero to one is the outreach this issue is actually about, and a test demanding it would sit red until someone else did that work — which isn't what a test is for.

They pin the labelling and the KPI scope instead, including that the disclaimer precedes the rows and that baseline/target share a unit. **7/7 here, 1/7 against `upstream/main`.**

## For whoever merges

#1611, #1624 and #1656 also touch `ADOPTERS.md`. This changes section headings and adds prose, so expect a conflict — though not an interesting one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
