### PR TITLE
Tolerate rpmfusion-rawhide liboapv skew on bonito-rawhide (#1810)

### DIFF
--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -162,13 +162,13 @@ elif [[ $IS_FEDORA == true ]]; then
 		"https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${FEDORA_VER}.noarch.rpm" \
 		"https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${FEDORA_VER}.noarch.rpm" || true
 
-	# Multimedia + common desktop packages in one transaction.
-	# gstreamer1-plugin-libav is Fedora's own package (measured in the F44
-	# repodata); with RPM Fusion's full ffmpeg installed alongside it, its
-	# libgstlibav.so resolves the full libavcodec sonames — that pairing is
-	# what gives GStreamer apps H.264/H.265 decode. gstreamer1-plugins-ugly
-	# is the RPM Fusion build. The build contract asserts the result
-	# (verify-desktop-experience.sh codec baseline).
+	# RPM Fusion multimedia set — its own transaction, tolerant ONLY on
+	# Rawhide (tunaOS#1810). gstreamer1-plugin-libav is Fedora's own package
+	# (measured in the F44 repodata); with RPM Fusion's full ffmpeg installed
+	# alongside it, its libgstlibav.so resolves the full libavcodec sonames —
+	# that pairing is what gives GStreamer apps H.264/H.265 decode.
+	# gstreamer1-plugins-ugly is the RPM Fusion build. The build contract
+	# asserts the result (verify-desktop-experience.sh codec baseline).
 	# Note: On Rawhide (Fedora 46+), exclude openh264* until fedora-cisco-openh264
 	# updates its openh264 RPMs signed with the F46 key (currently fc45 signed with F45 key).
 	# Remove this exclude once openh264-*.fc46 appears in fedora-cisco-openh264.
@@ -176,13 +176,29 @@ elif [[ $IS_FEDORA == true ]]; then
 	if [[ "${FEDORA_VER}" == "rawhide" ]]; then
 		dnf_opts+=(--exclude='openh264*')
 	fi
-	dnf -y install "${dnf_opts[@]}" \
+	# install_rawhide_tolerant (build_scripts/lib.sh) behaves exactly like a
+	# plain `dnf -y install` on every pinned Fedora release — including this
+	# one, bonito — and only degrades to a --skip-broken retry + loud
+	# wishlist record when FEDORA_VER=rawhide AND the strict transaction
+	# fails (e.g. rpmfusion-free-rawhide's ffmpeg-libs needing a liboapv
+	# SONAME Fedora rawhide no longer ships). Kept as its own transaction,
+	# separate from the required base packages below, so a rawhide codec
+	# skew can never tolerate away buildah/podman/etc — those still fail the
+	# build strictly on every release, rawhide included.
+	install_rawhide_tolerant "${dnf_opts[@]}" \
 		gstreamer1-plugins-good \
 		gstreamer1-plugins-ugly \
 		gstreamer1-plugin-libav \
 		gstreamer1-plugins-bad-free \
 		lame \
-		ffmpeg \
+		ffmpeg
+
+	# Common desktop + container-tooling packages — always a strict
+	# transaction; a failure here fails the build on every Fedora release,
+	# rawhide included. Never routed through install_rawhide_tolerant: none
+	# of these are expected to be affected by the rpmfusion/rawhide skew,
+	# and none of them should ever become silently optional.
+	dnf -y install \
 		buildah \
 		podman \
 		skopeo \

--- a/build_scripts/checks/package-miss-allowlist.txt
+++ b/build_scripts/checks/package-miss-allowlist.txt
@@ -109,3 +109,17 @@ xfce4-clipman-plugin
 fastfetch
 glow
 gum
+
+# ── build_scripts/10-base-packages.sh install_rawhide_tolerant path
+#    (tunaOS#1810) — the RPM Fusion Rawhide multimedia transaction, tolerant
+#    ONLY when FEDORA_VER=rawhide (see build_scripts/lib.sh). ffmpeg is the
+#    one that actually drops: rpmfusion-free-rawhide's ffmpeg-libs-8.1.2-5
+#    Requires: liboapv.so.2()(64bit), which nothing in the enabled repos
+#    provides — Fedora rawhide's openapv-libs moved to liboapv.so.3.
+#    gstreamer1-plugin-libav (the codec path GStreamer apps actually use)
+#    resolves independently via Fedora's own libavcodec-free, so it is NOT
+#    expected to appear here; if it ever does, that is a different, more
+#    serious break and should NOT be silently allowlisted alongside this
+#    one. Remove this entry once rpmfusion-free-rawhide rebuilds ffmpeg
+#    against openapv 0.3 (liboapv.so.3), restoring ffmpeg on bonito-rawhide.
+ffmpeg

--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -642,6 +642,80 @@ install_available() {
 	done
 }
 
+# Tolerate an unresolvable RPM Fusion Rawhide transaction without killing
+# the whole variant (tunaOS#1810). Fedora Rawhide and RPM Fusion Rawhide
+# are two independently-built repos; when Fedora bumps a shared library's
+# SONAME before RPM Fusion rebuilds against it, packages in the enabled
+# repo set can go unresolvable even though every requested name is real.
+# Measured 2026-08-17 against live repodata: Fedora rawhide's openapv-libs
+# now provides only `liboapv.so.3` (0.3.0.0-1.fc46), but
+# rpmfusion-free-rawhide's ffmpeg-libs-8.1.2-5.fc46 still
+# `Requires: liboapv.so.2()(64bit)` — nothing in either repo provides that
+# SONAME anymore. That is a depsolve failure, not a missing package name,
+# so install_available's `dnf repoquery --available` probe (which only
+# checks that the name exists) cannot see it: "ffmpeg" genuinely exists,
+# only its dependency chain does not resolve.
+#
+# Strategy: try the transaction exactly as given first. On any release
+# OTHER than rawhide, or whenever the strict transaction succeeds,
+# behavior is identical to a plain `dnf -y install` — pinned bonito (and
+# every other non-rawhide Fedora build) is provably unaffected. Only when
+# FEDORA_VER=rawhide AND the strict transaction fails do we retry once
+# with --skip-broken, then diff the originally-requested package list
+# against what's actually installed afterward to name exactly what
+# dropped out. Those names are routed through the same loud path
+# install_available uses: a ::warning per miss, and an append to
+# /usr/share/tunaos/missing-on-<image>.txt (record_package_wishlist) — so
+# checks/verify-package-wishlist.sh still gates the miss against
+# checks/package-miss-allowlist.txt. The omission is recorded, not
+# silent, and criterion no_silent_omissions has real evidence to point at.
+#
+# Usage: install_rawhide_tolerant [dnf-flag ...] pkg1 pkg2 pkg3 ...
+# (leading `-`-prefixed args are treated as dnf flags, e.g. --exclude=...,
+# everything after the first non-flag arg is a package name)
+install_rawhide_tolerant() {
+	local opts=()
+	while [[ "${1:-}" == -* ]]; do
+		opts+=("$1")
+		shift
+	done
+	local pkgs=("$@")
+	if [[ ${#pkgs[@]} -eq 0 ]]; then
+		echo "install_rawhide_tolerant: no packages requested" >&2
+		return 0
+	fi
+
+	if dnf -y install "${opts[@]}" "${pkgs[@]}"; then
+		return 0
+	fi
+
+	if [[ "${FEDORA_VER:-}" != "rawhide" ]]; then
+		echo "install_rawhide_tolerant: transaction failed on ${FEDORA_VER:-non-rawhide Fedora}; not tolerating (only Rawhide gets the --skip-broken retry — pinned Fedora releases stay strict)." >&2
+		return 1
+	fi
+
+	printf '::warning title=Rawhide multimedia transaction unresolvable (tunaOS#1810)::[%s] failed to resolve as a strict dnf transaction on Fedora Rawhide (an rpmfusion-rawhide/Fedora-rawhide packaging skew). Retrying with --skip-broken so this costs codecs, not the whole variant.\n' "${pkgs[*]}"
+
+	dnf -y install --skip-broken "${opts[@]}" "${pkgs[@]}" || true
+
+	local missing=() pkg
+	for pkg in "${pkgs[@]}"; do
+		rpm -q "$pkg" &>/dev/null || missing+=("$pkg")
+	done
+
+	if [[ ${#missing[@]} -eq 0 ]]; then
+		echo "install_rawhide_tolerant: --skip-broken retry actually installed everything requested; the earlier failure was transient." >&2
+		return 0
+	fi
+
+	record_package_wishlist \
+		"$(basename "${BASH_SOURCE[1]:-install_rawhide_tolerant}")" \
+		"${missing[@]}"
+
+	echo "install_rawhide_tolerant: proceeding without: ${missing[*]}" >&2
+	return 0
+}
+
 # systemctl enable wrapper that tolerates the unit-not-present case.
 # Build scripts run in a multi-stage container build where some units may
 # only exist on certain variants (e.g. tailscaled on EL10 but not on EL9).

--- a/tests/bats/test_install_rawhide_tolerant.bats
+++ b/tests/bats/test_install_rawhide_tolerant.bats
@@ -1,0 +1,230 @@
+#!/usr/bin/env bats
+# install_rawhide_tolerant() — tunaOS#1810.
+#
+# rpmfusion-free-rawhide's ffmpeg-libs-8.1.2-5.fc46 Requires:
+# liboapv.so.2()(64bit); Fedora rawhide's openapv-libs now provides only
+# liboapv.so.3 (measured against live repodata 2026-08-17) — nothing in the
+# enabled repo set satisfies the old SONAME, so the RPM Fusion multimedia
+# transaction fails on bonito-rawhide even though every requested package
+# name genuinely exists. install_available's `dnf repoquery --available`
+# probe cannot see this (the names all resolve); the failure is in the
+# depsolve, not the package list.
+#
+# These tests run the REAL install_rawhide_tolerant + record_package_wishlist
+# functions extracted verbatim from build_scripts/lib.sh (not a
+# reimplementation) against mocked dnf/rpm binaries — the same
+# extract-and-run technique test_package_wishlist_gate.bats uses for
+# record_package_wishlist itself.
+
+REPO_ROOT="${REPO_ROOT:-$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)}"
+LIB="${REPO_ROOT}/build_scripts/lib.sh"
+
+setup() {
+  BIN="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "$BIN"
+  WISH_DIR="${BATS_TEST_TMPDIR}/wish"
+  mkdir -p "$WISH_DIR"
+  INSTALLED_DIR="${BATS_TEST_TMPDIR}/installed"
+  mkdir -p "$INSTALLED_DIR"
+
+  FN_TOLERANT="$(awk '/^install_rawhide_tolerant\(\)/,/^}/' "$LIB")"
+  FN_WISHLIST="$(awk '/^record_package_wishlist\(\)/,/^}/' "$LIB")"
+  [[ -n "$FN_TOLERANT" ]]
+  [[ -n "$FN_WISHLIST" ]]
+
+  # Mock dnf:
+  #   - a plain `install` (no --skip-broken) succeeds/fails per
+  #     DNF_STRICT_RC and, on success, "installs" every requested name.
+  #   - `install --skip-broken` always exits 0 and "installs" every
+  #     requested name EXCEPT the ones listed in DNF_DROP — standing in for
+  #     the real depsolver dropping only the package(s) it can't resolve.
+  #   "Installing" a package means touching a marker file the rpm mock reads.
+  cat >"${BIN}/dnf" <<MOCK
+#!/usr/bin/env bash
+skip_broken=0
+pkgs=()
+for arg in "\$@"; do
+  case "\$arg" in
+    --skip-broken) skip_broken=1 ;;
+    -y|install) ;;
+    -*) ;;
+    *) pkgs+=("\$arg") ;;
+  esac
+done
+if [[ \$skip_broken -eq 1 ]]; then
+  for p in "\${pkgs[@]}"; do
+    case " \${DNF_DROP:-} " in
+      *" \$p "*) ;;
+      *) touch "${INSTALLED_DIR}/\$p" ;;
+    esac
+  done
+  exit 0
+fi
+if [[ "\${DNF_STRICT_RC:-1}" -eq 0 ]]; then
+  for p in "\${pkgs[@]}"; do touch "${INSTALLED_DIR}/\$p"; done
+fi
+exit "\${DNF_STRICT_RC:-1}"
+MOCK
+  chmod +x "${BIN}/dnf"
+
+  cat >"${BIN}/rpm" <<MOCK
+#!/usr/bin/env bash
+# rpm -q <pkg>
+[[ -e "${INSTALLED_DIR}/\$2" ]]
+MOCK
+  chmod +x "${BIN}/rpm"
+}
+
+# Runs the real install_rawhide_tolerant (with its real record_package_wishlist
+# dependency) in a fresh shell, against the mocked dnf/rpm on PATH.
+run_tolerant() {
+  PATH="${BIN}:/usr/bin:/bin" bash -c "
+    set -uo pipefail
+    ${FN_WISHLIST}
+    ${FN_TOLERANT}
+    install_rawhide_tolerant $*
+  "
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Pinned Fedora (non-rawhide): must behave EXACTLY like a plain dnf install —
+# this is the "bonito is provably unaffected" guarantee.
+# ═══════════════════════════════════════════════════════════════════════════
+
+@test "non-rawhide + strict success: installs cleanly, no warning, no wishlist" {
+  export FEDORA_VER=44
+  export DNF_STRICT_RC=0
+  export IMAGE_NAME=bonito
+  export TUNAOS_WISHLIST_DIR="$WISH_DIR"
+  run run_tolerant "ffmpeg gstreamer1-plugin-libav"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"::warning"* ]]
+  [ ! -e "${WISH_DIR}/missing-on-bonito.txt" ]
+  [ -e "${INSTALLED_DIR}/ffmpeg" ]
+}
+
+@test "non-rawhide + strict failure: fails hard, no skip-broken retry, no wishlist entry" {
+  export FEDORA_VER=44
+  export DNF_STRICT_RC=1
+  export IMAGE_NAME=bonito
+  export TUNAOS_WISHLIST_DIR="$WISH_DIR"
+  run run_tolerant "ffmpeg gstreamer1-plugin-libav"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"::warning"* ]]
+  [ ! -e "${WISH_DIR}/missing-on-bonito.txt" ]
+  [ ! -e "${INSTALLED_DIR}/ffmpeg" ]
+}
+
+@test "a release string that merely CONTAINS rawhide does not trigger tolerance" {
+  # Guards the exact-match comparison: only FEDORA_VER=rawhide qualifies.
+  export FEDORA_VER="not-rawhide"
+  export DNF_STRICT_RC=1
+  export IMAGE_NAME=bonito
+  export TUNAOS_WISHLIST_DIR="$WISH_DIR"
+  run run_tolerant "ffmpeg"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"::warning"* ]]
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Rawhide: the happy path is unaffected; the broken path is loud, not silent.
+# ═══════════════════════════════════════════════════════════════════════════
+
+@test "rawhide + strict success: no retry needed, no warning" {
+  export FEDORA_VER=rawhide
+  export DNF_STRICT_RC=0
+  export IMAGE_NAME=bonito-rawhide
+  export TUNAOS_WISHLIST_DIR="$WISH_DIR"
+  run run_tolerant "ffmpeg gstreamer1-plugin-libav"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"::warning"* ]]
+  [ ! -e "${WISH_DIR}/missing-on-bonito-rawhide.txt" ]
+}
+
+@test "rawhide tolerance: strict fails, skip-broken drops only ffmpeg, loudly recorded" {
+  export FEDORA_VER=rawhide
+  export DNF_STRICT_RC=1
+  export DNF_DROP="ffmpeg"
+  export IMAGE_NAME=bonito-rawhide
+  export TUNAOS_WISHLIST_DIR="$WISH_DIR"
+  run run_tolerant "gstreamer1-plugins-good gstreamer1-plugin-libav ffmpeg"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::warning"*"tunaOS#1810"* ]]
+  # the resolvable packages actually installed
+  [ -e "${INSTALLED_DIR}/gstreamer1-plugin-libav" ]
+  [ -e "${INSTALLED_DIR}/gstreamer1-plugins-good" ]
+  # the unresolvable one did not, and is named as the reason
+  [ ! -e "${INSTALLED_DIR}/ffmpeg" ]
+  [ -e "${WISH_DIR}/missing-on-bonito-rawhide.txt" ]
+  grep -qx "ffmpeg" "${WISH_DIR}/missing-on-bonito-rawhide.txt"
+  # only the actual miss is named — resolvable packages are never blamed
+  ! grep -qx "gstreamer1-plugin-libav" "${WISH_DIR}/missing-on-bonito-rawhide.txt"
+  ! grep -qx "gstreamer1-plugins-good" "${WISH_DIR}/missing-on-bonito-rawhide.txt"
+}
+
+@test "rawhide tolerance: skip-broken retry recovers everything — no wishlist noise" {
+  # The strict transaction can fail for reasons that clear on a plain
+  # retry (a transient mirror hiccup, not #1810's depsolve break). If
+  # --skip-broken ends up installing everything anyway, nothing should be
+  # reported missing.
+  export FEDORA_VER=rawhide
+  export DNF_STRICT_RC=1
+  export DNF_DROP=""
+  export IMAGE_NAME=bonito-rawhide
+  export TUNAOS_WISHLIST_DIR="$WISH_DIR"
+  run run_tolerant "ffmpeg gstreamer1-plugin-libav"
+  [ "$status" -eq 0 ]
+  [ -e "${INSTALLED_DIR}/ffmpeg" ]
+  [ ! -e "${WISH_DIR}/missing-on-bonito-rawhide.txt" ]
+}
+
+@test "leading dnf flags are passed through and never mistaken for a missing package" {
+  export FEDORA_VER=rawhide
+  export DNF_STRICT_RC=1
+  export DNF_DROP="ffmpeg"
+  export IMAGE_NAME=bonito-rawhide
+  export TUNAOS_WISHLIST_DIR="$WISH_DIR"
+  run run_tolerant "--exclude=openh264* gstreamer1-plugin-libav ffmpeg"
+  [ "$status" -eq 0 ]
+  [ -e "${WISH_DIR}/missing-on-bonito-rawhide.txt" ]
+  grep -qx "ffmpeg" "${WISH_DIR}/missing-on-bonito-rawhide.txt"
+  ! grep -q -- "--exclude" "${WISH_DIR}/missing-on-bonito-rawhide.txt"
+  [ -e "${INSTALLED_DIR}/gstreamer1-plugin-libav" ]
+}
+
+@test "no packages requested: returns 0 without calling dnf" {
+  export FEDORA_VER=rawhide
+  export TUNAOS_WISHLIST_DIR="$WISH_DIR"
+  export IMAGE_NAME=bonito-rawhide
+  run run_tolerant ""
+  [ "$status" -eq 0 ]
+  [ ! -e "${WISH_DIR}/missing-on-bonito-rawhide.txt" ]
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Wiring: the specific 10-base-packages.sh call site this exists for.
+# ═══════════════════════════════════════════════════════════════════════════
+
+@test "10-base-packages.sh routes the RPM Fusion multimedia set through install_rawhide_tolerant" {
+  local f="${REPO_ROOT}/build_scripts/10-base-packages.sh"
+  run awk '/install_rawhide_tolerant "/,/^$/' "$f"
+  [[ "$output" == *"ffmpeg"* ]]
+  [[ "$output" == *"gstreamer1-plugin-libav"* ]]
+}
+
+@test "10-base-packages.sh never routes buildah/podman/skopeo through install_rawhide_tolerant" {
+  # These are load-bearing on every release, rawhide included — the
+  # tolerance must be scoped to exactly the multimedia set.
+  local f="${REPO_ROOT}/build_scripts/10-base-packages.sh"
+  run awk '/install_rawhide_tolerant "/,/^$/' "$f"
+  [[ "$output" != *"buildah"* ]]
+  [[ "$output" != *"podman"* ]]
+  [[ "$output" != *"skopeo"* ]]
+}
+
+@test "package-miss-allowlist.txt declares ffmpeg acceptable to miss, scoped to the rawhide note" {
+  local allow="${REPO_ROOT}/build_scripts/checks/package-miss-allowlist.txt"
+  run grep -B2 -x "ffmpeg" "$allow"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rawhide"* ]]
+}


### PR DESCRIPTION
## Upstream evidence (fetched live, parsed with python3 against real repodata, 2026-08-17)

**Fedora rawhide** (`https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/repomd.xml` → `ee7fda3d…-primary.xml.zst`):
- `openapv-libs-0.3.0.0-1.fc46` provides `liboapv.so.3()(64bit)`.
- **No package anywhere in Fedora rawhide provides `liboapv.so.2` or `liboapv.so.2()(64bit)`** — the only `openapv`/`oapv` packages in the repo are `openapv`, `openapv-devel`, `openapv-libs`, all `0.3.0.0-1.fc46`.

**RPM Fusion free rawhide** (`https://download1.rpmfusion.org/free/fedora/development/rawhide/Everything/x86_64/os/repodata/repomd.xml` → `0eb26696…-primary.xml.gz`):
- `ffmpeg-libs-8.1.2-5.fc46` still `Requires: liboapv.so.2()(64bit)`.

So this is **not** resolved upstream — Fedora rawhide bumped the SONAME (`.so.2` → `.so.3`) before rpmfusion-free-rawhide rebuilt `ffmpeg` against it. It's a live cross-repo desync, confirmed by fetching and parsing today's repodata, not an eyeball guess.

One more thing measured, because it drives the design below: Fedora's **own** `libavcodec-free-8.1.2-10.fc46` (which is what `gstreamer1-plugin-libav`'s `libavcodec.so.62` requirement actually resolves against) already `Requires: liboapv.so.3` — i.e. it's already rebuilt correctly. Only `ffmpeg`'s hard `Requires: ffmpeg-libs(x86-64)` (satisfiable only by rpmfusion's package) is broken. So in the real transaction, `--skip-broken` is expected to drop exactly `ffmpeg` and nothing else in the multimedia set.

## Path taken

Path 3 (rawhide-scoped tolerance) per #1810 option 2, which the issue itself proposed ("`--skip-unavailable` scoped to the multimedia group, so a broken third-party repo costs codecs rather than the variant").

### What changed

- **`build_scripts/lib.sh`**: new `install_rawhide_tolerant()`. Tries the dnf transaction exactly as given first — identical to a plain `dnf -y install` on every release, including pinned bonito. Only when `FEDORA_VER=rawhide` **and** the strict transaction fails does it retry once with `--skip-broken`, then diffs the requested package list against what's actually installed (`rpm -q`) to name exactly what dropped.
- **`build_scripts/10-base-packages.sh`**: split the RPM Fusion multimedia set (`gstreamer1-plugins-*`, `lame`, `ffmpeg`) into its own transaction routed through `install_rawhide_tolerant`, separate from `buildah`/`podman`/`skopeo`/etc, which stay in a plain strict `dnf -y install` — the tolerance can never swallow a failure in a required package.
- **`build_scripts/checks/package-miss-allowlist.txt`**: added `ffmpeg`, with a comment scoped to this issue and this mechanism, and a note for when to remove it.
- **`tests/bats/test_install_rawhide_tolerant.bats`** (new): runs the real `install_rawhide_tolerant` + `record_package_wishlist` functions (extracted verbatim from `lib.sh`, same technique `test_package_wishlist_gate.bats` uses) against mocked `dnf`/`rpm`. Covers: non-rawhide strict success/failure (bonito unaffected either way, no retry, no wishlist), a release string that merely *contains* "rawhide" not matching, rawhide strict success (no retry), rawhide strict failure with `--skip-broken` dropping only `ffmpeg` (warns, records exactly `ffmpeg`, never blames the resolvable packages), a transient failure that `--skip-broken` fully recovers (no wishlist noise), dnf flags never being mistaken for package names, and wiring checks that the multimedia call site uses the tolerant path while `buildah`/`podman`/`skopeo` never do.

### Loudness guarantees (criterion `no_silent_omissions`)

- A `::warning` names the whole requested set the moment the strict transaction fails on rawhide.
- Any package that `--skip-broken` actually drops is written to `/usr/share/tunaos/missing-on-<image>.txt` via the existing `record_package_wishlist`.
- `checks/verify-package-wishlist.sh` still gates that file against `package-miss-allowlist.txt` — the miss has to be a *reviewed, committed* allowance (added here for `ffmpeg`, rawhide-scoped), not a free pass.
- Pinned bonito is provably unaffected: `install_rawhide_tolerant` only takes the tolerant branch when `FEDORA_VER=rawhide`; any other release with a broken transaction still fails the build exactly as before (asserted by the "non-rawhide + strict failure" test).

### Tests

- `python3 -m pytest tests/test_green_criteria.py tests/test_green_master_plan.py` — 12 passed (unaffected, `green-criteria.yml` not touched).
- `bats tests/bats/test_install_rawhide_tolerant.bats` — 11/11 passed.
- `bats tests/bats/test_10_base_packages.bats tests/bats/test_codec_baseline.bats tests/bats/test_live_podman_every_base.bats tests/bats/test_package_wishlist_gate.bats tests/bats/test_lib.bats tests/bats/test_build_scripts.bats tests/bats/test_containerfile_context.bats tests/bats/test_declared_flavors_installable.bats` — all passing, no regressions.
- `bash -n` and `shellcheck --exclude=SC1091` clean on both touched shell scripts.

Refs #1810.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_