### PR TITLE
ci(pantheon): re-verify manifest package names instead of trusting a one-off check

### DIFF
--- a/scripts/verify-manifest-packages.sh
+++ b/scripts/verify-manifest-packages.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# verify-manifest-packages.sh — do a desktop manifest's apt package names exist?
+#
+# manifests/desktops/pantheon.yaml states the rule this automates, and the
+# reason for it:
+#
+#   "Every package name below was verified published for noble via the
+#    Launchpad API ... rather than guessed. Names in this ecosystem are not
+#    guessable ... Do not add an unverified name here. An unresolvable name is
+#    what shipped a desktop-less image in tunaos-packages#132."
+#
+# That verification was done once, by hand, and nothing re-does it. A name that
+# was published when the manifest was written can be dropped from a PPA later,
+# and a name added afterwards gets whatever care its author felt like — which
+# is how tunaos-packages#132 happened. The failure mode is not a build error:
+# apt is invoked with the whole list, so one bad name takes the transaction
+# down, or (worse, with --skip-*) the desktop quietly ships incomplete.
+#
+# Checks each name against the manifest's declared PPA AND the Ubuntu primary
+# archive for the target series/arch. A name is fine if EITHER publishes it —
+# the manifests deliberately mix the two (Pantheon from elementary's PPA,
+# lightdm/gvfs/portals from the archive) and do not mark which is which.
+#
+# Usage:
+#   scripts/verify-manifest-packages.sh manifests/desktops/pantheon.yaml [series] [arch]
+#
+# Defaults: series noble, arch amd64. Run once per arch the variant declares —
+# a PPA can publish for amd64 and not arm64, and gurnard builds both.
+#
+# Exit: 0 all names resolve · 1 one or more do not · 2 could not run.
+
+set -uo pipefail
+
+MANIFEST="${1:?usage: verify-manifest-packages.sh <manifest.yaml> [series] [arch]}"
+SERIES="${2:-noble}"
+ARCH="${3:-amd64}"
+
+[[ -r "$MANIFEST" ]] || { echo "ERROR: cannot read ${MANIFEST}" >&2; exit 2; }
+command -v curl >/dev/null 2>&1 || { echo "ERROR: curl not found" >&2; exit 2; }
+command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 not found" >&2; exit 2; }
+
+DAS="https://api.launchpad.net/1.0/ubuntu/${SERIES}/${ARCH}"
+
+# The manifest's apt package list. Comments are stripped; the list ends at the
+# next top-level key.
+mapfile -t PKGS < <(
+	awk '/^    packages:$/{f=1;next}
+	     f && /^    - /{n=$2; sub(/#.*/,"",n); gsub(/[ \t]/,"",n); if (n != "") print n}
+	     f && /^[a-z_]+:$/{exit}' "$MANIFEST"
+)
+[[ "${#PKGS[@]}" -gt 0 ]] || { echo "ERROR: no apt packages parsed from ${MANIFEST}" >&2; exit 2; }
+
+# The PPA it declares, as a Launchpad archive URL. Absent is fine — then every
+# name must come from the primary archive.
+PPA_URL=""
+ppa_spec="$(awk '/repo: *"ppa:/{ if (match($0, /ppa:[^"]+/)) print substr($0, RSTART+4, RLENGTH-4); exit }' "$MANIFEST")"
+if [[ -n "$ppa_spec" ]]; then
+	owner="${ppa_spec%%/*}"
+	name="${ppa_spec#*/}"
+	[[ "$name" == "$ppa_spec" ]] && name="ppa"
+	PPA_URL="https://api.launchpad.net/1.0/~${owner}/+archive/ubuntu/${name}"
+fi
+
+published_in() { # archive_url package -> prints count, "ERR" on a bad response
+	curl -sS --max-time 30 -G "$1" \
+		--data-urlencode "ws.op=getPublishedBinaries" \
+		--data-urlencode "binary_name=$2" \
+		--data-urlencode "distro_arch_series=${DAS}" \
+		--data "exact_match=true&status=Published" 2>/dev/null |
+		python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("total_size", 0))
+except Exception: print("ERR")'
+}
+
+echo "==> ${MANIFEST}: ${#PKGS[@]} packages against ${SERIES}/${ARCH}"
+[[ -n "$PPA_URL" ]] && echo "    PPA: ${ppa_spec}"
+
+missing=0 errored=0
+for p in "${PKGS[@]}"; do
+	src=""
+	if [[ -n "$PPA_URL" ]]; then
+		n="$(published_in "$PPA_URL" "$p")"
+		[[ "$n" == "ERR" ]] && { errored=$((errored + 1)); echo "  ?? ${p} (PPA query failed)" >&2; continue; }
+		[[ "$n" -gt 0 ]] && src="ppa"
+	fi
+	if [[ -z "$src" ]]; then
+		n="$(published_in "https://api.launchpad.net/1.0/ubuntu/+archive/primary" "$p")"
+		[[ "$n" == "ERR" ]] && { errored=$((errored + 1)); echo "  ?? ${p} (archive query failed)" >&2; continue; }
+		[[ "$n" -gt 0 ]] && src="archive"
+	fi
+	if [[ -n "$src" ]]; then
+		printf '  ok %-32s %s\n' "$p" "$src"
+	else
+		printf '  MISSING %-28s not published in the PPA or the %s archive for %s/%s\n' \
+			"$p" "ubuntu" "$SERIES" "$ARCH" >&2
+		missing=$((missing + 1))
+	fi
+done
+
+if [[ "$errored" -gt 0 ]]; then
+	echo "==> ${errored} query/queries failed — result is inconclusive, not a pass." >&2
+	exit 2
+fi
+if [[ "$missing" -gt 0 ]]; then
+	echo "==> ${missing} package name(s) resolve nowhere. Fix the manifest before this" >&2
+	echo "    reaches a build: apt takes the whole list at once (tunaos-packages#132)." >&2
+	exit 1
+fi
+echo "==> all ${#PKGS[@]} names resolve for ${SERIES}/${ARCH}"

--- a/tests/bats/test_verify_manifest_packages.bats
+++ b/tests/bats/test_verify_manifest_packages.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# The manifest package-name checker (tunaOS#1469).
+#
+# manifests/desktops/pantheon.yaml states the rule and the incident behind it:
+# every name was verified published via the Launchpad API, "do not add an
+# unverified name here", and "an unresolvable name is what shipped a
+# desktop-less image in tunaos-packages#132". The verification was done once by
+# hand and nothing re-does it.
+#
+# scripts/verify-manifest-packages.sh re-does it. The network half cannot run
+# here, so these cover the half that decides whether the network half asks the
+# right questions: which names get extracted, and which archive they are looked
+# up in. A checker that silently parses zero packages would pass forever.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/verify-manifest-packages.sh"
+PANTHEON="${REPO_ROOT}/manifests/desktops/pantheon.yaml"
+
+# The script's own package-list parser, lifted so the test cannot drift from it.
+parse_pkgs() {
+  awk '/^    packages:$/{f=1;next}
+       f && /^    - /{n=$2; sub(/#.*/,"",n); gsub(/[ \t]/,"",n); if (n != "") print n}
+       f && /^[a-z_]+:$/{exit}' "$1"
+}
+
+@test "the script exists, is executable, and is valid bash" {
+  [ -x "$SCRIPT" ]
+  run bash -n "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "the parser finds the pantheon manifest's packages" {
+  run parse_pkgs "$PANTHEON"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | wc -l)" -ge 15 ]
+}
+
+@test "the parser strips trailing comments from a package line" {
+  # Most lines carry an inline comment; a parser that kept them would query
+  # Launchpad for "gala#8.5.1—windowmanager/compositor" and get 0 hits for
+  # every package, which reads as a catastrophic manifest failure.
+  run parse_pkgs "$PANTHEON"
+  [[ "$output" == *"gala"* ]]
+  [[ "$output" != *"#"* ]]
+  [[ "$output" != *"compositor"* ]]
+}
+
+@test "the parser stops at the next top-level key" {
+  # post_install: follows the package list. Swallowing it would query for
+  # script filenames.
+  run parse_pkgs "$PANTHEON"
+  [[ "$output" != *"tuna-flatpak-remote.sh"* ]]
+  [[ "$output" != *"flatpak-preinstall.sh"* ]]
+}
+
+@test "the manifest's own documented non-names are absent from the list" {
+  # The manifest header lists four names that resolve to nothing
+  # (pantheon-desktop, pantheon-session, io.elementary.files,
+  # pantheon-session-settings) as a warning. They must stay in prose and out of
+  # the package list — this is the exact class of entry #132 shipped.
+  run parse_pkgs "$PANTHEON"
+  [[ "$output" != *"pantheon-desktop"* ]]
+  [[ "$output" != *"pantheon-session"* ]]
+  [[ "$output" != *"io.elementary.files"* ]]
+}
+
+@test "the PPA spec is derivable from the manifest" {
+  run awk '/repo: *"ppa:/{ if (match($0, /ppa:[^"]+/)) print substr($0, RSTART+4, RLENGTH-4); exit }' "$PANTHEON"
+  [ "$status" -eq 0 ]
+  [ "$output" = "elementary-os/stable" ]
+}
+
+@test "an unreadable manifest is an error, not an empty pass" {
+  run bash "$SCRIPT" "${BATS_TEST_TMPDIR}/nope.yaml"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"cannot read"* ]]
+}
+
+@test "a manifest with no packages is an error, not a pass" {
+  # The failure this guards: a manifest-format change makes the parser return
+  # nothing, and a naive checker reports success having verified zero names.
+  local m="${BATS_TEST_TMPDIR}/empty.yaml"
+  printf 'display_manager: lightdm\npackages:\n  apt:\n    packages:\n' > "$m"
+  run bash "$SCRIPT" "$m"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"no apt packages parsed"* ]]
+}


### PR DESCRIPTION
Refs #1469 — **the tracker stays open**, it's an intake channel, not a defect.

## What was already covered

#1469's *process* half is built: **#1470** has the feedback-loop design, the six triage labels were created, and **#1628** documents the variant. What nobody had done is the triage the title asks for — actually looking at the Pantheon packaging.

## I did the triage. The manifest holds up.

Checked every name in `manifests/desktops/pantheon.yaml` against the live Launchpad API:

**All 20 resolve for noble on both amd64 and arm64** — 10 from `ppa:elementary-os/stable`, 10 from the Ubuntu archive.

The arch part is worth stating: gurnard declares `linux/amd64` **and** `linux/arm64`, and a PPA can publish for one and not the other. I checked specifically because that would have been a real bug. It publishes for both. **Nothing to fix in the manifest.**

## The actual gap

That check was possible only because I ran it by hand — which is exactly how the manifest says it was done the first time:

> "Every package name below was verified published for noble via the Launchpad API … rather than guessed … **Do not add an unverified name here.** An unresolvable name is what shipped a desktop-less image in tunaos-packages#132."

A rule with an incident behind it and no mechanism. A name published when the manifest was written can be dropped from a PPA later; a name added afterwards gets whatever care its author felt like.

And the failure isn't a tidy build error: apt takes the whole list at once, so one bad name fails the transaction — or, behind a `--skip-*` fallback, quietly ships an incomplete desktop. That's what #132 was.

## The checker

`scripts/verify-manifest-packages.sh` does what the manifest describes. Each name is looked up in the declared PPA **and** the Ubuntu primary archive for a given series/arch, passing if either publishes it — the manifests deliberately mix the two (Pantheon from the PPA, `lightdm`/`gvfs`/portals from the archive) and don't mark which is which, so demanding the PPA would fail 10 correct entries.

A failed query exits **2**, not 0. An inconclusive result must not read as a pass.

**Verified both directions:**

```
noble/amd64 → all 20 names resolve
noble/arm64 → all 20 names resolve

gala → pantheon-desktop  (one of the four non-names the manifest
                          documents as a warning)
  MISSING pantheon-desktop  not published in the PPA or the ubuntu archive
  exit 1
```

## Tests

The network half can't run in CI, so the tests cover the half that decides whether the network half asks the right question: comment stripping (an unstripped line would query for `gala#8.5.1—windowmanager` and report *every* package missing), stopping before `post_install`, PPA-spec derivation, and that an unreadable or empty manifest is an **error** rather than a zero-name pass.

**8/8.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
