### PR TITLE
fix(bonito-rawhide): detect Rawhide from os-release, not rpm -E %fedora

### DIFF
--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -150,10 +150,12 @@ if [[ $IS_HUMMINGBIRD == true ]]; then
 		gcc-c++ \
 		just || true
 elif [[ $IS_FEDORA == true ]]; then
-	FEDORA_VER="$(rpm -E %fedora)"
-	if [[ -z "${FEDORA_VER}" || "${FEDORA_VER}" == "%fedora" ]]; then
-		FEDORA_VER="rawhide"
-	fi
+	# detect_fedora_ver (lib.sh) yields "rawhide" on Rawhide images — from
+	# os-release, because `rpm -E %fedora` expands to the numeric NEXT
+	# release there and would leave the tolerance gate below permanently
+	# cold (run 32002010101). Also picks the -rawhide rpmfusion release
+	# RPMs instead of a not-yet-published numeric one.
+	FEDORA_VER="$(detect_fedora_ver)"
 	# Install config-manager, RPM Fusion, multimedia, and common packages
 	# in as few transactions as possible (each dnf invocation incurs ~10-20s
 	# metadata resolution overhead).

--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -670,6 +670,30 @@ install_available() {
 # checks/package-miss-allowlist.txt. The omission is recorded, not
 # silent, and criterion no_silent_omissions has real evidence to point at.
 #
+# Which Fedora is this buildroot, in the form the rpmfusion release RPMs and
+# the rawhide-tolerance gate below both need: a number for pinned releases,
+# the literal string "rawhide" for Rawhide.
+#
+# `rpm -E %fedora` alone cannot answer that: on Rawhide it expands to the
+# NEXT numeric release (46 today) and NEVER to "rawhide", so a gate comparing
+# against "rawhide" can never fire from it. Measured: bonito-rawhide run
+# 32002010101 printed "install_rawhide_tolerant: transaction failed on 46;
+# not tolerating" and the base failed on the exact skew the tolerance exists
+# for. os-release is the discriminator — Rawhide images carry "Rawhide" in
+# VERSION/PRETTY_NAME, branched and released images do not.
+#
+# OS_RELEASE is overridable for tests only; production callers use the default.
+detect_fedora_ver() {
+	local ver
+	ver="$(rpm -E %fedora 2>/dev/null || true)"
+	if [[ -z "$ver" || "$ver" == "%fedora" ]] \
+		|| grep -qi rawhide "${OS_RELEASE:-/etc/os-release}" 2>/dev/null; then
+		echo rawhide
+	else
+		echo "$ver"
+	fi
+}
+
 # Usage: install_rawhide_tolerant [dnf-flag ...] pkg1 pkg2 pkg3 ...
 # (leading `-`-prefixed args are treated as dnf flags, e.g. --exclude=...,
 # everything after the first non-flag arg is a package name)

--- a/tests/bats/test_install_rawhide_tolerant.bats
+++ b/tests/bats/test_install_rawhide_tolerant.bats
@@ -228,3 +228,69 @@ run_tolerant() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"rawhide"* ]]
 }
+
+# --- detect_fedora_ver: the gate above is only reachable if FEDORA_VER can
+# actually say "rawhide". `rpm -E %fedora` never does (it expands to the
+# numeric next release on Rawhide), so the derivation must consult
+# os-release. Run 32002010101 is the measured failure: "transaction failed
+# on 46; not tolerating" on a genuine Rawhide image.
+
+extract_detect() {
+  FN_DETECT="$(awk '/^detect_fedora_ver\(\)/,/^}/' "$LIB")"
+  [[ -n "$FN_DETECT" ]]
+}
+
+@test "detect_fedora_ver: pinned release stays numeric" {
+  extract_detect
+  cat >"${BIN}/rpm" <<'MOCK'
+#!/usr/bin/env bash
+[[ "$1" == "-E" && "$2" == "%fedora" ]] && { echo 44; exit 0; }
+exit 1
+MOCK
+  chmod +x "${BIN}/rpm"
+  printf 'PRETTY_NAME="Fedora Linux 44 (Container Image)"\nVERSION_ID=44\n' \
+    >"${BATS_TEST_TMPDIR}/os-release"
+  run env PATH="${BIN}:$PATH" OS_RELEASE="${BATS_TEST_TMPDIR}/os-release" \
+    bash -c "$FN_DETECT; detect_fedora_ver"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "44" ]]
+}
+
+@test "detect_fedora_ver: rawhide os-release wins over the numeric expansion" {
+  extract_detect
+  cat >"${BIN}/rpm" <<'MOCK'
+#!/usr/bin/env bash
+[[ "$1" == "-E" && "$2" == "%fedora" ]] && { echo 46; exit 0; }
+exit 1
+MOCK
+  chmod +x "${BIN}/rpm"
+  printf 'PRETTY_NAME="Fedora Linux Rawhide (Container Image Prerelease)"\nVERSION_ID=46\n' \
+    >"${BATS_TEST_TMPDIR}/os-release"
+  run env PATH="${BIN}:$PATH" OS_RELEASE="${BATS_TEST_TMPDIR}/os-release" \
+    bash -c "$FN_DETECT; detect_fedora_ver"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "rawhide" ]]
+}
+
+@test "detect_fedora_ver: unexpanded %fedora falls back to rawhide" {
+  extract_detect
+  cat >"${BIN}/rpm" <<'MOCK'
+#!/usr/bin/env bash
+[[ "$1" == "-E" && "$2" == "%fedora" ]] && { echo '%fedora'; exit 0; }
+exit 1
+MOCK
+  chmod +x "${BIN}/rpm"
+  printf 'PRETTY_NAME="Fedora Linux 44 (Container Image)"\n' \
+    >"${BATS_TEST_TMPDIR}/os-release"
+  run env PATH="${BIN}:$PATH" OS_RELEASE="${BATS_TEST_TMPDIR}/os-release" \
+    bash -c "$FN_DETECT; detect_fedora_ver"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "rawhide" ]]
+}
+
+@test "10-base-packages derives FEDORA_VER through detect_fedora_ver" {
+  grep -q 'FEDORA_VER="\$(detect_fedora_ver)"' \
+    "${REPO_ROOT}/build_scripts/10-base-packages.sh"
+  ! grep -q 'FEDORA_VER="\$(rpm -E %fedora)"' \
+    "${REPO_ROOT}/build_scripts/10-base-packages.sh"
+}


### PR DESCRIPTION
## What

The #1815 rawhide tolerance never fired. Its gate only reaches the `--skip-broken` retry when `FEDORA_VER` is the string `rawhide`, but the derivation was `FEDORA_VER="$(rpm -E %fedora)"` — which on Rawhide expands to the numeric **next** release (46 today) and can never say "rawhide". The gate was permanently cold.

Measured, not assumed — validation run [32002010101](https://github.com/tuna-os/tunaOS/actions/runs/32002010101) failed the base on both arches with the exact skew the tolerance exists for:

```
Problem: package ffmpeg-8.1.2-5.fc46.x86_64 from rpmfusion-free-rawhide requires ffmpeg-libs(x86-64) = 8.1.2-5.fc46 ...
  - nothing provides liboapv.so.2()(64bit) needed by ffmpeg-libs-8.1.2-5.fc46.x86_64
install_rawhide_tolerant: transaction failed on 46; not tolerating
(only Rawhide gets the --skip-broken retry — pinned Fedora releases stay strict).
```

(The same run's three Gate failures are the pre-#1818 qcow2 path bug — that run predates the merge; unrelated to this fix.)

## Fix

New `detect_fedora_ver()` in `build_scripts/lib.sh`: keeps the numeric expansion for pinned releases, but consults os-release for the Rawhide discriminator — Rawhide images carry "Rawhide" in `PRETTY_NAME`/`VERSION`, branched and released images do not. `10-base-packages.sh` derives `FEDORA_VER` through it.

Side benefit: the RPM Fusion release-RPM URLs now resolve to `rpmfusion-*-release-rawhide.noarch.rpm` on Rawhide instead of a numeric variant that may not be published yet.

`OS_RELEASE` is overridable for tests only; production callers use the default path.

## Tests

- 4 new bats cases in `tests/bats/test_install_rawhide_tolerant.bats`: pinned release stays numeric; rawhide os-release wins over the numeric expansion; unexpanded `%fedora` falls back to rawhide; the call site in `10-base-packages.sh` is pinned to `detect_fedora_ver`. File now 15/15.
- Full suite: **464 passed.**

After merge I'll re-dispatch Build Bonito-rawhide to confirm the base survives with the `::warning` + wishlist path (expect ffmpeg named, 14 cells building).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_