### PR TITLE
ci: bound upstream snapshot refresh size

### DIFF
--- a/.github/workflows/snapshot-upstreams.yml
+++ b/.github/workflows/snapshot-upstreams.yml
@@ -61,6 +61,16 @@ jobs:
         run: |
           ./scripts/sync-upstream-snapshots.sh "${UPSTREAM}"
 
+      - name: Enforce snapshot size budget
+        # Keep the vendored review surface bounded. A refresh over budget must
+        # be split, narrowed, or explicitly re-designed before it can create
+        # another large git snapshot commit (tuna-os/tunaos#1647).
+        env:
+          MAX_SNAPSHOT_FILES: '300'
+          MAX_SNAPSHOT_BYTES: '2097152'
+          MAX_SNAPSHOT_CHANGED_FILES: '150'
+        run: ./scripts/check-upstream-snapshot-size.sh
+
       - name: Detect changes
         id: diff
         run: |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,7 @@ Invoked by:
 | `resolve-image.sh` | Resolves image references (base, common, brew, akmods) |
 | `build-image-inner.sh` | The build engine (env-var driven) |
 | `sync-upstream-snapshots.sh` | Syncs and drift-checks the `_upstream-snapshots/` tree |
+| `check-upstream-snapshot-size.sh` | Fails refreshes that exceed the snapshot size or change budget |
 
 See `docs/AGENT_GUIDE.md`'s Key Files table for the fuller list and how
 these fit into the overall build pipeline (`docs/PIPELINE.md`,

--- a/scripts/check-upstream-snapshot-size.sh
+++ b/scripts/check-upstream-snapshot-size.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Reject unexpectedly large upstream snapshot refreshes before they are
+# committed. The snapshot workflow intentionally keeps a filtered tree in git,
+# so this is an admission budget rather than a replacement for reviewing the
+# content diff.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SNAPSHOT_DIR="${REPO_ROOT}/_upstream-snapshots"
+
+# Defaults leave room above the current tree (241 files, ~225 KiB) while
+# bounding accidental wholesale additions. The workflow sets these explicitly
+# so the policy is visible in its logs and can be changed without editing code.
+MAX_FILES="${MAX_SNAPSHOT_FILES:-300}"
+MAX_BYTES="${MAX_SNAPSHOT_BYTES:-2097152}"
+MAX_CHANGED_FILES="${MAX_SNAPSHOT_CHANGED_FILES:-150}"
+
+die() {
+	echo "::error::upstream snapshot budget exceeded: $*" >&2
+	exit 1
+}
+
+[[ -d "${SNAPSHOT_DIR}" ]] || die "${SNAPSHOT_DIR} does not exist"
+
+files=$(find "${SNAPSHOT_DIR}" -type f -print | wc -l)
+bytes=$(du -sb "${SNAPSHOT_DIR}" | awk '{print $1}')
+changed=$(git status --short --untracked-files=all -- "_upstream-snapshots/" | wc -l)
+
+echo "Snapshot budget: files=${files}/${MAX_FILES}, bytes=${bytes}/${MAX_BYTES}, changed_paths=${changed}/${MAX_CHANGED_FILES}"
+
+(( files <= MAX_FILES )) || die "${files} files exceeds the ${MAX_FILES}-file limit"
+(( bytes <= MAX_BYTES )) || die "${bytes} bytes exceeds the ${MAX_BYTES}-byte limit"
+(( changed <= MAX_CHANGED_FILES )) || die "${changed} changed paths exceeds the ${MAX_CHANGED_FILES}-path refresh limit"
+
+echo "Upstream snapshot budget: OK"


### PR DESCRIPTION
## Summary

- Add a fail-closed size/content budget to the upstream snapshot refresh workflow.
- Reject refreshes over 300 files, 2 MiB, or 150 changed paths before they are staged or committed.
- Document the helper alongside the existing snapshot sync script.

## Why

`_upstream-snapshots/` is intentionally kept in git as a filtered review surface, but the refresh workflow previously admitted any tree size. A broad upstream path change could silently add a wholesale vendor tree and permanently increase repository history. The new check keeps normal refreshes working while requiring an explicit follow-up for an over-budget change.

## Validation

- `bash -n scripts/check-upstream-snapshot-size.sh`
- Snapshot budget passes on the current tree: 241 files, 229,587 bytes, 0 changed paths.
- Forced low file and byte limits both fail with actionable GitHub error messages.
- `git diff --check`

Fixes #1647.