### PR TITLE
docs: define what green means, and what it does not

### DIFF
--- a/.github/green-criteria.yml
+++ b/.github/green-criteria.yml
@@ -1,0 +1,150 @@
+# What "green" means for a tunaOS cell.
+#
+# A cell is one (variant, flavor) pair — e.g. yellowfin:gnome. Historically
+# "green" meant the image built and promoted, which is the weakest claim the
+# pipeline can make: an image can build, push, promote, and ship no desktop at
+# all (tunaOS#858, marlin:kde with no /usr/share/wayland-sessions).
+#
+# This file is the source of truth for the criteria. docs/GREEN-CRITERIA.md is
+# the prose companion; tests/test_green_criteria.py keeps them honest.
+#
+# `enforcement` is deliberately explicit, because the failure mode this whole
+# exercise exists to fix is a criterion that everyone believes is checked and
+# which nothing actually blocks on:
+#
+#   blocking     a cell cannot be green without it
+#   advisory     measured and reported, does not yet block
+#   unimplemented  no automated assertion exists yet
+#
+# `status_2026_08_17` records where each criterion stood when the bar was
+# raised, so progress is measurable rather than remembered.
+
+version: 1
+raised_on: "2026-08-17"
+
+# The composite rule. This is the part that makes the list mean something:
+# without it, adding criteria just adds more things that silently do not run.
+rule:
+  summary: >-
+    A cell is green only if every blocking criterion has an affirmative,
+    current result. A criterion that was skipped, never tested, or whose
+    evidence is stale does not count as satisfied.
+  never_tested_is_not_green: true
+  skipped_is_not_green: true
+  stale_is_not_green: true
+
+criteria:
+  - id: builds
+    name: Image builds and promotes
+    proves: The image builds for every declared architecture and reaches its published tag.
+    asserted_by: .github/workflows/reusable-build-image.yml (build_push, Manifest, Promote)
+    enforcement: blocking
+    status_2026_08_17: "84 of 142 cells"
+
+  - id: desktop
+    name: The declared desktop is actually present and startable
+    proves: >-
+      The packages, session files and display manager for the flavor landed in
+      the published image, and verify-desktop-experience.sh passes against it.
+    asserted_by: .github/workflows/desktop-contract-sweep.yml + build_scripts/checks/verify-desktop-experience.sh
+    enforcement: advisory
+    status_2026_08_17: "35 of 52 cells (47 tested, 5 never tested)"
+    notes: >-
+      Runs against the published image without booting, so it is not subject to
+      the missing-DRM-render-node gap. This is the axis that catches "built
+      fine, shipped the wrong desktop".
+
+  - id: boots
+    name: The image boots to a graphical session
+    proves: A disk built from the image reaches a real graphical session under QEMU.
+    asserted_by: .github/workflows/reusable-build-image.yml (Gate → scripts/iso-e2e.sh)
+    enforcement: advisory
+    status_2026_08_17: "skippable per cell; silently broke matrix-wide on 2026-08-17 (#1811)"
+    notes: >-
+      Distinct from `desktop`: that one inspects the image, this one runs it.
+      Four of five desktops need a DRM render node hosted runners lack, so this
+      cannot be blocking for cosmic/niri/xfwl4/kde until GPU capacity exists.
+
+  - id: iso
+    name: The ISO boots and offers an installer
+    proves: The live ISO boots and the installer frontend appears on screen.
+    asserted_by: .github/workflows/iso-e2e.yml + scripts/iso-e2e.sh (Installer smoke)
+    enforcement: unimplemented
+    status_2026_08_17: "31 of 36 ISO cells ever tested; 0 pass"
+    blocked_by: ["#1772", "#1556"]
+    notes: >-
+      The only axis that checks a human could actually install. Zero cells pass
+      today, so "working ISOs" is currently unproven everywhere.
+
+  - id: install
+    name: Installation completes and the installed system boots
+    proves: >-
+      An unattended install runs to completion and the resulting system boots
+      on its own, including the encrypted-disk path.
+    asserted_by: .github/workflows/luks-e2e.yml
+    enforcement: advisory
+    status_2026_08_17: "31 of 52 cells (47 tested, 5 never tested)"
+    notes: >-
+      LUKS E2E drives fisherman over SSH and never looks at the screen, so it
+      proves install-and-boot but not that the installer GUI works. `iso` is
+      the complement and must not be conflated with it.
+
+  - id: lifecycle
+    name: Update, rebase and rollback work
+    proves: >-
+      A deployed system can bootc upgrade to a newer build, rebase across
+      streams, resolve aliases, and roll back off a bad deployment.
+    asserted_by: .github/workflows/bootc-lifecycle.yml
+    enforcement: unimplemented
+    status_2026_08_17: "0 of 52 cells (0 tested, 52 never tested)"
+    notes: >-
+      Has never run for a single cell. For a bootc OS the update transaction is
+      the product: an image that installs perfectly and cannot upgrade, or
+      cannot roll back off a bad deployment, has failed at the thing
+      immutability is sold on. Every user meets upgrade repeatedly and the ISO
+      once.
+
+  - id: parity
+    name: Package set matches the upstream reference
+    proves: The flavor ships the packages its upstream equivalent ships.
+    asserted_by: scripts/package-parity.sh
+    enforcement: unimplemented
+    status_2026_08_17: "not scheduled"
+
+  - id: no_silent_omissions
+    name: The build tells the truth about what it shipped
+    proves: >-
+      No package was dropped without the result being surfaced and acted on.
+    asserted_by: /usr/share/tunaos/missing-on-*.txt written into the image
+    enforcement: unimplemented
+    status_2026_08_17: "written into every image; read by nothing on a schedule"
+    notes: >-
+      Distinct from `parity`. Parity asks whether the set matches upstream;
+      this asks whether the build admitted what it silently skipped.
+      install_available and --skip-unavailable mean missing packages never fail
+      a build — which is deliberate, and is exactly how marlin:kde published
+      with no wayland-sessions at all (tunaOS#858).
+
+  - id: rebuildable
+    name: The image can still be built tomorrow
+    proves: Every pinned input still resolves.
+    asserted_by: scripts/check-base-image-pins.sh (.github/workflows/check-base-image-pins.yml)
+    enforcement: advisory
+    status_2026_08_17: "13 of 13 base-image pins resolve"
+    notes: >-
+      A cell that built last night and cannot build tonight was never really
+      green. On 2026-08-16 three variants died at once because upstream
+      garbage-collected their base digests with nothing in this repo changing
+      (#1788). Currently covers base-image pins only; package and toolchain
+      pins are not yet checked.
+
+  - id: arch_honesty
+    name: A cell may not declare an architecture it cannot satisfy
+    proves: Every declared platform has a resolvable package source.
+    asserted_by: null
+    enforcement: unimplemented
+    status_2026_08_17: "hummingbird declares linux/arm64 against a repo that 404s (#1755 §3)"
+    notes: >-
+      Four guaranteed-red cells per night that no change in this repository can
+      clear. Declaring an unsatisfiable architecture should be a configuration
+      error, not a nightly failure.

--- a/docs/GREEN-CRITERIA.md
+++ b/docs/GREEN-CRITERIA.md
@@ -1,0 +1,118 @@
+# What "green" means
+
+A **cell** is one (variant, flavor) pair — `yellowfin:gnome`, `marlin:kde`.
+
+Until 2026-08-17, green meant *the image built and promoted*. That is the
+weakest claim this pipeline can make. An image can build, push, promote and
+ship no desktop at all: `marlin:kde` published with no
+`/usr/share/wayland-sessions/` whatsoever, because one AUR-only package failed
+the entire KDE set silently (tunaOS#858).
+
+Green now means the image **works**: it boots, the desktop starts, the ISO
+installs, the installed system updates and rolls back, and the package set is
+what it claims to be.
+
+The criteria live in [`.github/green-criteria.yml`](../.github/green-criteria.yml).
+That file is the source of truth; this document explains the reasoning.
+`tests/test_green_criteria.py` keeps the two from drifting.
+
+---
+
+## The composite rule
+
+> A cell is green only if every **blocking** criterion has an affirmative,
+> current result. Skipped, never-tested and stale all count as **not green**.
+
+This rule matters more than the list. Every criterion below already existed in
+some form before the bar was raised, and almost none of them blocked anything:
+the boot Gate was skippable, the parity manifest was written into every image
+and read by nothing, and Bootc Lifecycle had never run for a single cell.
+
+Adding criteria to a system that does not enforce the ones it has just adds
+more things that silently do not run. On 2026-08-17 the boot Gate broke across
+the whole matrix — a moved file path — and marlin still looked fine, because
+21 of its 25 jobs were green and the 4 that mattered were the ones that
+vanished (#1811).
+
+**"Never tested" must never render as green.** It is the difference between
+"we checked and it works" and "nobody has ever looked".
+
+---
+
+## The criteria
+
+| # | Criterion | Enforcement | State on 2026-08-17 |
+|---|---|---|---|
+| 1 | Image builds and promotes | **blocking** | 84 / 142 cells |
+| 2 | Declared desktop is present and startable | advisory | 35 / 52 (5 never tested) |
+| 3 | Boots to a graphical session | advisory | skippable; broke matrix-wide |
+| 4 | ISO boots and offers an installer | unimplemented | 31/36 ever tested, **0 pass** |
+| 5 | Installation completes and boots | advisory | 31 / 52 (5 never tested) |
+| 6 | Update, rebase and rollback work | unimplemented | **0 / 52 — never run** |
+| 7 | Package parity with upstream | unimplemented | not scheduled |
+| 8 | The build tells the truth about what it shipped | unimplemented | written, never read |
+| 9 | The image can still be built tomorrow | advisory | 13 / 13 base pins resolve |
+| 10 | No cell declares an arch it cannot satisfy | unimplemented | hummingbird arm64 404s |
+
+### Why some of these are separate that look similar
+
+**2 vs 3 — present vs startable.** Desktop Contract Sweep inspects the
+published image without booting it; the Gate boots a disk and waits for a real
+session. An image can satisfy one and fail the other, and guppy:gnome
+currently does exactly that (#1801).
+
+**4 vs 5 — ISO vs install.** LUKS E2E drives the installer backend over SSH and
+never looks at the screen. It proves a system installs and boots; it does not
+prove a human could have started that install. `yellowfin:cosmic` was green on
+LUKS while its installer GUI had never once been observed.
+
+**7 vs 8 — parity vs honesty.** Parity asks whether the package set matches
+upstream. Honesty asks whether the build *admitted* what it dropped.
+`install_available` and `--skip-unavailable` mean missing packages never fail a
+build — deliberately, so a partial repo cannot hard-fail everything — and the
+consequence is an image that builds cleanly with a hole in it. The evidence is
+already written to `/usr/share/tunaos/missing-on-*.txt` inside every image. It
+just needs to be read.
+
+### Why lifecycle ranks higher than it looks
+
+Criterion 6 has never run for a single cell in 52. For a bootc OS the update
+transaction *is* the product. An image that installs perfectly and cannot
+`bootc upgrade`, or cannot roll back off a bad deployment, has failed at the
+one thing immutability is sold on. Every user meets upgrade repeatedly and the
+ISO exactly once.
+
+### What is deliberately excluded
+
+**Signature and attestation are not green-blocking.** Provenance is reported on
+its own axis. Sigstore outages are frequent and unrelated to whether an image
+works; coupling them cost the matrix a full day on 2026-08-15, when a Rekor 502
+took 136 cells down after signing had already succeeded (#1560).
+
+**Anything CI structurally cannot test.** Four of five desktops need a DRM
+render node that hosted runners do not have, and NVIDIA needs real hardware.
+Folding those into green manufactures permanent red that says nothing about the
+product. They are tracked as *not yet covered*, not as failures.
+
+---
+
+## Getting there
+
+The gap is not evenly distributed, and the cheapest wins are not the loudest
+ones:
+
+1. **Run Bootc Lifecycle once.** It is written and has never executed. Going
+   from "0 tested" to any number at all is the single largest information gain
+   available.
+2. **Make the boot Gate non-skippable** for any cell claiming green on a
+   desktop CI can actually test.
+3. **Read the omissions manifest on a schedule.** The data already exists in
+   every published image.
+4. **Unblock the ISO axis** (#1772, #1556). Zero cells pass today, so
+   "working ISOs" is unproven everywhere.
+5. **Make an unsatisfiable architecture a config error**, so it stops
+   producing nightly failures nobody can fix (#1755 §3).
+
+Raising the bar will drop the reported number sharply — a cell counted for
+building is not a cell that works. That drop is the point: the smaller number
+is the true one.

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -18,6 +18,20 @@ survived for weeks because the absence of evidence read as evidence of absence.
 
 ---
 
+## 0. What green means
+
+The bar was raised on 2026-08-17: green means the image **works**, not that it
+built. The criteria — desktop present and startable, boots to a session, ISO
+installs, installation completes, update and rollback work, upstream parity, no
+silent omissions, still rebuildable, no unsatisfiable architectures — are
+defined in [GREEN-CRITERIA.md](GREEN-CRITERIA.md), with
+[`.github/green-criteria.yml`](../.github/green-criteria.yml) as the machine
+readable source.
+
+The rule that makes the list mean anything: **skipped, never-tested and stale
+all count as not green.** The axes below are the evidence those criteria are
+scored against.
+
 ## 1. Scope: what each axis actually proves
 
 Passing one axis says nothing about the others. This caught us out repeatedly,

--- a/tests/test_green_criteria.py
+++ b/tests/test_green_criteria.py
@@ -1,0 +1,130 @@
+"""The green criteria must stay honest about what is actually enforced.
+
+Before 2026-08-17, "green" meant the image built and promoted. That is the
+weakest claim this pipeline can make -- `marlin:kde` published with no
+`/usr/share/wayland-sessions/` at all and counted as green (tunaOS#858).
+
+The criteria were raised to cover: desktop present, boots to a session, ISO
+installs, installation completes, update/rollback work, upstream parity, no
+silent omissions, still rebuildable, and no unsatisfiable architectures.
+
+The risk in a list like that is not that it is wrong -- it is that it becomes
+decorative. Every criterion in it already existed in some form and almost none
+of them blocked anything: the boot Gate was skippable, the parity manifest was
+written into every image and read by nothing, and Bootc Lifecycle had never
+run once for any of 52 cells. These tests exist so the file cannot quietly
+turn into a wish list: every criterion must declare how it is asserted and
+whether it actually blocks, and the prose must not drift from the data.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+CRITERIA = ROOT / ".github/green-criteria.yml"
+DOC = ROOT / "docs/GREEN-CRITERIA.md"
+
+VALID_ENFORCEMENT = {"blocking", "advisory", "unimplemented"}
+
+
+@pytest.fixture(scope="module")
+def spec():
+    return yaml.safe_load(CRITERIA.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def criteria(spec):
+    return spec["criteria"]
+
+
+def test_the_user_facing_criteria_are_all_present(criteria):
+    """The four the maintainer asked for, plus the ones added alongside them.
+
+    Pinned by id so a rename has to be deliberate rather than accidental.
+    """
+    ids = {c["id"] for c in criteria}
+    required = {
+        # asked for explicitly
+        "desktop", "parity", "iso", "install",
+        # added with them
+        "lifecycle", "rebuildable", "no_silent_omissions", "arch_honesty",
+        # the baseline that used to be the whole definition
+        "builds", "boots",
+    }
+    assert required <= ids, f"missing criteria: {sorted(required - ids)}"
+
+
+def test_every_criterion_says_how_it_is_asserted(criteria):
+    """A criterion with no named assertion is an aspiration, not a criterion.
+
+    `asserted_by: null` is allowed, but only together with
+    `enforcement: unimplemented` -- so the gap is visible rather than implied.
+    """
+    for c in criteria:
+        assert "asserted_by" in c, f"{c['id']}: no asserted_by field"
+        if not c["asserted_by"]:
+            assert c["enforcement"] == "unimplemented", (
+                f"{c['id']}: claims enforcement={c['enforcement']} but names "
+                "nothing that asserts it"
+            )
+
+
+def test_enforcement_is_explicit_and_valid(criteria):
+    """The whole point is that nobody has to guess what actually blocks."""
+    for c in criteria:
+        assert c.get("enforcement") in VALID_ENFORCEMENT, (
+            f"{c['id']}: enforcement={c.get('enforcement')!r} "
+            f"not one of {sorted(VALID_ENFORCEMENT)}"
+        )
+
+
+def test_every_criterion_records_where_it_stood_when_the_bar_was_raised(spec, criteria):
+    """Progress has to be measurable, not remembered."""
+    field = f"status_{spec['raised_on'].replace('-', '_')}"
+    for c in criteria:
+        assert c.get(field), f"{c['id']}: no {field} baseline recorded"
+
+
+def test_never_tested_does_not_count_as_green(spec):
+    """The distinction the whole exercise turns on.
+
+    "Nobody has ever looked" must not render the same as "we checked and it
+    works". Bootc Lifecycle is 0 tested of 52; if never-tested counted as
+    green, that axis would silently contribute nothing but look complete.
+    """
+    rule = spec["rule"]
+    assert rule["never_tested_is_not_green"] is True
+    assert rule["skipped_is_not_green"] is True
+    assert rule["stale_is_not_green"] is True
+
+
+def test_the_document_covers_every_criterion(criteria):
+    """The prose is what people read; it must not omit a criterion silently."""
+    doc = DOC.read_text(encoding="utf-8")
+    missing = [c["id"] for c in criteria if c["name"].split()[0].lower() not in doc.lower()]
+    assert not missing, f"criteria absent from {DOC.name}: {missing}"
+
+
+def test_the_document_points_at_the_machine_readable_source(criteria):
+    """Two sources of truth is one too many; the doc must defer to the file."""
+    doc = DOC.read_text(encoding="utf-8")
+    assert "green-criteria.yml" in doc
+
+
+def test_provenance_is_not_green_blocking(criteria):
+    """Deliberate exclusion, and an easy one to undo by accident.
+
+    A Rekor 502 took 136 cells down on 2026-08-15 after signing had already
+    succeeded (#1560). Signature availability is unrelated to whether an image
+    works, so it is reported on its own axis rather than gating green.
+    """
+    ids = {c["id"] for c in criteria}
+    assert not ({"provenance", "attestation", "signature"} & ids), (
+        "provenance became a green criterion — see #1560 for why that couples "
+        "the matrix to Sigstore availability"
+    )


### PR DESCRIPTION
Establishes the green bar. **Nothing about the reported number changes in this PR** — this defines the target so the work toward it can be scoped.

## Why

Green has meant *"the image built and promoted"*. That is the weakest claim this pipeline can make. `marlin:kde` published with **no `/usr/share/wayland-sessions/` at all** — one AUR-only package failed the entire KDE set silently — and counted as green (#858).

## The criteria

`.github/green-criteria.yml` is the source of truth; `docs/GREEN-CRITERIA.md` explains the reasoning; `tests/test_green_criteria.py` keeps them from drifting.

| # | Criterion | Enforcement | State on 2026-08-17 |
|---|---|---|---|
| 1 | Image builds and promotes | **blocking** | 84 / 142 |
| 2 | Declared desktop present and startable | advisory | 35 / 52 (5 never tested) |
| 3 | Boots to a graphical session | advisory | skippable; broke matrix-wide |
| 4 | ISO boots and offers an installer | unimplemented | 31/36 ever tested, **0 pass** |
| 5 | Installation completes and boots | advisory | 31 / 52 (5 never tested) |
| 6 | Update, rebase and rollback | unimplemented | **0 / 52 — never run** |
| 7 | Upstream package parity | unimplemented | not scheduled |
| 8 | Build tells the truth about what it shipped | unimplemented | written, read by nothing |
| 9 | Still buildable tomorrow | advisory | 13 / 13 base pins resolve |
| 10 | No unsatisfiable architectures | unimplemented | hummingbird arm64 404s |

Four were requested — desktops, parity, ISOs, installation. The rest came out of measuring those.

## The composite rule matters more than the list

> **Skipped, never-tested and stale all count as *not* green.**

Every criterion above already existed in some form, and almost none of them blocked anything: the boot Gate was skippable, the parity manifest was written into every image and read by nothing, Bootc Lifecycle had never run once for any of 52 cells.

Adding criteria to a system that doesn't enforce the ones it has just adds more things that silently don't run. That is not hypothetical — on 08-17 the boot Gate broke across the entire matrix (#1811) and marlin still *looked* fine, because 21 of its 25 jobs were green and the 4 that mattered were the ones that had vanished.

## Distinctions the file is careful about

- **desktop vs boots** — one inspects the published image, the other runs it. guppy:gnome satisfies the first and fails the second (#1801).
- **iso vs install** — LUKS E2E drives the installer backend over SSH and never looks at the screen. `yellowfin:cosmic` was green on LUKS while its GUI had never once been observed.
- **parity vs no_silent_omissions** — parity asks whether the set matches upstream; omissions asks whether the build *admitted* what it dropped. `--skip-unavailable` is deliberate, and is precisely how #858 happened.

## Deliberate exclusions

- **Provenance is not green-blocking.** A Rekor 502 took 136 cells down on 08-15 *after signing had already succeeded* (#1560). Image correctness and Sigstore availability are unrelated; there is a test asserting this stays uncoupled.
- **Anything CI structurally cannot test** — four of five desktops need a DRM render node hosted runners lack. Folding those in manufactures permanent red that says nothing about the product.

## Honest starting position

**1 blocking, 4 advisory, 5 unimplemented.** Criterion 6 has never executed. Criterion 4 has zero passes. Raising the bar will drop the reported number sharply, and that is the point — the smaller number is the true one.

## Suggested order of work

1. **Run Bootc Lifecycle once** — written, never executed; largest single information gain available
2. Make the boot Gate non-skippable where CI can actually test the desktop
3. Read the omissions manifest on a schedule — the data is already in every image
4. Unblock the ISO axis (#1772, #1556)
5. Make an unsatisfiable architecture a config error (#1755 §3)

## Tests

8 tests: every requested criterion present by id; every criterion names how it's asserted (`asserted_by: null` permitted *only* with `enforcement: unimplemented`, so gaps are visible); enforcement explicit and valid; every criterion carries a dated baseline; the never-tested/skipped/stale rule holds; the doc covers every criterion and defers to the YAML; and provenance has not crept in as a gate.

`29 passed` including the existing matrix-status suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_