### PR TITLE
docs: stop README claiming Apple Silicon is supported when ROADMAP says in progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,21 @@ Image tags are constructed as `<desktop>[-hardware]`:
 | Hardware | Status | Docs |
 |----------|--------|------|
 | Snapdragon X Elite (e.g. Lenovo ThinkPad X13s) | Supported | [docs.tunaos.org/bonito-x13s](https://github.com/tuna-os/docs/tree/main/docs/bonito-x13s), [docs.tunaos.org/dakota-x13s](https://github.com/tuna-os/docs/tree/main/docs/dakota-x13s) |
-| Apple Silicon (M1, M2) | Supported via [Asahi Linux](https://asahilinux.org/) | [bootc-installer-asahi](https://github.com/tuna-os/bootc-installer-asahi) |
-| Apple Silicon (M3 and newer) | Not yet supported | — |
+| Apple Silicon (M1, M2) | In progress via [Asahi Linux](https://asahilinux.org/) — see note below | [bootc-installer-asahi](https://github.com/tuna-os/bootc-installer-asahi) |
+| Apple Silicon (M3 and newer) | Not supported (no Asahi support for M3+ yet) | — |
+
+> **Apple Silicon status.** [ROADMAP.md](ROADMAP.md) is the canonical source
+> and lists Apple Silicon support as 🟡 **in progress**
+> ([#781](https://github.com/tuna-os/tunaOS/issues/781)), so this row says the
+> same thing rather than a flat "Supported". Concretely, what exists today:
+> the `-asahi` images build and are gated in CI (Bonito & Grouper, 36/36
+> verified, [#776](https://github.com/tuna-os/tunaOS/issues/776)), and the
+> installer track has D0–D2 and D4 done. What does not exist yet: the D3
+> macOS installer app, any tagged release of `bootc-installer-asahi`, and any
+> validation on real Apple hardware — that repo's deepest test is qemu +
+> U-Boot, which it describes as "the deepest fidelity achievable without
+> Apple hardware". Installing today means driving the Asahi installer path
+> by hand. If you have M1/M2 hardware to test on, #781 is the place to help.
 
 ---
 


### PR DESCRIPTION
Refs #1333, #781.

## Why this is on the DistroWatch issue

#1333 asks for a DistroWatch submission draft. That draft already exists and is already being fixed by **three open PRs** (#1458 metadata refresh, #1549 variant statuses, #1594 cadence claim). Rather than add a fourth conflicting diff to the same file, I fact-checked the claims **none of them touch** — the ones a DistroWatch editor or a new user could check themselves — and found one that does not hold up.

The draft says *"Apple Silicon (M1/M2) support via an Asahi-based installer"*. It inherits that from `README.md`, so this PR fixes it at the source. **`docs/DISTROWATCH-SUBMISSION.md` is deliberately untouched here** — see the note at the bottom.

## The discrepancy

| Source | Says |
|---|---|
| `README.md:121` (support matrix) | Apple Silicon (M1, M2) — **"Supported via Asahi Linux"** |
| `ROADMAP.md:119` | Apple Silicon (Asahi Linux) support — **"🟡 In progress (#781, D0–D4 installer track active)"** |

`ROADMAP.md` declares itself canonical for status ("this table is the canonical per-variant status; tunaos.org wiki and blog copy must track it") — the same rule #1549 used to correct the variant table. README is the one most people read first, so it's the one that misleads.

## Which way it resolves — checked, not assumed

I looked at `tuna-os/bootc-installer-asahi` rather than picking the safer-sounding wording:

- **No tagged release, and no published release at all** (`gh release list` and the tags API both return empty).
- **D3 — the macOS installer app — is still unchecked** in that repo's own Status list. D0–D2 and D4 are done.
- **No validation on real Apple hardware.** Its deepest test is qemu + U-Boot, which its README describes as *"the deepest fidelity achievable without Apple hardware"*.

The image side genuinely works and is CI-gated (Bonito & Grouper `-asahi`, 36/36 verified, #776), so this is **not** "nothing works" — it is precisely the "in progress" ROADMAP already states. But someone with an M1 who reads "Supported" goes looking for an installer to download and finds none.

## What changed

- The M1/M2 row now says **"In progress"**, matching ROADMAP.
- A short note states concretely what exists (images build, CI-gated, D0–D2/D4) and what doesn't (D3 app, any release, any real-hardware validation), so the row **informs rather than just hedges** — and points M1/M2 owners at #781, where hardware testers are the actual bottleneck.
- The M3+ row gets its reason (Asahi has no M3+ support yet) while I was in the same table.

## Checked but deliberately left alone

- **Snapdragon X Elite "Supported"** — verified: both linked doc paths exist in `tuna-os/docs`, and no canonical source contradicts it. No change.
- **"bootc (CNCF Sandbox)"** in the DistroWatch draft — verified accurate; bootc is `project: sandbox` in `cncf/landscape`.
- **Apache-2.0**, **Matrix community** — both check out (`LICENSE`, `COMMUNITY.md:29`).
- **`docs/DISTROWATCH-SUBMISSION.md`** — untouched on purpose. #1458/#1549/#1594 all have unmerged edits to it; a fourth diff would conflict with all three and delay them. Whoever lands those should carry the same correction into the draft's description paragraph — noted on #1333.

Docs-only; `.md` is in the lint workflow's `paths-ignore`, so no CI surface.
