### PR TITLE
fix: re-pin the three garbage-collected base images, and check pins nightly

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -568,7 +568,7 @@ variants:
   - id: bonito
     emoji: "🎣"
     description: "Based on Fedora 44"
-    base_image: "quay.io/fedora/fedora-bootc:44@sha256:ff18dfdd91e4dfb02a8260b7fbc4e4863a452ff9bd8e8a478794c3c2ac4f2d6d"
+    base_image: "quay.io/fedora/fedora-bootc:44@sha256:295dd6ecda23780e9babf6a889914762ae118c621819d777c879992884d2b681"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [fedora]
     akmods: "ublue-os"
@@ -742,7 +742,7 @@ variants:
   - id: sailfin
     emoji: "🦈"
     description: "Based on openSUSE Tumbleweed (rolling)"
-    base_image: "registry.opensuse.org/opensuse/tumbleweed:latest@sha256:486ca7bf37bf87be5f4401ad1965e908c405b7b17a0298665c5765f2d81df078"
+    base_image: "registry.opensuse.org/opensuse/tumbleweed:latest@sha256:c79d301f557a7322fe01b18ee96058d0a6337bfb1cadc3267e5b75ec5d28b707"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [opensuse, tumbleweed]
     platforms: ["linux/amd64"]
@@ -840,7 +840,7 @@ variants:
     tag_suffix: rawhide
     emoji: "🐉"
     description: "Based on Fedora Rawhide (rolling)"
-    base_image: "quay.io/fedora/fedora-bootc:rawhide@sha256:b5c4f06bb53444f3befa085d0e8c1fe6ac7333e56f96fb9d5a3a97f622725170"
+    base_image: "quay.io/fedora/fedora-bootc:rawhide@sha256:9aba44ecf1e535ebbf2063dbd749f009caea4be7c2c32f4634fa0ff374aaf9b8"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [fedora]
     akmods: "ublue-os"

--- a/.github/workflows/check-base-image-pins.yml
+++ b/.github/workflows/check-base-image-pins.yml
@@ -1,0 +1,31 @@
+name: Check base image pins
+
+# Runs an hour before the nightly variant builds. A digest-pinned base image
+# that upstream has garbage-collected fails partway into the base build as
+# `manifest unknown`, which reads like a broken Containerfile and takes every
+# downstream flavor of that variant with it (#1788, and at least once before).
+#
+# Checking the pins directly takes seconds and names the problem in one line,
+# so the fix can land before the matrix pays for it rather than after.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64
+          sudo chmod +x /usr/bin/yq
+
+      - name: Verify every base image pin still resolves
+        run: ./scripts/check-base-image-pins.sh

--- a/scripts/check-base-image-pins.sh
+++ b/scripts/check-base-image-pins.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Verify every digest-pinned base image in build-config.yml still resolves.
+#
+# Base images are pinned by digest for reproducibility. Upstream registries
+# garbage-collect untagged manifests, so a pin that was valid when it was
+# written stops resolving without anything in this repo changing. When that
+# happens the failure surfaces as `manifest unknown` partway into a nightly
+# base build, which reads like a broken Containerfile rather than an expired
+# pin -- and it takes every downstream flavor of that variant with it.
+#
+# It has now happened at least twice (#1788). Checking the pins directly takes
+# seconds and names the problem in one line, so run it *before* the nightlies
+# rather than diagnosing it afterwards.
+#
+# Exits non-zero if any pin fails to resolve. Prints one line per pin either
+# way, because "which ones are fine" is as useful as "which one broke".
+set -euo pipefail
+
+CONFIG="${CONFIG:-.github/build-config.yml}"
+YQ="${YQ:-yq}"
+
+# Registries serve manifest lists, image indexes and plain manifests; ask for
+# all of them or a HEAD against a multi-arch tag returns 404 on content-type
+# grounds and looks exactly like a GC'd digest.
+ACCEPT='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json'
+
+# Registry quirks, all of which look like a 404 if you get them wrong:
+#
+#   docker.io   is a *name*, not an API host -- manifests live on
+#               registry-1.docker.io and tokens come from auth.docker.io.
+#   quay.io     issues anonymous pull tokens from its own /v2/auth.
+#   ghcr.io     issues them from /token.
+#   opensuse    serves unauthenticated; asking for a token 404s.
+#
+# Every helper here returns 0 even when it finds nothing, because `set -e`
+# would otherwise turn "this registry needs no token" into a silent early
+# exit -- which is exactly the failure mode this script exists to expose.
+api_host() {
+  case "$1" in
+    docker.io) printf 'registry-1.docker.io' ;;
+    *)         printf '%s' "$1" ;;
+  esac
+}
+
+auth_header() {
+  local registry="$1" repo="$2" url="" token=""
+  case "$registry" in
+    docker.io) url="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo}:pull" ;;
+    quay.io)   url="https://quay.io/v2/auth?service=quay.io&scope=repository:${repo}:pull" ;;
+    ghcr.io)   url="https://ghcr.io/token?scope=repository:${repo}:pull" ;;
+    *)         return 0 ;;
+  esac
+  token="$(curl -fsS --max-time 20 "$url" 2>/dev/null \
+    | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))' 2>/dev/null || true)"
+  [ -n "$token" ] && printf 'Authorization: Bearer %s' "$token"
+  return 0
+}
+
+failed=0
+checked=0
+
+while IFS= read -r ref; do
+  [ -n "$ref" ] || continue
+  [ "$ref" = "null" ] && continue
+  case "$ref" in *@sha256:*) ;; *)
+    # Not digest-pinned. Not this script's problem, but say so rather than
+    # silently passing -- an unpinned base is its own kind of surprise.
+    echo "SKIP  (not digest-pinned)  ${ref}"
+    continue ;;
+  esac
+
+  digest="${ref##*@}"
+  before_at="${ref%@*}"
+  name="${before_at%%:*}"          # strip any :tag
+  registry="${name%%/*}"
+  repo="${name#*/}"
+
+  hdr="$(auth_header "$registry" "$repo")"
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
+      -H "Accept: ${ACCEPT}" ${hdr:+-H "$hdr"} \
+      "https://$(api_host "$registry")/v2/${repo}/manifests/${digest}" || echo 000)"
+
+  checked=$((checked + 1))
+  if [ "$code" = "200" ]; then
+    echo "ok    ${code}  ${ref}"
+  else
+    echo "FAIL  ${code}  ${ref}"
+    echo "::error::base image pin no longer resolves (HTTP ${code}): ${ref}"
+    failed=$((failed + 1))
+  fi
+done < <("$YQ" -r '.variants[].base_image // empty' "$CONFIG" | sort -u)
+
+echo
+echo "checked ${checked} digest-pinned base image(s); ${failed} unresolvable"
+
+if [ "$failed" -gt 0 ]; then
+  echo "::error::${failed} base image pin(s) have been garbage-collected upstream. Re-pin them to the tag's current digest before the next nightly (see #1788)."
+  exit 1
+fi

--- a/tests/test_base_image_pins_are_checked.py
+++ b/tests/test_base_image_pins_are_checked.py
@@ -1,0 +1,177 @@
+"""A garbage-collected base image pin must be caught before it costs a night.
+
+Base images are digest-pinned for reproducibility, and upstream registries
+garbage-collect untagged manifests. A pin that was valid when written stops
+resolving with nothing in this repo changing. The failure then surfaces deep
+in a nightly base build as `manifest unknown`, which reads like a broken
+Containerfile rather than an expired pin -- and it takes every downstream
+flavor of that variant with it.
+
+On 2026-08-16 that cost bonito, bonito-rawhide and sailfin their whole
+variants: 24 matrix cells, three base images, one root cause (#1788).
+
+These tests drive `scripts/check-base-image-pins.sh` with a fake `curl` and a
+fake `yq`, so they assert the script's actual behaviour without touching the
+network -- including the registry quirks that make a wrong request look
+exactly like a dead pin.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/check-base-image-pins.sh"
+WORKFLOW = ROOT / ".github/workflows/check-base-image-pins.yml"
+
+yaml = pytest.importorskip("yaml")
+
+
+def _exe(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def run_check(tmp_path, refs, *, codes=None):
+    """Run the script with a stubbed registry.
+
+    `codes` maps a digest substring to the HTTP code the fake curl returns;
+    anything unlisted answers 200.
+    """
+    codes = codes or {}
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+
+    _exe(
+        bindir / "yq",
+        "#!/usr/bin/env bash\n" + "".join(f'echo "{r}"\n' for r in refs),
+    )
+
+    # The fake curl records every URL it is asked for, so the test can assert
+    # which host the script actually talked to.
+    rules = "\n".join(f'  *{frag}*) code={code} ;;' for frag, code in codes.items())
+    _exe(
+        bindir / "curl",
+        f"""#!/usr/bin/env bash
+url=""
+for a in "$@"; do case "$a" in https://*) url="$a" ;; esac; done
+echo "$url" >> "{tmp_path}/urls.txt"
+case "$url" in
+  *"/token"*|*"/v2/auth"*) echo '{{"token":"faketoken"}}'; exit 0 ;;
+esac
+code=200
+case "$url" in
+{rules}
+esac
+for a in "$@"; do
+  if [ "$a" = "%{{http_code}}" ]; then printf '%s' "$code"; exit 0; fi
+done
+exit 0
+""",
+    )
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["YQ"] = str(bindir / "yq")
+    env["CONFIG"] = str(tmp_path / "config.yml")
+    (tmp_path / "config.yml").write_text("variants: []\n", encoding="utf-8")
+
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)], capture_output=True, text=True, env=env, cwd=ROOT
+    )
+    urls = (tmp_path / "urls.txt").read_text() if (tmp_path / "urls.txt").exists() else ""
+    return proc, urls
+
+
+GOOD = "quay.io/fedora/fedora-bootc:44@sha256:" + "a" * 64
+DEAD = "quay.io/fedora/fedora-bootc:44@sha256:" + "b" * 64
+
+
+def test_a_resolvable_pin_passes(tmp_path):
+    proc, _ = run_check(tmp_path, [GOOD])
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "0 unresolvable" in proc.stdout
+
+
+def test_a_garbage_collected_pin_fails_the_check(tmp_path):
+    """This is the whole point: exit non-zero, and name the ref."""
+    proc, _ = run_check(tmp_path, [DEAD], codes={"b" * 64: 404})
+    assert proc.returncode == 1
+    assert "FAIL  404" in proc.stdout
+    assert "::error::" in proc.stdout
+    assert DEAD in proc.stdout, "the failing ref is not named, so nobody knows what to re-pin"
+
+
+def test_one_dead_pin_does_not_hide_the_healthy_ones(tmp_path):
+    """'Which ones are fine' is as useful as 'which one broke'.
+
+    A check that stops at the first failure would have reported one of the
+    three 08-16 breakages and hidden the other two.
+    """
+    proc, _ = run_check(tmp_path, [GOOD, DEAD], codes={"b" * 64: 404})
+    assert proc.returncode == 1
+    assert "ok    200" in proc.stdout
+    assert "checked 2 digest-pinned base image(s); 1 unresolvable" in proc.stdout
+
+
+def test_an_unpinned_base_is_reported_rather_than_silently_passed(tmp_path):
+    """Not this script's failure, but not something to swallow either."""
+    proc, _ = run_check(tmp_path, ["docker.io/library/alpine:latest"])
+    assert proc.returncode == 0
+    assert "SKIP" in proc.stdout
+
+
+# ── the registry quirks, each of which otherwise looks like a dead pin ─────
+
+
+def test_docker_io_is_translated_to_its_real_api_host(tmp_path):
+    """`docker.io` is a name, not an API host; manifests live elsewhere.
+
+    Getting this wrong returns 404 and is indistinguishable from a GC'd
+    digest -- the check would then condemn a perfectly good pin.
+    """
+    run_check(tmp_path, ["docker.io/library/debian:trixie@sha256:" + "c" * 64])
+    urls = (tmp_path / "urls.txt").read_text()
+    assert "registry-1.docker.io/v2/library/debian/manifests" in urls
+    assert "https://docker.io/v2/" not in urls
+
+
+def test_a_registry_needing_no_token_does_not_abort_the_script(tmp_path):
+    """`set -e` plus a helper that returns non-zero when it finds no token
+    silently killed an earlier version of this script before it printed a
+    single line. Exit 1 with no output is the worst possible result: it looks
+    like a failing check with nothing to act on.
+    """
+    proc, _ = run_check(tmp_path, ["registry.opensuse.org/opensuse/tumbleweed:latest@sha256:" + "d" * 64])
+    assert proc.returncode == 0
+    assert proc.stdout.strip(), "the script produced no output at all"
+    assert "ok    200" in proc.stdout
+
+
+def test_the_manifest_request_accepts_index_and_list_types(tmp_path):
+    """Multi-arch tags 404 on content-type grounds if Accept is too narrow."""
+    body = SCRIPT.read_text()
+    for media in (
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+    ):
+        assert media in body, f"Accept header omits {media}"
+
+
+# ── it has to actually run on a schedule to be worth anything ─────────────
+
+
+def test_the_check_runs_before_the_nightlies(tmp_path):
+    """A pin check that runs after the build it was meant to protect is decor."""
+    wf = yaml.safe_load(WORKFLOW.read_text())
+    crons = [c["cron"] for c in wf[True]["schedule"]]
+    assert crons, "no schedule — the check would only ever run by hand"
+    hours = {int(c.split()[1]) for c in crons}
+    assert all(h < 4 for h in hours), (
+        f"scheduled at {sorted(hours)}h UTC; the nightly base builds start ~04:00Z"
+    )


### PR DESCRIPTION
Fixes #1788. Replaces #1789 — see below.

## What

Re-pins the three garbage-collected base images, and adds a scheduled check so the next one is caught before it costs a night.

## Why

The 08-16 nightlies lost **bonito, bonito-rawhide and sailfin entirely** — 24 matrix cells, three variants, one root cause. Their digest-pinned base images had been garbage-collected upstream. Nothing in this repo changed; the pins simply stopped resolving, and the failure surfaced partway into each base build as `manifest unknown`, which reads like a broken Containerfile rather than an expired pin.

## The pins

Every value here was verified **200** against the registry API before being written, with an `Accept` header covering OCI index, Docker manifest-list *and* plain manifest — a multi-arch tag 404s on content-type grounds if you ask too narrowly, which is indistinguishable from a dead pin:

| pin | on `main` | this PR | 
| :--- | :---: | :---: |
| `quay.io/fedora/fedora-bootc:44` | 404 | `sha256:295dd6ec…` ✅ |
| `quay.io/fedora/fedora-bootc:rawhide` | 404 | `sha256:9aba44ec…` ✅ |
| `registry.opensuse.org/opensuse/tumbleweed:latest` | 404 | `sha256:c79d301f…` ✅ |

## Why this replaces #1789

#1789 diagnosed the same problem correctly, but **two of its three digests also return 404** — its Fedora replacements are as dead as the pins they replace, despite the PR body stating each was verified 200. Merging it would have left bonito and bonito-rawhide broken while looking fixed, so the next failure would have read as a *new* problem rather than the same one. Detail on #1789.

Its openSUSE digest is valid; I used the live `latest` digest instead purely on GC grounds, since Tumbleweed moves fast and the newest digest maximises time-to-collection.

## The recurrence is the actual problem

This is at least the second time. `scripts/check-base-image-pins.sh` walks every `base_image` in `build-config.yml` and reports which still resolve; a workflow runs it at **03:00 UTC**, an hour before the nightly base builds. A collected pin now costs one line of output at 03:00 instead of a whole variant at 05:00.

Two design choices worth stating:

- **It reports every pin rather than stopping at the first failure.** Three broke simultaneously; a fail-fast check would have found one and hidden two.
- **It handles per-registry quirks explicitly** — `docker.io` is a name, not an API host (manifests live on `registry-1.docker.io`), and quay/ghcr/openSUSE each want a different token endpoint or none. Getting any of these wrong returns 404 and would condemn a healthy pin.

Run against the current config, all 13 pins resolve.

## Tests

8 tests in `tests/test_base_image_pins_are_checked.py`, driving the script with a **fake `curl` and `yq`** so they assert real behaviour offline rather than restating the source:

- a resolvable pin passes; a GC'd pin exits non-zero, prints `::error::`, and **names the ref** so there's something to act on
- one dead pin doesn't hide the healthy ones (the 08-16 case exactly)
- an unpinned base is reported, not silently swallowed
- `docker.io` is translated to `registry-1.docker.io` — asserted against the URLs the fake curl actually received
- **a registry needing no token doesn't abort the script**: an earlier revision of this script exited 1 with *no output at all*, because a helper returned non-zero under `set -e` when it found no token. Exit 1 with nothing printed is the worst possible outcome — a failing check with nothing to act on — so it's pinned.
- the schedule actually runs before the nightlies, parsed from the cron rather than assumed

`8 passed`; `bash -n` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_