### PR TITLE
docs: define branch protection verification exit criteria

### DIFF
--- a/Q4-MATURE-DEFINITION.md
+++ b/Q4-MATURE-DEFINITION.md
@@ -30,7 +30,7 @@ checkpoint (#1299). Q4 must close with evidence, not wishes.
 | Adoption metrics / usage telemetry | #1174 | First monthly download/usage snapshot **published by 2026-11-01**; dashboard or doc with numbers, not prose |
 | Adoption evidence | #1348 | ≥1 production adopter listed in ADOPTERS.md with a verifiable reference (deployment, testimonial, case study) |
 | Community governance model | #1168 | Governance doc merged (maintainer roles, decision rights, contribution ladder) and referenced from CONTRIBUTING.md |
-| Branch protection + required CI | #1167 | Active `main` ruleset on tunaos enforces required status checks (`lint`, `lint-summary`, `unit-tests`) — verified, not claimed |
+| Branch protection + required CI | #1167 | Active `main` ruleset on tunaos contains a `required_status_checks` rule for `lint`, `lint-summary`, and `unit-tests`; verify the rule and a clean merge-queue evaluation from a non-bypass PR |
 | Release automation | #1186 | Scheduled releases for **all supported flavors** (kde/xfce/cosmic/niri + gnome) with assets; ≥2 consecutive weekly cycles green |
 | Package signing / SBOM | #1187 | Signed SBOM attestation present on every published release artifact org-wide (not just gnome); verification docs public |
 | Supply chain hardening | #1193 | Dependency-freshness automation healthy org-wide: no halted Renovate configs, org automerge gate enforced (#1636, #1612) |

--- a/docs/BRANCH-PROTECTION.md
+++ b/docs/BRANCH-PROTECTION.md
@@ -65,6 +65,33 @@ ruleset should be `lint`, `lint-summary`, and `unit-tests`. Broader coverage
 widened to run unconditionally, or added as a separate, narrower ruleset
 scoped to the paths they already filter on.
 
+## Maintainer action and verification checklist
+
+This is the remaining live-repository work for #1167. A maintainer with
+ruleset-admin access should apply the proposal to the active `main` ruleset,
+then record the result in the issue. The API shape is intentionally shown as a
+checklist rather than embedded in CI: rulesets are repository configuration and
+must not be silently changed by a code workflow.
+
+1. Read back `GET /repos/tuna-os/tunaos/rulesets/10437561` and confirm that the
+   target is `main` and enforcement is `active`.
+2. Add one `required_status_checks` rule containing exactly these contexts:
+   `lint`, `lint-summary`, and `unit-tests`. Keep the merge-queue rule enabled.
+3. Decide whether the `OrganizationAdmin` and repository-role bypass actors
+   are still necessary. If they remain, document the operational exception;
+   if they are removed, verify that the merge queue can still be operated by
+   the normal maintainer workflow.
+4. Open a small PR that triggers all three jobs and confirm that the ruleset's
+   rule-suite evaluation reports success before the PR can merge. A direct
+   push or an admin merge is not evidence of enforcement because both can
+   bypass the ruleset.
+5. Re-read the ruleset and rule-suite history, capture the verification date,
+   and update this document and #1167 with the observed rule and test PR.
+
+The Q4 exit criterion is satisfied only after steps 1–5 are evidenced. The
+current audit is not that evidence: it explicitly found that the
+`required_status_checks` rule is absent.
+
 ## What this doc is not
 
 This is a documentation-only audit and proposal. Applying it (adding a


### PR DESCRIPTION
## Summary

- Correct the Q4 “Mature” exit criterion so it no longer claims required CI is already enforced.
- Add a maintainer checklist for applying and empirically verifying the `main` ruleset required checks.
- Record that direct pushes and admin merges are not enforcement evidence because they can bypass the ruleset.

This follows up on #1167 and the merged audit in #1429. The live ruleset mutation remains intentionally outside the code PR because it requires ruleset-admin access.

## Validation

- `git diff --check`
- Cross-checked the checklist against `.github/workflows/lint.yml` and `.github/workflows/test.yml`; `unit-tests` is path-filtered and therefore needs a dedicated verification PR.

Closes documentation follow-up for #1167; the maintainer settings change remains outstanding.