### PR TITLE
fix(ci): retry promotion copies, unbreak pytest collection, bound the non-blocking attestation

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -1001,8 +1001,30 @@ jobs:
           path: supply-chain/sboms
 
       - name: Attest SPDX SBOMs
+        # A hard ceiling on the whole step, because SIGN_DEADLINE_MINUTES is a
+        # budget PER cosign INVOCATION, not per step: the loop below runs
+        # `cosign attest` + `cosign verify-attestation` for every platform
+        # digest, and each call starts its own deadline. Slow-but-eventually-
+        # succeeding calls therefore multiply -- on gurnard run 31891742138
+        # this step was still going 48 minutes into a nominal "40 minute"
+        # budget, and a three-platform variant could reach 40m x 6. The env
+        # deadline governs one call; this governs the step.
+        timeout-minutes: 20
         env:
-          SIGN_DEADLINE_MINUTES: "40"
+          # Deliberately much shorter than Sign's 40m. Splitting this job off
+          # (#1560) took SBOM attestation off Promote's critical path, but not
+          # off the *clock*: build-variant.yml's stage 2 waits for the whole
+          # reusable-workflow call to finish, and this job is part of it. On
+          # the run above `pantheon` had still not started 48 minutes after
+          # base's images were built, signed and manifested -- held up purely
+          # by an attestation the pipeline is explicitly allowed to do without.
+          #
+          # 10m is far longer than any successful attestation (image signing
+          # completed in 19s on that same run) so genuine flakes are absorbed;
+          # what it stops absorbing is a sustained outage, which is exactly the
+          # case where continuing without the attestation is the intended
+          # behaviour.
+          SIGN_DEADLINE_MINUTES: "10"
           SIGN_BACKOFF_CAP_SECONDS: "120"
         run: |
           set -euo pipefail

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -1288,6 +1288,7 @@ jobs:
           MAJOR_VERSION: ${{ env.MAJOR_VERSION }}
           ALL_PLATFORMS_BUILT: ${{ needs.manifest.outputs.all_platforms_built }}
           INPUT_PLATFORMS: ${{ inputs.platforms }}
+          MAX_RETRIES: 4
         run: |
           set -ex
           # Promote the verified -testing manifest to the bare tags users
@@ -1296,22 +1297,52 @@ jobs:
 
           DATE_TAG="$(date +%Y%m%d)"
 
+          # Every promotion below is a blob-for-blob re-upload to GHCR, and
+          # GHCR drops upload sessions under load: run 31891742138 (gurnard)
+          # failed the whole Promote job on
+          #   writing blob: uploading layer to https://ghcr.io/v2/tuna-os/elementary/
+          #   blobs/upload/2.fbd191d4-...: blob upload unknown
+          # on the *sixth* copy, after five had already succeeded. Under
+          # `set -e` that leaves the flavor half-promoted -- the canonical
+          # tags written, one alias missing -- and the run red for a fault
+          # that clears on the next attempt.
+          #
+          # The rest of this workflow already retries the two other network
+          # legs (base pull, GHCR push); the promotion copies were the one
+          # bare path left. skopeo copy to the same destination is idempotent,
+          # so a retry after a partial upload is safe: blobs that landed are
+          # skipped by digest and only the failed one is re-sent.
+          copy_retry() {
+            local dest="$1" i
+            for i in $(seq "${MAX_RETRIES}"); do
+              if sudo skopeo copy --all "docker://${SOURCE_IMAGE}" "docker://${dest}"; then
+                return 0
+              fi
+              if [ "$i" -lt "${MAX_RETRIES}" ]; then
+                echo "::warning::promotion copy to ${dest} failed (attempt ${i}/${MAX_RETRIES}); retrying in $((i * 15))s..."
+                sleep $((i * 15))
+              fi
+            done
+            echo "::error::promotion copy to ${dest} failed after ${MAX_RETRIES} attempts."
+            return 1
+          }
+
           if [ "${ALL_PLATFORMS_BUILT}" = "true" ]; then
             echo "All default platforms built and boot gate passed - promoting"
 
             # Tag with flavor only
-            sudo skopeo copy --all "docker://${SOURCE_IMAGE}" "docker://${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}"
+            copy_retry "${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}"
 
             # Tag with flavor-date
-            sudo skopeo copy --all "docker://${SOURCE_IMAGE}" "docker://${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${DATE_TAG}"
+            copy_retry "${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${DATE_TAG}"
 
             # Tag each platform with flavor-arch and flavor-arch-date
             IFS=',' read -r -a PLATFORMS <<< "${INPUT_PLATFORMS}"
             for platform in "${PLATFORMS[@]}"; do
               arch="${platform#linux/}"
               arch="${arch//\//-}"
-              sudo skopeo copy --all "docker://${SOURCE_IMAGE}" "docker://${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${arch}"
-              sudo skopeo copy --all "docker://${SOURCE_IMAGE}" "docker://${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${arch}-${DATE_TAG}"
+              copy_retry "${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${arch}"
+              copy_retry "${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${arch}-${DATE_TAG}"
             done
 
             # Friendly aliases: the same digest under a name users can guess
@@ -1325,8 +1356,8 @@ jobs:
                 alias_name="$(echo "${alias_name}" | tr -d '[:space:]')"
                 [ -n "${alias_name}" ] || continue
                 echo "Publishing alias ${alias_name}:${DEFAULT_TAG}"
-                sudo skopeo copy --all "docker://${SOURCE_IMAGE}" "docker://${IMAGE_REGISTRY}/${alias_name}:${DEFAULT_TAG}"
-                sudo skopeo copy --all "docker://${SOURCE_IMAGE}" "docker://${IMAGE_REGISTRY}/${alias_name}:${DEFAULT_TAG}-${DATE_TAG}"
+                copy_retry "${IMAGE_REGISTRY}/${alias_name}:${DEFAULT_TAG}"
+                copy_retry "${IMAGE_REGISTRY}/${alias_name}:${DEFAULT_TAG}-${DATE_TAG}"
               done
             fi
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,29 @@
+# Two test files may share a basename without colliding.
+#
+# With pytest's default "prepend" import mode and no __init__.py in tests/,
+# a test file's module name is just its basename. tests/test_desktop_verify.py
+# (#1424, 08-13) and tests/pytest/test_desktop_verify.py (#1526, 08-14) are
+# separate suites for the same script, written a day apart, and the second one
+# to be imported raised
+#
+#     import file mismatch: imported module 'test_desktop_verify' has this
+#     __file__ attribute: .../tests/pytest/test_desktop_verify.py
+#
+# which pytest treats as a COLLECTION error, not a test failure: the whole run
+# is interrupted and exits 2. No pytest test ran in CI between 2026-08-14 and
+# this commit -- the Unit Tests job was red on every PR and on main, and the
+# coverage artifact was silently never uploaded ("No files were found with the
+# provided path: coverage-python.xml").
+#
+# importlib mode derives a unique module name from the full path instead of the
+# basename, so the collision cannot happen again for any future pair. It is
+# also the mode that does not mutate sys.path, which nothing here relies on:
+# no test imports a sibling test module, and the one sys.path.insert in the
+# tree (tests/pytest/test_desktop_verify.py) is explicit and self-contained.
+#
+# Deliberately not fixed by deleting one of the two files: they are different
+# suites by different authors and picking a winner is a call for whoever owns
+# them, not a side effect of unbreaking collection.
+[pytest]
+addopts = --import-mode=importlib
+testpaths = tests

--- a/tests/python/test_generate_boot_report.py
+++ b/tests/python/test_generate_boot_report.py
@@ -19,8 +19,11 @@ import pytest
 
 # ── Module loading (env-first, hyphenated filename) ────────────────────
 
-os.environ.setdefault("GITHUB_REPOSITORY", "tuna-os/tunaos")
-os.environ.setdefault("REPORT_DATE", "2026-08-10")
+# Assigned, not setdefault -- see the note in tests/test_boot_report_gh.py.
+# Under Actions GITHUB_REPOSITORY is already set, so setdefault silently hands
+# the module the real repository instead of this fixture.
+os.environ["GITHUB_REPOSITORY"] = "tuna-os/tunaos"
+os.environ["REPORT_DATE"] = "2026-08-10"
 
 _SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "generate-boot-report.py"
 _spec = importlib.util.spec_from_file_location("generate_boot_report", _SCRIPT)

--- a/tests/test_boot_report_gh.py
+++ b/tests/test_boot_report_gh.py
@@ -29,9 +29,16 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-os.environ.setdefault("GITHUB_REPOSITORY", "tuna-os/tunaos")
-os.environ.setdefault("REPORT_DATE", "2026-08-10")
-os.environ.setdefault("PREVIOUS_BRANCH", "boot/2026-08-03")
+# Assigned, not setdefault. These three are the module's entire configuration,
+# read once at import, and setdefault yields to whatever the environment
+# already has -- which under Actions means GITHUB_REPOSITORY arrives as the
+# real "tuna-os/tunaOS" instead of the fixture below. The suite then passed
+# locally (where the var is unset) and failed in CI on nothing but the capital
+# O. That went unnoticed because a collection error was aborting the whole
+# pytest run before these tests executed at all; see pytest.ini.
+os.environ["GITHUB_REPOSITORY"] = "tuna-os/tunaos"
+os.environ["REPORT_DATE"] = "2026-08-10"
+os.environ["PREVIOUS_BRANCH"] = "boot/2026-08-03"
 
 _SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "generate-boot-report.py"
 _spec = importlib.util.spec_from_file_location("generate_boot_report_gh", _SCRIPT)
@@ -365,7 +372,7 @@ class TestRenderComboRowScreenshots(unittest.TestCase):
         self.assertIn("✨ changed", row)
         self.assertIn("= same", row)
         self.assertIn(f"ghcr.io/{gbr.REPO_OWNER}/yellowfin:gnome", row)
-        self.assertIn("[run](https://github.com/tuna-os/tunaos/actions/runs/7)", row)
+        self.assertIn(f"[run](https://github.com/{gbr.REPO}/actions/runs/7)", row)
 
     def test_row_without_screenshots(self):
         combo = _combo()

--- a/tests/test_promote_retries_skopeo_copy.py
+++ b/tests/test_promote_retries_skopeo_copy.py
@@ -1,0 +1,160 @@
+"""Promotion copies must survive a dropped GHCR upload session.
+
+Promote is the last thing that happens to a variant, and it is six to
+sixteen full blob-for-blob re-uploads to GHCR back to back. On run
+31891742138 (gurnard, 2026-08-15) five of them succeeded and the sixth --
+the `elementary` alias -- died on::
+
+    copying image 2/2 from manifest list: writing blob: uploading layer to
+    https://ghcr.io/v2/tuna-os/elementary/blobs/upload/2.fbd191d4-...:
+    blob upload unknown
+
+GHCR had dropped the upload session. Under `set -e` that failed the job with
+the canonical tags already written and one alias missing, and it was the
+*first* thing to fail there in weeks -- Promote had been skipped wholesale
+by the Sigstore outage (#1560) until the sign/attest split let it run at
+all, so this surface had simply never been exercised.
+
+The workflow already retries the two other network legs it depends on: the
+base-image pull and the GHCR push. The promotion copies were the one bare
+path left, which is what these tests pin.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/reusable-build-image.yml"
+
+STEP = "Pull Image and Apply Tags"
+
+
+@pytest.fixture(scope="module")
+def promote_step():
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    steps = workflow["jobs"]["tag-image"]["steps"]
+    return next(s for s in steps if s.get("name") == STEP)
+
+
+def test_no_promotion_copy_is_unguarded(promote_step):
+    """Every destination goes through the wrapper, not just the one that broke.
+
+    The alias copy failed first only because it runs last; every earlier copy
+    is the same call to the same registry.
+    """
+    body = promote_step["run"]
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or "skopeo copy" not in stripped:
+            continue
+        assert "copy_retry" in body, "no copy_retry helper defined at all"
+        assert "if sudo skopeo copy" in stripped, (
+            f"promotion copy outside the retry helper: {stripped!r}"
+        )
+
+
+def test_the_helper_is_used_for_canonical_tags_and_aliases(promote_step):
+    """A retry that covers only some destinations leaves the same hole."""
+    body = promote_step["run"]
+    calls = re.findall(r"^\s*copy_retry .*$", body, re.M)
+    assert len(calls) >= 6, f"expected every promotion destination wrapped, found {calls}"
+    joined = "\n".join(calls)
+    assert "${alias_name}" in joined, "the alias copies -- the ones that failed -- are not retried"
+    assert "${DEFAULT_TAG}-${arch}" in joined, "the per-arch copies are not retried"
+
+
+# ── The helper's own behaviour, driven directly ───────────────────────────
+
+
+def _harness(promote_step, tmp_path: Path, skopeo_body: str, retries: str = "4"):
+    """Run the real copy_retry from the workflow against a fake skopeo.
+
+    The sleeps are real, so the fixtures below stay at one or two attempts.
+    """
+    body = promote_step["run"]
+    start = body.index("copy_retry() {")
+    end = body.index("\n}\n", start) + len("\n}\n")
+    helper = body[start:end]
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "sudo").write_text('#!/usr/bin/env bash\nexec "$@"\n')
+    (bin_dir / "skopeo").write_text(f"#!/usr/bin/env bash\n{skopeo_body}\n")
+    for f in bin_dir.iterdir():
+        f.chmod(0o755)
+
+    script = tmp_path / "probe.sh"
+    script.write_text(
+        "#!/usr/bin/env bash\nset -euo pipefail\n"
+        f'MAX_RETRIES={retries}\nSOURCE_IMAGE="ghcr.io/tuna-os/gurnard:latest-testing"\n'
+        f"{helper}\n"
+        'copy_retry "ghcr.io/tuna-os/elementary:latest" && echo PROMOTED\n'
+    )
+    return subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env={"PATH": f"{bin_dir}:/usr/bin:/bin"},
+        timeout=180,
+    )
+
+
+def test_a_dropped_upload_session_is_retried(promote_step, tmp_path):
+    """The gurnard failure, replayed: fail once, succeed on the retry."""
+    marker = tmp_path / "attempts"
+    proc = _harness(
+        promote_step,
+        tmp_path,
+        textwrap.dedent(
+            f"""\
+            n=0
+            [[ -f "{marker}" ]] && n=$(cat "{marker}")
+            n=$((n + 1)); echo "$n" > "{marker}"
+            if [[ "$n" -lt 2 ]]; then
+              echo 'level=fatal msg="copying image 2/2 from manifest list: writing blob: uploading layer to https://ghcr.io/v2/tuna-os/elementary/blobs/upload/2.fbd191d4: blob upload unknown"' >&2
+              exit 1
+            fi
+            """
+        ),
+    )
+    assert proc.returncode == 0, f"a recoverable copy still failed Promote: {proc.stderr!r}"
+    assert "PROMOTED" in proc.stdout
+    assert marker.read_text().strip() == "2"
+
+
+def test_exhaustion_still_fails_the_job(promote_step, tmp_path):
+    """A retry that swallows a real outage is worse than no retry.
+
+    If every attempt fails, the bare tag was not written and Promote must say
+    so -- otherwise users pull a tag that silently still points at yesterday.
+    """
+    proc = _harness(
+        promote_step,
+        tmp_path,
+        'echo "blob upload unknown" >&2; exit 1',
+        retries="2",
+    )
+    assert proc.returncode != 0, "every attempt failed and copy_retry reported success"
+    assert "PROMOTED" not in proc.stdout
+    assert "::error::" in proc.stdout + proc.stderr, "exhaustion is not surfaced as an error"
+
+
+def test_the_helper_does_not_sleep_after_its_last_attempt(promote_step, tmp_path):
+    """Dead sleep at the end buys nothing and lengthens every red run.
+
+    The same defect cosign-retry.sh carried before #1748; pinned here so the
+    two retry paths do not drift apart.
+    """
+    proc = _harness(promote_step, tmp_path, "exit 1", retries="1")
+    assert proc.returncode != 0
+    assert "retrying in" not in proc.stdout + proc.stderr, (
+        "a single-attempt budget still slept before giving up"
+    )

--- a/tests/test_sign_step_retries_cosign.py
+++ b/tests/test_sign_step_retries_cosign.py
@@ -83,26 +83,83 @@ def test_every_cosign_invocation_goes_through_the_retry_helper(workflow):
                     )
 
 
+def _deadline(workflow, job_name, step_name) -> int:
+    job = workflow["jobs"][job_name]
+    step = next(s for s in job["steps"] if s.get("name") == step_name)
+    env = step.get("env") or {}
+    assert "SIGN_DEADLINE_MINUTES" in env, (
+        f"{job_name}/{step_name} does not set SIGN_DEADLINE_MINUTES"
+    )
+    assert "MAX_RETRIES" not in env, (
+        f"{job_name}/{step_name} still carries the old MAX_RETRIES budget"
+    )
+    return int(env["SIGN_DEADLINE_MINUTES"])
+
+
 def test_the_retry_budget_is_a_deadline_not_an_attempt_count(workflow):
     """An attempt count silently changes duration whenever a call gets slower.
 
     Run 31858324517 is the counter-example: six attempts read like a long
     budget and delivered 16 minutes against a longer outage.
     """
-    for job_name, step_name, run in _cosign_run_blocks(workflow):
-        job = workflow["jobs"][job_name]
-        step = next(s for s in job["steps"] if s.get("name") == step_name)
-        env = step.get("env") or {}
-        assert "SIGN_DEADLINE_MINUTES" in env, (
-            f"{job_name}/{step_name} does not set SIGN_DEADLINE_MINUTES"
-        )
-        assert int(env["SIGN_DEADLINE_MINUTES"]) >= 30, (
-            f"{job_name}/{step_name}: deadline {env['SIGN_DEADLINE_MINUTES']}m is "
-            "shorter than outages already observed in production"
-        )
-        assert "MAX_RETRIES" not in env, (
-            f"{job_name}/{step_name} still carries the old MAX_RETRIES budget"
-        )
+    for job_name, step_name, _ in _cosign_run_blocks(workflow):
+        _deadline(workflow, job_name, step_name)
+
+
+def test_a_blocking_cosign_step_waits_out_a_real_outage(workflow):
+    """Signing gates promotion, so giving up early throws away a whole build."""
+    assert _deadline(workflow, "sign", "Sign images") >= 30, (
+        "the image-signing deadline is shorter than outages already observed "
+        "in production, and Promote requires it"
+    )
+
+
+def test_a_non_blocking_cosign_step_gives_up_much_sooner(workflow):
+    """Off the critical path still costs wall-clock, and that has to be cheap.
+
+    attest_sbom is continue-on-error and absent from Promote's needs, but
+    build-variant.yml's stage 2 waits for the entire reusable-workflow call --
+    this job included. On gurnard run 31891742138 `pantheon` sat idle while a
+    non-blocking attestation burned its budget against a Rekor outage. With a
+    40m deadline a four-stage chain spends ~2h40m per variant waiting for an
+    artifact it is explicitly allowed to do without.
+    """
+    attest = _deadline(workflow, "attest_sbom", "Attest SPDX SBOMs")
+    sign = _deadline(workflow, "sign", "Sign images")
+    assert attest < sign, (
+        f"attest_sbom waits {attest}m, as long as blocking signing -- a "
+        "transparency-log outage stalls every downstream stage for it"
+    )
+    assert attest <= 15, (
+        f"attest_sbom's {attest}m deadline is charged to every later stage's "
+        "wall clock during an outage"
+    )
+    # Long enough that an ordinary flake is still absorbed: image signing
+    # completed in 19s on the run above.
+    assert attest >= 5, f"{attest}m is too short to ride out an ordinary flake"
+
+
+def test_the_non_blocking_step_has_a_ceiling_the_env_deadline_cannot_give_it(workflow):
+    """SIGN_DEADLINE_MINUTES bounds one cosign call, not the step.
+
+    The attest loop runs `cosign attest` + `cosign verify-attestation` per
+    platform digest and each call starts its own deadline, so the step's real
+    worst case is deadline x 2 x platforms. Run 31891742138 is the proof: the
+    step was still running 48 minutes into a nominal 40-minute budget. Only a
+    step-level timeout bounds the thing stage 2 is actually waiting on.
+    """
+    attest = workflow["jobs"]["attest_sbom"]
+    step = next(s for s in attest["steps"] if s.get("name") == "Attest SPDX SBOMs")
+    ceiling = step.get("timeout-minutes")
+    assert ceiling, (
+        "the attest step has no timeout-minutes, so its duration is "
+        "deadline x 2 x platforms with nothing bounding the total"
+    )
+    per_call = int(step["env"]["SIGN_DEADLINE_MINUTES"])
+    assert per_call <= int(ceiling), (
+        f"a {per_call}m per-call deadline cannot fit inside a {ceiling}m step "
+        "ceiling, so even one slow call trips the timeout"
+    )
 
 
 # ── The promotion contract ────────────────────────────────────────────────


### PR DESCRIPTION
Three faults, all found by watching gurnard [run 31891742138](https://github.com/tuna-os/tunaOS/actions/runs/31891742138) — the first run in weeks where Promote actually executed, after #1748 unblocked it. Each one was invisible until the one before it was fixed.

---

## 1. Promotion copies had no retry

`Manifest` ✅, `Sign` ✅ in 19s, then Promote:

```
level=fatal msg="copying image 2/2 from manifest list: writing blob: uploading layer to
https://ghcr.io/v2/tuna-os/elementary/blobs/upload/2.fbd191d4-...: blob upload unknown"
```

GHCR dropped the upload session on the **sixth** copy, after five had succeeded. Under `set -e` that leaves the flavor half-promoted — canonical tags written, one alias missing.

Promote is six to sixteen full blob-for-blob re-uploads back to back, and every one was a bare `skopeo copy`. The workflow already retries its two other network legs (base-image pull, GHCR push); this was the one bare path left. `copy_retry()` now wraps all six destinations — canonical, dated, per-arch, per-arch-dated, and both alias forms. `skopeo copy` to the same destination is idempotent, so a retry after a partial upload re-sends only the blob that failed.

Exhausting the budget stays a hard failure. A `copy_retry` that returned 0 after four failures would leave users pulling a bare `:latest` that silently still points at yesterday — worse than a red run.

## 2. No pytest test has run in CI since 2026-08-14

Not caused by this branch — `main` is red the same way, which is how I found it.

`tests/test_desktop_verify.py` (#1424, 08-13) and `tests/pytest/test_desktop_verify.py` (#1526, 08-14) are two independent suites for the same script that happen to share a filename. With no `__init__.py`, pytest names modules by basename, so the second import raises `import file mismatch` — a **collection** error, not a test failure. The run is interrupted and exits 2 before a single test executes.

Two consequences worth naming:

- Unit Tests has been red on `main` and on every PR for a day, so nothing merged in that window was actually tested.
- The coverage artifact silently never uploaded (`No files were found with the provided path: coverage-python.xml`), which is part of why the README reports low coverage.

`pytest.ini` sets `--import-mode=importlib`, which derives module names from the full path so no future pair can collide either. Collection goes from `367 items / 1 error` to **382 collected**. Deliberately *not* fixed by deleting one of the two files — they're different suites by different authors, and picking a winner is their call, not a side effect of unbreaking collection.

## 3. `attest_sbom` is off Promote's dependency path but not off its clock

#1560 split SBOM attestation out so a Rekor outage couldn't skip Promote. It still stalls everything downstream: `build-variant.yml`'s stage 2 waits for the whole reusable-workflow call, this job included.

On that run, `Sign` succeeded in **19 seconds** and `Attest SPDX SBOMs` was still running **57 minutes** later, with `pantheon` unable to start — for an artifact the job is explicitly allowed to fail to produce. (Sign passing while attest hangs is the same asymmetry seen on albacore in #1560: attest uploads a whole SBOM predicate, not just a signature. Attestation is systematically the fragile call, not randomly unlucky.)

Two bounds, because they bound different things:

| | value | governs |
|---|---|---|
| `SIGN_DEADLINE_MINUTES` | 40 → **10** | one cosign call |
| `timeout-minutes` | **20** (new) | the step |

The env deadline alone cannot bound the step: the loop runs `cosign attest` **plus** `cosign verify-attestation` per platform digest, and each call starts a fresh deadline — so the real worst case is `deadline × 2 × platforms`. That is why a "40 minute" budget was still running at 57. Image signing keeps its 40m: it gates promotion, so giving up early throws away a whole build.

## Tests

`tests/test_promote_retries_skopeo_copy.py` lifts `copy_retry` straight out of the workflow — exercising the shipped code, not a copy — and drives it against a fake `skopeo`: the gurnard error replayed and recovered; every attempt failing → non-zero exit, `::error::`, bare tag not claimed; a one-attempt budget not sleeping before it gives up; and static checks that no `skopeo copy` sits outside the wrapper. All five fail against `main`.

`tests/test_sign_step_retries_cosign.py`'s deadline test is split rather than loosened. The old flat `>= 30` couldn't express the distinction that matters, so it now pins three things separately: blocking cosign steps wait out a real outage, non-blocking ones give up sooner, and the non-blocking step carries a ceiling its per-call deadline cannot give it.