### PR TITLE
docs: index press kit for outreach campaigns

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ user-facing site:
 | [DISTROWATCH-SUBMISSION.md](DISTROWATCH-SUBMISSION.md) | DistroWatch project submission draft |
 | [ADOPTION-OUTREACH-STATUS.md](ADOPTION-OUTREACH-STATUS.md) | Evidence ledger for DistroWatch, CNCF, and adopter outreach |
 | [REDDIT-LEMMY-PLAYBOOK.md](REDDIT-LEMMY-PLAYBOOK.md) | Release-announcement playbook for Reddit / Lemmy |
+| [PRESSKIT.md](PRESSKIT.md) | One-page media kit for tech press and Linux YouTubers (#1646) |
 | [YOUTUBER-REVIEW-KIT.md](YOUTUBER-REVIEW-KIT.md) | Linux YouTuber review kit — verified working downloads, ARM story (#1535) |
 | [FEDORA-MAGAZINE-PITCH.md](FEDORA-MAGAZINE-PITCH.md) | Guest-post pitch draft for Fedora Magazine |
 | [EDUCATION-PITCH.md](EDUCATION-PITCH.md) | Education & teaching lab adoption brief for CS departments (#1600) |


### PR DESCRIPTION
## Summary

- Add the existing TunaOS press kit to the maintainer documentation index.
- Make the one-page media kit easy for tech-press and Linux YouTuber campaigns to discover.

## Context

`docs/PRESSKIT.md` is the source of the project one-liner, variant matrix, headline stories, links, branding references, contact details, and boilerplate requested by #1646. This change wires that asset into `docs/README.md` alongside the other outreach documents.

## Validation

- `git diff --check`

Closes #1646