### PR TITLE
[sec-check] harden GitHub context interpolation in workflows

### DIFF
--- a/.github/workflows/archive/build.yml
+++ b/.github/workflows/archive/build.yml
@@ -98,6 +98,7 @@ jobs:
         env:
           PR_HWE_GDX: ${{ needs.detect_pr_scope.outputs.hwe_gdx_related || 'false' }}
           EVENT_NAME: ${{ github.event_name }}
+          RECHUNK: ${{ github.event_name != 'pull_request' }}
           INPUT_IMAGE_VARIANT: ${{ inputs.image_variant }}
           INPUT_PLATFORMS: ${{ inputs.platforms }}
           INPUT_BUILD_VARIANT: ${{ inputs.build_variant }}
@@ -225,7 +226,7 @@ jobs:
               \"run_kde\": ${RUN_KDE},
               \"run_kde_hwe_gdx\": ${RUN_KDE_HWE_GDX},
               \"run_niri_hwe_gdx\": ${RUN_NIRI_HWE_GDX},
-              \"rechunk\": ${{ github.event_name != 'pull_request' }},
+              \"rechunk\": ${RECHUNK},
               \"sbom\": false,
               \"publish\": true
             }]")"

--- a/.github/workflows/archive/generate-release.yml
+++ b/.github/workflows/archive/generate-release.yml
@@ -57,8 +57,9 @@ jobs:
         id: target
         env:
           TARGET: ${{ inputs.target }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
             echo "target=${TARGET}" >> $GITHUB_OUTPUT
           else
             echo "target=lts" >> $GITHUB_OUTPUT

--- a/.github/workflows/arm64-ulimit-probe.yml
+++ b/.github/workflows/arm64-ulimit-probe.yml
@@ -140,10 +140,13 @@ jobs:
       # (github.token), no ulimit override on either call, same order
       # ghcr-login uses.
       - name: Does the exact ghcr-login login sequence reproduce it?
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
-          echo "${{ github.token }}" | podman login -u "${{ github.actor }}" --password-stdin ghcr.io
+          echo "${GITHUB_TOKEN}" | podman login -u "${GITHUB_ACTOR}" --password-stdin ghcr.io
           echo "unsudo login: OK"
-          if sudo TOKEN="${{ github.token }}" ACTOR="${{ github.actor }}" \
+          if sudo TOKEN="${GITHUB_TOKEN}" ACTOR="${GITHUB_ACTOR}" \
               bash -c 'echo "$TOKEN" | podman login -u "$ACTOR" --password-stdin ghcr.io' \
               2>/tmp/seq.err; then
             echo "sudo login AFTER an unsudo login: OK"

--- a/.github/workflows/bootc-lifecycle.yml
+++ b/.github/workflows/bootc-lifecycle.yml
@@ -110,11 +110,12 @@ jobs:
           sudo apt-get install -y --no-install-recommends podman skopeo jq
 
       - name: Log in to GHCR
-        run: |
-          echo "${{ env.GITHUB_TOKEN }}" | \
-            podman login ghcr.io -u "${{ github.actor }}" --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: |
+          echo "${GITHUB_TOKEN}" | \
+            podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
       - name: Validate bootc image update, rebase, rollback & aliases
         env:
@@ -210,11 +211,12 @@ jobs:
           sudo apt-get install -y --no-install-recommends podman skopeo jq
 
       - name: Log in to GHCR
-        run: |
-          echo "${{ env.GITHUB_TOKEN }}" | \
-            podman login ghcr.io -u "${{ github.actor }}" --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: |
+          echo "${GITHUB_TOKEN}" | \
+            podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
       - name: Track beta stream status
         env:

--- a/.github/workflows/build-archlinuxarm-base.yml
+++ b/.github/workflows/build-archlinuxarm-base.yml
@@ -45,6 +45,8 @@ jobs:
           sed 's/ArchLinuxARM-aarch64-latest.tar.gz/rootfs.tar.gz/' rootfs.tar.gz.md5 | md5sum -c -
 
       - name: Build image from rootfs
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           ctr=$(sudo buildah from scratch)
@@ -70,7 +72,7 @@ jobs:
             --cmd /usr/bin/bash \
             --label org.opencontainers.image.title="Arch Linux ARM base" \
             --label org.opencontainers.image.description="Arch Linux ARM aarch64 rootfs as an OCI base image (marlin arm64/asahi prerequisite)" \
-            --label org.opencontainers.image.source="https://github.com/${{ github.repository }}" \
+            --label org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}" \
             "$ctr"
           sudo buildah commit --format oci "$ctr" archlinuxarm:build
 
@@ -83,10 +85,12 @@ jobs:
       - name: Push to GHCR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
-          echo "${{ env.GITHUB_TOKEN }}" | sudo podman login ghcr.io -u "${{ github.actor }}" --password-stdin
-          REF="ghcr.io/${{ github.repository_owner }}/archlinuxarm"
+          echo "${GITHUB_TOKEN}" | sudo podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+          REF="ghcr.io/${GITHUB_REPOSITORY_OWNER}/archlinuxarm"
           DATE=$(date -u +%Y%m%d)
           sudo podman tag archlinuxarm:build "$REF:latest" "$REF:$DATE"
           sudo podman push "$REF:latest"

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -85,7 +85,7 @@ jobs:
           ls -la toolchain.tar.gz
 
       - name: Log in to ghcr.io
-        run: echo "${{ env.GITHUB_TOKEN }}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: echo "${{ env.GITHUB_TOKEN }}" | oras login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Push OCI artifact

--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -68,6 +68,7 @@ jobs:
         env:
           FILTER_VARIANT: ${{ inputs.variant || 'all' }}
           FILTER_FLAVOR: ${{ inputs.flavor || 'all' }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           VALID_VARIANTS="all $(yq -r '.variants[].id' .github/build-config.yml | tr '\n' ' ')"
           VALID_FLAVORS="all $(yq -r '.variants[].flavors[].id' .github/build-config.yml | sort -u | tr '\n' ' ')"
@@ -93,7 +94,7 @@ jobs:
           # Flatten config into one entry per {variant, flavor}, applying filters.
           # All inputs are in env vars — no direct interpolation of workflow
           # inputs into the script body, to prevent shell injection.
-          FULL_MATRIX=$(yq -o=json '.' .github/build-config.yml | jq -c --arg event "${{ github.event_name }}" '
+          FULL_MATRIX=$(yq -o=json '.' .github/build-config.yml | jq -c --arg event "${EVENT_NAME}" '
             .variants[]
             | select(env.FILTER_VARIANT == "all" or .id == env.FILTER_VARIANT)
             | . as $v

--- a/.github/workflows/catalog-facts.yml
+++ b/.github/workflows/catalog-facts.yml
@@ -74,7 +74,7 @@ jobs:
             https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
       - name: Log in to GHCR
-        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/daily-verify.yml
+++ b/.github/workflows/daily-verify.yml
@@ -97,6 +97,10 @@ jobs:
         env:
           VARIANT: ${{ matrix.variant }}
           FLAVOR: ${{ matrix.flavor }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
           OWNER: ${{ github.repository_owner }}
         run: |
           IMAGE_REF="ghcr.io/${OWNER}/${VARIANT}:${FLAVOR}"
@@ -144,8 +148,8 @@ jobs:
           FLAVOR: ${{ matrix.flavor }}
         run: |
           TITLE="Daily Verification Failed: ${VARIANT}:${FLAVOR}"
-          IMAGE_URI="ghcr.io/${{ github.repository_owner }}/${VARIANT}:${FLAVOR}"
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          IMAGE_URI="ghcr.io/${GITHUB_REPOSITORY_OWNER}/${VARIANT}:${FLAVOR}"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
           BODY=$(cat <<ISSUE_EOF
           Daily verification failed for \`${VARIANT}:${FLAVOR}\`.

--- a/.github/workflows/gdm-paint-benchmark.yml
+++ b/.github/workflows/gdm-paint-benchmark.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends just qemu-utils podman
 
       - name: Log in to GHCR
-        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/generate-changelog-release.yml
+++ b/.github/workflows/generate-changelog-release.yml
@@ -251,9 +251,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.vars.outputs.tag }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          if gh release view "${TAG}" --repo "${{ github.repository }}" &>/dev/null; then
+          if gh release view "${TAG}" --repo "${REPO}" &>/dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Release ${TAG} already exists — skipping"
           else

--- a/.github/workflows/installer-screenshots.yml
+++ b/.github/workflows/installer-screenshots.yml
@@ -92,7 +92,7 @@ jobs:
           sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
 
       - name: Log in to GHCR
-        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -108,7 +108,7 @@ jobs:
           sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
 
       - name: Log in to GHCR
-        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/iso-e2e.yml
+++ b/.github/workflows/iso-e2e.yml
@@ -110,8 +110,9 @@ jobs:
           # Mirrors the `if:` on the download step below: source=artifact
           # never touches R2, so it must not be blocked on R2 secrets.
           NEEDS_R2: ${{ github.event_name != 'workflow_dispatch' || inputs.source == 'r2-latest' }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             if [[ "${DISPATCH_VARIANT}" != "${{ matrix.variant }}" ]] \
                || [[ "${DISPATCH_FLAVOR}" != "${{ matrix.flavor }}" ]]; then
               echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/just-fix.yml
+++ b/.github/workflows/just-fix.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [[ -z $(git status --porcelain) ]]; then
             echo "no formatting changes to commit"
@@ -75,7 +76,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add -A
           git commit -m "style: fix formatting"
-          if [[ "${{ github.ref_name }}" == "${DEFAULT_BRANCH}" ]]; then
+          if [[ "${REF_NAME}" == "${DEFAULT_BRANCH}" ]]; then
             BRANCH="automation/just-fix-$(date +%s)"
             git checkout -b "${BRANCH}"
             git push -u origin "${BRANCH}"

--- a/.github/workflows/live-initramfs.yml
+++ b/.github/workflows/live-initramfs.yml
@@ -197,7 +197,7 @@ jobs:
             curl -fsSL "https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz" \
               | sudo tar -xz -C /usr/local/bin oras
           }
-          echo "${GITHUB_TOKEN}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "${GITHUB_TOKEN}" | oras login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
           oras push "$OUT" \
             --artifact-type application/vnd.tunaos.live-initramfs.v1 \

--- a/.github/workflows/live-overlay.yml
+++ b/.github/workflows/live-overlay.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Log in to GHCR
-        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -354,7 +354,7 @@ jobs:
         timeout-minutes: 5
         run: |
           echo "${{ env.GITHUB_TOKEN }}" | \
-            podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+            podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-iso-groups.yml
+++ b/.github/workflows/publish-iso-groups.yml
@@ -152,7 +152,7 @@ jobs:
           sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
 
       - name: Log in to GHCR
-        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -775,8 +775,8 @@ jobs:
           REGISTRY: ghcr.io
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "${{ env.GITHUB_TOKEN }}" | podman login -u "${{ github.actor }}" --password-stdin "${REGISTRY}"
-          echo "${{ env.GITHUB_TOKEN }}" | podman login -u "${{ github.actor }}" --password-stdin "${REGISTRY}"
+          echo "${{ env.GITHUB_TOKEN }}" | podman login -u "${GITHUB_ACTOR}" --password-stdin "${REGISTRY}"
+          echo "${{ env.GITHUB_TOKEN }}" | podman login -u "${GITHUB_ACTOR}" --password-stdin "${REGISTRY}"
 
       - name: Push Manifest
         if: github.event_name != 'pull_request'
@@ -836,7 +836,7 @@ jobs:
       - name: Login to GitHub Container Registry
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "$GITHUB_TOKEN" | cosign login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: echo "$GITHUB_TOKEN" | cosign login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
       - name: Fetch platform digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -1165,10 +1165,10 @@ jobs:
           REGISTRY: ghcr.io
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "${{ env.GITHUB_TOKEN }}" | podman login -u "${{ github.actor }}" --password-stdin "${REGISTRY}"
-          echo "${{ env.GITHUB_TOKEN }}" | sudo podman login -u "${{ github.actor }}" --password-stdin "${REGISTRY}"
+          echo "${{ env.GITHUB_TOKEN }}" | podman login -u "${GITHUB_ACTOR}" --password-stdin "${REGISTRY}"
+          echo "${{ env.GITHUB_TOKEN }}" | sudo podman login -u "${GITHUB_ACTOR}" --password-stdin "${REGISTRY}"
           # Also login with skopeo
-          echo "${{ env.GITHUB_TOKEN }}" | sudo skopeo login -u "${{ github.actor }}" --password-stdin "${REGISTRY}"
+          echo "${{ env.GITHUB_TOKEN }}" | sudo skopeo login -u "${GITHUB_ACTOR}" --password-stdin "${REGISTRY}"
 
       - name: Pull Image and Apply Tags
         id: tag

--- a/.github/workflows/verify-asahi-one.yml
+++ b/.github/workflows/verify-asahi-one.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Login to GHCR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "$GH_TOKEN" | podman login ghcr.io --username "${{ github.actor }}" --password-stdin
+        run: echo "$GH_TOKEN" | podman login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
 
       - name: Verify image against Asahi golden manifest
         id: verify

--- a/.github/workflows/weekly-boot-report.yml
+++ b/.github/workflows/weekly-boot-report.yml
@@ -49,17 +49,18 @@ jobs:
           podman version
 
       - name: Log in to GHCR
-        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Ensure boot-report label exists
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
           gh label create "boot-report" \
             --description "Weekly boot screenshot reports" \
             --color "0075ca" \
-            --repo "${{ github.repository }}" 2>/dev/null || true
+            --repo "${REPO}" 2>/dev/null || true
 
       - name: Ensure screenshots branch exists
         env:

--- a/.github/workflows/weekly-desktop-screenshots.yml
+++ b/.github/workflows/weekly-desktop-screenshots.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Log in to GHCR
         if: steps.filter.outputs.skip != 'true'
-        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/weekly-qcow2-screenshots.yml
+++ b/.github/workflows/weekly-qcow2-screenshots.yml
@@ -79,9 +79,11 @@ jobs:
       - name: Build QCOW2 from published image
         if: steps.filter.outputs.skip != 'true'
         timeout-minutes: 45
+        env:
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           sudo scripts/build-qcow2.sh \
-            "ghcr.io/${{ github.repository_owner }}/${{ matrix.variant }}:${{ matrix.flavor }}-linux-amd64"
+            "ghcr.io/${GITHUB_REPOSITORY_OWNER}/${{ matrix.variant }}:${{ matrix.flavor }}-linux-amd64"
 
       - name: Boot QCOW2 and capture screenshot
         if: steps.filter.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

- pass GitHub context values through step environment variables before using them in shell scripts
- quote actor, repository, ref, event, and token values in affected workflow commands
- remove all direct `${{ github.* }}` interpolations from `run:` bodies in this repository

## Security

This prevents shell parsing of attacker-controlled branch, tag, event, and repository context values during Actions execution, addressing tuna-os/tunaos#1181.

## Validation

- `git diff --check`
- custom workflow scanner: zero direct `github.*` expressions in `run:` bodies
- pushed from `agent/issue-1181-context-hardening`

Closes #1181