### PR TITLE
docs: refresh external contribution capacity evidence

### DIFF
--- a/ADOPTION-METRICS.md
+++ b/ADOPTION-METRICS.md
@@ -1,6 +1,6 @@
 # TunaOS Adoption Metrics Plan
 
-**Last updated**: 2026-08-10 | **Owner**: strategist (snapshot), ci-maintainer (R2/Releases data), guide (publishing)
+**Last updated**: 2026-08-14 | **Owner**: strategist (snapshot), ci-maintainer (R2/Releases data), guide (publishing)
 **Tracking**: [tunaos#1174](https://github.com/tuna-os/tunaos/issues/1174)
 
 ---
@@ -29,7 +29,7 @@ publish, and *how* the snapshot feeds roadmap decisions.
 | Download | ISO downloads by variant+desktop | R2 access logs (tunaos.org/download) | **not measured** | ≥1k ISO downloads/mo; variant ranking |
 | Download | GitHub Release asset downloads | Releases API (resumed 08-09, #1106) | 0 (assets were empty shells) | assets present on all flavors; downloads counted |
 | Install | Installs / successful boots | opt-in telemetry or boot-report gating | **not measured** | Q4 design decision (#577 GUI gate, #763) |
-| Community | Open PRs from external contributors | GitHub API | 0 external contributors | ≥2 external contributor PRs merged |
+| Community | Merged PRs from external human contributors | GitHub API | **3 merged contributions from 3 verified humans** (docs#234, docs#239 on 08-14; one bootc-migrate contribution on 08-05) | ≥5 merged PRs from ≥3 humans, including one repeat contributor |
 | Community | Discussion posts, `good first issue` pickups | GitHub API | 0 starter issues (dead label, #1308) | ≥5 starter issues picked up |
 | Community | Public adopters (production or evaluation), [ADOPTERS.md](./ADOPTERS.md) | Manual — PR from the adopting org, or outreach asking permission to list | 0 production entries (#1348) | ≥2–3 public evaluator/production entries |
 | Community | Adoption-call conversion | GitHub Discussion + follow-up PRs | **not measured** | Record responses, consent-confirmed named entries, anonymous reports, and ADOPTERS.md PRs |
@@ -65,6 +65,14 @@ The current outreach record is kept in
 an intended recipient, or an ecosystem relationship is not an outreach result;
 the monthly snapshot must record a sent date, public URL, response, or an
 explicitly unattempted status.
+
+### Contribution evidence is not adoption evidence
+
+The 2026-08-14 docs merges establish a real external-contribution channel and
+are useful leading evidence for the Hacktoberfest funnel. They do not establish
+that the authors use TunaOS. Keep the contribution count separate from
+production/evaluation entries in `ADOPTERS.md`; only a consent-confirmed report
+belongs in the adopter funnel.
 
 ## Decision linkage
 

--- a/docs/HACKTOBERFEST-2026.md
+++ b/docs/HACKTOBERFEST-2026.md
@@ -68,6 +68,30 @@ then re-check wootc, protota, iso-builder, and Tavern before the 09-08 audit.
 Keep two alternates available for tasks that are claimed or found to be too
 broad.
 
+## Conversion-loop evidence (2026-08-14)
+
+The “no external capacity” assumption is no longer valid for the docs channel.
+Two first-time, human-authored docs contributions converted from seeded issues
+to merged PRs on 2026-08-14:
+
+| Seed / surface | Result | Evidence |
+|---|---|---|
+| QEMU/KVM evaluation guide | Merged | [docs#234](https://github.com/tuna-os/docs/pull/234), Dipak Chaudhari, 07:16Z |
+| Gurnard Pantheon edition fix | Merged | [docs#239](https://github.com/tuna-os/docs/pull/239), Shawn, 09:19Z |
+
+This is a proven GFI → review → merge loop: **2 converted in one day from
+roughly 6–9 usable seeds** (about a 25% observed conversion rate). It is
+evidence for docs-channel external contribution capacity, not evidence of
+TunaOS adoption or production use. Keep core-code capacity and adopter
+evidence as separate checkpoint inputs.
+
+Re-baseline the seeding plan against **net usable tasks**, not gross issues:
+replace consumed tasks promptly, preserve 15–20 usable candidates by the
+2026-09-15 deadline, and carry two alternates through the 09-08 audit. At the
+first post-launch snapshot, record claims, merged PRs, distinct contributors,
+and whether any contributor returns; do not count a contribution as an adopter
+entry without the consent workflow in `ADOPTERS.md`.
+
 ## Curation checklist
 
 For every selected issue, the maintainer should confirm:
@@ -92,7 +116,7 @@ as Hacktoberfest starter tasks.
 | Date | Deliverable | Owner |
 |---|---|---|
 | By 2026-09-01 | Confirm registration and label guidance | strategist |
-| By 2026-09-08 | Audit the six repositories and select 10–15 tasks plus two alternates — **re-check net pool vs consumption** (5 consumed 08-13→08-14; #1537) | guide + repository maintainers |
+| By 2026-09-08 | Audit the six repositories and select 10–15 tasks plus two alternates — **re-check net pool vs consumption** and preserve the proven docs conversion loop (#1537, #1714) | guide + repository maintainers |
 | By 2026-09-15 | Apply final labels, add missing acceptance criteria, and publish the backlog | guide |
 | 2026-09-15–30 | Announce participation on the blog and Matrix; link directly to the filtered issue view | outreach |
 | 2026-10-01–31 | Triage claims, answer questions, and review starter PRs promptly | repository maintainers |

--- a/docs/Q3_CHECKPOINT-2026-08-22.md
+++ b/docs/Q3_CHECKPOINT-2026-08-22.md
@@ -38,6 +38,16 @@ To ensure decision inputs survive upstream merge delays:
 1. **Issue Thread Auditing**: Checkpoint recommendations and status updates must be posted directly to their primary tracking issues (#1299, #1341, #272, #1123, #1383, #1657).
 2. **Divergence Correction**: Public status tables (including `ROADMAP.md` and `ADOPTION-METRICS.md`) maintain an issue comment audit log matching verified repository state (e.g. tracking non-queue merges such as `bootc-installer` and external human contributor PRs).
 
+### External-capacity correction (2026-08-14)
+
+The prior “no external capacity” framing is stale. Two verified human-authored
+docs PRs merged on 2026-08-14 ([docs#234](https://github.com/tuna-os/docs/pull/234)
+and [docs#239](https://github.com/tuna-os/docs/pull/239)), demonstrating a
+docs-channel contribution path. For #272/#1123, preserve the conclusion only
+with the narrower evidence statement **“no core-code capacity”**; do not cite
+“no external capacity.” Contribution activity is not adopter evidence and must
+remain separate from the Q4 adoption metrics. See #1714.
+
 ---
 
 ## Escalation Path (#1657)


### PR DESCRIPTION
Closes #1714

## What changed
- document the verified 2026-08-14 docs contribution conversion loop and re-baseline Hacktoberfest planning around net usable tasks
- add merged external-human contribution evidence to the Q4 adoption metrics plan, while keeping it distinct from adopter evidence
- correct the Q3 checkpoint framing from “no external capacity” to “no core-code capacity”

## Validation
- `git diff --check`
- verified docs#234 and docs#239 are merged and human-authored via GitHub metadata