### PR TITLE
fix(ci): stop BATS failures from silently skipping pytest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
           exit $FAILED
 
       - name: Run pytest tests
+        if: always()
         run: |
           echo "=== pytest Tests ==="
           python3 -m pytest tests/ tests/pytest/ -v --tb=short --cov=. --cov-report=term --cov-report=xml:coverage-python.xml
@@ -88,3 +89,4 @@ jobs:
           name: coverage-python
           path: coverage-python.xml
           retention-days: 30
+          if-no-files-found: ignore

--- a/tests/bats/test_test_yml_pytest_always_runs.bats
+++ b/tests/bats/test_test_yml_pytest_always_runs.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+# tunaOS#1702: "Run pytest tests" had no `if:` condition, so GitHub Actions'
+# implicit `if: success()` skipped the entire pytest suite whenever the
+# preceding BATS step failed. That silently masked Python regressions and
+# left coverage-python.xml missing, which then made the "Upload Python
+# coverage" step's "No files were found" warning look like the real failure
+# in the failing-checks feed (~45 PRs), when the actual failure was BATS.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+WORKFLOW="${REPO_ROOT}/.github/workflows/test.yml"
+
+@test "test.yml: Run pytest tests step runs even when BATS failed" {
+  # Isolate the "Run pytest tests" step block up to the next "- name:".
+  block="$(awk '/- name: Run pytest tests/,/- name: Test summary/' "$WORKFLOW")"
+  [[ "$block" == *"if: always()"* ]]
+}
+
+@test "test.yml: Upload Python coverage step ignores a missing coverage file" {
+  block="$(awk '/- name: Upload Python coverage/,0' "$WORKFLOW")"
+  [[ "$block" == *"if-no-files-found: ignore"* ]]
+}


### PR DESCRIPTION
## Summary

Fixes #1702.

`.github/workflows/test.yml`'s `Unit Tests` job runs pytest with an implicit `if: success()` (no `if:` was set), so any BATS failure silently skips the entire 249-test Python suite. Two consequences:

1. **Python regressions are masked** — a PR that breaks a BATS assertion never runs pytest, so Python breakage can ride along unnoticed.
2. **`coverage-python.xml` is never produced**, so the `Upload Python coverage` step's `if-no-files-found` (defaulting to `warn`) surfaces `No files were found with the provided path: coverage-python.xml` — the annotation that flagged ~45 PRs in the failing-checks feed (e.g. #1679, #1676, #1673, #1668, #1666), even though the real failure was a stale BATS assertion, not a workflow/artifact bug.

## What changed

Two-line workflow hardening (test infrastructure only), exactly as scoped in the issue:

1. Added `if: always()` to the `Run pytest tests` step so both test layers run and report independently, regardless of whether BATS passed.
2. Added `if-no-files-found: ignore` to the `Upload Python coverage` step so a missing artifact (e.g. because pytest itself also failed before writing the report) is not a misleading extra warning on top of the real failure.

Also added `tests/bats/test_test_yml_pytest_always_runs.bats`, asserting both conditions are present in the workflow (source-grep pattern, matching this repo's existing style for workflow-content regression tests, e.g. `test_oci_metadata_no_personal_identity.bats`).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — parses cleanly
- [x] `yamllint` — same pre-existing warnings as before (document-start/truthy/comment-spacing), no new ones
- [x] `bats tests/bats/test_test_yml_pytest_always_runs.bats` — 2/2 passing
- [x] `shellcheck` on the new bats file — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_014mkpNM2ZMGG78bAiYM1osn)_