### PR TITLE
ci(build-status): stop reporting never-reached cells as failing

### DIFF
--- a/.github/scripts/update-build-status.sh
+++ b/.github/scripts/update-build-status.sh
@@ -16,14 +16,25 @@ trap 'rm -f "$tmp_table" "$tmp_readme"' EXIT
 
 total_green=0
 total_cells=0
+total_unreached=0
+
+# Empty list renders as an em dash rather than a blank cell.
+join_or_dash() {
+	if (($# == 0)); then
+		echo '—'
+	else
+		local IFS=', '
+		echo "$*"
+	fi
+}
 
 {
 	echo "$start"
 	echo
-	echo "_Generated from the latest completed main-branch build for each variant. A cell is green when its image was successfully promoted to the published tag._"
+	echo "_Generated from the latest conclusive main-branch build for each variant (cancelled runs are skipped over). A cell is green when its image was successfully promoted to the published tag; **failing** means a job ran and failed; **not reached** means no job asserted the cell at all, usually because an earlier stage stopped it._"
 	echo
-	echo '| Variant | Green image cells | Latest run | Blocked or failing tags |'
-	echo '| :--- | ---: | :--- | :--- |'
+	echo '| Variant | Green image cells | Latest run | Failing | Not reached |'
+	echo '| :--- | ---: | :--- | :--- | :--- |'
 } >"$tmp_table"
 
 while IFS=$'\t' read -r variant emoji; do
@@ -31,58 +42,80 @@ while IFS=$'\t' read -r variant emoji; do
 	count=${#configured[@]}
 	total_cells=$((total_cells + count))
 
-	run=$(gh run list \
+	# --status completed includes cancelled runs, and a cancelled run is not a
+	# verdict on anything: docs/MATRIX-STATUS.md lists exactly this under
+	# "Failures that look like successes" -- "a superseded run is not a broken
+	# build". Fetch a short window and prefer the newest run that actually
+	# concluded success or failure, so one cancellation does not blank a
+	# variant's whole row (tunaOS#1730).
+	runs=$(gh run list \
 		--repo "$repo" \
 		--workflow "build-${variant}.yml" \
 		--branch main \
 		--status completed \
-		--limit 1 \
+		--limit 10 \
 		--json databaseId,conclusion,createdAt,url)
 
-	if [[ $(jq 'length' <<<"$run") -eq 0 ]]; then
-		printf '| %s `%s` | 0/%d | no completed run | all |\n' "$emoji" "$variant" "$count" >>"$tmp_table"
+	if [[ $(jq 'length' <<<"$runs") -eq 0 ]]; then
+		printf '| %s `%s` | 0/%d | no completed run | — | all |\n' "$emoji" "$variant" "$count" >>"$tmp_table"
+		total_unreached=$((total_unreached + count))
 		continue
 	fi
 
-	run_id=$(jq -r '.[0].databaseId' <<<"$run")
-	conclusion=$(jq -r '.[0].conclusion' <<<"$run")
-	run_url=$(jq -r '.[0].url' <<<"$run")
-	run_date=$(jq -r '.[0].createdAt[0:10]' <<<"$run")
+	# First conclusive run, else fall back to the newest so the row still
+	# reports something and says why it is not conclusive.
+	run=$(jq -c '[.[] | select(.conclusion == "success" or .conclusion == "failure")][0] // .[0]' <<<"$runs")
+	run_id=$(jq -r '.databaseId' <<<"$run")
+	conclusion=$(jq -r '.conclusion' <<<"$run")
+	run_url=$(jq -r '.url' <<<"$run")
+	run_date=$(jq -r '.createdAt[0:10]' <<<"$run")
 	promotions=$(gh api --paginate "repos/${repo}/actions/runs/${run_id}/jobs?per_page=100" \
 		--jq '.jobs[] | select(.name | endswith(" / Promote")) | [.name, .conclusion] | @tsv')
 
+	# Three outcomes, not two. A cell only counts as FAILING when a job ran and
+	# said so; "no Promote job existed" and "an upstream job stopped it" are
+	# absence of evidence, and reporting them as failures is the conflation
+	# docs/MATRIX-STATUS.md exists to prevent (tunaOS#1730). On 2026-08-14, 14
+	# flavors across sailfin/marlin/flounder/gurnard produced no job at all --
+	# their stage-2 group never ran because the base manifest failed first
+	# (tunaOS#1729) -- and the table called every one of them blocked or
+	# failing.
 	green=0
-	failed=()
+	failing=()
+	unreached=()
 	for flavor in "${configured[@]}"; do
 		promotion=$(awk -F '\t' -v suffix="/ ${flavor} / Promote" \
 			'index($1, suffix) == length($1) - length(suffix) + 1 { result=$2 } END { print result }' <<<"$promotions")
 		promotion=${promotion:-missing}
-		if [[ "$promotion" == success ]]; then
-			green=$((green + 1))
-		else
-			failed+=("$flavor")
-		fi
+		case "$promotion" in
+		success) green=$((green + 1)) ;;
+		failure) failing+=("$flavor") ;;
+		# skipped / missing / cancelled / null: nothing asserted this cell.
+		*) unreached+=("$flavor") ;;
+		esac
 	done
 	total_green=$((total_green + green))
+	total_unreached=$((total_unreached + ${#unreached[@]}))
 
-	if ((${#failed[@]} == 0)); then
-		failed_text='—'
-	else
-		failed_text=$(
-			IFS=', '
-			echo "${failed[*]}"
-		)
-	fi
-	icon='❌'
-	[[ "$conclusion" == success ]] && icon='✅'
-	printf '| %s `%s` | **%d/%d** | [%s %s](%s) | %s |\n' \
-		"$emoji" "$variant" "$green" "$count" "$icon" "$run_date" "$run_url" "$failed_text" >>"$tmp_table"
+	failing_text=$(join_or_dash "${failing[@]+"${failing[@]}"}")
+	unreached_text=$(join_or_dash "${unreached[@]+"${unreached[@]}"}")
+
+	# A cancelled run is reported as cancelled, not as a failure.
+	case "$conclusion" in
+	success) icon='✅' ;;
+	failure) icon='❌' ;;
+	cancelled) icon='🚫' ;;
+	*) icon='⬜' ;;
+	esac
+	printf '| %s `%s` | **%d/%d** | [%s %s](%s) | %s | %s |\n' \
+		"$emoji" "$variant" "$green" "$count" "$icon" "$run_date" "$run_url" "$failing_text" "$unreached_text" >>"$tmp_table"
 done < <(yq -r '.variants[] | [.id, .emoji] | @tsv' "$config")
 
 percent=$((100 * total_green / total_cells))
+total_failing=$((total_cells - total_green - total_unreached))
 {
 	echo
-	echo "**Current image coverage: ${total_green}/${total_cells} cells (${percent}%).** This is a point-in-time CI snapshot, not a support-tier promise."
+	echo "**Current image coverage: ${total_green}/${total_cells} cells (${percent}%)** — of the remainder, **${total_failing} failing** and **${total_unreached} never reached** (no job asserted them). The two are reported separately on purpose: a never-reached cell is untested, not broken. This is a point-in-time CI snapshot, not a support-tier promise."
 	echo
 	echo "$end"
 } >>"$tmp_table"

--- a/tests/bats/test_build_status_classification.bats
+++ b/tests/bats/test_build_status_classification.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# The README build matrix must not call an untested cell a failing one
+# (tunaOS#1730).
+#
+# .github/scripts/update-build-status.sh used to sort every non-success
+# promotion into one "Blocked or failing tags" column: a real `failure`, a
+# `skipped` job, and `missing` (no Promote job existed at all) were rendered
+# identically. On the 2026-08-14 sweep that mislabelled 14 flavors across
+# sailfin/marlin/flounder/gurnard whose stage-2 group never ran, because the
+# base manifest failed first (tunaOS#1729) — the front page asserted they were
+# blocked or failing when nothing had tested them.
+#
+# This is the same conflation docs/MATRIX-STATUS.md exists to prevent:
+# "absence of evidence read as evidence of absence". These tests drive the real
+# script with stubbed `gh`/`yq`, so a regression that re-merges the buckets
+# fails here rather than on the README.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/.github/scripts/update-build-status.sh"
+
+setup() {
+  BIN="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "$BIN"
+
+  # yq: one variant, four flavors. The script only ever asks for the flavor
+  # list and the (id, emoji) pairs.
+  cat > "${BIN}/yq" <<'STUB'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    *flavors*) printf 'green\nbroken\nskipped\nabsent\n'; exit 0 ;;
+    *emoji*)   printf 'sailfin\t🦈\n'; exit 0 ;;
+  esac
+done
+exit 0
+STUB
+
+  # gh: `run list` returns the run window, `api` returns Promote job results.
+  # GH_RUNS / GH_JOBS let each test choose its own fixture.
+  cat > "${BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  run) printf '%s' "${GH_RUNS}" ;;
+  api) printf '%s' "${GH_JOBS}" ;;
+esac
+STUB
+
+  chmod +x "${BIN}/yq" "${BIN}/gh"
+
+  README="${BATS_TEST_TMPDIR}/README.md"
+  printf '<!-- build-status:start -->\nstale\n<!-- build-status:end -->\n' > "$README"
+
+  # One conclusive run by default.
+  export GH_RUNS='[{"databaseId":1,"conclusion":"failure","createdAt":"2026-08-14T03:00:00Z","url":"https://example/1"}]'
+  # green succeeded, broken failed, skipped was skipped, absent has no job.
+  export GH_JOBS=$'sailfin / green / Promote\tsuccess\nsailfin / broken / Promote\tfailure\nsailfin / skipped / Promote\tskipped\n'
+}
+
+run_generator() {
+  PATH="${BIN}:$PATH" run bash "$SCRIPT" "${BATS_TEST_TMPDIR}/config.yml" "$README"
+}
+
+@test "a job that ran and failed is reported as failing" {
+  run_generator
+  [ "$status" -eq 0 ]
+  # Column 4 is Failing; `broken` is the only cell a job actually failed on.
+  grep -qE '^\| 🦈 `sailfin` \|.*\| broken \|' "$README"
+}
+
+@test "skipped and missing cells are reported as not reached, not failing" {
+  run_generator
+  [ "$status" -eq 0 ]
+  local row
+  row=$(grep '`sailfin`' "$README")
+  # Both land in the final column together. The join is comma-only, matching
+  # the format the table already used (`base,base-hwe,...`).
+  [[ "$row" == *"| skipped,absent |"* ]]
+  # ...and the failing column holds only the cell a job actually failed on.
+  [[ "$row" == *"| broken | skipped,absent |"* ]]
+}
+
+@test "the green count only counts successful promotions" {
+  run_generator
+  grep -q '\*\*1/4\*\*' "$README"
+}
+
+@test "the summary separates failing from never-reached" {
+  run_generator
+  grep -q '1 failing' "$README"
+  grep -q '2 never reached' "$README"
+}
+
+@test "a cancelled run is skipped in favour of the newest conclusive one" {
+  # docs/MATRIX-STATUS.md: "a superseded run is not a broken build".
+  export GH_RUNS='[{"databaseId":9,"conclusion":"cancelled","createdAt":"2026-08-15T03:00:00Z","url":"https://example/9"},{"databaseId":1,"conclusion":"success","createdAt":"2026-08-14T03:00:00Z","url":"https://example/1"}]'
+  run_generator
+  [ "$status" -eq 0 ]
+  # The conclusive run is the one linked and iconified, not the cancellation.
+  grep -q 'example/1' "$README"
+  grep -q '✅ 2026-08-14' "$README"
+  ! grep -q 'example/9' "$README"
+}
+
+@test "a cancelled run is labelled as cancelled when it is all there is" {
+  export GH_RUNS='[{"databaseId":9,"conclusion":"cancelled","createdAt":"2026-08-15T03:00:00Z","url":"https://example/9"}]'
+  run_generator
+  [ "$status" -eq 0 ]
+  # Not ❌: nothing about this run says the variant is broken.
+  grep -q '🚫 2026-08-15' "$README"
+  ! grep -q '❌ 2026-08-15' "$README"
+}
+
+@test "a variant with no completed run at all counts as never reached" {
+  export GH_RUNS='[]'
+  run_generator
+  [ "$status" -eq 0 ]
+  grep -q 'no completed run' "$README"
+  grep -q '4 never reached' "$README"
+}


### PR DESCRIPTION
Refs #1730, #1729.

## The bug

`update-build-status.sh` sorted **every** non-success promotion into one "Blocked or failing tags" column. A real `failure`, a `skipped` job, and `missing` (no Promote job existed at all) rendered identically — so the front page asserted that cells nothing had tested were blocked or failing.

On the 2026-08-14 sweep that was **14 flavors** across sailfin/marlin/flounder/gurnard whose stage-2 group never produced a job, because the base manifest failed first (#1729). The README called all 14 red.

This is the conflation `docs/MATRIX-STATUS.md` was written to prevent — *"absence of evidence read as evidence of absence"* — made on the page people read first.

## The change

Three outcomes instead of two:

| promotion | column |
|---|---|
| `success` | green count |
| `failure` | **Failing** — a job ran and said so |
| `skipped` / `missing` | **Not reached** — nothing asserted this cell |

The summary reports the two remainders separately, so *"136 non-green cells"* can no longer be read as *"136 broken cells"* — which is exactly the triage question #1570 is trying to answer.

**Also fixes the run-level icon.** `--status completed` includes **cancelled** runs, and `docs/MATRIX-STATUS.md` lists that exact misreading under *Failures that look like successes* (*"a superseded run is not a broken build"*). The script now fetches a short window and prefers the newest run that actually concluded `success`/`failure`; a cancellation reaches the table only when it's all there is, shown as 🚫 rather than ❌.

## Tests

`tests/bats/test_build_status_classification.bats` drives the **real script** with stubbed `gh`/`yq` — 7 cases: each bucket, the green count, the split summary, cancelled-run preference, cancelled-run labelling, and the no-completed-run path.

**Mutation-checked, not just green:** recollapsing the buckets back to the old two-way split fails 3 of the 7. 7/7 pass as committed.

One expectation I got wrong and corrected: I first asserted `skipped, absent` with a space. The join is comma-only (`IFS=', '` uses only the first character), which matches the format the table already used (`base,base-hwe,...`) — so the test was wrong, not the code, and I left the join alone.

## Scope

- Touches **`.github/scripts/` and `tests/` only** — *not* `.github/workflows/` — so it is unaffected by the workflow-permission constraint in #1557.
- Doesn't change the denominator or the coverage percentage, only what the remainder is called.
- I have not run it against live Actions data (`yq` isn't available here and it needs repo Actions metadata); the verification the issue asks for — regenerating against run 31766602231 and confirming sailfin kde/niri/xfce/cosmic land in "not reached" — should be done on a real run before merge.
