### PR TITLE
build(just): extract image pipeline recipes into a module

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -12,6 +12,7 @@ export platform := env("PLATFORM", if arch == "x86_64" { if `rpm -q kernel 2>/de
 import 'just/utilities.just'
 import 'just/custom-overlay.just'
 import 'just/vm-pipeline.just'
+import 'just/image-pipeline.just'
 
 # ==============================================================================
 #  BUILD PIPELINE
@@ -52,134 +53,6 @@ _build target_tag_with_version target_tag container_file base_image_for_build ta
     # OVERLAY_TYPE inherited from parent shell (exported by build recipe)
     ./scripts/build-image-inner.sh
 
-# Build a TunaOS variant
-build variant='albacore' flavor='gnome' target_platform='' is_ci="0" tag='latest' chain_base_image='' enable_sshd="0": _ensure-deps
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    # Initialize submodules locally
-    DID_INIT="0"
-    if [[ "{{ is_ci }}" != "1" ]] && [[ "${SKIP_SUBMODULES:-0}" != "1" ]]; then
-        if [[ "{{ flavor }}" == *"gnome"* ]]; then
-            git submodule update --init --recursive
-            DID_INIT="1"
-        fi
-    fi
-
-    BLUE='\033[0;34m'
-    GREEN='\033[0;32m'
-    YELLOW='\033[1;33m'
-    NC='\033[0m'
-
-    if [[ -z "{{ target_platform }}" ]]; then
-        if [[ "{{ is_ci }}" != "1" ]]; then PLATFORM="{{ platform }}"; else
-            PLATFORM=$({{ yq }} -r ".variants[] | select(.id == \"{{ variant }}\") | .platforms | join(\",\")" .github/build-config.yml)
-        fi
-    else PLATFORM="{{ target_platform }}"; fi
-
-    BASE_FOR_BUILD=""
-    ENABLE_SSHD="{{ enable_sshd_var }}"
-    FLAVOR="{{ flavor }}"
-
-    if [[ "${FLAVOR}" == "all" ]]; then
-        readarray -t FLAVORS < <({{ yq }} -r '.variants[] | select(.id == "{{ variant }}") | .flavors[].id' .github/build-config.yml)
-        for f in "${FLAVORS[@]}"; do {{ just }} build "{{ variant }}" "$f"; done
-        exit 0
-    fi
-
-    # Resolve flavor into build parameters via external script (testable, DRY)
-    eval "$(./scripts/resolve-flavor.sh "{{ variant }}" "${FLAVOR}" "{{ is_ci }}")"
-    # CONTAINERFILE, DESKTOP_FLAVOR, ENABLE_HWE, ENABLE_NVIDIA, OVERLAY_TYPE, ENABLE_ASAHI, PARENT_FLAVOR now set
-    export OVERLAY_TYPE
-    export ENABLE_ASAHI
-
-    # Resolve BASE_FOR_BUILD based on PARENT_FLAVOR
-    if [[ -z "${PARENT_FLAVOR}" ]]; then
-        BASE_FOR_BUILD=$(./scripts/get-base-image.sh "{{ variant }}" "${PLATFORM}")
-    elif [[ "{{ is_ci }}" = "1" ]]; then
-        # CI chains on the -testing stream tag
-        BASE_FOR_BUILD=$(./scripts/published-image-ref.sh "{{ variant }}" "${PARENT_FLAVOR}-testing" ghcr)
-    else
-        # Stage-3 flavors (-nvidia, -hwe) chain on their parent flavor's image.
-        # Locally that is normally in podman storage from an earlier `just
-        # build`, but it is NOT there for a dev/e2e ISO: `just iso ... dev=1`
-        # calls build with is_ci="0" hardcoded, so on a CI runner this branch
-        # asked for an image nobody had built and buildah tried to resolve
-        # "localhost" as a registry:
-        #
-        #   Error: initializing source docker://localhost/yellowfin:gnome:
-        #   pinging container registry localhost
-        #
-        # That is the single cause of all 24 NVIDIA cells failing LUKS E2E
-        # (run 29978067348) — one systemic issue, not 24. Fall back to the
-        # published parent when the local one is absent, which also makes
-        # `just iso <variant> <flavor>-nvidia ... 1` work on a clean machine.
-        BASE_FOR_BUILD="localhost/{{ variant }}:${PARENT_FLAVOR}"
-        if ! podman image exists "${BASE_FOR_BUILD}" 2>/dev/null; then
-            echo "==> ${BASE_FOR_BUILD} not in local storage; chaining on the published parent instead"
-            BASE_FOR_BUILD=$(./scripts/published-image-ref.sh "{{ variant }}" "${PARENT_FLAVOR}-testing" ghcr)
-        fi
-    fi
-
-    if [[ -n "{{ chain_base_image }}" ]] && [[ "${FLAVOR}" != "base" ]]; then
-        BASE_FOR_BUILD="{{ chain_base_image }}"
-    fi
-
-    TARGET_TAG="{{ variant }}"
-    TARGET_IMAGE_TAG="{{ tag }}"
-    [[ "{{ tag }}" == "latest" ]] && TARGET_IMAGE_TAG="${FLAVOR}"
-    TARGET_TAG_WITH_VERSION="${TARGET_TAG}:${TARGET_IMAGE_TAG}"
-
-    if [[ "{{ is_ci }}" == "0" ]]; then
-        {{ just }} _build "${TARGET_TAG_WITH_VERSION}" "{{ variant }}" "${CONTAINERFILE}" "${BASE_FOR_BUILD}" "$PLATFORM" "1" "${ENABLE_NVIDIA}" "${ENABLE_HWE}" "${DESKTOP_FLAVOR}" "{{ is_ci }}" "{{ enable_sshd }}"
-        ./scripts/sync-build-cache.sh "${TARGET_TAG}" || true
-    else
-        {{ just }} _build "${TARGET_TAG_WITH_VERSION}" "{{ variant }}" "${CONTAINERFILE}" "${BASE_FOR_BUILD}" "$PLATFORM" "0" "${ENABLE_NVIDIA}" "${ENABLE_HWE}" "${DESKTOP_FLAVOR}" "{{ is_ci }}" "{{ enable_sshd }}"
-    fi
-
-    if [[ "$DID_INIT" == "1" ]]; then
-        echo "De-initializing submodules..."
-        git submodule deinit -f --all
-    fi
-
-# Full lifecycle test: build → ISO → boot → install → verify (nested QEMU on corral VM)
-# Usage: just lifecycle-test redfin gnome
-# just lifecycle-test albacore kde
-lifecycle-test variant='albacore' flavor='gnome':
-    ./scripts/lifecycle-test.sh "{{ variant }}" "{{ flavor }}"
-
-# Build on a corral VM (fans out the full flavor matrix on a KubeVirt builder)
-# Usage: just corral-build redfin all
-# just corral-build yellowfin gnome kde
-corral-build variant='redfin' +flavors='all':
-    ./scripts/corral-build.sh "{{ variant }}" {{ flavors }}
-
-# Build a TunaOS live ISO via tacklebox (no Anaconda, tbox-live + sd-boot)
-# Build a live ISO via tacklebox (replaces deprecated bootc-image-builder approach)
-iso variant='skipjack' flavor='gnome' repo='local' tag='' dev='0':
-    #!/usr/bin/env bash
-    set -euo pipefail
-    _tag="{{ tag }}"
-    [[ -z "$_tag" ]] && _tag="{{ flavor }}"
-    _repo="{{ repo }}"
-    if [[ "{{ dev }}" == "1" ]]; then
-        # Dev mode: rebuild locally with SSH enabled for e2e testing, and
-        # customize that fresh local image — regardless of `repo`. Published
-        # images (ghcr/registry) never have ENABLE_SSHD set, so pulling one
-        # for a dev/e2e ISO leaves SSH unavailable (and, on apt-based
-        # variants like grouper, no sshd package installed at all).
-        {{ just }} build "{{ variant }}" "{{ flavor }}" "" "0" "$_tag" "" "1"
-        _repo="local"
-    fi
-    sudo -E bash ./scripts/build-iso-tacklebox.sh "{{ variant }}" "{{ flavor }}" "$_repo" "$_tag" "{{ dev }}"
-
-# Build ONE combined dedup ISO containing every desktop in an iso_group (#455).
-# group: '' / default (flagship gnome+hwe), community (kde/cosmic/niri), nvidia.
-iso-group variant='yellowfin' group='default' repo='ghcr':
-    # --preserve-env: the inner sudo must not strip the CI-pinned tacklebox
-    # source build vars (a plain sudo here silently fell back to the stale
-    # ghcr tacklebox image while CI believed it was testing pinned fixes).
-    sudo --preserve-env=GITHUB_REPOSITORY_OWNER,TACKLEBOX_FROM_SOURCE,TACKLEBOX_SHA,TACKLEBOX_IMAGE,TACKLEBOX_CACHE bash ./scripts/build-iso-group.sh "{{ variant }}" "{{ group }}" "{{ repo }}"
 # Generate a QCOW2 disk image using bootc install to-disk (via loopback in a privileged container)
 qcow2 variant flavor='gnome' repo='local' tag='':
     #!/usr/bin/env bash

--- a/just/image-pipeline.just
+++ b/just/image-pipeline.just
@@ -1,0 +1,77 @@
+# Image build and ISO orchestration recipes.
+#
+# Extracted from the root Justfile for issue #508. Imports share one flat
+# namespace, so these recipes retain the existing names and can call root
+# helpers such as _build and _ensure-deps without wrappers.
+
+# Build a TunaOS variant
+build variant='albacore' flavor='gnome' target_platform='' is_ci="0" tag='latest' chain_base_image='' enable_sshd="0": _ensure-deps
+    #!/usr/bin/env bash
+    set -euo pipefail
+    DID_INIT="0"
+    if [[ "{{ is_ci }}" != "1" ]] && [[ "${SKIP_SUBMODULES:-0}" != "1" ]] && [[ "{{ flavor }}" == *"gnome"* ]]; then
+        git submodule update --init --recursive
+        DID_INIT="1"
+    fi
+    if [[ -z "{{ target_platform }}" ]]; then
+        if [[ "{{ is_ci }}" != "1" ]]; then PLATFORM="{{ platform }}"; else
+            PLATFORM=$({{ yq }} -r ".variants[] | select(.id == \"{{ variant }}\") | .platforms | join(\",\")" .github/build-config.yml)
+        fi
+    else PLATFORM="{{ target_platform }}"; fi
+    BASE_FOR_BUILD=""
+    ENABLE_SSHD="{{ enable_sshd_var }}"
+    FLAVOR="{{ flavor }}"
+    if [[ "${FLAVOR}" == "all" ]]; then
+        readarray -t FLAVORS < <({{ yq }} -r '.variants[] | select(.id == "{{ variant }}") | .flavors[].id' .github/build-config.yml)
+        for f in "${FLAVORS[@]}"; do {{ just }} build "{{ variant }}" "$f"; done
+        exit 0
+    fi
+    eval "$(./scripts/resolve-flavor.sh "{{ variant }}" "${FLAVOR}" "{{ is_ci }}")"
+    export OVERLAY_TYPE ENABLE_ASAHI
+    if [[ -z "${PARENT_FLAVOR}" ]]; then
+        BASE_FOR_BUILD=$(./scripts/get-base-image.sh "{{ variant }}" "${PLATFORM}")
+    elif [[ "{{ is_ci }}" = "1" ]]; then
+        BASE_FOR_BUILD=$(./scripts/published-image-ref.sh "{{ variant }}" "${PARENT_FLAVOR}-testing" ghcr)
+    else
+        BASE_FOR_BUILD="localhost/{{ variant }}:${PARENT_FLAVOR}"
+        if ! podman image exists "${BASE_FOR_BUILD}" 2>/dev/null; then
+            echo "==> ${BASE_FOR_BUILD} not in local storage; chaining on the published parent instead"
+            BASE_FOR_BUILD=$(./scripts/published-image-ref.sh "{{ variant }}" "${PARENT_FLAVOR}-testing" ghcr)
+        fi
+    fi
+    if [[ -n "{{ chain_base_image }}" ]] && [[ "${FLAVOR}" != "base" ]]; then BASE_FOR_BUILD="{{ chain_base_image }}"; fi
+    TARGET_TAG="{{ variant }}"
+    TARGET_IMAGE_TAG="{{ tag }}"
+    [[ "{{ tag }}" == "latest" ]] && TARGET_IMAGE_TAG="${FLAVOR}"
+    TARGET_TAG_WITH_VERSION="${TARGET_TAG}:${TARGET_IMAGE_TAG}"
+    if [[ "{{ is_ci }}" == "0" ]]; then
+        {{ just }} _build "${TARGET_TAG_WITH_VERSION}" "{{ variant }}" "${CONTAINERFILE}" "${BASE_FOR_BUILD}" "$PLATFORM" "1" "${ENABLE_NVIDIA}" "${ENABLE_HWE}" "${DESKTOP_FLAVOR}" "{{ is_ci }}" "{{ enable_sshd }}"
+        ./scripts/sync-build-cache.sh "${TARGET_TAG}" || true
+    else
+        {{ just }} _build "${TARGET_TAG_WITH_VERSION}" "{{ variant }}" "${CONTAINERFILE}" "${BASE_FOR_BUILD}" "$PLATFORM" "0" "${ENABLE_NVIDIA}" "${ENABLE_HWE}" "${DESKTOP_FLAVOR}" "{{ is_ci }}" "{{ enable_sshd }}"
+    fi
+    if [[ "$DID_INIT" == "1" ]]; then git submodule deinit -f --all; fi
+
+# Full lifecycle test and remote corral build helpers.
+lifecycle-test variant='albacore' flavor='gnome':
+    ./scripts/lifecycle-test.sh "{{ variant }}" "{{ flavor }}"
+
+corral-build variant='redfin' +flavors='all':
+    ./scripts/corral-build.sh "{{ variant }}" {{ flavors }}
+
+# Build a TunaOS live ISO via tacklebox.
+iso variant='skipjack' flavor='gnome' repo='local' tag='' dev='0':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    _tag="{{ tag }}"
+    [[ -z "$_tag" ]] && _tag="{{ flavor }}"
+    _repo="{{ repo }}"
+    if [[ "{{ dev }}" == "1" ]]; then
+        {{ just }} build "{{ variant }}" "{{ flavor }}" "" "0" "$_tag" "" "1"
+        _repo="local"
+    fi
+    sudo -E bash ./scripts/build-iso-tacklebox.sh "{{ variant }}" "{{ flavor }}" "$_repo" "$_tag" "{{ dev }}"
+
+# Build one combined deduplicated ISO for an iso_group.
+iso-group variant='yellowfin' group='default' repo='ghcr':
+    sudo --preserve-env=GITHUB_REPOSITORY_OWNER,TACKLEBOX_FROM_SOURCE,TACKLEBOX_SHA,TACKLEBOX_IMAGE,TACKLEBOX_CACHE bash ./scripts/build-iso-group.sh "{{ variant }}" "{{ group }}" "{{ repo }}"

--- a/tests/bats/test_justfile.bats
+++ b/tests/bats/test_justfile.bats
@@ -20,7 +20,7 @@ setup() {
 }
 
 @test "justfile: has 'build' recipe" {
-  run grep -E '^build[:( ]' "${JUSTFILE}"
+  run grep -hE '^build[:( ]' "${JUSTFILE}" "${REPO_ROOT}/just"/*.just
   [ "$status" -eq 0 ]
 }
 
@@ -44,8 +44,16 @@ setup() {
 }
 
 @test "justfile: has container build recipe" {
-  # Justfile uses 'build' recipe with parameters, not build-* prefixes
-  run grep -E '^build[ (:]' "${JUSTFILE}"
+  # Justfile uses 'build' recipe with parameters, not build-* prefixes. The
+  # recipe may live in an imported module because imports share one namespace.
+  run grep -hE '^build[ (:]' "${JUSTFILE}" "${REPO_ROOT}/just"/*.just
+  [ "$status" -eq 0 ]
+}
+
+@test "justfile: image pipeline recipes live in an imported module" {
+  run grep -F "import 'just/image-pipeline.just'" "${JUSTFILE}"
+  [ "$status" -eq 0 ]
+  run grep -hE '^(build|lifecycle-test|corral-build|iso|iso-group)[ :(]' "${REPO_ROOT}/just/image-pipeline.just"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary

This continues the local modular Justfile pattern established by `just/custom-overlay.just`, `just/utilities.just`, and `just/vm-pipeline.just`.

- moves `build`, lifecycle/corral helpers, and ISO recipes into `just/image-pipeline.just`
- keeps the existing recipe names and flat imported namespace
- updates Justfile tests to find recipes in imported modules
- reduces the root Justfile from 432 to 305 lines on this base

## Why

`just` resolves imports from local files; it does not fetch Git URLs. This keeps the change within the working mechanism already used by tunaOS while reducing root-file inflation and establishing another reusable module boundary.

## Validation

- `git diff --check`
- static import and recipe-presence assertions passed
- `bats` and `just` are unavailable in this checkout, so runtime parsing and Bats execution could not be run locally

Refs #508