### PR TITLE
fix(ci): stop a dead SBOM scan taking the whole variant down with it

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -445,13 +445,27 @@ jobs:
           syft-version: v1.39.0
 
       - name: Generate SBOM
+        id: sbom
         if: inputs.sbom && github.event_name != 'pull_request'
-        # Scan the published, immutable platform image. Stable publication is
-        # intentionally fail-closed: an image without its SBOM cannot be
-        # signed or promoted by the supply-chain gate below.
         # Scan the final filesystem view rather than every historical layer:
         # the latter made the Gentoo base job spend its remaining runner time
         # in Syft after the image had already built and pushed (tunaOS#956).
+        #
+        # NOT fail-closed any more, and the distinction matters. The image is
+        # already built, pushed and immutable in GHCR before this step runs --
+        # a failed scan cannot un-publish it. What a hard failure here *did*
+        # do was skip `Create Job Outputs`, which is the step that writes the
+        # digest artifact `Manifest` fans in on. So one dead scan cost the
+        # whole variant: Manifest failed at `Load Outputs`, and Sign, Gate,
+        # Promote and every stage-2 flavor were skipped behind it
+        # (2026-08-16 nightly, guppy run 31921372675).
+        #
+        # An image signature gates promotion; an SBOM does not. That is the
+        # same line drawn for SBOM *attestation* in #1560/#1766, applied one
+        # step earlier to SBOM *generation*. A missing SBOM is still reported
+        # loudly by attest_sbom ("::error::missing SPDX SBOM"), which is
+        # continue-on-error and therefore visible without being fatal.
+        continue-on-error: true
         timeout-minutes: 20
         env:
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
@@ -461,25 +475,59 @@ jobs:
           SAFE_PLATFORM: ${{ matrix.safeplatform }}
           GOMEMLIMIT: 3GiB
           GOGC: "25"
+          # Hard ceiling for the cgroup below. Left generous: the point is to
+          # keep the runner agent alive, not to make the scan frugal.
+          SYFT_MEMORY_MAX: 5G
         run: |
           set -euo pipefail
           IMAGE="${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${SAFE_PLATFORM}"
           OUT="sbom-${IMAGE_NAME}-${DEFAULT_TAG}-${SAFE_PLATFORM}.spdx.json"
-          # timeout-minutes above is enforced by the runner agent, which is
-          # exactly the thing that wedges when syft OOM-thrashes the runner:
-          # on 08-14 (tunaOS#1567) the guppy base job sat in this step for
-          # 51 minutes past its 20-minute limit, died for lost communication
-          # and uploaded no logs. GOMEMLIMIT is advisory, so bound the scan
-          # externally: `timeout` fails the step fast (exit 124), with logs,
-          # while the agent is still healthy enough to report it.
-          timeout --kill-after=30s 18m $SYFT_CMD "$IMAGE" --scope squashed -o spdx-json="$OUT"
+
+          # Two bounds, because the two previous attempts each caught only one
+          # failure mode and the scan has now escaped both:
+          #
+          #   timeout-minutes: 20   enforced by the runner AGENT -- useless
+          #                         precisely when the agent is the casualty.
+          #                         On 08-14 (#1567) the step overran it by 51
+          #                         minutes and uploaded no logs at all.
+          #   timeout 18m           wall-clock, added by #1572. On the 08-16
+          #                         nightly the runner died at 7m56s, well
+          #                         inside it: "The runner has received a
+          #                         shutdown signal."
+          #
+          # Time was never the fault. Memory is: GOMEMLIMIT is advisory, so a
+          # large enough file inventory sails past 3GiB and takes the agent
+          # down with it. A cgroup cap makes the kernel kill syft instead --
+          # a real exit code, with logs, while the agent is still healthy.
+          # The wall-clock bound stays for the orthogonal case of a scan that
+          # is slow rather than hungry.
+          syft_cmd=( timeout --kill-after=30s 18m
+                     "$SYFT_CMD" "$IMAGE" --scope squashed -o spdx-json="$OUT" )
+
+          if command -v systemd-run >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo systemd-run --scope --quiet \
+              --uid="$(id -u)" --gid="$(id -g)" \
+              -p MemoryMax="${SYFT_MEMORY_MAX}" -p MemorySwapMax=0 \
+              -- "${syft_cmd[@]}"
+          else
+            # Never silently drop the guard: without it a hungry scan can
+            # still take the agent, which is the failure this step exists to
+            # stop being invisible.
+            echo "::warning::systemd-run unavailable; syft is time-bounded but NOT memory-bounded"
+            "${syft_cmd[@]}"
+          fi
+
           jq -e '
             .spdxVersion | startswith("SPDX-")
           ' "$OUT" >/dev/null
           jq -e '(.packages // []) | length > 0' "$OUT" >/dev/null
 
       - name: Upload SBOM
-        if: inputs.sbom && github.event_name != 'pull_request'
+        # steps.sbom.outcome, not the job status: Generate SBOM is
+        # continue-on-error, so its failure leaves the job green and this
+        # step would otherwise run and fail on `if-no-files-found: error`,
+        # converting the soft failure straight back into a hard one.
+        if: inputs.sbom && github.event_name != 'pull_request' && steps.sbom.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-${{ env.IMAGE_NAME }}-${{ inputs.default-tag }}-${{ matrix.safeplatform }}

--- a/tests/bats/test_sbom_scope.bats
+++ b/tests/bats/test_sbom_scope.bats
@@ -1,6 +1,20 @@
 #!/usr/bin/env bats
-# SBOM generation must describe the final image and fail closed before a
-# stable image is signed or promoted.
+# SBOM generation must describe the final image, and must not be able to take
+# the variant down with it.
+#
+# This file used to assert the opposite -- "SBOM is blocking" -- and that was
+# a deliberate contract, not an accident. It changed because the contract was
+# wrong in a way only production showed: `Generate SBOM` runs AFTER the image
+# is built, pushed and immutable in GHCR, but sits BEFORE `Create Job
+# Outputs`, which writes the digest artifact `Manifest` fans in on. So a dead
+# scan skipped the digest artifact, `Manifest` failed at `Load Outputs`, and
+# Sign, Gate, Promote and every stage-2 flavor were skipped behind it -- a
+# 0/N night for an artifact that is not a promotion precondition
+# (2026-08-16 nightly, guppy run 31921372675; tunaOS#1567, #1784).
+#
+# "Fail closed" still holds where it belongs: an image signature gates
+# promotion (see "promotion requires the signing gate" below). An SBOM does
+# not. Same line drawn for SBOM attestation in #1560/#1766.
 
 REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
 WORKFLOW="${REPO_ROOT}/.github/workflows/reusable-build-image.yml"
@@ -12,12 +26,40 @@ WORKFLOW="${REPO_ROOT}/.github/workflows/reusable-build-image.yml"
   [ "$status" -ne 0 ]
 }
 
-@test "SBOM is blocking, validated, and time-bounded" {
-  run bash -c "sed -n '/- name: Generate SBOM/,/- name: Upload SBOM/p' '$WORKFLOW' | grep 'continue-on-error'"
-  [ "$status" -ne 0 ]
-  grep -q '^        timeout-minutes: 20$' "$WORKFLOW"
-  grep -q 'if-no-files-found: error' "$WORKFLOW"
+@test "SBOM output is still validated, not merely produced" {
+  # Unchanged by the blocking/non-blocking switch: a scan that returns
+  # something useless must still fail. An empty package list is the shape a
+  # silently-degraded scan takes.
   grep -q 'length > 0' "$WORKFLOW"
+  grep -q 'startswith("SPDX-")' "$WORKFLOW"
+  grep -q 'if-no-files-found: error' "$WORKFLOW"
+}
+
+@test "a failed SBOM scan costs the SBOM, not the variant" {
+  # The inverse of this file's original assertion -- see the header.
+  run bash -c "sed -n '/- name: Generate SBOM/,/- name: Upload SBOM/p' '$WORKFLOW' | grep -c 'continue-on-error: true'"
+  [ "$status" -eq 0 ]
+
+  # ...and the soft failure must not be converted straight back into a hard
+  # one. `Upload SBOM` carries `if-no-files-found: error`, so with the job
+  # left green by continue-on-error it would otherwise run against a file
+  # that was never written.
+  grep -q "steps.sbom.outcome == 'success'" "$WORKFLOW"
+}
+
+@test "the scan is bounded by memory as well as by time" {
+  # Two bounds, two different faults. `timeout-minutes` is enforced by the
+  # runner agent and so cannot fire when the agent is the casualty (#1567:
+  # the step overran its 20-minute limit by 51 minutes and uploaded no logs).
+  # The wall clock added by #1572 catches a scan that is slow -- but on the
+  # 2026-08-16 nightly the runner died at 7m56s, inside it, because the scan
+  # was hungry rather than slow. GOMEMLIMIT is advisory; only a cgroup cap
+  # makes the kernel kill syft instead of the agent.
+  grep -q '^        timeout-minutes: 20$' "$WORKFLOW"
+  grep -q 'timeout --kill-after' "$WORKFLOW"
+  grep -q 'systemd-run' "$WORKFLOW"
+  grep -q 'MemoryMax' "$WORKFLOW"
+  grep -q 'MemorySwapMax=0' "$WORKFLOW"
 }
 
 @test "published images use keyless signing and signed SPDX attestations" {

--- a/tests/test_sbom_step_cannot_kill_the_variant.py
+++ b/tests/test_sbom_step_cannot_kill_the_variant.py
@@ -1,0 +1,143 @@
+"""A failed SBOM scan must cost the SBOM, not the whole variant.
+
+`Generate SBOM` runs *after* the platform image is built, pushed and
+immutable in GHCR. Nothing it does can un-publish that image. Yet twice now a
+dead scan has taken a whole variant down with it, because the step sits
+upstream of `Create Job Outputs` -- the step that writes the digest artifact
+`Manifest` fans in on. Kill the scan and the chain is:
+
+    Generate SBOM      dies
+    Create Job Outputs skipped        (no digest artifact written)
+    Manifest           fails at `Load Outputs`
+    Sign / Gate / Promote             skipped
+    every stage-2 flavor              skipped
+
+A 0/N night for the variant, caused by an artifact that is not a promotion
+precondition.
+
+The scan has now escaped two separate bounds, each of which caught only one
+failure mode:
+
+    timeout-minutes: 20   enforced by the runner AGENT, so it cannot fire when
+                          the agent is the casualty. On 2026-08-14 (#1567) the
+                          step overran it by 51 minutes and uploaded no logs.
+    timeout 18m           wall-clock, added by #1572. On the 2026-08-16
+                          nightly the runner died at 7m56s -- well inside it --
+                          with "The runner has received a shutdown signal."
+
+Time was never the fault. Memory is: GOMEMLIMIT is advisory, so a large enough
+file inventory sails past it and takes the agent down. These tests pin both
+halves of the fix -- a cgroup cap so the kernel kills syft instead of the
+agent, and a soft failure so a dead scan cannot skip the digest artifact.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/reusable-build-image.yml"
+
+
+@pytest.fixture(scope="module")
+def build_push():
+    return yaml.safe_load(WORKFLOW.read_text())["jobs"]["build_push"]
+
+
+def step(build_push, name):
+    return next(s for s in build_push["steps"] if s.get("name") == name)
+
+
+# ── the scan must not be able to kill the runner ──────────────────────────
+
+
+def test_the_scan_is_memory_bounded_not_only_time_bounded(build_push):
+    """The agent cannot enforce a limit while it is the thing dying.
+
+    Only a kernel-level cap turns "runner disappears, no logs, variant lost"
+    into "syft is killed, step fails, logs intact".
+    """
+    run = step(build_push, "Generate SBOM")["run"]
+    assert "systemd-run" in run, "syft is not run under a cgroup, so nothing bounds its memory"
+    assert "MemoryMax" in run, "systemd-run is used without a MemoryMax cap"
+    assert "MemorySwapMax=0" in run, (
+        "swap is not capped, so the cgroup can thrash instead of killing the scan"
+    )
+
+
+def test_the_wall_clock_bound_is_kept_too(build_push):
+    """The two bounds cover different faults; the new one does not replace the old.
+
+    A scan that is merely slow, rather than hungry, is still only caught by
+    the wall clock.
+    """
+    assert "timeout --kill-after" in step(build_push, "Generate SBOM")["run"]
+
+
+def test_a_missing_cgroup_tool_is_announced_not_silently_ignored(build_push):
+    """Falling back without saying so would restore the original failure quietly."""
+    run = step(build_push, "Generate SBOM")["run"]
+    assert "::warning::" in run, "the unbounded fallback path emits no warning"
+    assert "NOT memory-bounded" in run
+
+
+# ── a dead scan must not cost the variant ─────────────────────────────────
+
+
+def test_a_failed_scan_does_not_fail_the_build_job(build_push):
+    """The image is already pushed; the SBOM is not a promotion precondition.
+
+    Same line drawn for SBOM attestation in #1560/#1766, applied one step
+    earlier to SBOM generation.
+    """
+    assert step(build_push, "Generate SBOM").get("continue-on-error") is True, (
+        "a failed SBOM scan still fails build_push, which skips Create Job "
+        "Outputs and takes Manifest, Sign, Gate, Promote and every stage-2 "
+        "flavor down with it"
+    )
+
+
+def test_the_digest_artifact_does_not_depend_on_the_sbom(build_push):
+    """`Manifest` fans in on this. It must survive a dead scan.
+
+    This is the step whose skipping caused the cascade, so its condition must
+    not acquire an SBOM dependency.
+    """
+    for name in ("Create Job Outputs", "Upload Output Artifacts"):
+        condition = str(step(build_push, name).get("if", ""))
+        assert "sbom" not in condition.lower(), (
+            f"{name!r} is gated on the SBOM, so a failed scan loses the digest "
+            "artifact and the variant with it"
+        )
+
+
+def test_the_soft_failure_is_not_converted_straight_back_into_a_hard_one(build_push):
+    """`Upload SBOM` carries `if-no-files-found: error`.
+
+    With `Generate SBOM` continue-on-error, the job stays green and this step
+    would otherwise run against a file that was never written -- turning the
+    deliberately soft failure back into a hard one for exactly the same runs.
+    """
+    generate = step(build_push, "Generate SBOM")
+    upload = step(build_push, "Upload SBOM")
+    assert generate.get("id") == "sbom", "Generate SBOM has no id to key the upload on"
+    assert "steps.sbom.outcome == 'success'" in upload["if"], (
+        "Upload SBOM does not check whether the scan actually produced anything"
+    )
+
+
+def test_a_missing_sbom_is_still_reported_somewhere(build_push):
+    """Soft must not mean silent.
+
+    attest_sbom is the backstop: it is continue-on-error, so it cannot fail
+    the run, but it must still say the SBOM is missing.
+    """
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    attest = workflow["jobs"]["attest_sbom"]
+    assert attest.get("continue-on-error") is True
+    body = next(s for s in attest["steps"] if s.get("name") == "Attest SPDX SBOMs")["run"]
+    assert "::error::missing SPDX SBOM" in body


### PR DESCRIPTION
Fixes the failure that cost guppy the entire 2026-08-16 nightly. Reopens the other half of #1567.

## What happened

[Run 31921372675](https://github.com/tuna-os/tunaOS/actions/runs/31921372675), `base / linux-amd64`:

```
04:32:47  timeout --kill-after=30s 18m syft ... --scope squashed   (GOMEMLIMIT=3GiB, GOGC=25)
04:40:43  ##[error]The runner has received a shutdown signal.
04:40:44  ##[error]The operation was canceled.
```

**7m56s.** Inside the 18-minute wall clock added by #1572, and inside the step's own `timeout-minutes: 20`. Neither fired, because neither was the fault.

## Two distinct problems

### 1. The scan can kill the runner, and only the kernel can stop it

Both existing bounds are *time* bounds:

| bound | why it didn't help |
|---|---|
| `timeout-minutes: 20` | enforced by the runner **agent** — useless exactly when the agent is the casualty. On 08-14 (#1567) the step overran it by 51 minutes and uploaded **no logs at all**. |
| `timeout 18m` (#1572) | wall clock. Catches a scan that is *slow*. This one wasn't slow, it was **hungry**. |

`GOMEMLIMIT` is advisory, so a large enough file inventory sails past 3GiB and takes the agent down. syft now runs inside a cgroup with a hard `MemoryMax` and `MemorySwapMax=0` (so it can't thrash instead of dying). The kernel kills syft; the agent survives to report a real exit code **with logs**. The wall-clock bound stays for the orthogonal slow-scan case.

If `systemd-run` is unavailable the step emits `::warning::` rather than silently running unbounded — an invisible guard is how this became invisible in the first place.

#1567 proposed precisely this: *"`sudo systemd-run --scope -p MemoryMax=4G` **and/or** shell `timeout 18m`"*. #1572 merged the `or` branch. This adds the other one. #1567 is already reopened because the merged half wasn't enough.

### 2. A dead scan should never have cost the variant

`Generate SBOM` sits upstream of `Create Job Outputs` — the step that writes the digest artifact `Manifest` fans in on:

```
Generate SBOM       dies
Create Job Outputs  skipped        ← no digest artifact
Manifest            fails at `Load Outputs`
Sign / Gate / Promote              skipped
every stage-2 flavor               skipped
```

A 0/N night, caused by an artifact that is **not a promotion precondition**. The image is already built, pushed and immutable in GHCR before this step runs — a failed scan cannot un-publish it.

An image signature gates promotion; an SBOM does not. That line was already drawn for SBOM *attestation* in #1560/#1766; this applies it one step earlier, to SBOM *generation*. `Generate SBOM` is now `continue-on-error`.

**The two fixes are not alternatives.** `continue-on-error` cannot help a runner death — there's no runner left to continue on. The cgroup cap is what converts that into an ordinary step failure, and only then does `continue-on-error` save the variant.

## One trap worth naming

`Upload SBOM` carries `if-no-files-found: error`. With the job left green by `continue-on-error`, it would otherwise run against a file that was never written and convert the deliberately soft failure straight back into a hard one — same runs, same red. It now keys on `steps.sbom.outcome == 'success'`.

Soft is not silent: `attest_sbom` still emits `::error::missing SPDX SBOM`, and is itself `continue-on-error`, so the gap is reported without being fatal.

## Tests

`tests/test_sbom_step_cannot_kill_the_variant.py` pins both halves plus the three invariants that make them work — the wall-clock bound is kept, the digest artifact never acquires an SBOM dependency, and a missing SBOM is still reported somewhere. **4 of the 7 fail against `main`**; the other 3 are regression guards on properties that are already true.

## Not covered here

This does not make syft use less memory. If guppy's Gentoo inventory genuinely needs more than the cap, the scan will now fail *deterministically and fast, with logs* instead of intermittently killing the runner — and the variant will still build, sign and promote without an SBOM. #1567's option 2 (generate SPDX from the existing package manifest instead of re-scanning) remains the real fix for that, and is untouched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_