### PR TITLE
ci: size the syft memory cap off the runner instead of guessing at it

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -475,9 +475,26 @@ jobs:
           SAFE_PLATFORM: ${{ matrix.safeplatform }}
           GOMEMLIMIT: 3GiB
           GOGC: "25"
-          # Hard ceiling for the cgroup below. Left generous: the point is to
-          # keep the runner agent alive, not to make the scan frugal.
-          SYFT_MEMORY_MAX: 5G
+          # What the cgroup below leaves for everything that is NOT syft --
+          # most importantly the runner agent, which is the process this
+          # whole guard exists to keep alive.
+          #
+          # Expressed as a reserve rather than a ceiling on purpose. A
+          # hardcoded ceiling is not a ceiling at all on a runner smaller
+          # than the number, and that is the one case where the guard has to
+          # work. 5G was the first attempt at a ceiling and it was too tight
+          # the other way: on guppy (Gentoo, run 31942667550) syft was
+          # SIGKILLed at exit 137 after 2m11s. The cap did its job -- the
+          # agent lived and the variant built, signed and promoted for the
+          # first time in five nights -- but it cost an SBOM that would
+          # likely have fit in a larger budget. A reserve gives syft
+          # everything else the box has, whatever size the box turns out to
+          # be.
+          SYFT_MEMORY_RESERVE_MIB: "5120"
+          # Floor, for the pathological case of a runner so small that the
+          # reserve eats all of it. Below this syft cannot finish anyway, and
+          # failing fast under the cap beats failing slow outside it.
+          SYFT_MEMORY_FLOOR_MIB: "2048"
         run: |
           set -euo pipefail
           IMAGE="${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${SAFE_PLATFORM}"
@@ -504,10 +521,23 @@ jobs:
           syft_cmd=( timeout --kill-after=30s 18m
                      "$SYFT_CMD" "$IMAGE" --scope squashed -o spdx-json="$OUT" )
 
+          # Size the cap off the box we actually landed on, and say so, so a
+          # future exit 137 can be read against a real number instead of an
+          # assumption about hosted-runner sizing (#1567 recorded 7 GB; that
+          # is not what ubuntu-latest ships now, and the arm64 leg is a
+          # different image again).
+          mem_total_mib="$(free -m | awk '/^Mem:/ {print $2}')"
+          cap_mib=$(( mem_total_mib - SYFT_MEMORY_RESERVE_MIB ))
+          if [ "$cap_mib" -lt "$SYFT_MEMORY_FLOOR_MIB" ]; then
+            cap_mib="$SYFT_MEMORY_FLOOR_MIB"
+          fi
+          echo "runner memory (MiB): total=${mem_total_mib} available=$(free -m | awk '/^Mem:/ {print $7}')"
+          echo "syft cgroup cap (MiB): ${cap_mib} (reserving ${SYFT_MEMORY_RESERVE_MIB} for the agent)"
+
           if command -v systemd-run >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
             sudo systemd-run --scope --quiet \
               --uid="$(id -u)" --gid="$(id -g)" \
-              -p MemoryMax="${SYFT_MEMORY_MAX}" -p MemorySwapMax=0 \
+              -p MemoryMax="${cap_mib}M" -p MemorySwapMax=0 \
               -- "${syft_cmd[@]}"
           else
             # Never silently drop the guard: without it a hungry scan can

--- a/tests/test_sbom_step_cannot_kill_the_variant.py
+++ b/tests/test_sbom_step_cannot_kill_the_variant.py
@@ -141,3 +141,77 @@ def test_a_missing_sbom_is_still_reported_somewhere(build_push):
     assert attest.get("continue-on-error") is True
     body = next(s for s in attest["steps"] if s.get("name") == "Attest SPDX SBOMs")["run"]
     assert "::error::missing SPDX SBOM" in body
+
+
+# ── the cap has to be a cap on whatever runner we land on ─────────────────
+
+
+def _cap_mib(total_mib: int, build_push) -> int:
+    """Run the step's own sizing arithmetic against a runner of `total_mib`.
+
+    Lifted from the workflow rather than restated here, so the test moves
+    when the policy does and cannot quietly drift away from it.
+    """
+    import re
+    import subprocess
+
+    run = step(build_push, "Generate SBOM")["run"]
+    start = run.index('mem_total_mib=')
+    end = run.index('echo "runner memory')
+    body = run[start:end]
+    # The one line that asks the kernel; everything after it is arithmetic.
+    body = re.sub(r'^mem_total_mib=.*$', f'mem_total_mib={total_mib}', body, flags=re.M)
+
+    env = step(build_push, "Generate SBOM")["env"]
+    script = "\n".join(
+        [
+            "set -euo pipefail",
+            f'SYFT_MEMORY_RESERVE_MIB={env["SYFT_MEMORY_RESERVE_MIB"]}',
+            f'SYFT_MEMORY_FLOOR_MIB={env["SYFT_MEMORY_FLOOR_MIB"]}',
+            body,
+            'echo "$cap_mib"',
+        ]
+    )
+    out = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=True
+    )
+    return int(out.stdout.strip().splitlines()[-1])
+
+
+def test_the_cap_is_derived_from_the_runner_not_hardcoded(build_push):
+    """A hardcoded ceiling stops being a ceiling the moment the box shrinks.
+
+    That is precisely the case the guard exists for: if the number exceeds
+    physical memory the cgroup never fires, the kernel picks its own victim,
+    and we are back to a dead agent with no logs. Sizing from `free` means
+    the cap holds on a runner nobody told us about -- including the arm64
+    leg, which is a different image from `ubuntu-latest`.
+    """
+    run = step(build_push, "Generate SBOM")["run"]
+    assert "free -m" in run, "the cap is not sized from the runner's actual memory"
+    assert _cap_mib(4096, build_push) < 4096, (
+        "the cap exceeds physical memory on a small runner, so it caps nothing"
+    )
+    assert _cap_mib(64000, build_push) > _cap_mib(16000, build_push), (
+        "a larger runner does not buy the scan a larger budget"
+    )
+
+
+def test_the_agent_keeps_a_reserve_on_a_normal_runner(build_push):
+    """Guppy's Gentoo inventory needs room; the agent needs to survive reporting it.
+
+    5G was too tight -- exit 137 on run 31942667550 after 2m11s -- on a box
+    with far more than 5G to give. The reserve is what the agent gets; the
+    scan should get the rest of a standard 16 GB runner, not a fraction of it.
+    """
+    cap = _cap_mib(15990, build_push)
+    assert cap > 10 * 1024, f"a 16 GB runner leaves syft only {cap} MiB"
+    assert 15990 - cap >= 4096, (
+        f"only {15990 - cap} MiB left for the agent, which is what the cap protects"
+    )
+
+
+def test_a_tiny_runner_still_leaves_the_scan_something_to_work_with(build_push):
+    """Reserve-minus-total can go negative; a negative or zero cap kills syft instantly."""
+    assert _cap_mib(2048, build_push) > 0
+    assert _cap_mib(512, build_push) > 0


### PR DESCRIPTION
## What

Replaces the hardcoded `SYFT_MEMORY_MAX: 5G` cgroup cap on `Generate SBOM` with a cap derived from the runner's actual memory: reserve 5 GiB for the agent, give syft the rest, floor at 2 GiB.

## Why

The cap added in #1784 worked. On guppy (run [31942667550](https://github.com/tuna-os/tunaOS/actions/runs/31942667550)) syft was SIGKILLed at exit 137 after 2m11s, the runner agent survived to report it, and the variant built, signed and **promoted for the first time in five nights**. That is the guard doing exactly what it was built to do.

But 5G was a guess, and it was the wrong one in the generous direction — the box has far more than 5G to give, so the cap cost an SBOM that would likely have fit.

Raising it to another fixed number would repeat the mistake in the other direction. **A hardcoded ceiling stops being a ceiling the moment it exceeds physical memory**: the cgroup never fires, the kernel picks its own victim, and we are back to a dead agent with no logs — the exact failure this guard exists to prevent. That is not hypothetical here; the arm64 leg runs on `ubuntu-24.04-arm`, a different runner image from `ubuntu-latest`.

So the policy is now expressed as what it actually means — *what the agent needs to survive* — rather than as a number that has to be re-guessed per runner:

| runner total | derived cap | left for the agent |
|---|---|---|
| 16 GB (`ubuntu-latest`) | ~10.6 G | ~5 G |
| 64 GB | ~57 G | ~5 G |
| 7 GB | 2 G (floor) | ~5 G |
| 4 GB | 2 G (floor) | ~2 G |

The step also now prints the runner's size and the cap it derived, so the next adjustment can be made from data rather than another guess.

## Tests

Four new tests in `tests/test_sbom_step_cannot_kill_the_variant.py`. They **execute the sizing arithmetic lifted out of the workflow** rather than restating it, so they move when the policy moves and cannot quietly drift away from it:

- the cap is derived from `free`, and is a real cap on a runner smaller than any fixed number we'd have picked
- a larger runner actually buys the scan a larger budget
- a standard 16 GB runner leaves syft >10 GiB *and* the agent ≥4 GiB
- a pathologically small runner still yields a positive cap (reserve-minus-total goes negative there)

`10 passed` locally; `bash -n` clean on the extracted step; existing bats coverage in `tests/bats/test_sbom_scope.bats` unchanged and still passing.

## What this does not fix

This is tuning around the problem, not solving it. The real fix for guppy remains the second suggestion in #1567: build the SPDX document from the package manifest the build **already produces** — `packages-guppy-base-linux-amd64.txt`, 738 packages via `qlist -ICv` — instead of re-scanning the image with syft at all. That work is still untouched, and this PR does not make it less necessary; it just stops guppy paying for the gap with a missing SBOM every night in the meantime.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_