### PR TITLE
fix(nvidia): accept built-in boot drivers in the initramfs parity check

### DIFF
--- a/build_scripts/checks/verify-nvidia.sh
+++ b/build_scripts/checks/verify-nvidia.sh
@@ -248,7 +248,41 @@ echo "== initramfs boot-driver parity =="
 # present in the nvidia image's swapped-kernel initramfs (720 modules) —
 # this is a parity floor, not a wish list; dm_crypt is deliberately absent
 # because the parent's initramfs does not carry it either.
+#
+# A driver satisfies the floor two ways, and BOTH are a real boot (#1561):
+#   1. it ships as a .ko in the initramfs, or
+#   2. it is built into the kernel image, so there is no .ko to ship and
+#      dracut correctly emits none.
+# Case 2 is not hypothetical. The floor above was measured on an el10 6.x
+# kernel, where all eight are modules. After the swap to Fedora 43's
+# 7.1.4-100.fc43 the check went red on exactly sr_mod/cdrom/virtio_blk
+# across 9 image cells — because that kernel builds them in. Read out of
+# the Fedora 43 and rawhide kernel configs (kernel-x86_64-fedora.config):
+#   CONFIG_BLK_DEV_SR=y   -> sr_mod   built in
+#   CONFIG_VIRTIO_BLK=y   -> virtio_blk built in
+#   CONFIG_CDROM          -> invisible tristate, select'd by BLK_DEV_SR,
+#                            so it follows it to =y -> cdrom built in
+# while the five that kept passing (isofs/squashfs/virtio_scsi/overlay/loop)
+# are all =m there. The FAIL set and the =y set are the same set — that is
+# the whole failure. Independently corroborated by the non-nvidia gnome-hwe
+# image on the same kernel passing the full qcow2 boot-verify Gate, which a
+# genuinely virtio_blk-less initramfs could not do.
+# So: consult modules.builtin before failing. A driver missing from BOTH the
+# initramfs and modules.builtin is still fatal — this widens what counts as
+# proof of a bootable initramfs, it does not stop demanding proof.
 INITRAMFS="${NV_ROOT}/usr/lib/modules/${KERNEL_VRA}/initramfs.img"
+MODULES_BUILTIN="${NV_ROOT}/usr/lib/modules/${KERNEL_VRA}/modules.builtin"
+# modules.builtin lists one object per line, kernel-relative. The canonical
+# form carries the .ko suffix (kernel/drivers/scsi/sr_mod.ko), but the
+# suffix has not been read off one of these images directly — no rpm/zstd
+# in the authoring environment — so match a bare name at end-of-line too
+# rather than assert a form that was not measured. Both alternatives are
+# anchored on / and on the driver name, so they cannot match a substring of
+# a longer module name.
+_is_builtin() {
+	[[ -s "$MODULES_BUILTIN" ]] || return 1
+	grep -qE "/${1}\.ko([.][^/]*)?$|/${1}$" "$MODULES_BUILTIN"
+}
 if [[ ! -s "$INITRAMFS" ]]; then
 	fail "missing or empty initramfs for the installed kernel: /usr/lib/modules/${KERNEL_VRA}/initramfs.img"
 elif ! command -v lsinitrd >/dev/null 2>&1; then
@@ -258,8 +292,12 @@ else
 	for _drv in sr_mod cdrom isofs squashfs virtio_scsi virtio_blk overlay loop; do
 		if grep -qE "/${_drv}\.ko" <<<"$_initrd_list"; then
 			pass "initramfs carries ${_drv}"
+		elif _is_builtin "$_drv"; then
+			# Distinct wording on purpose: "carries" would be a lie here, and
+			# these verdict lines are what a human reads off a red matrix.
+			pass "${_drv} is built into the kernel (modules.builtin) — no initramfs .ko expected"
 		else
-			fail "initramfs is missing ${_drv} — the live ISO or installed boot cannot mount its root"
+			fail "initramfs is missing ${_drv} and it is not in modules.builtin — the live ISO or installed boot cannot mount its root"
 		fi
 	done
 fi

--- a/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
+++ b/build_scripts/overlay/overrides/nvidia/20-nvidia.sh
@@ -177,16 +177,23 @@ if [[ ! -f /usr/lib/dracut/dracut.conf.d/99-nvidia.conf ]]; then
 fi
 sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
 # As we need forced load, also must pre-load intel/amd iGPU else chromium web
-# browsers fail to use hardware acceleration. tunaos#1499: also force
-# sr_mod/cdrom/virtio_blk — --no-hostonly alone stopped being enough to
-# guarantee these on the live ISO / installed-disk boot path on this
-# negativo17 conf; they started coming up missing from the rebuilt
-# initramfs on every *-nvidia nightly (10/10 red 08-03..08-13) while present
-# in the parent (non-nvidia) image's initramfs and in this image's own
-# initramfs before this 99-nvidia.conf edit. virtio_scsi/isofs/squashfs/
-# overlay/loop were unaffected, so this isn't a wholesale hostonly-detection
-# failure — just these three. Same mechanism as i915/amdgpu: force them in
-# explicitly rather than trust generic-mode autodetection to include them.
+# browsers fail to use hardware acceleration. tunaos#1499 also forces
+# sr_mod/cdrom/virtio_blk here, so that the live ISO (CD path) and the
+# installed disk (virtio_blk) both come up on the kernels where those are
+# modules — the el10 6.x akmods kernel behind the non-HWE yellowfin/
+# albacore/skipjack nvidia flavors. Keep them: dropping them regresses
+# exactly the case #1499 was opened for.
+#
+# #1499's stated mechanism was wrong, though, and #1561 corrected it: these
+# three did not go missing because --no-hostonly "stopped being enough".
+# They went missing because the kernel swapped to Fedora 43's 7.1.4-100.fc43,
+# which BUILDS THEM IN (CONFIG_BLK_DEV_SR=y, CONFIG_VIRTIO_BLK=y, and CDROM
+# is an invisible tristate select'd by BLK_DEV_SR, so it follows to =y) —
+# there is no .ko for dracut to add, on any dracut setting. That is also why
+# forcing them here did not turn the nightlies green. dracut tolerates being
+# asked for a builtin, so this line is harmless on fc43 and load-bearing on
+# el10; the honest fix belongs in the contract check, which now accepts
+# modules.builtin as proof (verify-nvidia.sh, "initramfs boot-driver parity").
 sed -i 's@ nvidia @ i915 amdgpu nvidia sr_mod cdrom virtio_blk @g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
 
 # Make sure initramfs is rebuilt after nvidia drivers or kernel replacement

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -596,6 +596,94 @@ STUB
   [[ "$output" == *"initramfs is missing virtio_scsi"* ]]
 }
 
+# ── builtin boot drivers (#1561) ───────────────────────────────────────────
+# The floor was measured on an el10 6.x kernel where all eight drivers are
+# modules. Fedora 43's 7.1.4-100.fc43 builds sr_mod/cdrom/virtio_blk INTO the
+# kernel (CONFIG_BLK_DEV_SR=y, CONFIG_VIRTIO_BLK=y, CDROM select'd to =y), so
+# dracut ships no .ko for them and the check false-FAILed on 9 image cells.
+# A builtin is a working boot; a driver that is neither shipped nor built in
+# is still fatal.
+lsinitrd_without() {
+  # Emit the floor minus the named drivers, as lsinitrd prints it.
+  local skip=" $* "
+  cat > "${BATS_TEST_TMPDIR}/bin/lsinitrd" <<STUB
+#!/usr/bin/env bash
+for d in sr_mod cdrom isofs squashfs virtio_scsi virtio_blk overlay loop; do
+  case "${skip}" in *" \${d} "*) continue ;; esac
+  echo "usr/lib/modules/${KVER}/kernel/drivers/misc/\${d}.ko.xz"
+done
+STUB
+  chmod +x "${BATS_TEST_TMPDIR}/bin/lsinitrd"
+}
+
+@test "verify-nvidia accepts boot drivers that are built into the kernel" {
+  make_stub_tools
+  root="$(make_good_root)"
+  lsinitrd_without sr_mod cdrom virtio_blk
+  # The fc43 shape: exactly the three that vanished are in modules.builtin.
+  cat > "$root/usr/lib/modules/${KVER}/modules.builtin" <<'BUILTIN'
+kernel/drivers/scsi/sr_mod.ko
+kernel/drivers/cdrom/cdrom.ko
+kernel/drivers/block/virtio_blk.ko
+BUILTIN
+  run_verify "$root"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"sr_mod is built into the kernel"* ]]
+  [[ "$output" == *"cdrom is built into the kernel"* ]]
+  [[ "$output" == *"virtio_blk is built into the kernel"* ]]
+  # The modular five must still be proven the normal way, not waved through.
+  [[ "$output" == *"initramfs carries virtio_scsi"* ]]
+}
+
+@test "verify-nvidia accepts modules.builtin entries written without a .ko suffix" {
+  make_stub_tools
+  root="$(make_good_root)"
+  lsinitrd_without virtio_blk
+  # Suffix form was not measured on-image, so the matcher tolerates both.
+  echo "kernel/drivers/block/virtio_blk" \
+    > "$root/usr/lib/modules/${KVER}/modules.builtin"
+  run_verify "$root"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"virtio_blk is built into the kernel"* ]]
+}
+
+@test "verify-nvidia still fails when a driver is neither shipped nor built in" {
+  make_stub_tools
+  root="$(make_good_root)"
+  lsinitrd_without sr_mod virtio_blk
+  # modules.builtin exists and is honest: it accounts for sr_mod only.
+  echo "kernel/drivers/scsi/sr_mod.ko" \
+    > "$root/usr/lib/modules/${KVER}/modules.builtin"
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"sr_mod is built into the kernel"* ]]
+  [[ "$output" == *"initramfs is missing virtio_blk"* ]]
+}
+
+@test "verify-nvidia does not treat a missing modules.builtin as proof of builtin" {
+  make_stub_tools
+  root="$(make_good_root)"
+  lsinitrd_without virtio_blk
+  # No modules.builtin at all — absence of evidence is not evidence, so the
+  # check must stay red rather than silently pass every driver.
+  [ ! -e "$root/usr/lib/modules/${KVER}/modules.builtin" ]
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"initramfs is missing virtio_blk"* ]]
+}
+
+@test "verify-nvidia does not let a longer module name satisfy a shorter one" {
+  make_stub_tools
+  root="$(make_good_root)"
+  lsinitrd_without loop
+  # loop_extra must not be mistaken for loop by a sloppy substring match.
+  echo "kernel/drivers/block/loop_extra.ko" \
+    > "$root/usr/lib/modules/${KVER}/modules.builtin"
+  run_verify "$root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"initramfs is missing loop"* ]]
+}
+
 @test "verify-nvidia fails when the installed kernel has no initramfs at all" {
   make_stub_tools
   root="$(make_good_root)"


### PR DESCRIPTION
Fixes #1561.

## What was wrong

`verify-nvidia.sh`'s initramfs parity check demanded a literal `/<drv>.ko` in `lsinitrd` output for all eight boot drivers. That floor was measured on an **el10 6.x** kernel, where all eight are modules. After the swap to Fedora 43's `7.1.4-100.fc43`, the check went deterministically red on exactly `sr_mod`/`cdrom`/`virtio_blk` across 9 image cells — every bonito and bonito-rawhide nvidia flavor, plus `gnome-nvidia-hwe` on albacore/skipjack/yellowfin — every night since it landed on 08-08.

## Root cause — measured, not inferred

Those three are not missing. That kernel **builds them in**, so there is no `.ko` for dracut to ship. Read straight out of the Fedora 43 and rawhide `kernel-x86_64-fedora.config`:

| symbol | f43 / rawhide | driver |
|---|---|---|
| `CONFIG_BLK_DEV_SR` | `=y` | `sr_mod` built in |
| `CONFIG_VIRTIO_BLK` | `=y` | `virtio_blk` built in |
| `CONFIG_CDROM` | invisible `tristate`, `select`'d by `BLK_DEV_SR` → follows to `=y` | `cdrom` built in |
| `ISO9660_FS`, `SQUASHFS`, `SCSI_VIRTIO`, `OVERLAY_FS`, `BLK_DEV_LOOP` | `=m` | still shipped as `.ko` — still pass |

**The FAIL set and the `=y` set are the same set.** That is the whole failure.

Two independent corroborations:

1. The non-nvidia `gnome-hwe` image on the same kernel passes the full qcow2 boot-verify Gate — a genuinely `virtio_blk`-less initramfs could not do that.
2. #1499 already tried forcing these three in via `99-nvidia.conf` (landed 08-13) and the nightlies stayed red on 08-14 — because dracut cannot add a module that does not exist. That is the misdiagnosis this PR corrects.

## The fix

Consult `modules.builtin` before failing, and report it with distinct wording — `"cdrom is built into the kernel (modules.builtin) — no initramfs .ko expected"` rather than `"carries"`, since these verdict lines are what a human reads off a red matrix.

This **widens what counts as proof of a bootable initramfs; it does not stop demanding proof**:

- missing from *both* the initramfs and `modules.builtin` → still fatal
- `modules.builtin` absent entirely → **not** treated as proof of builtin; still fatal
- the five modular drivers → still proven the normal way

The `modules.builtin` matcher deliberately accepts both `…/sr_mod.ko` and a bare `…/sr_mod` at end-of-line. The suffix form could not be read off one of these images directly (no `rpm`/`zstd` in the authoring environment), so per this repo's rule about not asserting a form you have not seen resolve, it tolerates both rather than guessing. Both alternatives stay anchored on `/` and the driver name, so a longer module name cannot satisfy a shorter one (covered by a test).

### `20-nvidia.sh`

The #1499 `force_drivers` line is **kept** — it is still load-bearing on the el10 akmods kernel behind the non-HWE nvidia flavors, where these three really are modules; dropping it would regress exactly the case #1499 was opened for. Only its comment changes, to record the measured cause instead of the mechanism it wrongly asserted.

## Tests

Five new bats cases covering every branch: builtin accepted; the no-suffix `modules.builtin` form; neither-shipped-nor-builtin still fails; missing `modules.builtin` still fails; and a longer module name not satisfying a shorter one.

Verified **red→green**, not just green: against the unpatched `verify-nvidia.sh` the new cases fail (35, 36, 37), and the pre-existing parity test (34) passes unchanged both before and after. Full suite: **40/40 pass** (1 pre-existing skip, `pyyaml` not installed).
