### PR TITLE
docs: add R2 cost visibility and retention runbook

### DIFF
--- a/docs/R2-COST-VISIBILITY.md
+++ b/docs/R2-COST-VISIBILITY.md
@@ -1,0 +1,65 @@
+# Cloudflare R2 cost visibility and retention
+
+This is the maintainer runbook for the TunaOS portion of the shared Cloudflare
+R2 bucket. It records what this repository writes, which paths are expected to
+be retained, and the measurements to capture from Cloudflare. It intentionally
+does not contain bucket names, endpoints, access keys, or guessed prices.
+
+Issue: [#1618](https://github.com/tuna-os/tunaos/issues/1618)
+
+## Monthly visibility check
+
+An organization owner with Cloudflare billing access should record these values
+for the previous calendar month, then attach the export or dashboard link to
+the issue or the operations log:
+
+| Metric | Cloudflare source | Required breakdown |
+| --- | --- | --- |
+| Stored data, GB-month | R2 dashboard → Storage | bucket, then `live-isos/` and `screenshots/` where available |
+| Class A operations | R2 dashboard → Operations | PUT/COPY, LIST, and DELETE; identify the largest producer |
+| Class B operations | R2 dashboard → Operations | GET/HEAD; separate public downloads from CI reads if available |
+| Egress | R2 dashboard → Egress | confirm the R2 free-egress assumption for the account and traffic path |
+| Object count | R2 usage or an authenticated inventory | `live-isos/`, `screenshots/`, and any unexpected top-level prefix |
+
+Record the measurement date, billing period, bucket, account, and dashboard
+currency/units. Do not infer cost from object count alone: package-repository
+syncs can be operation-heavy while ISOs and screenshots are storage-heavy.
+
+## TunaOS write inventory
+
+| Prefix | Writers in this repository | Intended retention | Owner/action |
+| --- | --- | --- | --- |
+| `live-isos/` | `reusable-build-artifacts.yml`, `publish-iso-groups.yml`, and the variant workflows | 14 days for dated objects; `*-latest` objects are live pointers | `prune-r2.yml`; verify the scheduled job is succeeding |
+| `screenshots/` | `weekly-desktop-screenshots.yml`, `weekly-qcow2-screenshots.yml`, and installer screenshot jobs | 60 days for dated evidence; `*-latest` objects are live pointers | `prune-r2.yml`; review growth monthly |
+
+The names above are logical prefixes. The configured bucket comes from the
+`R2_BUCKET` secret and must be resolved only in the Cloudflare/GitHub settings
+that authorized maintainers can access.
+
+The R2 retention workflow is deliberately independent of ISO publishing. A
+failed or manually skipped build must not also skip housekeeping. Its dry-run
+mode should be used after changing a prefix or age threshold; inspect the
+listed deletion set before enabling a destructive run.
+
+## Retention safety rules
+
+- Never delete `*-latest` objects as part of dated-object cleanup; download
+  documentation and smoke tests use those stable names.
+- Keep ISO sidecars (`.sha256` and `.sigstore.json`) with their dated ISO. A
+  sidecar without its ISO is not useful evidence or a usable download.
+- Prefer a dry run and a bounded age threshold before changing a cleanup job.
+- Treat an unknown top-level prefix as an ownership question, not as disposable
+  data. Identify its writer and consumer before deleting it.
+- A Cloudflare bucket deletion or account-level lifecycle rule requires an
+  owner with dashboard access; this repository cannot prove that `tunaosdev`
+  is unused or safely delete it.
+
+## Follow-up outside this repository
+
+This runbook covers only TunaOS workflows. The same inventory must be completed
+for `tunaos-packages`, `tromso`, `xfce-linux`, and the tacklebox repositories.
+In particular, package-repository `rclone sync` calls should be compared by
+Class A operation volume before anyone changes the distribution architecture.
+Provider migration is a separate decision and should not be proposed from
+storage estimates alone; retention and operation patterns must be measured
+first.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ user-facing site:
 | [BRANCH-PROTECTION.md](BRANCH-PROTECTION.md) | Current-state audit + proposal for main-branch protection & required CI (#1167) |
 | [BRANCH-POLICY.md](BRANCH-POLICY.md) | Branch naming conventions, RFC disposition, and 30-day staleness rules |
 | [CI_SPEC.md](CI_SPEC.md) | CI behavior specification |
+| [R2-COST-VISIBILITY.md](R2-COST-VISIBILITY.md) | Cloudflare R2 cost, retention, and ownership runbook (#1618) |
 | [TESTING.md](TESTING.md) | ISO end-to-end test harness |
 | [MATRIX-STATUS.md](MATRIX-STATUS.md) | Which variant×desktop combinations are actually verified — and which have never been tested |
 | [ASAHI-HARDWARE-TIERS.md](ASAHI-HARDWARE-TIERS.md) | Real Apple Silicon hardware CI: rented Scaleway rental + personal-machine tiers, and the m1n1/boot.bin safety rule both must follow |


### PR DESCRIPTION
## Summary

Addresses the cost-visibility portion of #1618 without inventing billing data or changing bucket state.

- adds `docs/R2-COST-VISIBILITY.md` with a monthly Cloudflare measurement checklist
- maps TunaOS R2 prefixes to writers, retention expectations, and owners
- documents dry-run/deletion safety rules and the `tunaosdev` maintainer follow-up
- records cross-repo follow-up for package syncs and other R2 writers
- links the runbook from `docs/README.md`

The existing retention implementation is tracked separately in #1619; this PR supplies the durable operational record for the measurements and decisions that require Cloudflare dashboard access.

## Validation

- `git diff --check`
- static checks confirm the documented prefixes, metrics, secret boundary, and README link

Refs #1618