### PR TITLE
fix(nvidia): accept modules.builtin drivers in verify-nvidia.sh initramfs parity check

### DIFF
--- a/build_scripts/checks/verify-nvidia.sh
+++ b/build_scripts/checks/verify-nvidia.sh
@@ -255,9 +255,12 @@ elif ! command -v lsinitrd >/dev/null 2>&1; then
 	fail "lsinitrd is unavailable — cannot prove the initramfs carries the boot drivers"
 else
 	_initrd_list="$(lsinitrd "$INITRAMFS" 2>/dev/null || true)"
+	_builtin_file="${NV_ROOT}/usr/lib/modules/${KERNEL_VRA}/modules.builtin"
 	for _drv in sr_mod cdrom isofs squashfs virtio_scsi virtio_blk overlay loop; do
 		if grep -qE "/${_drv}\.ko" <<<"$_initrd_list"; then
 			pass "initramfs carries ${_drv}"
+		elif [[ -f "$_builtin_file" ]] && grep -qE "/${_drv}\.ko" "$_builtin_file"; then
+			pass "kernel carries ${_drv} as builtin (modules.builtin)"
 		else
 			fail "initramfs is missing ${_drv} — the live ISO or installed boot cannot mount its root"
 		fi

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -596,6 +596,29 @@ STUB
   [[ "$output" == *"initramfs is missing virtio_scsi"* ]]
 }
 
+@test "verify-nvidia passes when a driver is built into the kernel (modules.builtin)" {
+  make_stub_tools
+  root="$(make_good_root)"
+  # lsinitrd missing sr_mod, cdrom, and virtio_blk (as on 7.1.4 fc43 kernel)
+  cat > "${BATS_TEST_TMPDIR}/bin/lsinitrd" <<STUB
+#!/usr/bin/env bash
+for d in isofs squashfs virtio_scsi overlay loop; do
+  echo "usr/lib/modules/${KVER}/kernel/drivers/misc/\${d}.ko.xz"
+done
+STUB
+  chmod +x "${BATS_TEST_TMPDIR}/bin/lsinitrd"
+  # Provide modules.builtin with the missing drivers
+  cat > "$root/usr/lib/modules/${KVER}/modules.builtin" <<'EOF'
+kernel/drivers/block/virtio_blk.ko
+kernel/drivers/cdrom/cdrom.ko
+kernel/drivers/scsi/sr_mod.ko
+EOF
+  run_verify "$root"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"kernel carries sr_mod as builtin (modules.builtin)"* ]]
+  [[ "$output" == *"TUNAOS_NVIDIA_CONTRACT_OK"* ]]
+}
+
 @test "verify-nvidia fails when the installed kernel has no initramfs at all" {
   make_stub_tools
   root="$(make_good_root)"


### PR DESCRIPTION
Fixes #1561

## Summary
On newer kernel builds (such as  on , , and  builds), boot drivers like , , or  may be built directly into the kernel image rather than packaged as standalone loadable  files in the initramfs.

This caused  to report false failures (, , ) even though the boot drivers were available in the kernel.

This PR updates  to:
1. Check  when a driver is not matched in  output.
2. Consider the driver check passed if it is listed in .
3. Add unit test coverage in .

## Verification
- Added bats unit test  in .
---
🐝 **Hive Agent**: `contributor` | **SHA:** `4e5db477`