### PR TITLE
fix: the base-image pin check ran after the builds it protects

### DIFF
--- a/.github/workflows/check-base-image-pins.yml
+++ b/.github/workflows/check-base-image-pins.yml
@@ -1,16 +1,23 @@
 name: Check base image pins
 
-# Runs an hour before the nightly variant builds. A digest-pinned base image
-# that upstream has garbage-collected fails partway into the base build as
+# Runs well before the nightly variant builds. A digest-pinned base image that
+# upstream has garbage-collected fails partway into the base build as
 # `manifest unknown`, which reads like a broken Containerfile and takes every
 # downstream flavor of that variant with it (#1788, and at least once before).
 #
 # Checking the pins directly takes seconds and names the problem in one line,
 # so the fix can land before the matrix pays for it rather than after.
+#
+# The variant builds are `cron: "0 1 * * *"`. This first shipped at 03:00,
+# which is two hours AFTER them -- the check would have run on the wreckage it
+# was meant to prevent. 22:20 leaves ~2h40m of margin, and GitHub's scheduler
+# needs it: on 2026-08-17 the 01:00 nightlies did not actually start until
+# 02:17, a 77-minute delay. Off the hour on purpose, since :00 is the most
+# contended minute and attracts the longest queueing.
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '20 22 * * *'
 
 permissions:
   contents: read

--- a/tests/test_base_image_pins_are_checked.py
+++ b/tests/test_base_image_pins_are_checked.py
@@ -166,12 +166,79 @@ def test_the_manifest_request_accepts_index_and_list_types(tmp_path):
 # ── it has to actually run on a schedule to be worth anything ─────────────
 
 
-def test_the_check_runs_before_the_nightlies(tmp_path):
-    """A pin check that runs after the build it was meant to protect is decor."""
+def _cron_minutes_after_midnight(expr):
+    """`m h * * *` -> minutes since 00:00 UTC. Only the daily form is used here."""
+    minute, hour = expr.split()[0], expr.split()[1]
+    return int(hour) * 60 + int(minute)
+
+
+def _nightly_build_schedules():
+    """Read the real variant-build crons off disk.
+
+    Deliberately derived, not written down. The first version of this test
+    hardcoded "the nightly base builds start ~04:00Z" and asserted `hour < 4`.
+    The builds actually run at 01:00, so the check shipped at 03:00 -- two
+    hours AFTER the thing it exists to protect -- and the test passed anyway,
+    because it was checking my assumption rather than the repository.
+    """
+    out = {}
+    for wf in sorted((ROOT / ".github/workflows").glob("build-*.yml")):
+        data = yaml.safe_load(wf.read_text())
+        if not isinstance(data, dict):
+            continue
+        sched = (data.get(True) or {}).get("schedule") if isinstance(data.get(True), dict) else None
+        if not sched:
+            continue
+        for entry in sched:
+            cron = entry.get("cron", "")
+            if len(cron.split()) == 5 and cron.split()[1].isdigit() and cron.split()[0].isdigit():
+                out.setdefault(wf.name, []).append(cron)
+    return out
+
+
+def test_the_check_runs_before_the_nightlies():
+    """A pin check that runs after the build it was meant to protect is decor.
+
+    The margin matters as much as the order: GitHub's scheduler is not
+    punctual. On 2026-08-17 the 01:00 nightlies did not start until 02:17 --
+    a 77-minute delay -- so a check scheduled shortly beforehand can still
+    lose the race.
+    """
     wf = yaml.safe_load(WORKFLOW.read_text())
     crons = [c["cron"] for c in wf[True]["schedule"]]
     assert crons, "no schedule — the check would only ever run by hand"
-    hours = {int(c.split()[1]) for c in crons}
-    assert all(h < 4 for h in hours), (
-        f"scheduled at {sorted(hours)}h UTC; the nightly base builds start ~04:00Z"
+
+    nightlies = _nightly_build_schedules()
+    assert nightlies, "found no scheduled build-*.yml workflows to compare against"
+
+    earliest_build = min(
+        _cron_minutes_after_midnight(c) for crons_ in nightlies.values() for c in crons_
     )
+    check_at = min(_cron_minutes_after_midnight(c) for c in crons)
+
+    # Same-day comparison only makes sense if the check is earlier in the day;
+    # a check late the previous evening wraps to a negative margin, so measure
+    # the gap the way the clock actually runs.
+    margin = earliest_build - check_at
+    if margin < 0:
+        margin += 24 * 60
+
+    # Bounded at BOTH ends. A lower bound alone is not enough: because the
+    # gap wraps around midnight, a check that runs two hours *after* the
+    # nightly scores 22 hours of "margin" against the following night's run.
+    # That is how the 03:00 schedule passed this test while being exactly the
+    # thing the test exists to forbid. An upper bound makes it a pre-flight
+    # rather than a day-stale reading.
+    assert 120 <= margin <= 360, (
+        f"pin check fires {margin} min before the earliest nightly build "
+        f"(at {earliest_build // 60:02d}:{earliest_build % 60:02d}Z, from "
+        f"{sorted(nightlies)[:3]}…). Want 2-6h: enough slack for GitHub's "
+        "scheduling delay, close enough that the pins are still current."
+    )
+
+
+def test_the_check_avoids_the_top_of_the_hour():
+    """:00 is the most contended minute and attracts the longest queueing."""
+    wf = yaml.safe_load(WORKFLOW.read_text())
+    minutes = {int(c["cron"].split()[0]) for c in wf[True]["schedule"]}
+    assert 0 not in minutes, "scheduled on the hour, where GitHub queues longest"


### PR DESCRIPTION
Fixes a defect I introduced in #1806.

## What was wrong

#1806 scheduled the pin check at `0 3 * * *` on the stated grounds that it runs *"an hour before the nightly variant builds"*.

The nightly builds are `cron: "0 1 * * *"`.

```
01:00  nightly variant builds      ← what the check protects
03:00  check base image pins       ← ran two hours later
```

So the check would have run **on the wreckage it exists to prevent** — reporting a garbage-collected pin only after the matrix had already lost a night to it. That is the exact failure mode #1806 was written to stop.

## Why the test didn't catch it

Because the test asserted the same wrong premise:

```python
assert all(h < 4 for h in hours)   # "the nightly base builds start ~04:00Z"
```

`3 < 4`, so it passed. It was checking my assumption, not the repository. I never verified where the builds actually run.

## The fix

Schedule moves to `20 22 * * *` — **~2h40m ahead** of the 01:00 builds.

The margin is deliberate rather than minimal: GitHub's scheduler is not punctual. On 2026-08-17 the 01:00 nightlies did not start until **02:17**, a 77-minute delay. A check scheduled shortly beforehand can lose that race. Off the hour for the same reason — `:00` is the most contended minute and queues longest.

## The test now reads the repository instead of me

`_nightly_build_schedules()` parses the crons out of every scheduled `build-*.yml` and computes the gap, so the premise cannot silently drift or be restated wrongly again.

**It is bounded at both ends, and that turned out to matter.** My first attempt used only `margin >= 120` — and it *passed against the broken 03:00 schedule*. The gap wraps around midnight, so a check running two hours **after** the nightly scores 22 hours of "margin" against the following night's run. Technically true, practically useless: the pins would be a day stale.

Verified the corrected test actually catches the regression by running it against the old schedule:

```
E   AssertionError: pin check fires 1320 min before the earliest nightly build
    (at 01:00Z, from ['build-albacore.yml', 'build-archlinuxarm-base.yml', …]).
    Want 2-6h: enough slack for GitHub's scheduling delay, close enough that
    the pins are still current.
E   assert 1320 <= 360
```

Plus a test that the schedule avoids `:00`.

`9 passed`.

## Note

The 03:00 schedule never fired — as of 03:21Z the workflow had zero runs, which is consistent with GitHub's usual delay on newly-registered scheduled workflows. So nothing has run on the wrong schedule; this corrects it before its first firing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_