### PR TITLE
fix(just): run module recipes from the repo root on every just version

### DIFF
--- a/just/custom-overlay.just
+++ b/just/custom-overlay.just
@@ -8,6 +8,7 @@
 build-custom base="" tag="": _ensure-deps
     #!/usr/bin/env bash
     set -euo pipefail
+    cd {{ justfile_directory() }}
     BASE_IMAGE="{{ base }}"
     if [[ -z "${BASE_IMAGE}" ]]; then
         # yq, not a regex: `_ensure-deps` above already guarantees it, and it
@@ -37,6 +38,7 @@ build-custom base="" tag="": _ensure-deps
 run-custom-vm tag="":
     #!/usr/bin/env bash
     set -euo pipefail
+    cd {{ justfile_directory() }}
     TARGET_TAG="{{ tag }}"
     if [[ -z "${TARGET_TAG}" ]]; then
         TARGET_TAG=$({{ yq }} -r '.tag // ""' custom/image.yaml 2>/dev/null || true)
@@ -49,6 +51,7 @@ run-custom-vm tag="":
 check-custom:
     #!/usr/bin/env bash
     set -euo pipefail
+    cd {{ justfile_directory() }}
     echo "==> Validating custom/ overlay configuration..."
     if [[ -f custom/packages.yaml ]]; then
         if INVALID=$(grep -nvE '^[[:space:]]*(#.*)?$|^[a-zA-Z0-9_-]+[[:space:]]*:|^[[:space:]]*-[[:space:]]*' custom/packages.yaml); then
@@ -68,6 +71,7 @@ check-custom:
 custom-iso base_image='':
     #!/usr/bin/env bash
     set -euo pipefail
+    cd {{ justfile_directory() }}
     {{ just }} build-custom "{{ base_image }}"
     TAG="my-custom-os"
     if [[ -f "custom/image.yaml" ]]; then

--- a/just/qcow2-build.just
+++ b/just/qcow2-build.just
@@ -7,6 +7,7 @@
 qcow2 variant flavor='gnome' repo='local' tag='':
     #!/usr/bin/env bash
     set -euo pipefail
+    cd {{ justfile_directory() }}
 
     IMG_REF=""
     if [[ "{{ variant }}" == *":"* || "{{ variant }}" == *"/"* ]]; then
@@ -57,7 +58,7 @@ qcow2 variant flavor='gnome' repo='local' tag='':
     # We also mount the correct install config from the repo over the top of
     # whatever is baked into the image, so stale cached builds can't break
     # the TOML parse step.
-    INSTALL_TOML="$(pwd)/system_files/usr/lib/bootc/install/00-tunaos.toml"
+    INSTALL_TOML="{{ justfile_directory() }}/system_files/usr/lib/bootc/install/00-tunaos.toml"
 
     # Collect the local user's SSH public keys to inject into root's authorized_keys
     SSH_PUBKEYS_FILE=""

--- a/just/utilities.just
+++ b/just/utilities.just
@@ -6,6 +6,7 @@ export base_image_tag := env("BASE_IMAGE_TAG", "10")
 # Simulate the GitHub Actions CI matrix
 simulate-matrix:
     #!/usr/bin/env bash
+    cd {{ justfile_directory() }}
     ./scripts/simulate-matrix.sh
 
 [private]
@@ -14,6 +15,7 @@ default:
 
 _ensure_check_deps:
     #!/usr/bin/env bash
+    cd {{ justfile_directory() }}
     if ! command -v shellcheck &> /dev/null; then brew install shellcheck; fi
     if ! command -v shfmt &> /dev/null; then brew install shfmt; fi
     if ! command -v yamllint &> /dev/null; then brew install yamllint; fi
@@ -23,6 +25,7 @@ _ensure_check_deps:
 # Check Just Syntax
 check: _ensure_check_deps
     #!/usr/bin/env bash
+    cd {{ justfile_directory() }}
     echo "Checking syntax of shell scripts..."
     find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './.build/*' -iname "*.sh" -type f -exec shellcheck --exclude=SC1091 "{}" ";"
     find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './.build/*' -type f -name "*.yaml" -exec yamllint -c ./.yamllint.yml {} \; -o -name "*.yml" -exec yamllint {} \; 2>/dev/null || true
@@ -41,36 +44,43 @@ check: _ensure_check_deps
 # --- Test Targets ---
 _ensure_test_deps: _ensure_check_deps
     #!/usr/bin/env bash
+    cd {{ justfile_directory() }}
     if ! command -v bats &> /dev/null; then brew install bats-core; fi
     if ! python3 -c "import pytest" 2>/dev/null; then pip3 install pytest --break-system-packages 2>/dev/null || pip3 install pytest --user; fi
 
 test: _ensure_test_deps
     #!/usr/bin/env bash
     set -euo pipefail; FAILED=0
+    cd {{ justfile_directory() }}
     for f in tests/bats/*.bats; do [[ -f "$f" ]] || continue; bats --formatter tap "$f" || FAILED=1; done
     python3 -m pytest tests/ tests/pytest/ -v --tb=short || FAILED=1
     exit $FAILED
 
 test-bats: _ensure_test_deps
     #!/usr/bin/env bash
+    cd {{ justfile_directory() }}
     for f in tests/bats/*.bats; do [[ -f "$f" ]] || continue; bats --formatter tap "$f"; done
 
 test-pytest: _ensure_test_deps
     #!/usr/bin/env bash
+    cd {{ justfile_directory() }}
     python3 -m pytest tests/ tests/pytest/ -v --tb=short
 
 generate-workflows:
     #!/usr/bin/env bash
+    cd {{ justfile_directory() }}
     chmod +x {{ justfile_directory() }}/scripts/generate-workflows.py && python3 {{ justfile_directory() }}/scripts/generate-workflows.py
 
 fix:
     #!/usr/bin/env bash
+    cd {{ justfile_directory() }}
     find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -iname "*.sh" -type f -exec shfmt --write "{}" ";"
     find . -type f -name "*.just" -exec just --unstable --fmt -f {} \;
     just --unstable --fmt -f Justfile || { exit 1; }
 
 clean:
     #!/usr/bin/env bash
+    cd {{ justfile_directory() }}
     echo "Cleaning up build artifacts and images..."
     echo "Note: Preserving .rpm-cache for faster rebuilds. Use 'just clean-cache' to remove."
     rm -rf .build-logs; sudo rm -rf .build/*; rm -f out.ociarchive
@@ -85,6 +95,7 @@ clean:
 
 clean-cache:
     #!/usr/bin/env bash
+    cd {{ justfile_directory() }}
     echo "Pruning local build caches..."
     rm -rf .rpm-cache
     echo "Use 'podman system prune --build-cache' to prune BuildKit cache."

--- a/just/vm-pipeline.just
+++ b/just/vm-pipeline.just
@@ -19,6 +19,7 @@ run-iso variant flavor='gnome' iso_file='':
 demo variant='albacore' flavor='gnome' rebuild='0':
     #!/usr/bin/env bash
     set -euo pipefail
+    cd {{ justfile_directory() }}
 
     if [[ -f "{{ variant }}-{{ flavor }}.qcow2" ]]; then
         QCOW2_FILE="{{ variant }}-{{ flavor }}.qcow2"
@@ -46,6 +47,7 @@ demo variant='albacore' flavor='gnome' rebuild='0':
 demo-iso variant='skipjack' flavor='gnome' rebuild='0':
     #!/usr/bin/env bash
     set -euo pipefail
+    cd {{ justfile_directory() }}
 
     BUILD_DIR=".build/live-iso/{{ variant }}-{{ flavor }}"
     ISO_FILE=$(find "${BUILD_DIR}" -maxdepth 1 -name "*.iso" 2>/dev/null | head -1 || true)
@@ -68,6 +70,7 @@ demo-iso variant='skipjack' flavor='gnome' rebuild='0':
 _lima-novnc vm_name type image_path:
     #!/usr/bin/env bash
     set -euo pipefail
+    cd {{ justfile_directory() }}
 
     VM_NAME="{{ vm_name }}"
     TYPE="{{ type }}"
@@ -218,6 +221,7 @@ _lima-novnc vm_name type image_path:
 boot-gate variant flavor='gnome' tag='':
     #!/usr/bin/env bash
     set -euo pipefail
+    cd {{ justfile_directory() }}
     REPO_ORGANIZATION="{{ repo_organization }}" ./scripts/boot-gate.sh "{{ variant }}" "{{ flavor }}" "{{ tag }}"
 
 # Boot-gate a whole matrix of images in parallel across the KubeVirt cluster,
@@ -234,12 +238,14 @@ boot-gate-matrix +targets='yellowfin':
 verify-disk disk_image timeout='600':
     #!/usr/bin/env bash
     set -euo pipefail
+    cd {{ justfile_directory() }}
     sudo ./scripts/iso-e2e.sh "{{ disk_image }}" --disk --output verify-out --timeout "{{ timeout }}"
 
 # Verify an ISO using Lima
 verify-iso iso_file:
     #!/usr/bin/env bash
     set -euo pipefail
+    cd {{ justfile_directory() }}
     ./scripts/verify-iso.sh "{{ iso_file }}"
 
 # Boot an ISO and expose the Anaconda WebUI on http://localhost:19090
@@ -248,6 +254,7 @@ verify-iso iso_file:
 install-test iso_file kickstart='':
     #!/usr/bin/env bash
     set -euo pipefail
+    cd {{ justfile_directory() }}
     ks_arg=""
     [[ -n "{{ kickstart }}" ]] && ks_arg="--kickstart {{ kickstart }}"
     # shellcheck disable=SC2086
@@ -258,6 +265,7 @@ install-test iso_file kickstart='':
 _run-vm type variant flavor='gnome' iso_file='':
     #!/usr/bin/env bash
     set -eoux pipefail
+    cd {{ justfile_directory() }}
 
     if [[ -n "{{ iso_file }}" ]]; then
         image_file="{{ iso_file }}"

--- a/tests/test_just_modules_resolve_repo_paths.py
+++ b/tests/test_just_modules_resolve_repo_paths.py
@@ -74,3 +74,58 @@ def test_the_qcow2_probe_is_anchored():
     body = (MODULE_DIR / "qcow2-build.just").read_text(encoding="utf-8")
     assert "{{ justfile_directory() }}/scripts/lib/common.sh" in body
     assert ". scripts/lib/common.sh" not in body
+
+
+SHEBANG = "#!/usr/bin/env bash"
+CD_ANCHOR = "cd {{ justfile_directory() }}"
+
+
+@pytest.mark.parametrize("module", MODULES, ids=lambda p: p.name)
+def test_module_shebang_recipes_start_at_the_repo_root(module):
+    """Every bash recipe in an imported module must cd to the repo root first.
+
+    The just version decides an imported recipe's working directory: 1.21.0
+    (what Ubuntu 24.04's apt installs on the Gate runners) runs it from the
+    directory of the imported file — just/ — while 1.25+ runs it from the root
+    justfile's directory.  Measured, not assumed: marlin's Gate run
+    31999186436 rendered $(pwd)/system_files/... as
+    tunaOS/just/system_files/... and bootc failed the statfs, one step after
+    the scripts/lib/common.sh fix from the same import move (#1586, #1811).
+
+    An explicit `cd {{ justfile_directory() }}` is version-proof: the function
+    is evaluated by just itself and returns the root justfile's directory on
+    every version (verified on 1.21.0, 1.42.4 and 1.55.1).  It also puts
+    recipe outputs (marlin.qcow2) back at the repo root, where the workflow's
+    `find . -maxdepth 1 -name '*.qcow2'` expects them.
+    """
+    lines = module.read_text(encoding="utf-8").splitlines()
+    offenders = []
+    for lineno, line in enumerate(lines, 1):
+        if line.strip() != SHEBANG:
+            continue
+        # The cd must appear within the next two lines (a `set` line may
+        # come first so an unwritable root fails loudly under -e).
+        window = [l.strip() for l in lines[lineno:lineno + 2]]
+        if not any(CD_ANCHOR in l for l in window):
+            offenders.append(f"{module.name}:{lineno}")
+
+    assert not offenders, (
+        "bash recipe in a just module without an explicit repo-root cd — on "
+        "the Gate runners' just 1.21.0 it runs from just/ and every "
+        "repo-relative path or output lands in the wrong place:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_no_pwd_anchored_repo_paths_in_modules():
+    """$(pwd) said repo root in the root Justfile; in a module it lies."""
+    for module in MODULES:
+        for lineno, line in enumerate(
+            module.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            for token in ("$(pwd)/system_files", "$(pwd)/scripts",
+                          "${PWD}/system_files", "${PWD}/scripts"):
+                assert token not in line, (
+                    f"{module.name}:{lineno} anchors a repo path to the "
+                    "working directory; use '{{ justfile_directory() }}/'"
+                )


### PR DESCRIPTION
## What

Second regression from the #1586 module extraction, one step past the first. #1811 anchored `scripts/lib/common.sh` and the marlin Gates got past the image probe — verification run [31999186436](https://github.com/tuna-os/tunaOS/actions/runs/31999186436) then failed at `bootc install to-disk`:

```
statfs .../tunaOS/just/system_files/usr/lib/bootc/install/00-tunaos.toml: no such file or directory
```

## Root cause — measured, not assumed

The working directory of a recipe in an **imported** just file depends on the just version:

| just version | imported shebang recipe cwd |
|---|---|
| 1.21.0 (Ubuntu 24.04 apt — what the Gate jobs `apt-get install`) | **the module's directory (`just/`)** |
| 1.25.2 / 1.34.0 / 1.42.4 / 1.55.1 (the build jobs pin 1.55.1) | repo root |

So on Gate runners, `$(pwd)`-anchored paths lie (`$(pwd)/system_files/…` → `just/system_files/…`), and recipe outputs (`marlin.qcow2`) land in `just/` where the workflow's `find . -maxdepth 1 -name "*.qcow2"` can't see them. `{{ justfile_directory() }}` is evaluated by just itself and returns the root justfile's directory on every version — which is why #1811's fix held on the same runners.

## Fix

Make the whole class impossible instead of chasing paths one by one:

- every bash recipe in `just/*.just` now begins with `cd {{ justfile_directory() }}` (24 recipes across the four modules), restoring the pre-#1586 working directory wholesale — outputs at repo root, repo-relative paths valid, identical behavior on apt just and pinned just
- `INSTALL_TOML` anchored explicitly with `{{ justfile_directory() }}` as defense in depth
- tests: a parametrized sweep asserts every module shebang recipe carries the cd, and `$(pwd)`/`${PWD}`-anchored repo paths are forbidden in modules — the docstring records the per-version measurements

## Verification

- Justfile parses and renders correctly on just 1.21.0, 1.42.4 and 1.55.1 (local binaries)
- Synthetic import reproduces the 1.21.0 cwd behavior and the fix on all three versions
- Full suite: **464 passed**
- After merge I'll re-dispatch Build Marlin to confirm the four Gates reach boot-and-verify

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_