### PR TITLE
fix(cachyos): require one kernel tree before rebuilding initramfs

### DIFF
--- a/build_scripts/overlay/cachyos.sh
+++ b/build_scripts/overlay/cachyos.sh
@@ -38,14 +38,35 @@ Include = /etc/pacman.d/cachyos-mirrorlist
 EOF
 fi
 
-pacman -Syu --noconfirm --needed \
+# Do not upgrade the base image here: a full -Syu can install or update the
+# stock linux package alongside linux-cachyos, leaving bootc with multiple
+# kernel trees.  The image must have one kernel whose initramfs is unambiguous.
+pacman -S --noconfirm --needed \
 	cachyos-keyring cachyos-mirrorlist cachyos-settings \
 	linux-cachyos linux-cachyos-headers tpm2-tss
+
+# linux-cachyos is the kernel selected for CachyOS images.  Remove Arch's
+# stock kernel after the replacement is installed; -Rdd is intentional here
+# because the stock kernel's dependencies are also provided by the CachyOS
+# kernel package, but pacman cannot infer that relationship from package
+# metadata.
+if pacman -Qq linux >/dev/null 2>&1; then
+	pacman -Rdd --noconfirm linux
+fi
 
 # Mark as CachyOS-augmented for install-desktop.sh detection
 install -D /dev/null /etc/cachyos-release
 printf 'CachyOS\n' >/etc/cachyos-release
 
-# Rebuild initramfs via dracut
-dracut --force --omit "tpm2-tss" "$(find /usr/lib/modules -maxdepth 1 -type d | grep -v '\.img' | tail -1)/initramfs.img"
+# Rebuild initramfs via dracut.  Do not use find | tail -1: directory order is
+# unspecified, and selecting the wrong tree leaves the bootloader with a
+# kernel that has no matching initramfs.
+mapfile -t _module_dirs < <(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d ! -name '*.img' | sort -V)
+if [[ "${#_module_dirs[@]}" -ne 1 ]]; then
+	echo "ERROR: CachyOS overlay expected exactly one kernel module tree, found ${#_module_dirs[@]}: ${_module_dirs[*]}" >&2
+	exit 1
+fi
+_kernel_dir="${_module_dirs[0]}"
+_kernel="$(basename "${_kernel_dir}")"
+dracut --force --omit "tpm2-tss" "${_kernel_dir}/initramfs.img" "${_kernel}"
 pacman -Scc --noconfirm || true

--- a/tests/bats/test_cachyos_overlay.bats
+++ b/tests/bats/test_cachyos_overlay.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+CACHYOS_SH="${REPO_ROOT}/build_scripts/overlay/cachyos.sh"
+
+@test "CachyOS overlay does not upgrade the stock kernel during install" {
+  run grep -E '^pacman -Syu' "$CACHYOS_SH"
+  [ "$status" -ne 0 ]
+  run grep -E '^pacman -S --noconfirm --needed' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "CachyOS overlay removes the stock linux kernel when installed" {
+  run grep -F 'pacman -Qq linux' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'pacman -Rdd --noconfirm linux' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+}
+
+@test "CachyOS overlay builds initramfs for the only module tree" {
+  run grep -F 'expected exactly one kernel module tree' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'dracut --force --omit "tpm2-tss" "${_kernel_dir}/initramfs.img" "${_kernel}"' "$CACHYOS_SH"
+  [ "$status" -eq 0 ]
+  run grep -F 'tail -1' "$CACHYOS_SH"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

- stop running a full `pacman -Syu` in the CachyOS overlay
- remove the stock `linux` package when present
- select and validate the sole remaining module tree before rebuilding its initramfs

## Validation

- `bash -n build_scripts/overlay/cachyos.sh`
- `git diff --check`
- static regression assertions in `tests/bats/test_cachyos_overlay.bats` (Bats is unavailable in this checkout)

Fixes #1563
Related to #1570