### PR TITLE
docs: correct the attestation timing #1766 cites in two places

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -1004,11 +1004,15 @@ jobs:
         # A hard ceiling on the whole step, because SIGN_DEADLINE_MINUTES is a
         # budget PER cosign INVOCATION, not per step: the loop below runs
         # `cosign attest` + `cosign verify-attestation` for every platform
-        # digest, and each call starts its own deadline. Slow-but-eventually-
-        # succeeding calls therefore multiply -- on gurnard run 31891742138
-        # this step was still going 48 minutes into a nominal "40 minute"
-        # budget, and a three-platform variant could reach 40m x 6. The env
-        # deadline governs one call; this governs the step.
+        # digest, and each call starts its own deadline (see cosign_retry --
+        # `deadline` is a local, recomputed on entry). Under `set -e` a
+        # *failing* call aborts the step after one deadline, which is what
+        # gurnard run 31891742138 did: 21 Rekor 502s over 39m19s, then
+        # SIGSTORE_OUTAGE. The unbounded case is calls that SUCCEED slowly --
+        # nothing aborts, and a three-platform variant can reach 40m x 6.
+        # That case has not been observed in production; this ceiling is
+        # here so it cannot be, since the env deadline structurally cannot
+        # bound the step.
         timeout-minutes: 20
         env:
           # Deliberately much shorter than Sign's 40m. Splitting this job off

--- a/tests/test_sign_step_retries_cosign.py
+++ b/tests/test_sign_step_retries_cosign.py
@@ -143,9 +143,14 @@ def test_the_non_blocking_step_has_a_ceiling_the_env_deadline_cannot_give_it(wor
     """SIGN_DEADLINE_MINUTES bounds one cosign call, not the step.
 
     The attest loop runs `cosign attest` + `cosign verify-attestation` per
-    platform digest and each call starts its own deadline, so the step's real
-    worst case is deadline x 2 x platforms. Run 31891742138 is the proof: the
-    step was still running 48 minutes into a nominal 40-minute budget. Only a
+    platform digest and each call starts its own deadline, so the step's worst
+    case is deadline x 2 x platforms.
+
+    That worst case is a code property, not a measured one, and the
+    distinction matters. On run 31891742138 the step took 39m19s -- 21 Rekor
+    502s against a single 40-minute deadline, then SIGSTORE_OUTAGE -- because
+    `set -e` aborts the loop on the first *failing* call. Multiplication needs
+    calls that succeed slowly, one after another, which nothing aborts. Only a
     step-level timeout bounds the thing stage 2 is actually waiting on.
     """
     attest = workflow["jobs"]["attest_sbom"]


### PR DESCRIPTION
Correcting a claim I made in #1766. The change it justified is sound; the evidence I attached to it was wrong, and that evidence is now quoted in a workflow comment and a test docstring where it will be read as fact.

## What I said

> `Attest SPDX SBOMs` was still running **57 minutes** later ... That is why a "40 minute" budget was still running at 57.

I read that as proof that per-invocation deadlines were multiplying, and it became the stated rationale for `timeout-minutes: 20`.

## What the log says

[Job 95033806873](https://github.com/tuna-os/tunaOS/actions/runs/31891742138/job/95033806873):

```
15:48:40  job start
...       21 attempts, every one: Post "https://rekor.sigstore.dev/api/v1/log/entries":
          giving up after 2 attempt(s): status 502 Bad Gateway
16:27:58  ::error::SIGSTORE_OUTAGE: attest still failing after 40m of
          Sigstore unavailability; giving up.
16:27:59  job end                                        -- 39m19s
```

One deadline, honoured exactly. `cosign-retry.sh` did precisely what it was written to do, including emitting the `SIGSTORE_OUTAGE` marker `rerun-infra-failures.yml` greps for.

The 48- and 57-minute figures came from polling the jobs API, which kept returning `in_progress` for a job that had finished at 16:27:59. I trusted the API over the log and should have read the log first.

## What this changes

The ceiling stays, but its justification is narrower and the comments now say so. Each `cosign_retry` does start its own deadline — `deadline` is a local, recomputed on entry — but under `set -e` a **failing** call aborts the step after one, which is the observed case. Multiplication needs calls that *succeed* slowly in sequence, which nothing aborts. That is unobserved in production, so `timeout-minutes` is a structural bound the env deadline cannot provide, not a fix for a measured overrun.

**Unaffected: the 40m → 10m deadline change.** base's manifest was pushed at 15:47:58 and `pantheon` could not start until this job ended at 16:27:59 — ~40 minutes of downstream stall for an artifact the job is explicitly allowed to fail to produce. That part was measured, and it remains the reason for the shorter deadline.

No behaviour change in this PR: comments and a docstring only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_