### PR TITLE
docs: clarify Fedora Magazine pitch validation

### DIFF
--- a/docs/FEDORA-MAGAZINE-PITCH.md
+++ b/docs/FEDORA-MAGAZINE-PITCH.md
@@ -34,7 +34,8 @@ ecosystem news, not an advert.
 
 **What we'd include.** A short tour of Bonito: what it is, how bootc changes
 the update model, what works today (Fedora 44 base, GNOME, Niri, XFCE
-flavors, verified boot reports), and how to try it. All content is already
+flavors, automated boot verification, and weekly boot reports), and how to try
+it. All content is already
 published on [tunaos.org/blog](https://tunaos.org/blog) and
 [github.com/tuna-os/tunaOS](https://github.com/tuna-os/tunaOS), so we can
 provide a full draft in Magazine house style on request.
@@ -42,8 +43,7 @@ provide a full draft in Magazine house style on request.
 **About the author.** TunaOS is an open-source project with a daily rolling
 build cadence (plus weekly and quarterly-LTS stability tiers for users who
 want less churn) and an active community on Matrix. Happy to adapt length,
-tone, and
-depth to the Magazine's editorial preferences.
+tone, and depth to the Magazine's editorial preferences.
 
 Thanks for considering,
 [Maintainer name]


### PR DESCRIPTION
## What changed

- Replace the vague “verified boot reports” wording with the project’s documented automated boot verification and weekly boot reports.
- Fix the author paragraph line wrap so the submission-ready email reads cleanly.

## Why

This keeps the Fedora Magazine pitch tied to concrete TunaOS validation artifacts while preserving the scope of issue #1137.

## Validation

- `git diff --check`
- Confirmed `.github/workflows/live-iso-bootc.yml` and `.github/workflows/weekly-boot-report.yml` exist.

Refs #1137