### PR TITLE
ci: stop Just Fix stranding every PR in UNSTABLE merge state

### DIFF
--- a/.github/workflows/just-fix.yml
+++ b/.github/workflows/just-fix.yml
@@ -1,6 +1,18 @@
 name: Just Fix
 on:
+  # Restricted to the default branch on purpose. An unfiltered `push` fires on
+  # every feature-branch push as well, which produces a second run for the
+  # same head SHA as the `pull_request` event. The concurrency group below
+  # then cancels one of them -- and a *cancelled* check run stays attached to
+  # the head SHA, where GitHub's merge-state computation counts it as
+  # non-success. Every PR carrying a Just Fix run therefore sat in UNSTABLE
+  # even though the run that mattered had passed, which is what stalls
+  # auto-merge and the queue paths that key off merge state (#1790).
+  #
+  # PR branches are still formatted: the `pull_request` event covers the same
+  # head SHA. Pushes to main keep the auto-fix and automation-PR behaviour.
   push:
+    branches: [main]
   pull_request:
 
 concurrency:

--- a/tests/test_just_fix_does_not_strand_prs_in_unstable.py
+++ b/tests/test_just_fix_does_not_strand_prs_in_unstable.py
@@ -1,0 +1,85 @@
+"""A cancelled duplicate check run must not hold every PR in UNSTABLE.
+
+`Just Fix` reformats code. It used to trigger on an unfiltered `push` *and*
+on `pull_request`, which produces two runs for the same head SHA whenever a
+PR branch is pushed. The concurrency group cancels one of them -- and a
+cancelled check run stays attached to that SHA, where GitHub's merge-state
+computation counts it as non-success.
+
+The consequence was not a failing check, which someone would have noticed.
+It was every PR sitting in `mergeStateStatus: UNSTABLE` with a green-looking
+checks list, which quietly stalls auto-merge and the queue paths that key off
+merge state. Automation PRs then accumulate unmerged -- the README build
+matrix sat at a stale 6/142 for nine hours on 08-16 for exactly this reason,
+while the real figure was 84/142 (#1790).
+
+The `pull_request` event covers PR branches at the same head SHA, so nothing
+stops being formatted; the duplicate simply stops being created.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/just-fix.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow():
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+@pytest.fixture(scope="module")
+def triggers(workflow):
+    # PyYAML resolves the bare key `on:` to the boolean True.
+    return workflow[True]
+
+
+def test_push_does_not_fire_on_feature_branches(triggers):
+    """An unfiltered push duplicates the pull_request run on the same SHA."""
+    push = triggers["push"]
+    assert isinstance(push, dict) and push.get("branches"), (
+        "`push` has no branch filter, so every feature-branch push races the "
+        "pull_request event for the same head SHA"
+    )
+    assert push["branches"] == ["main"]
+
+
+def test_pull_requests_are_still_formatted(triggers):
+    """Removing the duplicate must not remove the coverage.
+
+    If this went too, PR branches would stop being formatted entirely -- a
+    worse outcome than the merge-state problem being fixed.
+    """
+    assert "pull_request" in triggers
+
+
+def test_the_two_triggers_still_share_a_concurrency_group(workflow):
+    """Main-push and PR runs for one branch remain one unit of work.
+
+    The group is still keyed on the branch, so a rapid series of pushes to
+    main collapses as before. Only the cross-event duplicate is gone.
+    """
+    group = workflow["concurrency"]["group"]
+    assert "head_ref" in group and "ref_name" in group
+
+
+def test_the_reason_is_recorded_next_to_the_trigger():
+    """A bare `branches: [main]` invites someone to widen it again.
+
+    The failure it prevents is invisible -- a green checks list with a stuck
+    merge state -- so the next reader needs the reason in front of them.
+    """
+    body = WORKFLOW.read_text()
+    head = body[: body.index("jobs:")]
+    assert "#1790" in head, "the issue is not cited next to the trigger"
+    assert "UNSTABLE" in head, "the comment does not name the state this prevents"
+    assert "pull_request" in head, (
+        "the comment does not say PR branches are still covered, which is the "
+        "first thing someone will worry about"
+    )


### PR DESCRIPTION
Fixes #1790.

## What

One-line trigger change: `Just Fix` no longer fires on feature-branch pushes.

```diff
 on:
-  push:
+  push:
+    branches: [main]
   pull_request:
```

## Why

`Just Fix` triggered on an unfiltered `push` *and* on `pull_request`, so every feature-branch push produced **two runs for the same head SHA**. The concurrency group cancelled one — and a **cancelled check run stays attached to that SHA**, where GitHub's merge-state computation counts it as non-success.

The symptom was not a failing check; someone would have noticed that. It was every PR sitting in `mergeStateStatus: UNSTABLE` behind a **green-looking checks list**, which stalls auto-merge and the queue paths that key off merge state.

**This has a measurable cost.** The README build matrix reported a stale **6/142 (4%)** for nine hours on 08-16 while the real figure was **84/142 (59%)** — because the refresh PR (#1797) had been sitting open since 13:51 with nobody merging it. #1789 and #1785 were in the same state. The project looked an order of magnitude worse than it was, all day, because of a cancelled formatting run.

I confirmed the mechanism independently before changing anything — two `Just Fix` runs from my own PRs earlier today show `cancelled` (runs `31948125402`, `31948378105`) alongside passing runs for the same branches.

## Why this PR and not #1790's

#1790 diagnosed this correctly and prepared exactly this fix, but could not push it:

```
refusing to allow a GitHub App to create or update workflow
`.github/workflows/just-fix.yml` without `workflows` permission
```

That's blocked on #1557. This session can push workflow files, so the fix can land now rather than waiting on the App permission.

## What does not change

- **PR branches are still formatted** — the `pull_request` event covers the same head SHA. This is the first thing to worry about, so there's a test for it.
- **Pushes to main keep the auto-fix and automation-PR behaviour.**
- **The concurrency group is untouched**, so consecutive pushes to main still collapse into one run. Only the cross-event duplicate is gone.

## Tests

4 tests in `tests/test_just_fix_does_not_strand_prs_in_unstable.py`:

- `push` is branch-filtered to `main`
- `pull_request` coverage survives — removing the duplicate must not remove the coverage, which would be a worse outcome than the bug
- the concurrency group still keys on the branch
- the reason is recorded next to the trigger, citing #1790 and naming UNSTABLE. The failure this prevents is *invisible* in a checks list, so a bare `branches: [main]` would invite someone to widen it back.

`4 passed`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_