### PR TITLE
ci: measure whether workflow files are pushable instead of assuming

### DIFF
--- a/scripts/check-workflow-push.sh
+++ b/scripts/check-workflow-push.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# check-workflow-push.sh — can this token push a workflow-file change?
+#
+# tunaOS#1557 records that pushes touching .github/workflows/*.yml were rejected
+# with
+#
+#   refusing to allow a GitHub App to create or update workflow ...
+#   without workflows permission
+#
+# and that the workaround in use was posting the patch as an issue comment.
+# docs/CI-WORKFLOW-PUBLISHING.md (#1614) covers what to do about a rejection.
+# What was missing is the step before that: knowing whether you are actually
+# rejected. The cost of guessing wrong is asymmetric —
+#
+#   * assume you CAN and you cannot: one failed push, then you read the runbook;
+#   * assume you CANNOT and you can: the fix strands in a comment, where #1390
+#     and #1430 sat until someone re-did them as #1621 and #1622.
+#
+# The second is the expensive one and it is the one that happened. So: measure
+# instead of assuming. There is no API that answers this reliably — the App's
+# effective permission is not readable from inside a job — so the honest test is
+# to attempt the push, which is what the runbook's own step 3 asks for.
+#
+# This pushes a throwaway branch to YOUR FORK and deletes it again. It never
+# touches upstream and never opens a PR.
+#
+# Usage:
+#   scripts/check-workflow-push.sh [remote]     # default remote: origin
+#
+# Exit codes:
+#   0  workflow files are pushable to <remote>
+#   1  push rejected for lack of `workflows` permission — see the runbook
+#   2  could not run the check (dirty tree, no remote, no workflow file)
+
+set -uo pipefail
+
+REMOTE="${1:-origin}"
+RUNBOOK="docs/CI-WORKFLOW-PUBLISHING.md"
+
+die() {
+	echo "ERROR: $*" >&2
+	exit 2
+}
+
+command -v git >/dev/null 2>&1 || die "git not found"
+git rev-parse --git-dir >/dev/null 2>&1 || die "not inside a git repository"
+
+# A dirty tree would get swept into the probe commit. Refuse rather than commit
+# someone's work-in-progress to a branch this script then deletes.
+if [[ -n "$(git status --porcelain)" ]]; then
+	die "working tree is dirty — commit or stash first (this script commits and pushes)"
+fi
+
+git remote get-url "$REMOTE" >/dev/null 2>&1 || die "no such remote: ${REMOTE}"
+
+# Probe an existing workflow so the push carries a real workflow-file change.
+# Creating a new file would test the same permission, but touching one that is
+# already tracked keeps the diff to a single appended comment line.
+PROBE_FILE="$(git ls-files '.github/workflows/*.yml' | head -1)"
+[[ -n "$PROBE_FILE" ]] || die "no .github/workflows/*.yml tracked in this repo"
+
+START_REF="$(git rev-parse --abbrev-ref HEAD)"
+BRANCH="wf-push-probe-$$"
+
+cleanup() {
+	git checkout -q "$START_REF" 2>/dev/null || true
+	git branch -qD "$BRANCH" 2>/dev/null || true
+	# Best effort: if the push DID land, take it back off the fork.
+	git push -q "$REMOTE" --delete "$BRANCH" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "==> probing ${REMOTE} with a one-line change to ${PROBE_FILE}"
+git checkout -q -b "$BRANCH" || die "could not create probe branch"
+printf '\n# workflow-push permission probe (tunaOS#1557) — not intended to merge\n' >>"$PROBE_FILE"
+git commit -q -am "probe: workflow-file push permission check" || die "probe commit failed"
+
+push_output="$(git push "$REMOTE" "$BRANCH" 2>&1)"
+push_rc=$?
+
+if [[ "$push_rc" -eq 0 ]]; then
+	echo "==> RESULT: workflow files ARE pushable to '${REMOTE}'."
+	echo "    Open the fix as a normal fork PR. Do not park the patch in an issue"
+	echo "    comment — that is how #1390 and #1430 stranded."
+	exit 0
+fi
+
+# Distinguish the permission rejection from every other push failure. Only the
+# first means "workflow files specifically are blocked"; the rest are ordinary
+# problems a runbook about App permissions will not solve.
+if grep -qiE 'without .?workflows.? permission|refusing to allow (a|an) (GitHub App|OAuth App|integration) to (create or update )?workflow' <<<"$push_output"; then
+	echo "==> RESULT: push REJECTED for lack of 'workflows' permission." >&2
+	echo "$push_output" | sed 's/^/    /' >&2
+	echo "    See ${RUNBOOK} — a workflow YAML permissions: block cannot grant" >&2
+	echo "    this; it is an App-level setting." >&2
+	exit 1
+fi
+
+echo "==> Push failed, but NOT for the workflows permission:" >&2
+echo "$push_output" | sed 's/^/    /' >&2
+echo "    That is an ordinary push problem (auth, network, branch protection)," >&2
+echo "    not the #1557 condition. The runbook will not help." >&2
+exit 2

--- a/tests/bats/test_check_workflow_push.bats
+++ b/tests/bats/test_check_workflow_push.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# The workflow-push preflight (tunaOS#1557).
+#
+# #1557's real cost was not the rejected push — it was the response to it:
+# patches for #1390 and #1430 parked in issue comments, where they sat until
+# someone re-did them as #1621 and #1622. Both of those turned out to be
+# pushable (#1621 pushed .github/workflows/catalog-facts.yml from a fork;
+# #1622 pushed two workflow files to an upstream branch), so the work was
+# stranded on an assumption rather than a measurement.
+#
+# scripts/check-workflow-push.sh measures instead. These tests cover the parts
+# that need no network: the refusals, and the classifier that separates "the
+# App lacks workflows permission" from an ordinary push failure — because
+# telling a user to go read an App-permission runbook when their real problem
+# is a bad credential wastes exactly the time this script exists to save.
+#
+# The push path itself is not covered here; it needs a real remote, which is
+# what the script is for.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/check-workflow-push.sh"
+
+@test "the script exists, is executable, and is valid bash" {
+  [ -x "$SCRIPT" ]
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+# A throwaway repo with one tracked workflow file, so the script gets far
+# enough to reach the checks under test.
+make_repo() {
+  local r="${BATS_TEST_TMPDIR}/repo"
+  mkdir -p "$r/.github/workflows"
+  cd "$r" || return 1
+  git init -q .
+  git config user.email t@example.com
+  git config user.name t
+  printf 'name: t\non: push\njobs: {}\n' > .github/workflows/t.yml
+  git add -A && git commit -qm init
+  echo "$r"
+}
+
+@test "refuses on a dirty tree instead of committing someone's work in progress" {
+  # The script commits -a. Sweeping unrelated changes into a branch it then
+  # deletes would lose them.
+  local r; r="$(make_repo)"
+  cd "$r" || return 1
+  echo "uncommitted" > scratch.txt
+  run bash "$SCRIPT" origin
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"dirty"* ]]
+}
+
+@test "refuses when the named remote does not exist" {
+  local r; r="$(make_repo)"
+  cd "$r" || return 1
+  run bash "$SCRIPT" nosuchremote
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no such remote"* ]]
+}
+
+@test "refuses when the repo tracks no workflow file to probe with" {
+  local r="${BATS_TEST_TMPDIR}/bare"
+  mkdir -p "$r"; cd "$r" || return 1
+  git init -q .; git config user.email t@example.com; git config user.name t
+  echo hi > README.md; git add -A; git commit -qm init
+  git remote add origin https://example.invalid/x.git
+  run bash "$SCRIPT" origin
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no .github/workflows"* ]]
+}
+
+# ── the classifier ────────────────────────────────────────────────────────
+#
+# Extracted from the script rather than retyped, so it cannot drift from the
+# code it is asserting about.
+
+classifier() {
+  grep -oE "grep -qiE '[^']+'" "$SCRIPT" | head -1 | sed "s/^grep -qiE '//; s/'$//"
+}
+
+matches() { # message -> 0 if classified as the permission rejection
+  local pat; pat="$(classifier)"
+  [ -n "$pat" ] || return 2
+  grep -qiE "$pat" <<<"$1"
+}
+
+@test "the classifier pattern is extractable" {
+  run classifier
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+@test "GitHub's actual refusal message is classified as the permission problem" {
+  # The message quoted in #1557.
+  run matches "! [remote rejected] br -> br (refusing to allow a GitHub App to create or update workflow \`.github/workflows/x.yml\` without \`workflows\` permission)"
+  [ "$status" -eq 0 ]
+  # OAuth apps and integrations word it differently for the same cause.
+  run matches "refusing to allow an OAuth App to create or update workflow \`.github/workflows/x.yml\` without \`workflow\` scope"
+  [ "$status" -eq 0 ]
+}
+
+@test "ordinary push failures are NOT classified as the permission problem" {
+  # Sending someone to an App-permission runbook for a bad credential or a
+  # protected branch is worse than saying nothing.
+  run matches "remote: Invalid username or password. fatal: Authentication failed"
+  [ "$status" -ne 0 ]
+  run matches "! [remote rejected] main -> main (protected branch hook declined)"
+  [ "$status" -ne 0 ]
+  run matches "fatal: unable to access 'https://github.com/x.git/': Could not resolve host: github.com"
+  [ "$status" -ne 0 ]
+  run matches "! [rejected] main -> main (non-fast-forward)"
+  [ "$status" -ne 0 ]
+}
+
+@test "the three outcomes use distinct exit codes" {
+  # 0 pushable / 1 permission-rejected / 2 could not run. A caller that cannot
+  # tell 1 from 2 will send people to the wrong runbook.
+  run grep -cE '^(	)?exit [012]$' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 3 ]
+}


### PR DESCRIPTION
Refs #1557. **Not closing it** — whether the App *should* hold `workflows` permission for direct upstream pushes is a maintainer decision this doesn't make.

## The premise has outlived the condition

#1557 says every workflow-file push is rejected, and records the workaround: post the patch as an issue comment. Both patches it names as stranded are now open PRs, and both contain workflow files:

| | what it pushed | from |
|---|---|---|
| **#1621** (the #1390 patch) | `.github/workflows/catalog-facts.yml` | a **fork** branch |
| **#1622** (the #1430 patch) | `bootc-lifecycle.yml` + `reusable-build-image.yml` | an **upstream** branch |
| **#1661** (mine, earlier today) | `reusable-build-image.yml` | fork branch |

And a fourth data point, from running the script this PR adds against my fork just now:

```
==> probing origin with a one-line change to .github/workflows/archive/build.yml
==> RESULT: workflow files ARE pushable to 'origin'.
```

**Both "blocked" patches were pushable the whole time.**

## Why that's worth a script

The cost wasn't the rejected push — it was the response to it. Guessing wrong is asymmetric:

- assume you **can** and you can't → one failed push, then you read the runbook
- assume you **can't** and you can → the fix strands in a comment until someone re-does it

The second is the expensive one, and it happened twice.

#1614's runbook already covers *what to do about a rejection*. What was missing is the step before: knowing whether you're rejected. There's no API that answers it reliably — an App's effective permission isn't readable from inside a job — so the honest test is to attempt the push, which is what the runbook's own step 3 asks a human to do by hand.

The script does exactly that, against **your fork**, on a throwaway branch, and deletes it again. It never touches upstream and never opens a PR. Verified end-to-end: correct verdict, original branch restored, clean tree, **zero probe branches left behind**.

## The classifier is the part that earns its keep

Only GitHub's workflows-permission refusal means *"workflow files specifically are blocked"*. Auth failures, protected branches, non-fast-forwards and DNS errors are ordinary problems an App-permission runbook won't solve — and sending someone there wastes exactly the time this is meant to save.

Three exit codes keep them apart: `0` pushable, `1` permission-rejected, `2` couldn't run.

## Tests

Refusals (dirty tree, missing remote, no workflow file) plus the classifier — including that it does **not** fire on four real non-permission push failures. The pattern is extracted from the script rather than retyped, so it can't drift from the code it asserts about.

**8/8.** The push path itself isn't covered — it needs a real remote, which is what the script is for.

## One caveat on my evidence

My probe proves the **fork** path works for this token. #1622 suggests the upstream path worked for at least one session too, but I haven't tested that myself and I'm not claiming it. If the App genuinely lacks the permission for direct upstream pushes, the fork flow is still the documented normal path for a contributor — and this script tells you which situation you're in instead of leaving you to assume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
