### PR TITLE
fix: retire stale tuna-os/github-copr refs in tunaOS build scripts and CI

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -498,7 +498,7 @@ variants:
         build_qcow2: false
       # gnome-nvidia-hwe re-enabled (tunaOS#639): the gnome-shell-49 vs
       # gnome-shell-common-48 file conflict is fixed upstream in the spec
-      # (tuna-os/github-copr#23 merged: Obsoletes: gnome-shell-common <
+      # (tuna-os/tunaos-packages#23 merged: Obsoletes: gnome-shell-common <
       # %{major_version}), verified live in the published spec, not just
       # by the PR having merged.
       - id: gnome-nvidia-hwe

--- a/.github/scripts/check-el10-packages.py
+++ b/.github/scripts/check-el10-packages.py
@@ -2,8 +2,8 @@
 """Check EL10 package availability for packages mentioned in the upstream diff.
 
 Spins up an AlmaLinux Kitten 10 container, enables EPEL 10 + CRB +
-ublue-os/packages COPR + tuna-os/github-copr, then queries dnf for every
-package candidate found in the diff's added lines.
+the ublue-os/packages COPR, then queries dnf for every package candidate
+found in the diff's added lines.
 
 Results are appended to GEMINI_TASK.md so the AI knows exactly which packages
 can go in both blocks vs. the IS_FEDORA-only block.
@@ -101,7 +101,16 @@ setup = " && ".join([
     "dnf install -y dnf-plugins-core epel-release --quiet --nogpgcheck 2>/dev/null",
     "crb enable --quiet 2>/dev/null || true",
     "dnf copr enable -y ublue-os/packages --quiet 2>/dev/null || true",
-    "dnf copr enable -y tuna-os/github-copr --quiet 2>/dev/null || true",
+    # The tuna-os/github-copr COPR that used to be enabled here is gone —
+    # copr.fedorainfracloud.org/coprs/tuna-os/github-copr 404s, and no COPR
+    # exists under tuna-os/* at all (the GitHub repo was renamed to
+    # tunaos-packages, but that never had a COPR project). The line was a
+    # silent no-op: `dnf copr enable` failed and `|| true` swallowed it, so
+    # removing it changes nothing at runtime — it only stops this script
+    # claiming to check a repo it never reached. The live EL10 GNOME COPRs are
+    # jreilly1821/c10s-gnome-50-fresh and jreilly1821/c10s-gnome-50 (see
+    # manifests/desktops/gnome.yaml); adding either here would change which
+    # packages count as available, so that is a maintainer call, not a rename.
     "dnf makecache --quiet 2>/dev/null || true",
 ])
 query = "dnf repoquery --available --quiet " + " ".join(pkg_list) + " 2>/dev/null"
@@ -152,7 +161,7 @@ lines = [
     "## EL10 Package Availability Check",
     "",
     "Packages from the diff were queried against **AlmaLinux Kitten 10 + EPEL 10 + CRB + "
-    "`ublue-os/packages` + `tuna-os/github-copr`**.",
+    "`ublue-os/packages`**.",
     "",
     "**Port as much as possible.** Use this report to place packages correctly:",
     "",
@@ -214,7 +223,7 @@ for pkg in unavailable:
         f"cannot include this package. It is currently added to the "
         f"`IS_FEDORA == true` block only.\n\n"
         f"### Options\n\n"
-        f"- [ ] Package it in `tuna-os/github-copr`\n"
+        f"- [ ] Package it in `tuna-os/tunaos-packages`\n"
         f"- [ ] Find an EL10-compatible alternative\n"
         f"- [ ] Accept the Fedora-only status and document it\n"
     )

--- a/build_scripts/checks/verify-package-wishlist.sh
+++ b/build_scripts/checks/verify-package-wishlist.sh
@@ -91,7 +91,7 @@ if [[ ${#unexpected[@]} -gt 0 ]]; then
 		echo "These packages were requested, silently skipped as unavailable, and are"
 		echo "NOT in checks/package-miss-allowlist.txt:"
 		printf '  %s\n' "${unexpected[@]}"
-		echo "Either package them (tuna-os/github-copr), install them strictly, or —"
+		echo "Either package them (tuna-os/tunaos-packages), install them strictly, or —"
 		echo "if they are genuinely optional — add them to the allowlist with a comment."
 	} >&2
 	exit 1

--- a/build_scripts/desktop/xfce.sh
+++ b/build_scripts/desktop/xfce.sh
@@ -36,13 +36,17 @@ case "${1:-}" in
 			# EL10 (AlmaLinux/CentOS Stream): the hanthor/xfce-wayland port —
 			# xfwl4 (Rust/Smithay compositor) plus Wayland-adapted
 			# panel/session/xfdesktop/settings/thunar. Packaged from
-			# tuna-os/github-copr src/xfce-wayland, served by repo.tunaos.org
+			# tuna-os/tunaos-packages (formerly github-copr) src/xfce-wayland,
+			# served by repo.tunaos.org
 			# (EL10 x86_64 only — build-config restricts xfce* platforms).
 			# NOTE: the stack is not published yet — the EL10 xfce flavors
-			# are commented out in build-config until tuna-os/github-copr#65
+			# are commented out in build-config until tunaos-packages#65
 			# lands. This branch is the intended install path once it does.
+			# URL follows the rename: the github-copr path still resolves only
+			# via GitHub's rename redirect (byte-identical content), which a
+			# future repo of that name would silently break.
 			curl -fsSLo /etc/yum.repos.d/tuna-os.repo \
-				https://raw.githubusercontent.com/tuna-os/github-copr/main/contrib/tuna-os.repo
+				https://raw.githubusercontent.com/tuna-os/tunaos-packages/main/contrib/tuna-os.repo
 
 			# xfce4-wayland is the meta package tracking the whole adapted
 			# stack (xfwl4, panel, session, xfdesktop, settings, thunar,

--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -496,7 +496,7 @@ record_package_wishlist() {
 
 	local miss
 	for miss in "${misses[@]}"; do
-		printf '::warning title=Missing package (%s on %s)::%s is requested by %s but not in the active repos. Consider packaging it for EL10 via tuna-os/github-copr.\n' \
+		printf '::warning title=Missing package (%s on %s)::%s is requested by %s but not in the active repos. Consider packaging it for EL10 via tuna-os/tunaos-packages.\n' \
 			"${IMAGE_NAME:-?}" "${MAJOR_VERSION_NUMBER:-?}" "$miss" "$caller_script"
 	done
 

--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -150,7 +150,7 @@ packages:
     # cosmic-greeter hard-requires fprintd-pam, which CentOS Stream 10 only
     # builds for x86_64 -- that gap is why aarch64 cosmic was pinned off in
     # tunaOS's build-config.yml (tunaOS#732). It's now built
-    # (tuna-os/github-copr#110, same pinned version as x86_64's 1.94.5) and
+    # (tuna-os/tunaos-packages#110, same pinned version as x86_64's 1.94.5) and
     # published at its own R2 path, separate from the main tuna-os.repo.
     # baseurl is not $basearch-templated (only aarch64 RPMs are published
     # here), so this is harmless to enable unconditionally on x86_64 --

--- a/scripts/generate-boot-report.py
+++ b/scripts/generate-boot-report.py
@@ -522,7 +522,7 @@ def render_report(
         out.append(
             "Packages requested by build_scripts but not in the active EL10 "
             "repos (BaseOS/AppStream/EPEL/CRB/COPRs). Candidates for "
-            "[tuna-os/github-copr](https://github.com/tuna-os/github-copr)."
+            "[tuna-os/tunaos-packages](https://github.com/tuna-os/tunaos-packages)."
         )
         out.append("")
         # Flatten + dedupe across all images

--- a/scripts/report-missing-packages.sh
+++ b/scripts/report-missing-packages.sh
@@ -74,7 +74,7 @@ echo "Generated $(date -u +%Y-%m-%dT%H:%M:%SZ) from \`install_available\`'s buil
 echo
 echo "These packages were requested by tunaos's build scripts but did not"
 echo "resolve against the active DNF repos at build time. Add them to"
-echo "\`tuna-os/github-copr\` (or another COPR we control) to bring them"
+echo "\`tuna-os/tunaos-packages\` (or another repo we control) to bring them"
 echo "into EL10 reach."
 echo
 


### PR DESCRIPTION
Refs #1680 — the build/CI half, which the guide agent left for review because some strings are functional. #1635 (agent docs) and #1662 (IMPROVEMENT_PLAN, merged) cover the rest.

I split these by **what each string actually is**, rather than find-and-replacing the name.

## 🔴 Removed — one genuinely dead functional string

`.github/scripts/check-el10-packages.py` enabled `tuna-os/github-copr` in the AlmaLinux Kitten 10 container before querying package availability. **That COPR is gone:**

| Checked | Result |
|---|---|
| `copr.fedorainfracloud.org/coprs/tuna-os/github-copr/` | **404** |
| `.../coprs/g/tuna-os/github-copr/` (group) | **404** |
| `.../coprs/tuna-os/tunaos-packages/` | **404** — no COPR under `tuna-os/*` at all |
| `.../coprs/jreilly1821/c10s-gnome-50{,-fresh}/` | **200** — the live EL10 GNOME COPRs |

The GitHub *repo* was renamed; the COPR *project* was not. **So renaming this line would have produced a still-dead command that merely looks fixed** — exactly the case the issue flagged for review.

**Removing it is behavior-preserving**: `dnf copr enable` already failed and `|| true` swallowed it. What it changes is that the script stops overstating its own coverage — and that matters here, because packages judged unavailable get **a GitHub issue filed** (`for pkg in unavailable:` → `gh issue create`, deduped only against already-open ones).

Worth noting the script was already half-honest: the **issue body it writes** says `EL10 + EPEL 10 + CRB + ublue-os/packages` — *without* github-copr. Only the module docstring and the `GEMINI_TASK.md` report overclaimed. Both now match the real setup list.

Swapping in `jreilly1821/c10s-gnome-50-fresh` would change which packages count as available — a real behavior change — so that's left as a comment for a maintainer, not made here.

## 🟡 Renamed — one functional URL, verified safe

`build_scripts/desktop/xfce.sh` fetched `contrib/tuna-os.repo` from the github-copr raw path. Both URLs return **200 with byte-identical content**, and the file points at `repo.tunaos.org` rather than a COPR — so the rename is safe, not speculative. It's also an *improvement*: the old path resolves only via GitHub's rename redirect, which a future repo of that name would silently break.

## 🟢 Renamed — pure references and packaging destinations

`lib.sh`, `verify-package-wishlist.sh`, `report-missing-packages.sh`, `generate-boot-report.py`, `cosmic.yaml` (#110), `build-config.yml` (#23), `xfce.sh` (#65).

**Issue numbers survive a rename** — I confirmed #23 (gnome-shell-common obsoletes), #65 (publish xfce-wayland to repo.tunaos.org) and #110 (aarch64 fprintd) each exist in `tunaos-packages` and match their comment's context. So these refs become searchable again rather than dangling.

Historical mentions keep the old name where it's the point, following the `tunaos-packages` (formerly `github-copr`) convention #1662 established — and matching existing repo usage (`tests/bats/test_hummingbird_desktop_wiring.bats` already writes `tuna-os/tunaos-packages#250`).

**Untouched on purpose:** `.github/copilot-instructions.md` and `.github/prompts/{aurora,zirconium}-port.md` — those are #1635's diff.

## Verification

- `python3 -m py_compile` and `bash -n` clean on every edited file; YAML edits are comment-only.
- **109 bats tests pass**: `test_lib` (50), `test_10_base_packages` (25), `test_report_missing_packages` (13), `test_package_wishlist_gate` (12), `test_xfce_greeter_contract` (9).
- ⚠️ `test_verify_image_packages` has **3 failures that reproduce on clean `upstream/main`** (verified by stashing) — pre-existing and unrelated to these files.

## Still outstanding — the other two repos

Out of scope for a tunaOS PR; enumerated via code search so they need no re-discovery:

- **`tunaos-packages`** (11 files): `src/xfce-wayland/{garcon,xfconf,libxfce4ui,libxfce4windowing}` specs, `src/deps/gnome50-el10-compat/useradd-wrapper`, `src/gnome-49/gnome49-el10-compat/useradd-wrapper`, `docs/superpowers/plans/2026-03-15-gnome49-gha-pipeline.md`, `build-order-xfce.yml`, `tests/bats/README.md`, `.github/workflows/build-xfce-{arch-validation,package}.yml`
- **`debian-copr`** (5 files): `builder/Containerfile`, `scripts/build-chain.sh`, `src/xfce-wayland/xfwl4/debian/{rules,changelog}`, `build-order-xfce.yml`

Each needs its own PR. Note `build-xfce-package.yml` wasn't in the issue's list.
