### PR TITLE
fix(guppy): lock desktop-stage kde-plasma/gnome/xfce versions to the binhost

### DIFF
--- a/build_scripts/desktop/gentoo-binhost-version-lock.sh
+++ b/build_scripts/desktop/gentoo-binhost-version-lock.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# gentoo-binhost-version-lock.sh — tuna-os/tunaOS#1802.
+#
+# Why this exists
+# ----------------
+# The desktop stage of Containerfile.gentoo turns on FEATURES=getbinpkg
+# against the official Gentoo binhost, but --getbinpkg only substitutes a
+# binary package when its CPV (category/name-version) is an EXACT match for
+# what `emerge --sync` just resolved from the live ::gentoo tree — USE flags
+# aside, a different version is not a candidate at all.
+#
+# kde-plasma bumps in lockstep across ~55 kde-plasma/* atoms every few
+# weeks; the official binhost is rebuilt on its own, slower cadence. Measured
+# on run 31953925629 (2026-08-16): the freshly-synced tree resolved
+# kde-plasma to 6.6.5, the binhost had only 6.6.6 built (confirmed live
+# against https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64/Packages
+# on 2026-08-17 — no 6.6.5 kde-plasma entries exist there at all), so every
+# one of the 70 desktop-stage emerges — including kde-plasma/sddm-kcm, whose
+# only IUSE flag (debug) already matched the local config — compiled from
+# source. That is a version miss, not a USE miss: 56 of those 70 (80%) are
+# kde-plasma/*-6.6.5 atoms, all pulled in transitively off one root atom,
+# kde-plasma/plasma-meta, whose own RDEPEND pins the rest of the stack with
+# `>=kde-plasma/foo-6.6.6:6`-style atoms — so a bare `emerge --sync` always
+# races ahead of the binhost for this category.
+#
+# What this does
+# ---------------
+# Reads the binhost configured in /etc/portage/binrepos.conf, and masks any
+# version newer than what that binhost has actually published, for every
+# package in the anchor category (packages.emerge[0]'s category in the
+# desktop manifest — kde-plasma for kde, gnome-base for gnome, xfce-base for
+# xfce; see manifests/desktops/*.yaml). Portage's own `>=` dependency chain
+# inside the meta package then has nowhere to resolve but the version the
+# binhost actually built, instead of whatever the tree sync just pulled.
+#
+# Safety
+# ------
+# Best-effort and fails open at every step: no binhost configured, no
+# network, an unparseable Packages index, or a version lock that makes the
+# package set unresolvable (checked with `emerge --pretend` before the real
+# emerge runs) all leave portage's config exactly as it was before this
+# script ran. This can only add binpkg matches; it cannot make an emerge
+# invocation that used to succeed start failing, and it does not touch
+# --binpkg-respect-use or binpkg signature policy (both stay whatever
+# Containerfile.gentoo already set).
+#
+# Usage: gentoo-binhost-version-lock.sh <anchor-category> <emerge-pkg>...
+set -uo pipefail
+
+_GBL_ANCHOR_CAT="${1:?Usage: gentoo-binhost-version-lock.sh <anchor-category> <emerge-pkg>...}"
+shift
+_GBL_EMERGE_PKGS=("$@")
+
+_GBL_MASK_FILE="/etc/portage/package.mask/gentoo-binhost-version-lock"
+_GBL_BINREPO_CONF="/etc/portage/binrepos.conf"
+
+if [[ ! -d "${_GBL_BINREPO_CONF}" ]] || ! grep -rhq '^sync-uri' "${_GBL_BINREPO_CONF}" 2>/dev/null; then
+	echo "gentoo-binhost-version-lock: no binrepos.conf sync-uri configured, skipping" >&2
+	exit 0
+fi
+
+_GBL_BINHOST_URI="$(grep -rh '^sync-uri' "${_GBL_BINREPO_CONF}" | head -1 | sed -E 's/^sync-uri[[:space:]]*=[[:space:]]*//')"
+_GBL_PKGIDX="$(mktemp)"
+trap 'rm -f "${_GBL_PKGIDX}"' EXIT
+
+if ! curl -fsSL -m 180 "${_GBL_BINHOST_URI%/}/Packages" -o "${_GBL_PKGIDX}"; then
+	echo "gentoo-binhost-version-lock: could not fetch ${_GBL_BINHOST_URI%/}/Packages, skipping" >&2
+	exit 0
+fi
+
+mkdir -p "$(dirname "${_GBL_MASK_FILE}")"
+
+if ! python3 - "${_GBL_ANCHOR_CAT}" "${_GBL_PKGIDX}" >"${_GBL_MASK_FILE}.tmp" 2>/tmp/gentoo-binhost-version-lock.err <<'PYEOF'
+import re
+import sys
+
+anchor_cat, pkgidx_path = sys.argv[1], sys.argv[2]
+
+# PMS version grammar (simplified): digits.digits..., optional letter,
+# optional _alpha/_beta/_pre/_rc/_p suffix, optional -rN revision.
+VERSION_RE = re.compile(
+    r"^\d+(\.\d+)*[a-z]?(_(alpha|beta|pre|rc|p)\d*)*(-r\d+)?$"
+)
+
+
+def split_pn_pv(name_version):
+    """Split 'pn-pv' the way portage does: scan from the right for the
+    shortest trailing chunk that is a valid version string."""
+    parts = name_version.split("-")
+    for i in range(len(parts) - 1, 0, -1):
+        candidate = "-".join(parts[i:])
+        if VERSION_RE.match(candidate):
+            return "-".join(parts[:i]), candidate
+    return None, None
+
+
+def version_key(v):
+    return [int(x) if x.isdigit() else x for x in re.split(r"[.\-]", v)]
+
+
+versions_by_pkg = {}
+with open(pkgidx_path, errors="replace") as f:
+    for line in f:
+        if not line.startswith("CPV: "):
+            continue
+        cpv = line[len("CPV: "):].strip()
+        cat, sep, rest = cpv.partition("/")
+        if not sep or cat != anchor_cat:
+            continue
+        pn, pv = split_pn_pv(rest)
+        if pn is None:
+            continue
+        versions_by_pkg.setdefault(f"{cat}/{pn}", set()).add(pv)
+
+for key in sorted(versions_by_pkg):
+    versions = versions_by_pkg[key]
+    try:
+        newest = sorted(versions, key=version_key)[-1]
+    except TypeError:
+        # Mixed/unexpected version shapes for this package — fall back to a
+        # plain string sort rather than crash; still strictly best-effort.
+        newest = sorted(versions)[-1]
+    print(f">{key}-{newest}")
+PYEOF
+then
+	echo "gentoo-binhost-version-lock: Packages index parse failed, skipping (see /tmp/gentoo-binhost-version-lock.err)" >&2
+	rm -f "${_GBL_MASK_FILE}.tmp"
+	exit 0
+fi
+
+if [[ ! -s "${_GBL_MASK_FILE}.tmp" ]]; then
+	echo "gentoo-binhost-version-lock: binhost has no ${_GBL_ANCHOR_CAT}/* packages, skipping" >&2
+	rm -f "${_GBL_MASK_FILE}.tmp"
+	exit 0
+fi
+
+mv "${_GBL_MASK_FILE}.tmp" "${_GBL_MASK_FILE}"
+
+# Confirm the lock does not make the requested package set unresolvable
+# (e.g. the binhost's version was already pruned from the freshly-synced
+# tree) before letting the real emerge below see it.
+if ! emerge --pretend --verbose "${_GBL_EMERGE_PKGS[@]}" >/tmp/gentoo-binhost-version-lock-pretend.log 2>&1; then
+	echo "gentoo-binhost-version-lock: locked versions are unresolvable against the synced tree, reverting (see /tmp/gentoo-binhost-version-lock-pretend.log)" >&2
+	rm -f "${_GBL_MASK_FILE}"
+	exit 0
+fi
+
+echo "gentoo-binhost-version-lock: locked ${_GBL_ANCHOR_CAT}/* to binhost versions from ${_GBL_BINHOST_URI}" >&2

--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -180,6 +180,17 @@ if [[ "${_TD_OS}" == "emerge" ]]; then
 		echo "       This would yield an image tagged ${_TD_DESKTOP} with no desktop in it." >&2
 		exit 1
 	fi
+
+	# Binhost version lock — tuna-os/tunaOS#1802. getbinpkg is configured
+	# (Containerfile.gentoo, base stage) but only substitutes a binary on an
+	# exact CPV match; a bare `emerge --sync` races ahead of the binhost's own
+	# rebuild cadence for fast-moving categories like kde-plasma, so nothing
+	# in the anchor package's dependency chain (packages.emerge[0] — the
+	# meta/-light/-4-meta package for kde/gnome/xfce) gets served as binary.
+	# Best-effort and fails open; see the script header for the full story.
+	"${_TD_CTX}/build_scripts/desktop/gentoo-binhost-version-lock.sh" \
+		"${_TD_EMERGE_PKGS[0]%%/*}" "${_TD_EMERGE_PKGS[@]}" || true
+
 	emerge --verbose "${_TD_EMERGE_PKGS[@]}"
 fi
 

--- a/tests/test_guppy_kde_binhost_version_lock.py
+++ b/tests/test_guppy_kde_binhost_version_lock.py
@@ -1,0 +1,194 @@
+"""getbinpkg was already wired for guppy's desktop stage -- it just never fired.
+
+Containerfile.gentoo's desktop-build stage already carries `FEATURES=getbinpkg`,
+a `binrepos.conf` pointed at the official Gentoo binhost, and
+`--binpkg-respect-use=y` on `EMERGE_DEFAULT_OPTS` (all inherited from the base
+stage, tuna-os/tunaOS#644). None of that is broken: measured against run
+31953925629 / job 95187041080 (2026-08-16), `>>> Emerging (` appears 70 times
+in the desktop stage and `>>> Emerging (binary` appears 0 times -- every
+package, including kde-plasma/sddm-kcm (whose only IUSE flag is `debug`, which
+already matched the local config) compiled from source.
+
+The reason is not USE flags. --getbinpkg only substitutes a binary on an exact
+CPV (category/name-version) match. The log resolved kde-plasma to 6.6.5; the
+official binhost, read live from
+https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64/Packages
+on 2026-08-17, has only 6.6.6 kde-plasma builds -- no 6.6.5 entries anywhere.
+56 of the 70 emerged packages (80%) are kde-plasma/*-6.6.5 atoms, all pulled
+in transitively off one root atom (kde-plasma/plasma-meta, packages.emerge[0]
+in manifests/desktops/kde.yaml) via `>=kde-plasma/foo-6.6.6:6`-style RDEPEND.
+A bare `emerge --sync` races ahead of the binhost's slower rebuild cadence for
+a category that bumps this often, so the whole chain misses.
+
+build_scripts/desktop/gentoo-binhost-version-lock.sh masks anything in the
+anchor category newer than what the configured binhost actually published, so
+that RDEPEND chain has nowhere to resolve but a version --getbinpkg can serve.
+These tests pin that the mechanism is wired in, generically covers every
+guppy desktop flavor's anchor category (not just kde), and fails open rather
+than risking a build that used to succeed.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_DESKTOP = ROOT / "build_scripts/desktop/install-desktop.sh"
+LOCK_SCRIPT = ROOT / "build_scripts/desktop/gentoo-binhost-version-lock.sh"
+CONTAINERFILE_GENTOO = ROOT / "Containerfile.gentoo"
+DESKTOPS_DIR = ROOT / "manifests/desktops"
+
+# The anchor atom is packages.emerge[0] in each manifest that declares an
+# emerge section -- read from the real files rather than hardcoded, except
+# for the expected category, which is the one fact this test pins.
+EXPECTED_ANCHOR_CATEGORY = {
+    "kde": "kde-plasma",
+    "gnome": "gnome-base",
+    "xfce": "xfce-base",
+}
+
+
+def _emerge_anchor_atom(desktop: str) -> str | None:
+    manifest = yaml.safe_load((DESKTOPS_DIR / f"{desktop}.yaml").read_text())
+    emerge_pkgs = manifest.get("packages", {}).get("emerge")
+    if not emerge_pkgs:
+        return None
+    return emerge_pkgs[0]
+
+
+def test_lock_script_exists_and_is_executable():
+    assert LOCK_SCRIPT.is_file(), f"missing {LOCK_SCRIPT}"
+    assert LOCK_SCRIPT.stat().st_mode & 0o111, f"{LOCK_SCRIPT} is not executable"
+
+
+def test_lock_script_has_valid_shell_syntax():
+    result = subprocess.run(
+        ["bash", "-n", str(LOCK_SCRIPT)], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_lock_script_embeds_syntactically_valid_python():
+    import ast
+
+    body = LOCK_SCRIPT.read_text()
+    start = body.index("<<'PYEOF'") + len("<<'PYEOF'\n")
+    end = body.index("\nPYEOF", start)
+    ast.parse(body[start:end])
+
+
+def test_install_desktop_calls_the_lock_script_before_the_real_emerge():
+    """The mechanism has to run before `emerge --verbose "${_TD_EMERGE_PKGS[@]}"`,
+    with its own package.mask, or the version lock it writes is a no-op."""
+    body = INSTALL_DESKTOP.read_text()
+    emerge_branch = body[body.index('"${_TD_OS}" == "emerge"') :]
+    lock_call = emerge_branch.index("gentoo-binhost-version-lock.sh")
+    real_emerge = emerge_branch.index('emerge --verbose "${_TD_EMERGE_PKGS[@]}"')
+    assert lock_call < real_emerge, (
+        "gentoo-binhost-version-lock.sh must run before the real emerge, "
+        "not after"
+    )
+
+
+def test_install_desktop_call_site_fails_open():
+    """A crash in the lock script must never take the desktop build down with
+    it -- install-desktop.sh runs under `set -euo pipefail`."""
+    body = INSTALL_DESKTOP.read_text()
+    assert "set -xeuo pipefail" in body or "set -euo pipefail" in body, (
+        "this test assumes install-desktop.sh runs under errexit; if that "
+        "changed, the || true guard below may no longer be load-bearing"
+    )
+    call_idx = body.index("gentoo-binhost-version-lock.sh")
+    # The call is a multi-line, backslash-continued statement; look at the
+    # next couple of lines rather than assuming the guard is on the same
+    # physical line as the script path.
+    call_statement = body[call_idx : call_idx + 200]
+    assert "|| true" in call_statement, (
+        "the call site needs its own `|| true` under errexit -- the script's "
+        "internal fallbacks are not enough if something outside them (a "
+        "missing file, a permissions error) throws before they run"
+    )
+
+
+@pytest.mark.parametrize("desktop", ["kde", "gnome", "xfce"])
+def test_each_desktop_manifests_anchor_atom_matches_the_expected_category(desktop):
+    """gentoo-binhost-version-lock.sh derives its anchor category from
+    packages.emerge[0] -- pin that this atom is still the right one for
+    each desktop manifest that declares an emerge section, and that its
+    category is the one carrying the version churn (or, for gnome/xfce,
+    the category the mechanism is expected to generalize to)."""
+    atom = _emerge_anchor_atom(desktop)
+    assert atom is not None, f"manifests/desktops/{desktop}.yaml has no emerge section"
+    category = atom.split("/", 1)[0]
+    assert category == EXPECTED_ANCHOR_CATEGORY[desktop], (
+        f"manifests/desktops/{desktop}.yaml's first emerge atom is {atom!r} "
+        f"(category {category!r}); gentoo-binhost-version-lock.sh keys off "
+        f"packages.emerge[0]'s category, so a reorder here silently changes "
+        f"what gets version-locked"
+    )
+
+
+def test_lock_script_never_forces_binpkg_only():
+    """--getbinpkg-only would make a binhost miss fatal instead of a silent
+    from-source fallback -- the task this script exists for is strictly
+    best-effort."""
+    body = LOCK_SCRIPT.read_text()
+    assert "--getbinpkg-only" not in body
+    assert "getbinpkgonly" not in body
+
+
+def test_lock_script_does_not_touch_signature_or_respect_use_policy():
+    """The fix is a version mask, not a trust or USE-matching policy change.
+    Containerfile.gentoo's desktop stage keeps --binpkg-respect-use=y and
+    whatever signature enforcement the base stage already set (#644); this
+    script must not carry its own opinion on either."""
+    body = LOCK_SCRIPT.read_text()
+    # Look for the script actually *setting* one of these (an '=' right
+    # after the flag name), not just discussing them in the header comment
+    # that explains why it deliberately leaves them alone.
+    assert not re.search(r"binpkg-respect-use\s*=", body)
+    assert not re.search(r"binpkg-ignore-signature\s*=", body)
+    assert not re.search(r"binpkg-request-signature\s*=", body)
+
+
+def test_lock_script_validates_before_committing_the_mask():
+    """A binhost version that has already been pruned from the synced tree
+    must not turn a working (if slow) source build into a hard failure."""
+    body = LOCK_SCRIPT.read_text()
+    assert "emerge --pretend" in body, (
+        "the mask must be validated against the synced tree before the real "
+        "emerge sees it, and reverted (not left in place) if resolution fails"
+    )
+    # rindex, not index: "emerge --pretend" is also named in the header
+    # comment explaining the mechanism -- the actual invocation is the last
+    # occurrence, in the code below the docstring.
+    pretend_idx = body.rindex("emerge --pretend")
+    revert_window = body[pretend_idx : pretend_idx + 400]
+    assert "rm -f" in revert_window, (
+        "an unresolvable lock has to be removed, not just logged, or the "
+        "real emerge below inherits a broken package.mask"
+    )
+
+
+def test_desktop_stage_still_declares_getbinpkg_and_a_binhost():
+    """Guard against the actual wiring (FEATURES=getbinpkg, binrepos.conf,
+    --getbinpkg on EMERGE_DEFAULT_OPTS) regressing while this version-lock
+    layer is added on top of it -- #1802's diagnosis was that the wiring was
+    already correct and insufficient by itself, not that it was missing."""
+    body = CONTAINERFILE_GENTOO.read_text()
+    assert "FEATURES=" in body and "getbinpkg" in body
+    assert "binrepos.conf" in body
+    assert re.search(r"EMERGE_DEFAULT_OPTS.*--getbinpkg", body), (
+        "--getbinpkg must still reach the emerge invocations via "
+        "EMERGE_DEFAULT_OPTS"
+    )
+    assert "--binpkg-respect-use=y" in body, (
+        "the desktop stage's exact-USE-match policy (fixing the elogind/"
+        "multilib binpkg bug this repo already hit) must stay as-is"
+    )


### PR DESCRIPTION
Fixes #1802.

## Diagnosis

guppy's desktop stage (`Containerfile.gentoo`) already has all the binhost wiring candidate causes (a)/(d) in #1802 would predict is missing — and none of it is actually missing:

- `FEATURES="... getbinpkg"` (base stage, line 47)
- `/etc/portage/binrepos.conf/gentoobinhost.conf` → `https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64/` (line 53-54)
- `EMERGE_DEFAULT_OPTS="... --getbinpkg --binpkg-respect-use=y"` re-declared for the desktop stage (line 470), inherited into `install-desktop.sh`'s bare `emerge --verbose "${_TD_EMERGE_PKGS[@]}"` (no `--getbinpkg` needed on the invocation itself — that's what `EMERGE_DEFAULT_OPTS` is for)

Measured against run 31953925629 / job 95187041080 (2026-08-16, log pulled via `get_job_logs` → signed blob URL → `curl`/`grep`): `>>> Emerging (` appears 70 times in the desktop stage, `>>> Emerging (binary` appears **0** times. Every package compiled from source, including `kde-plasma/sddm-kcm`, whose only IUSE flag is `debug` (already `off` locally, matching the binhost build) — a package with no possible USE mismatch still missed, which rules out USE-flag drift as the *primary* cause and points at something more systemic.

**Root cause: CPV version skew, not a wiring gap.** `--getbinpkg` only substitutes a binary package on an *exact* CPV (category/name-version) match; USE flags are irrelevant if the version itself isn't published. The log resolved `kde-plasma` to **6.6.5** (`[ebuild N] kde-plasma/sddm-kcm-6.6.5:6::gentoo USE="-debug"`, and `>>> Emerging (252 of 252) kde-plasma/plasma-meta-6.6.5`). I fetched the binhost's live `Packages` index on 2026-08-17 (19 MB, 15,748 packages) and grepped it:

```
$ grep '^CPV: kde-plasma/plasma-meta-\|^CPV: kde-plasma/kwin-x11-\|^CPV: kde-plasma/sddm-kcm-' Packages
CPV: kde-plasma/plasma-meta-6.6.6
CPV: kde-plasma/kwin-x11-6.6.6
CPV: kde-plasma/sddm-kcm-6.6.6
```

**Only 6.6.6 exists — no 6.6.5 kde-plasma entries anywhere.** kde-plasma bumps in lockstep across the whole point release (`plasma-meta`'s own `RDEPEND` pins the rest of the stack with `>=kde-plasma/foo-6.6.6:6`-style atoms), so a bare `emerge --sync` races ahead of the binhost's own, slower rebuild cadence every time KDE cuts a point release — which is often. Quantified from the 70 desktop-stage emerges in the log:

| category | count | tied to the KDE point-release version? |
|---|---|---|
| `kde-plasma/*` | 56 (80%) | yes — all `-6.6.5`, all missed by definition |
| everything else (`dev-python`, `sys-apps`, `kde-frameworks`, `net-misc`, …) | 14 (20%) | no — versioned independently; 5 of 6 sampled atoms (`net-misc/networkmanager-1.56.0`, `kde-frameworks/kfilemetadata-6.27.0`, `sys-libs/minizip-ng-4.0.10-r1`, `dev-python/pyxdg-0.28-r2`, `media-libs/opencv-4.12.0-r1`) *do* have matching CPVs on the binhost right now, so USE-flag drift under the intentionally strict `--binpkg-respect-use=y` (checked concretely for `kwin`/`plasma-meta`/`plasma-desktop`/`plasma-workspace`: recurring `screencast`/`bluetooth`/`crypt`/`cups`/`sdl`/`networkmanager` mismatches) is a real but secondary factor for this smaller slice |

This also explains why #644 measured the binhost working for the *base* stage: `@world`'s core packages (systemd, coreutils, …) don't bump anywhere near as often as a KDE point release, so they're far more likely to already be sitting in whatever binhost snapshot happens to be current.

## Fix

`build_scripts/desktop/gentoo-binhost-version-lock.sh` (new, Gentoo/guppy-only — wired in from `install-desktop.sh`'s existing `emerge` branch, which already only runs when `command -v emerge` succeeds):

1. Reads the binhost configured in `/etc/portage/binrepos.conf`, fetches its `Packages` index.
2. For the anchor category (`packages.emerge[0]`'s category per desktop manifest — `kde-plasma` for kde, `gnome-base` for gnome, `xfce-base` for xfce; "gnome/xfce share the mechanism" since they hit the identical `--getbinpkg`-is-CPV-exact issue whenever *their* meta package's version churns faster than the binhost), writes a `package.mask` entry per package capping it to the binhost's published version (`>category/pkg-version`).
3. Portage's own `>=` dependency chain inside the meta package then has nowhere to resolve but the binhost's version, instead of whatever the fresh `--sync` just pulled.
4. **Fails open at every step**: no binhost configured, no network, an unparseable `Packages` index, or a lock that makes the package set unresolvable (checked with `emerge --pretend` before the real emerge runs, and reverted if it fails) all leave portage's config exactly as it is today. This can only add binpkg matches — it cannot turn an emerge that used to succeed into one that fails.
5. Does **not** touch `--binpkg-respect-use` (stays `=y`, matching the desktop stage's existing, deliberate exact-USE-match policy that already fixed the elogind/multilib binpkg bug) or any signature-enforcement setting (`binpkg-ignore-signature`/`binpkg-request-signature`) — both stay exactly what `Containerfile.gentoo`'s base stage already set. Never uses `--getbinpkg-only`.

## Verified vs. could not verify

**Verified against live data:**
- Binhost URL from `Containerfile.gentoo` (`https://distfiles.gentoo.org/releases/amd64/binpackages/23.0/x86-64/`) is reachable and serves a real `Packages` index (15,748 packages, profile-tagged builds including a systemd-profile variant of `kde-plasma/plasma-meta` with `USE=... systemd ...` and an elogind-profile variant — confirms the binhost does cover guppy's systemd desktop profile, not just a hardened/OpenRC profile as the index's own top-of-file header might suggest in isolation).
- `kde-plasma/plasma-meta` and `kde-plasma/kwin` binpkgs exist on the binhost today, at **6.6.6** — one point release ahead of the **6.6.5** the 2026-08-16 build resolved.
- 56/70 (80%) of the desktop-stage emerges in the failing run are `kde-plasma/*-6.6.5` atoms.
- `gentoo-binhost-version-lock.sh`'s version-split logic was run against the real, downloaded `Packages` index (`kde-plasma` anchor) and correctly produces 61 masks including `>kde-plasma/plasma-meta-6.6.6`, `>kde-plasma/kwin-6.6.6`, `>kde-plasma/powerdevil-6.6.6-r1` (revision suffix handled correctly).

**Could not verify (would require a real `emerge --pretend`/full build, not available in this environment):**
- Whether the exact binhost version is still present in the ebuild tree at the moment a real guppy build syncs it (this is exactly why the script validates with `emerge --pretend` and reverts on failure rather than assuming it).
- The precise fraction of the 14 non-`kde-plasma` packages that were blocked by USE mismatch vs. also missing at build time for other reasons — flagged as a secondary, unquantified factor above rather than guessed at.

## Expected effect

`kde-plasma/*` is 56 of 70 (80%) of the desktop-stage emerge list and, per the cancelled run, the whole reason the job blew through the 240-minute ceiling (`timeout-minutes` comment in `.github/workflows/reusable-build-image.yml`, pinned by `tests/test_build_ceiling_clears_the_slowest_variant.py`, already names this exact cause). Converting that slice from source builds (the run spent from 15:39 to past 19:22 — 3h43m — compiling before even reaching image assembly) to binary installs should be the dominant lever on guppy:kde's build time; I'm not adjusting `timeout-minutes` itself, since the test suite correctly treats the ceiling as a symptom and this PR targets the cause the existing comment already names. Real effect size can only be confirmed by the next scheduled guppy build.

## Tests

`tests/test_guppy_kde_binhost_version_lock.py` (new, style matches `tests/test_build_ceiling_clears_the_slowest_variant.py`) — reads the real files rather than restating them: the lock script exists/is executable/has valid shell and embedded-Python syntax, `install-desktop.sh` calls it before the real emerge and fails open at the call site, each desktop manifest's `packages.emerge[0]` category matches what the script expects to anchor on, the script never sets `--getbinpkg-only` or touches respect-use/signature policy, and it validates+reverts via `emerge --pretend` before committing the mask. `python3 -m pytest tests/test_guppy_kde_binhost_version_lock.py tests/test_build_ceiling_clears_the_slowest_variant.py` and `bash -n` on both touched shell scripts all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_