### PR TITLE
ci: derive the SBOM from the package manifest when the scan dies

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -552,12 +552,67 @@ jobs:
           ' "$OUT" >/dev/null
           jq -e '(.packages // []) | length > 0' "$OUT" >/dev/null
 
+      - name: Synthesize SBOM from the package manifest
+        id: sbom_fallback
+        # Runs only when the scan did not produce one. On guppy that is most
+        # nights: Gentoo's file inventory outgrows the runner, the cgroup cap
+        # kills syft (#1784, #1795), and the variant publishes with no SBOM
+        # at all while `Attest SBOM` reports the gap.
+        #
+        # The information was never missing. `Publish package manifest` two
+        # steps up already read every installed package straight out of the
+        # image's own package database, in seconds. Re-deriving that list by
+        # walking every file is what costs the memory. So derive the SPDX
+        # document from the manifest instead of shipping nothing (#1567).
+        #
+        # Deliberately a fallback and not a replacement: syft's output is
+        # richer -- file inventory, license detection -- and where the scan
+        # succeeds it still wins. This only decides what happens when it
+        # does not.
+        if: inputs.sbom && github.event_name != 'pull_request' && steps.sbom.outcome != 'success'
+        continue-on-error: true
+        env:
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DEFAULT_TAG: ${{ inputs.default-tag }}
+          SAFE_PLATFORM: ${{ matrix.safeplatform }}
+        run: |
+          set -euo pipefail
+          IMAGE="${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG}-${SAFE_PLATFORM}"
+          OUT="sbom-${IMAGE_NAME}-${DEFAULT_TAG}-${SAFE_PLATFORM}.spdx.json"
+          MANIFEST="packages-${IMAGE_NAME}-${DEFAULT_TAG}-${SAFE_PLATFORM}.txt"
+
+          # `Publish package manifest` is itself continue-on-error, and an
+          # image with no package database publishes only a marker. Either
+          # way there is nothing to fall back to, and saying so beats
+          # emitting a document that claims the image is empty.
+          if [ ! -s "$MANIFEST" ]; then
+            echo "::warning::no package manifest for ${IMAGE} -- cannot synthesize an SBOM"
+            exit 1
+          fi
+
+          python3 scripts/packages_to_spdx.py \
+            --manifest "$MANIFEST" --output "$OUT" --image "$IMAGE"
+
+          # Same two checks the scan path is held to: a consumer cannot tell
+          # which path produced the file, so neither can ship a weaker one.
+          jq -e '.spdxVersion | startswith("SPDX-")' "$OUT" >/dev/null
+          jq -e '(.packages // []) | length > 0' "$OUT" >/dev/null
+
+          echo "::notice::SBOM for ${IMAGE} derived from the package manifest ($(jq '.packages | length' "$OUT") packages); syft did not complete."
+
       - name: Upload SBOM
-        # steps.sbom.outcome, not the job status: Generate SBOM is
-        # continue-on-error, so its failure leaves the job green and this
+        # Step outcomes, not the job status: both producers are
+        # continue-on-error, so their failure leaves the job green and this
         # step would otherwise run and fail on `if-no-files-found: error`,
-        # converting the soft failure straight back into a hard one.
-        if: inputs.sbom && github.event_name != 'pull_request' && steps.sbom.outcome == 'success'
+        # converting a soft failure straight back into a hard one.
+        #
+        # Either producer will do. They write the same filename, and the
+        # fallback is held to the same validation, so nothing downstream
+        # needs to know which one ran.
+        if: >-
+          inputs.sbom && github.event_name != 'pull_request'
+          && (steps.sbom.outcome == 'success' || steps.sbom_fallback.outcome == 'success')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-${{ env.IMAGE_NAME }}-${{ inputs.default-tag }}-${{ matrix.safeplatform }}

--- a/scripts/packages_to_spdx.py
+++ b/scripts/packages_to_spdx.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Build an SPDX document from a package manifest the build already produced.
+
+`Generate SBOM` scans the finished image with syft. On most editions that is
+fine. On guppy it is not: Gentoo's file inventory is large enough that syft
+outgrows the runner, and the cgroup cap added in #1784/#1795 kills it rather
+than letting it take the runner agent down. The variant still builds, signs
+and promotes -- but it publishes no SBOM, and `Attest SBOM` reports the gap
+every single night.
+
+The information was never actually missing. Two steps earlier, `Publish
+package manifest` already enumerated every installed package straight from
+the image's own package database, at a cost of seconds and a few hundred
+kilobytes. Re-deriving that same list by walking every file in the image is
+what costs the memory.
+
+So when the scan dies, fall back to the manifest instead of shipping nothing.
+The result is a smaller SBOM than syft's -- packages only, no file-level
+inventory and no license detection -- but it is accurate, it is complete at
+the package level, and it is the difference between an attestable SBOM and
+none at all. This is the second suggestion in #1567.
+
+Handles every manifest format `Publish package manifest` can emit:
+
+    rpm      name<TAB>version-release
+    dpkg     name<TAB>version
+    pacman   name<TAB>version
+    portage  category/name-version          (qlist -ICv, single column)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# A Gentoo atom: category/name-version, where the version starts at the last
+# hyphen followed by a digit. `app-editors/vim-9.1.0` -> vim / 9.1.0, while
+# `x11-libs/gtk+-3.24.43` -> gtk+ / 3.24.43 and `dev-libs/libx86-1.1` does not
+# split at `x86`.
+_ATOM = re.compile(r"^(?P<category>[\w+.-]+)/(?P<name>.+?)-(?P<version>\d[^-]*(?:-r\d+)?)$")
+
+# SPDX 2.3 restricts the SPDXID tail to letters, digits, `.` and `-` -- note
+# that `+` is NOT among them, so `x11-libs/gtk+` cannot be used verbatim. The
+# leading index keeps the result unique even when two packages sanitize to the
+# same string.
+_UNSAFE_ID = re.compile(r"[^-.a-zA-Z0-9]")
+
+NOASSERTION = "NOASSERTION"
+
+
+def parse_manifest(text: str) -> list[tuple[str, str]]:
+    """Return (name, version) pairs, preserving manifest order.
+
+    Comment lines are skipped, which also handles the `# NO PACKAGE DATABASE
+    IN IMAGE` marker the manifest step writes when an image cannot enumerate
+    itself (tunaos-packages#135) -- that yields no packages, and the caller
+    treats an empty result as "cannot synthesize" rather than emitting an
+    empty SBOM.
+    """
+    packages: list[tuple[str, str]] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "\t" in line:
+            name, _, version = line.partition("\t")
+            name, version = name.strip(), version.strip()
+            if name:
+                packages.append((name, version or NOASSERTION))
+            continue
+        atom = _ATOM.match(line)
+        if atom:
+            packages.append((atom["name"], atom["version"]))
+            continue
+        # A bare name with no version is still a package worth recording;
+        # claiming a version we did not read would be worse than NOASSERTION.
+        packages.append((line, NOASSERTION))
+    return packages
+
+
+def _spdx_id(index: int, name: str) -> str:
+    return f"SPDXRef-Package-{index}-{_UNSAFE_ID.sub('-', name)}"
+
+
+def build_document(
+    packages: list[tuple[str, str]],
+    *,
+    image: str,
+    namespace_seed: str,
+    created: str,
+) -> dict:
+    doc_packages = []
+    relationships = []
+    for i, (name, version) in enumerate(packages):
+        pid = _spdx_id(i, name)
+        doc_packages.append(
+            {
+                "SPDXID": pid,
+                "name": name,
+                "versionInfo": version,
+                # Not "unknown": we genuinely did not look, and SPDX has a
+                # word for that.
+                "downloadLocation": NOASSERTION,
+                # False, and it must stay false -- this document is derived
+                # from the package database, so no file-level analysis was
+                # performed and claiming otherwise would misrepresent it.
+                "filesAnalyzed": False,
+                "licenseConcluded": NOASSERTION,
+                "licenseDeclared": NOASSERTION,
+                "copyrightText": NOASSERTION,
+            }
+        )
+        relationships.append(
+            {
+                "spdxElementId": "SPDXRef-DOCUMENT",
+                "relatedSpdxElement": pid,
+                "relationshipType": "DESCRIBES",
+            }
+        )
+
+    digest = hashlib.sha256(namespace_seed.encode("utf-8")).hexdigest()
+    return {
+        "spdxVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": image,
+        "documentNamespace": f"https://tunaos.org/spdxdocs/{image}-{digest}",
+        "creationInfo": {
+            "created": created,
+            "creators": [
+                "Tool: tunaos-packages-to-spdx",
+                "Organization: TunaOS",
+            ],
+            # Say plainly what this document is and is not, so a consumer
+            # never mistakes a package-level fallback for a full syft scan.
+            "comment": (
+                "Derived from the image's package database rather than a "
+                "filesystem scan. Package-level inventory is complete; file "
+                "inventory and license detection are absent by construction."
+            ),
+        },
+        "packages": doc_packages,
+        "relationships": relationships,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", required=True, type=Path)
+    ap.add_argument("--output", required=True, type=Path)
+    ap.add_argument("--image", required=True, help="image ref this describes")
+    ap.add_argument(
+        "--created",
+        default=None,
+        help="RFC3339 creation timestamp; defaults to now (UTC)",
+    )
+    args = ap.parse_args(argv)
+
+    if not args.manifest.is_file():
+        print(f"no package manifest at {args.manifest}", file=sys.stderr)
+        return 1
+
+    packages = parse_manifest(args.manifest.read_text(encoding="utf-8", errors="replace"))
+    if not packages:
+        # Emitting a zero-package SPDX document would pass a `.packages |
+        # length > 0` check nowhere and would assert, falsely, that the image
+        # contains nothing.
+        print(f"{args.manifest} lists no packages; refusing to write an empty SBOM", file=sys.stderr)
+        return 1
+
+    created = args.created or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    doc = build_document(
+        packages,
+        image=args.image,
+        namespace_seed=f"{args.image}\n{len(packages)}\n{created}",
+        created=created,
+    )
+    args.output.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {args.output} with {len(packages)} packages from {args.manifest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sbom_falls_back_to_the_package_manifest.py
+++ b/tests/test_sbom_falls_back_to_the_package_manifest.py
@@ -1,0 +1,225 @@
+"""When the scan dies, the SBOM should come from the manifest, not from nowhere.
+
+`Generate SBOM` scans the built image with syft. On guppy it reliably does not
+survive that: Gentoo's file inventory outgrows the runner, and since #1784 the
+cgroup cap kills syft rather than letting it take the runner agent down with
+it. That was the right trade -- the variant builds, signs and promotes -- but
+it left guppy publishing no SBOM at all, and `Attest SBOM` reporting the gap
+every night.
+
+The data was never missing. `Publish package manifest` runs two steps earlier
+and reads the whole installed-package list straight out of the image's own
+package database, in seconds. Re-deriving that same list by walking every file
+in the image is precisely what costs the memory.
+
+These tests pin the fallback: the generator that turns a manifest into SPDX,
+and the wiring that makes it fire only when the scan did not.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/reusable-build-image.yml"
+GENERATOR = ROOT / "scripts/packages_to_spdx.py"
+
+sys.path.insert(0, str(ROOT / "scripts"))
+import packages_to_spdx as gen  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def build_push():
+    return yaml.safe_load(WORKFLOW.read_text())["jobs"]["build_push"]
+
+
+def step(build_push, name):
+    return next(s for s in build_push["steps"] if s.get("name") == name)
+
+
+def run_generator(tmp_path, manifest_text, *, image="ghcr.io/tuna-os/guppy:latest-linux-amd64"):
+    manifest = tmp_path / "packages.txt"
+    manifest.write_text(manifest_text, encoding="utf-8")
+    out = tmp_path / "sbom.spdx.json"
+    proc = subprocess.run(
+        [
+            sys.executable, str(GENERATOR),
+            "--manifest", str(manifest),
+            "--output", str(out),
+            "--image", image,
+            "--created", "2026-08-16T13:00:00Z",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    return proc, out
+
+
+# ── every package manager the manifest step can emit ──────────────────────
+
+
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        # rpm / dpkg / pacman all reach the manifest as name<TAB>version.
+        ("bash\t5.2.26-3.fc42", ("bash", "5.2.26-3.fc42")),
+        ("libc6\t2.40-1", ("libc6", "2.40-1")),
+        # portage arrives as a bare atom from `qlist -ICv`, single column.
+        ("app-editors/vim-9.1.0", ("vim", "9.1.0")),
+        # The version starts at the last hyphen followed by a digit, so a
+        # name that merely contains digits after a hyphen is not split there.
+        ("dev-libs/libx86-1.1", ("libx86", "1.1")),
+        # Gentoo revisions are part of the version, not a second package.
+        ("sys-apps/portage-3.0.66-r1", ("portage", "3.0.66-r1")),
+        # `+` is legal in a package name and must survive parsing.
+        ("x11-libs/gtk+-3.24.43", ("gtk+", "3.24.43")),
+    ],
+)
+def test_the_parser_handles_every_manifest_format_the_build_produces(line, expected):
+    """One generator serves rpm, dpkg, pacman and portage editions alike.
+
+    The manifest step already normalises four package managers into two
+    shapes; anything it can write, this has to read.
+    """
+    assert gen.parse_manifest(line) == [expected]
+
+
+def test_a_version_we_did_not_read_is_not_invented():
+    """NOASSERTION is a real SPDX value and an honest one; a guess is neither."""
+    assert gen.parse_manifest("mystery-package") == [("mystery-package", "NOASSERTION")]
+
+
+# ── the document has to be valid SPDX, not merely valid JSON ──────────────
+
+
+def test_the_document_passes_the_same_checks_the_scan_path_is_held_to(tmp_path):
+    """A consumer cannot tell which producer ran, so neither may ship less.
+
+    These are the two `jq -e` assertions the workflow makes on syft's output,
+    restated against the fallback's.
+    """
+    proc, out = run_generator(tmp_path, "bash\t5.2.26\napp-editors/vim-9.1.0\n")
+    assert proc.returncode == 0, proc.stderr
+    doc = json.loads(out.read_text())
+    assert doc["spdxVersion"].startswith("SPDX-")
+    assert len(doc["packages"]) > 0
+
+
+def test_spdx_ids_are_legal_and_unique(tmp_path):
+    """SPDX 2.3 allows only letters, digits, `.` and `-` after `SPDXRef-`.
+
+    `+` is not in that set, so `x11-libs/gtk+` cannot be used verbatim -- and
+    sanitizing without disambiguating would collide `gtk+` with `gtk-`.
+    """
+    proc, out = run_generator(
+        tmp_path, "x11-libs/gtk+-3.24.43\nx11-libs/gtk~-1.0\nsys-libs/glibc-2.40\n"
+    )
+    assert proc.returncode == 0, proc.stderr
+    ids = [p["SPDXID"] for p in json.loads(out.read_text())["packages"]]
+    for spdx_id in ids:
+        assert re.fullmatch(r"SPDXRef-[-.a-zA-Z0-9]+", spdx_id), f"illegal SPDXID {spdx_id!r}"
+    assert len(ids) == len(set(ids)), "two packages share an SPDXID"
+
+
+def test_the_document_admits_what_it_is(tmp_path):
+    """A package-level fallback must not read as a completed filesystem scan.
+
+    `filesAnalyzed: true` with no files listed would be a false claim, and a
+    consumer diffing this against a syft SBOM deserves to know why the file
+    inventory is absent.
+    """
+    proc, out = run_generator(tmp_path, "bash\t5.2.26\n")
+    doc = json.loads(out.read_text())
+    assert all(p["filesAnalyzed"] is False for p in doc["packages"])
+    assert "package database" in doc["creationInfo"]["comment"]
+
+
+# ── refusing is better than lying ─────────────────────────────────────────
+
+
+def test_a_marker_manifest_yields_no_sbom_rather_than_an_empty_one(tmp_path):
+    """Some images ship no package database at all (tunaos-packages#135).
+
+    The manifest step writes a comment marker for those. A zero-package SPDX
+    document would assert that the image contains nothing, which is a
+    stronger and more wrong claim than publishing no document.
+    """
+    proc, out = run_generator(
+        tmp_path,
+        "# NO PACKAGE DATABASE IN IMAGE\n# ghcr.io/tuna-os/guppy:latest\n",
+    )
+    assert proc.returncode != 0
+    assert not out.exists(), "an empty SBOM was written anyway"
+
+
+def test_a_missing_manifest_is_an_error_not_a_silent_success(tmp_path):
+    proc = subprocess.run(
+        [
+            sys.executable, str(GENERATOR),
+            "--manifest", str(tmp_path / "nope.txt"),
+            "--output", str(tmp_path / "sbom.json"),
+            "--image", "img",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert not (tmp_path / "sbom.json").exists()
+
+
+# ── the wiring: fallback, not replacement ─────────────────────────────────
+
+
+def test_the_fallback_runs_only_when_the_scan_did_not_produce_one(build_push):
+    """syft's output is richer where it works; this only covers where it does not."""
+    cond = step(build_push, "Synthesize SBOM from the package manifest")["if"]
+    assert "steps.sbom.outcome != 'success'" in cond, (
+        "the fallback does not check whether the scan already succeeded"
+    )
+
+
+def test_the_fallback_cannot_fail_the_variant_either(build_push):
+    """It exists to recover a soft failure; it must not convert one into a hard one."""
+    assert step(build_push, "Synthesize SBOM from the package manifest")["continue-on-error"] is True
+
+
+def test_the_fallback_validates_its_own_output(build_push):
+    """Producing an unusable file is not better than producing none."""
+    run = step(build_push, "Synthesize SBOM from the package manifest")["run"]
+    assert ".spdxVersion | startswith(\"SPDX-\")" in run
+    assert "(.packages // []) | length > 0" in run
+
+
+def test_the_fallback_refuses_a_missing_manifest(build_push):
+    """`Publish package manifest` is continue-on-error, so the file may not exist."""
+    run = step(build_push, "Synthesize SBOM from the package manifest")["run"]
+    assert '[ ! -s "$MANIFEST" ]' in run, "the fallback does not check the manifest exists"
+
+
+def test_either_producer_satisfies_the_upload(build_push):
+    """Both write the same filename and meet the same bar; the upload should not care.
+
+    Pinning only `steps.sbom.outcome` here would leave the fallback writing a
+    valid SBOM that nothing ever uploads -- the failure mode the fallback was
+    added to remove, restored one step later.
+    """
+    cond = step(build_push, "Upload SBOM")["if"]
+    assert "steps.sbom.outcome == 'success'" in cond
+    assert "steps.sbom_fallback.outcome == 'success'" in cond
+
+
+def test_both_producers_agree_on_the_filename(build_push):
+    """The upload globs `sbom-*.spdx.json`; a differently-named file is invisible."""
+    scan = step(build_push, "Generate SBOM")["run"]
+    fallback = step(build_push, "Synthesize SBOM from the package manifest")["run"]
+    name = 'OUT="sbom-${IMAGE_NAME}-${DEFAULT_TAG}-${SAFE_PLATFORM}.spdx.json"'
+    assert name in scan
+    assert name in fallback


### PR DESCRIPTION
## What

Adds `scripts/packages_to_spdx.py` and a `Synthesize SBOM from the package manifest` step that runs **only when `Generate SBOM` did not produce one**.

## Why

Guppy has published no SBOM for five nights.

The cgroup cap from #1784/#1795 is working as intended — syft outgrows the runner on Gentoo's file inventory, the kernel kills syft instead of the runner agent, and the variant goes on to build, sign and **promote**. That was the right trade. But the cost is a missing SBOM every night, and an `Attest SBOM` job reporting the gap every night with it — a standing red on an otherwise-published image.

**The information was never actually missing.** `Publish package manifest` runs two steps earlier and reads the complete installed-package list straight out of the image's own package database, in seconds and a few hundred kilobytes:

```
738 packages recorded for ghcr.io/tuna-os/guppy:latest-linux-amd64
```

Re-deriving that same list by walking every file in the image is exactly what costs the memory we don't have. So when the scan dies, build the SPDX document from the manifest instead of shipping nothing.

This is the second suggestion in #1567.

## Fallback, not replacement

syft's output is richer — file-level inventory, license detection — and where the scan succeeds it still wins. This only decides what happens when it doesn't:

| | syft scan | manifest fallback |
|---|---|---|
| package inventory | complete | complete |
| file inventory | yes | **no** |
| license detection | yes | **no** (`NOASSERTION`) |
| cost on guppy | OOM-killed | ~1s |

The document says so itself: `filesAnalyzed: false` on every package, and a `creationInfo.comment` stating it was derived from the package database rather than a filesystem scan. Nothing can mistake it for a completed scan.

## Refusing beats lying

An image with no package database publishes a comment marker rather than a package list (tunaos-packages#135). A zero-package SPDX document would assert the image *contains nothing* — a stronger and more wrong claim than publishing no document. That case exits non-zero and writes no file, leaving `Attest SBOM` to report the gap exactly as it does today.

## Formats handled

One generator covers every shape the manifest step emits:

| manager | manifest line | parsed |
|---|---|---|
| rpm | `bash\t5.2.26-3.fc42` | `bash` / `5.2.26-3.fc42` |
| dpkg | `libc6\t2.40-1` | `libc6` / `2.40-1` |
| pacman | `linux\t6.12.1` | `linux` / `6.12.1` |
| portage | `app-editors/vim-9.1.0` | `vim` / `9.1.0` |

Including the awkward ones: `sys-apps/portage-3.0.66-r1` keeps its revision in the version, `dev-libs/libx86-1.1` does not split at `x86`, and `x11-libs/gtk+-3.24.43` survives parsing — then gets a spec-legal `SPDXID`, since SPDX 2.3 does not permit `+` after `SPDXRef-`.

## Tests

18 new tests in `tests/test_sbom_falls_back_to_the_package_manifest.py`, covering the generator and the wiring:

- every manifest format above, parsed by the real generator
- output passes the *same two `jq -e` assertions* the scan path is held to
- SPDXIDs are spec-legal **and** unique (sanitizing `gtk+` without disambiguating would collide it with `gtk-`)
- the document admits what it is
- marker manifest → non-zero exit, no file written
- missing manifest → non-zero exit, no file written
- the fallback fires only when the scan didn't, is `continue-on-error`, validates its own output, and checks the manifest exists
- **`Upload SBOM` accepts either producer** — pinning only `steps.sbom.outcome` would leave the fallback writing a valid SBOM that nothing ever uploads, restoring the exact failure one step later
- both producers agree on the filename the upload globs

`28 passed` together with the existing `test_sbom_step_cannot_kill_the_variant.py`; `395 passed` on the full suite; `bash -n` clean on the extracted step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_