### PR TITLE
ci: raise the build ceiling to 240m so guppy kde can finish

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -103,10 +103,22 @@ jobs:
   build_push:
     name: ${{ matrix.safeplatform }}
     runs-on: ${{ contains(matrix.platform, 'amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
-    # 180 to give the source-based experimental variants headroom —
-    # guppy (Gentoo) still compiles bootc from git even with the binhost (#644).
-    # A max, not a fixed duration: RPM variants finish in ~20-40m unaffected.
-    timeout-minutes: 180
+    # Headroom for the source-based experimental variants — guppy (Gentoo)
+    # still compiles bootc from git even with the binhost (#644).
+    # A max, not a fixed duration: RPM variants finish in ~20-40m unaffected,
+    # so raising it costs nothing on the variants that do not need it.
+    #
+    # 60 was too low (#644); 180 was too low as well (#1802). guppy's kde was
+    # cancelled at 2h57m with 245 of 252 emerge jobs complete and still
+    # compiling steadily — it ran out of clock, not progress, and took the
+    # whole cell with it because a cancelled build writes no digest artifact.
+    # Measured on that run: base 36m, xfce ~1h57m, gnome ~1h59m, kde 2h57m+.
+    #
+    # This is the symptom, not the cause. The cause is that the whole
+    # kde-plasma set is being compiled from source rather than pulled from the
+    # binhost, which is #644's preferred fix and is tracked in #1802. Until
+    # that lands, the ceiling has to clear the slowest real build.
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:

--- a/tests/test_build_ceiling_clears_the_slowest_variant.py
+++ b/tests/test_build_ceiling_clears_the_slowest_variant.py
@@ -1,0 +1,86 @@
+"""The build ceiling has to clear the slowest real build, or it eats whole cells.
+
+`timeout-minutes` on `build_push` is a max, not a budget: RPM variants finish
+in 20-40 minutes and never approach it. It exists for the source-based
+experimental variants, where guppy (Gentoo) compiles the desktop from source.
+
+When it is set too low the failure is not "the build was slow" -- it is a
+cancelled job, which writes no digest artifact, so `Manifest` fails at
+`Load Outputs` and `Sign`, `Gate`, `Promote` and `Attest SBOM` are all
+skipped. One cell lost, and it reports as a cancellation rather than as a
+timeout, which reads like infrastructure rather than a ceiling.
+
+That has now happened twice:
+
+    #644   at 60   guppy base could not finish from stage3
+    #1802  at 180  guppy kde cancelled at 2h57m with 245 of 252 emerge jobs
+                   complete, still compiling steadily (load avg 2.61)
+
+These tests pin the ceiling against the slowest build actually observed, so
+the next person to lower it has to argue with a measurement.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/reusable-build-image.yml"
+
+# Build Image durations from run 31942667550, the first run in five nights
+# where guppy got far enough for stage-2 to build at all.
+OBSERVED_MINUTES = {
+    "guppy base": 36,
+    "guppy xfce": 117,
+    "guppy gnome": 119,
+    # Cancelled at the ceiling rather than completing, so this is a floor on
+    # the true duration, not the duration.
+    "guppy kde": 177,
+}
+
+
+@pytest.fixture(scope="module")
+def build_push():
+    return yaml.safe_load(WORKFLOW.read_text())["jobs"]["build_push"]
+
+
+def test_the_ceiling_clears_the_slowest_build_we_have_measured(build_push):
+    """kde was still emerging at 177 minutes; a ceiling at 180 is not headroom."""
+    ceiling = build_push["timeout-minutes"]
+    slowest = max(OBSERVED_MINUTES.values())
+    assert ceiling > slowest, (
+        f"ceiling {ceiling}m does not clear the slowest observed build ({slowest}m)"
+    )
+    assert ceiling - slowest >= 30, (
+        f"only {ceiling - slowest}m of headroom above a build that was still "
+        "compiling when it was cancelled -- the next package pushes it over again"
+    )
+
+
+def test_the_ceiling_stays_within_the_platform_limit(build_push):
+    """GitHub caps a hosted job at 6 hours; a larger number is silently useless.
+
+    Worth pinning because the failure would be indistinguishable from the
+    ceiling working -- the job would just die at 360 with a different message.
+    """
+    assert build_push["timeout-minutes"] <= 360
+
+
+def test_the_reason_for_the_number_is_recorded_next_to_it():
+    """Twice now the ceiling has been raised without the next reader knowing why.
+
+    A bare number invites someone to trim it back for runner-cost reasons
+    without the measurement that set it.
+    """
+    body = WORKFLOW.read_text()
+    ceiling_line = body.index("timeout-minutes: 240")
+    preamble = body[max(0, ceiling_line - 1200):ceiling_line]
+    assert "#644" in preamble, "the 60-minute precedent is not cited"
+    assert "#1802" in preamble, "the 180-minute measurement is not cited"
+    assert "binhost" in preamble, (
+        "the comment does not say that compiling from source is the real cause"
+    )


### PR DESCRIPTION
Closes the immediate half of #1802.

## What

`build_push` `timeout-minutes: 180` → `240`, with the measurement recorded next to it and tests pinning it.

## Why

`guppy / kde / linux-amd64` was cancelled at **2h57m24s** on [run 31942667550](https://github.com/tuna-os/tunaOS/actions/runs/31942667550). It was not hung:

```
>>> Completed (244 of 252) kde-plasma/kwin-6.6.5-r1::gentoo
>>> Jobs: 245 of 252 complete, 1 running          Load avg: 2.61, 3.85, 4.52
>>> Emerging (246 of 252) kde-plasma/plasma-workspace-6.6.5-r1::gentoo
##[error]The operation was canceled.
```

245 of 252 emerge jobs done, load average 2.61, packages completing minutes apart. It ran out of clock, not progress — probably 10–20 minutes short.

**The cost is not a slow build, it's a lost cell.** A cancelled build writes no digest artifact, so `kde / Manifest` failed at `Load Outputs` and `Sign`, `Gate`, `Promote` and `Attest SBOM` all skipped. It also reports as a *cancellation*, which reads like infrastructure rather than a ceiling — the kind of thing that gets re-run rather than fixed.

Measured on the same run, same runner class:

| job | Build Image |
| :--- | ---: |
| `base / linux-amd64` | 35m42s |
| `xfce / linux-amd64` | ~1h57m |
| `gnome / linux-amd64` | ~1h59m |
| `kde / linux-amd64` | **2h57m+, cancelled** |

240 clears the slowest by an hour. The value costs nothing on variants that don't need it — RPM variants finish in 20–40m and never approach it, which is why the ceiling is written as a max rather than a budget.

## This is the symptom, not the cause

Being explicit, because this is the second time: #644 was the same wall at 60 minutes, and it offered two fixes — use the Gentoo binhost, or raise the timeout. Raising it is what happened, and here we are again at 180.

The cause is that the entire `kde-plasma/*` set is being compiled from source rather than pulled from the binhost. That's #644's preferred fix, still undone, now tracked in #1802. **This PR does not do it.** It unblocks the cell today and does nothing to stop the next heavier desktop finding the new line.

## Tests

`tests/test_build_ceiling_clears_the_slowest_variant.py`, 3 tests:

- the ceiling clears the slowest *observed* build with ≥30m headroom — encoding kde's 177m as a **floor** on its true duration, since it was cancelled rather than finished
- the ceiling stays ≤360m, GitHub's hosted-job cap; above that the number is silently useless and the job dies at 360 with a different message
- the reason is recorded next to the number — the comment must cite #644, #1802 and name the binhost as the real cause, so the next person to trim it for runner-cost reasons has to argue with a measurement

`3 passed`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_