### PR TITLE
docs: index SeaGL 2026 CFP draft

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ user-facing site:
 | [../VARIANT-LIFECYCLE.md](../VARIANT-LIFECYCLE.md) | Variant/flavor admission, capacity, promotion, and deprecation policy (#1196, #1175) |
 | [CFP-FOSDEM-2027.md](CFP-FOSDEM-2027.md) | FOSDEM 2027 CFP draft |
 | [CFP-SCALE-21X.md](CFP-SCALE-21X.md) | SCaLE 21x CFP draft, adapted from the FOSDEM abstract |
+| [CFP-SEAGL-2026.md](CFP-SEAGL-2026.md) | SeaGL 2026 CFP draft, adapted for a community-first audience |
 | [DISTROWATCH-SUBMISSION.md](DISTROWATCH-SUBMISSION.md) | DistroWatch project submission draft |
 | [ADOPTION-OUTREACH-STATUS.md](ADOPTION-OUTREACH-STATUS.md) | Evidence ledger for DistroWatch, CNCF, and adopter outreach |
 | [REDDIT-LEMMY-PLAYBOOK.md](REDDIT-LEMMY-PLAYBOOK.md) | Release-announcement playbook for Reddit / Lemmy |


### PR DESCRIPTION
## Summary

The SeaGL CFP draft was added by merged PR #1693 but was missing from the maintainer documentation index. This follow-up adds `CFP-SEAGL-2026.md` beside the FOSDEM and SCaLE CFP drafts in `docs/README.md`.

This keeps the submission artifact discoverable for the maintainer review and submission checklist described in #1691.

## Validation

- `git diff --check`
- verified the indexed file exists on current `upstream/main`

Related: #1691