### PR TITLE
test(iso-e2e): stop pinning the x86 EFI fallback name, unblocking #1595

### DIFF
--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -810,7 +810,14 @@ setup_runtime_check_stubs() {
   # removable fallback the firmware needs is missing.
   grep -q 'ESP contents' "$SCRIPT"
   grep -q 'esp: removable fallback present' "$SCRIPT"
-  grep -q 'WARN: esp has NO EFI/BOOT/BOOTX64.EFI' "$SCRIPT"
+  # Accept either the x86 literal or the arch-parameterised form. The thing
+  # this guarantees is that a missing removable fallback is called out BY
+  # NAME -- not that the name is always BOOTX64.EFI. On arm64 the firmware
+  # looks for BOOTAA64.EFI, so pinning the x86 spelling makes the assertion
+  # wrong on exactly the platform #1592 started scheduling ISO cells for,
+  # and blocks #1595 from fixing it. Enumerated rather than left open
+  # (`EFI/BOOT/` alone) so a typo'd or empty suffix still fails.
+  grep -qE 'WARN: esp has NO EFI/BOOT/(BOOTX64\.EFI|\$\{fallback_efi\})' "$SCRIPT"
 }
 
 @test "install: the LUKS workflow gives the guest more RAM than the image" {


### PR DESCRIPTION
Unblocks #1595 without needing a change on its branch.

## The problem

`tests/bats/test_iso_e2e.bats:813` asserts the ESP diagnostic by its exact x86 spelling:

```bash
grep -q 'WARN: esp has NO EFI/BOOT/BOOTX64.EFI' "$SCRIPT"
```

That is simply **wrong on arm64** — the firmware there looks for `BOOTAA64.EFI`. So the assertion is incorrect on exactly the platform #1592 started scheduling ISO cells for, and it is the **sole failing check** on #1595, which fixes the arch-awareness and therefore has to change the string:

```bash
echo "WARN: esp has NO EFI/BOOT/${fallback_efi}; firmware has no fallback to boot"
```

## The fix

What this test exists to guarantee is that a missing removable fallback is **called out by name** — not that the name is always `BOOTX64.EFI`. The assertion now accepts either form:

```bash
grep -qE 'WARN: esp has NO EFI/BOOT/(BOOTX64\.EFI|\$\{fallback_efi\})' "$SCRIPT"
```

so it is true **before and after** #1595, and that PR can land without a coordinated cross-branch change.

Deliberately enumerated rather than relaxed to a bare `EFI/BOOT/` prefix: an empty or typo'd suffix must still fail, since *"the fallback is missing"* with no filename is precisely the useless diagnostic this test was written to prevent.

## Verified against all three inputs

| input | result |
|---|---|
| current `main` (`BOOTX64.EFI` literal) | passes |
| #1595's parameterised form (`${fallback_efi}`) | passes |
| empty suffix (`EFI/BOOT/;`) | **rejected** |

The diff is one assertion line; the surrounding comment records why the x86 spelling was wrong rather than just deleting it.

Refs #1592, #1593, #1595.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_