### PR TITLE
fix(just): anchor module script paths, restoring the boot gates

### DIFF
--- a/just/qcow2-build.just
+++ b/just/qcow2-build.just
@@ -121,7 +121,7 @@ qcow2 variant flavor='gnome' repo='local' tag='':
     # a broken podman on the runner made the probe report ostree/unsealed for
     # an image its kde/xfce siblings probed as composefs-native/SEALED=1.
     PROBE_ERR=$(mktemp)
-    if ! PROBE=$(. scripts/lib/common.sh && probe_image_backend "$IMG_REF" sudo podman 2>"$PROBE_ERR"); then
+    if ! PROBE=$(. {{ justfile_directory() }}/scripts/lib/common.sh && probe_image_backend "$IMG_REF" sudo podman 2>"$PROBE_ERR"); then
         echo "ERROR: could not probe $IMG_REF for its bootc backend:" >&2
         cat "$PROBE_ERR" >&2
         rm -f "$PROBE_ERR"

--- a/just/utilities.just
+++ b/just/utilities.just
@@ -32,7 +32,7 @@ check: _ensure_check_deps
     fi
     just --unstable --fmt --check -f Justfile
     echo "Checking workflow drift..."
-    python3 scripts/generate-workflows.py
+    python3 {{ justfile_directory() }}/scripts/generate-workflows.py
     if ! git diff --exit-code .github/workflows/build-*.yml; then
         echo "::error::Generated workflow files are stale. Run 'just generate-workflows' and commit the changes."
         exit 1
@@ -61,7 +61,7 @@ test-pytest: _ensure_test_deps
 
 generate-workflows:
     #!/usr/bin/env bash
-    chmod +x scripts/generate-workflows.py && python3 scripts/generate-workflows.py
+    chmod +x {{ justfile_directory() }}/scripts/generate-workflows.py && python3 {{ justfile_directory() }}/scripts/generate-workflows.py
 
 fix:
     #!/usr/bin/env bash

--- a/just/vm-pipeline.just
+++ b/just/vm-pipeline.just
@@ -169,7 +169,7 @@ _lima-novnc vm_name type image_path:
     podman run -d --rm \
         --name "${VM_NAME}-novnc" \
         --network host \
-        "$(source scripts/_registry.sh 2>/dev/null && registry_ref novnc || echo 'ghcr.io/novnc/novnc:latest')" \
+        "$(source {{ justfile_directory() }}/scripts/_registry.sh 2>/dev/null && registry_ref novnc || echo 'ghcr.io/novnc/novnc:latest')" \
         /usr/share/novnc/utils/novnc_proxy \
             --listen "${NOVNC_PORT}" \
             --vnc "${VNC_HOST}:${VNC_PORT}"
@@ -292,7 +292,7 @@ _run-vm type variant flavor='gnome' iso_file='':
     echo "Connect via SSH: ssh centos@127.0.0.1 -p ${ssh_port}"
     run_args+=(--publish "0.0.0.0:${ssh_port}:22" --env "USER_PORTS=22" --env "NETWORK=user")
 
-    QEMU_IMAGE="$(source scripts/_registry.sh 2>/dev/null && registry_ref qemu || echo 'ghcr.io/qemus/qemu')"
+    QEMU_IMAGE="$(source {{ justfile_directory() }}/scripts/_registry.sh 2>/dev/null && registry_ref qemu || echo 'ghcr.io/qemus/qemu')"
     run_args+=(--volume "${PWD}/${image_file}":"/boot.{{ type }}" "${QEMU_IMAGE}")
 
     (sleep 5 && xdg-open "http://127.0.0.1:${port}") &

--- a/tests/test_just_modules_resolve_repo_paths.py
+++ b/tests/test_just_modules_resolve_repo_paths.py
@@ -1,0 +1,76 @@
+"""A recipe moved into just/ must not carry a relative repo path with it.
+
+Recipes in the root `Justfile` can say `scripts/lib/common.sh` and it
+resolves, because that is where the file is. When #508's modularisation moves
+a recipe into `just/*.just`, the *text* is unchanged but the path no longer
+resolves the same way -- shebang recipes execute from a temp file, and the
+relative path is interpreted against a working directory the recipe never
+declared.
+
+The failure is invisible in review, because the moved line is byte-identical
+to the line that worked. It surfaces only at runtime:
+
+    /tmp/justDGc4ap/qcow2: line 124: scripts/lib/common.sh: No such file or directory
+    ERROR: could not probe ghcr.io/tuna-os/marlin:gnome-testing for its bootc backend
+
+On the 2026-08-17 nightly that took out every `Gate` job on marlin (4) and
+grouper (2). The boot gate is what proves an image actually reaches a
+graphical session, so losing it silently removes the strongest evidence the
+matrix has that a cell really works.
+
+`{{ justfile_directory() }}` anchors to the root justfile's directory
+regardless of how or from where the recipe is invoked.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_DIR = ROOT / "just"
+
+# A repo-relative path used as a command or sourced file: `. scripts/x`,
+# `source scripts/x`, `python3 scripts/x`, `bash scripts/x`. Anchored ones
+# ({{ justfile_directory() }}/scripts/... or /abs/scripts/...) are fine, as
+# are strings inside a longer path such as `docs/scripts/`.
+BARE_RELATIVE = re.compile(
+    r"(?:^|[^/\w.{-])(?:\.|source|bash|sh|python3)\s+(scripts/[\w./-]+)"
+)
+
+MODULES = sorted(MODULE_DIR.glob("*.just")) if MODULE_DIR.is_dir() else []
+
+
+def test_there_are_modules_to_check():
+    """Guard against this whole file silently passing if just/ moves."""
+    assert MODULES, f"no just modules found under {MODULE_DIR}"
+
+
+@pytest.mark.parametrize("module", MODULES, ids=lambda p: p.name)
+def test_module_scripts_are_anchored_to_the_justfile_directory(module):
+    offenders = []
+    for lineno, line in enumerate(module.read_text(encoding="utf-8").splitlines(), 1):
+        if line.strip().startswith("#"):
+            continue
+        for match in BARE_RELATIVE.finditer(line):
+            offenders.append(f"{module.name}:{lineno}: {match.group(1)}")
+
+    assert not offenders, (
+        "repo-relative script path in a just module — it resolved in the root "
+        "Justfile and will not resolve here. Prefix with "
+        "'{{ justfile_directory() }}/':\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_qcow2_probe_is_anchored():
+    """The specific line that cost marlin and grouper their boot gates.
+
+    Named explicitly rather than left to the sweep above, so that if someone
+    rewrites the pattern-matching this particular regression keeps a test of
+    its own.
+    """
+    body = (MODULE_DIR / "qcow2-build.just").read_text(encoding="utf-8")
+    assert "{{ justfile_directory() }}/scripts/lib/common.sh" in body
+    assert ". scripts/lib/common.sh" not in body


### PR DESCRIPTION
Regression from #1586, caught on tonight's nightly.

## Symptom

Every `Gate` job on **marlin** (gnome, kde, cosmic, xfce) and **grouper** (kde, xfce) failed at *"Build qcow2 from testing image"*:

```
/tmp/justDGc4ap/qcow2: line 124: scripts/lib/common.sh: No such file or directory
ERROR: could not probe ghcr.io/tuna-os/marlin:gnome-testing for its bootc backend
error: Recipe `qcow2` failed with exit code 1
```

marlin was one of only **three fully-green variants (16/16)**, so this is a regression rather than a standing gap. 21 of its jobs passed; only the gates fell over.

## Cause

`da50e5b` was authored 08-14 and **merged tonight via #1586**, moving the `qcow2` recipe out of the root `Justfile` into `just/qcow2-build.just`.

The sourcing line is **byte-identical** to the one that worked there for months — I diffed it against `da50e5b^:Justfile`, where it sits at line 301 unchanged. That is exactly why it passed review: nothing about the line looks wrong.

A repo-relative path resolves in the root `Justfile` because that is where the file is. From a module it is interpreted against a working directory the recipe never declares, and shebang recipes execute from a temp file. Same text, different meaning.

## Fix

`{{ justfile_directory() }}` anchors to the root justfile's directory regardless of how or from where the recipe is invoked.

Applied to **every** bare relative script path across all three modules, not only the one that was caught:

| module | occurrences |
| :--- | ---: |
| `qcow2-build.just` | 1 — `scripts/lib/common.sh` (the one that broke) |
| `utilities.just` | 3 — `scripts/generate-workflows.py` |
| `vm-pipeline.just` | 2 — `scripts/_registry.sh` |

The latter two carry the identical latent break and would have surfaced whenever something next exercised them. Fixing only the reported one would have left the same bug waiting in two files.

## Why this one matters more than the job count suggests

The boot gate is what proves an image **reaches a graphical session** — it is the strongest evidence the matrix has that a cell genuinely works rather than merely building. A cell whose build is green and whose gate never ran looks identical to a cell that works, which is the failure mode worth being least quiet about.

## Tests

`tests/test_just_modules_resolve_repo_paths.py`, 6 tests:

- sweeps every `just/*.just` for repo-relative script paths used as commands or sourced files, skipping comments and correctly ignoring already-anchored and unrelated (`docs/scripts/…`) paths
- **names the qcow2 line specifically**, so a future rewrite of the pattern-matching cannot silently drop the regression it was written for
- asserts modules were actually found, so the file cannot pass vacuously if `just/` moves

Verified against the pre-fix tree, where it fails with the real offender:

```
E   qcow2-build.just:124: scripts/lib/common.sh
E   assert not ['qcow2-build.just:124: scripts/lib/common.sh']
```

`6 passed` after the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_