### PR TITLE
feat(sweep): read the omissions manifest from every published image (W5)

### DIFF
--- a/.github/green-criteria.yml
+++ b/.github/green-criteria.yml
@@ -115,9 +115,13 @@ criteria:
     name: The build tells the truth about what it shipped
     proves: >-
       No package was dropped without the result being surfaced and acted on.
-    asserted_by: /usr/share/tunaos/missing-on-*.txt written into the image
-    enforcement: unimplemented
+    asserted_by: >-
+      build_scripts/checks/verify-package-wishlist.sh — at build time as a
+      gate, and daily against every published image by
+      .github/workflows/desktop-contract-sweep.yml (omissions read)
+    enforcement: advisory
     status_2026_08_17: "written into every image; read by nothing on a schedule"
+    status_2026_08_17_pm: "scheduled: the contract sweep reads the manifest from every image it pulls and scores it against package-miss-allowlist.txt"
     notes: >-
       Distinct from `parity`. Parity asks whether the set matches upstream;
       this asks whether the build admitted what it silently skipped.

--- a/.github/workflows/desktop-contract-sweep.yml
+++ b/.github/workflows/desktop-contract-sweep.yml
@@ -115,6 +115,7 @@ jobs:
           fi
 
           status=missing; exitcode=""; reason="no published image"
+          omissions_status=untested; omissions_reason="image not read"
           # Existence check WITHOUT pulling: a cell with no image is untested,
           # not failing, and must not cost a multi-GB download to discover.
           #
@@ -153,6 +154,34 @@ jobs:
                 reason=$(grep -m1 -E "^missing (required|unit)" <<<"$out" || echo "exit ${exitcode}")
               fi
               echo "$out" | tail -40
+
+              # Same pulled image, second axis (green criterion 8,
+              # no_silent_omissions): run the SAME gate the build runs
+              # (checks/verify-package-wishlist.sh) against what was actually
+              # published. The build-time gate covers new builds; this read
+              # covers what users pull today — images published before the
+              # gate existed, or through paths that bypass it. Reuses this
+              # job's multi-GB pull instead of funding a second sweep.
+              # IS_HUMMINGBIRD is mirrored from the build context: those
+              # images skip the gate there, so they skip it here, for the
+              # same recorded reason.
+              is_hb=false
+              [[ "${{ matrix.variant }}" == hummingbird* ]] && is_hb=true
+              wl_out=$(sudo podman run --rm \
+                -v "$PWD/build_scripts/checks/verify-package-wishlist.sh:/vpw.sh:z" \
+                -v "$PWD/build_scripts/checks/package-miss-allowlist.txt:/allow.txt:z" \
+                -e TUNAOS_WISHLIST_ALLOWLIST=/allow.txt \
+                -e IS_HUMMINGBIRD="$is_hb" \
+                --entrypoint /bin/bash "$REF" /vpw.sh 2>&1)
+              wl_exit=$?
+              if [[ "$wl_exit" -eq 0 ]]; then
+                omissions_status=pass
+              else
+                omissions_status=fail
+              fi
+              omissions_reason=$(grep -m1 -E '^TUNAOS_WISHLIST_(OK|FAIL|SKIPPED)' <<<"$wl_out" \
+                || echo "gate exited ${wl_exit} without its verdict line")
+              echo "$wl_out" | tail -20
             fi
           fi
 
@@ -160,7 +189,8 @@ jobs:
           jq -n --arg cell "$CELL" --arg variant "${{ matrix.variant }}" \
                 --arg desktop "${{ matrix.desktop }}" --arg status "$status" \
                 --arg reason "$reason" --arg exitcode "${exitcode:-}" \
-             '{cell:$cell,variant:$variant,desktop:$desktop,status:$status,reason:$reason,exit:$exitcode}' \
+                --arg om "$omissions_status" --arg omr "$omissions_reason" \
+             '{cell:$cell,variant:$variant,desktop:$desktop,status:$status,reason:$reason,exit:$exitcode,omissions_status:$om,omissions_reason:$omr}' \
              > "result.json"
 
       - name: Upload cell result
@@ -205,7 +235,9 @@ jobs:
             | .[0] + [ .[1][] | select(.cell as $c | $got | index($c) | not)
                        | {cell: .cell, variant: (.cell|split(":")[0]),
                           desktop: (.cell|split(":")[1]), status: "lost",
-                          reason: "job produced no result (see its log)", exit: ""} ]
+                          reason: "job produced no result (see its log)", exit: "",
+                          omissions_status: "untested",
+                          omissions_reason: "job produced no result"} ]
             | sort_by(.cell)' found.json expected.json > all.json
 
           pass=$(jq '[.[]|select(.status=="pass")]|length' all.json)
@@ -233,6 +265,20 @@ jobs:
                else "⬜" end) +
               " | \(.reason) |"' all.json
           } | tee -a "$GITHUB_STEP_SUMMARY" > baseline.md
+
+          om_pass=$(jq '[.[]|select(.omissions_status=="pass")]|length' all.json)
+          om_fail=$(jq '[.[]|select(.omissions_status=="fail")]|length' all.json)
+          {
+            echo
+            echo "**Silent omissions (criterion 8): ${om_pass} clean, ${om_fail} shipping unallowlisted misses** (cells whose image was not read score untested, not clean)."
+            if (( om_fail > 0 )); then
+              echo
+              echo "| cell | omissions |"
+              echo "|---|---|"
+              jq -r '.[] | select(.omissions_status=="fail")
+                | "| \(.cell) | \(.omissions_reason) |"' all.json
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY" >> baseline.md
 
           echo "DESKTOP CONTRACT BASELINE: ${pass}/${total} pass, ${fail} fail, ${miss} no image, ${err} error, ${lost} lost"
 

--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -91,8 +91,10 @@ per-cell skippable, and `base` cells promote with the Gate skipped.
 
 Every image already writes `/usr/share/tunaos/missing-on-*.txt`.
 
-- [ ] Scheduled job: pull each promoted image, read the manifest, publish a
-      table; nonzero omissions on a cell claiming green ⇒ not green.
+- [x] Scheduled job: the desktop contract sweep now runs
+      `verify-package-wishlist.sh` against every published image it pulls
+      (one pull, two axes), records `omissions_status` per cell, and the
+      composite scores it; unallowlisted omissions ⇒ not clean.
 - [ ] This is what catches the #858 class (published image, no desktop) and
       the #1755 class (hummingbird desktops installing nothing) *at publish
       time* instead of at verification time.

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -66,7 +66,7 @@ it.
 
 ## Composite green — the bar
 
-Scored against `.github/green-criteria.yml`: a cell is green only when every **blocking** criterion applicable to it has a current affirmative result; a criterion that was skipped, never tested, or unasserted renders ⬜ and does not count as satisfied. Blocking today: `builds`. Advisory (measured in the sections below, not yet biting): `desktop`, `boots`, `install`, `rebuildable`. Unimplemented: `iso`, `lifecycle`, `parity`, `no_silent_omissions`, `arch_honesty`. Graduating a criterion is an edit to `enforcement:` in that file — this table and the README count tighten with no code change.
+Scored against `.github/green-criteria.yml`: a cell is green only when every **blocking** criterion applicable to it has a current affirmative result; a criterion that was skipped, never tested, or unasserted renders ⬜ and does not count as satisfied. Blocking today: `builds`. Advisory (measured in the sections below, not yet biting): `desktop`, `boots`, `install`, `no_silent_omissions`, `rebuildable`. Unimplemented: `iso`, `lifecycle`, `parity`, `arch_honesty`. Graduating a criterion is an edit to `enforcement:` in that file — this table and the README count tighten with no code change.
 
 **0 of 142** published cells are composite-green.
 
@@ -86,6 +86,27 @@ Scored against `.github/green-criteria.yml`: a cell is green only when every **b
 | **yellowfin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 
 Cells outside the desktop columns (base, hwe, nvidia and friends) are in the count above but not the table; only `builds` applies to them today.
+
+## Silent omissions
+
+**0 of 52** cells clean (0 read, 52 never read).
+
+Green criterion 8 (`no_silent_omissions`): the sweep runs `checks/verify-package-wishlist.sh` against every published image it pulls — the same gate new builds pass at build time — so an image shipping a silently-skipped package outside `package-miss-allowlist.txt` reads ❌ here even if it was published before the gate existed. A cell whose image was not read (no image, pull error, job lost) is ⬜, not clean.
+
+| Variant | gnome | kde | cosmic | niri | xfce |
+|---|:--:|:--:|:--:|:--:|:--:|
+| **albacore** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **bonito** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **bonito-rawhide** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **flounder** | ⬜ | ⬜ | — | — | ⬜ |
+| **flounder-sid** | ⬜ | ⬜ | — | — | ⬜ |
+| **grouper** | ⬜ | ⬜ | ⬜ | — | ⬜ |
+| **guppy** | ⬜ | ⬜ | — | — | ⬜ |
+| **hummingbird** | ⬜ | ⬜ | ⬜ | ⬜ | — |
+| **marlin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **sailfin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **skipjack** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **yellowfin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 
 ## LUKS E2E
 

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -304,6 +304,65 @@ def overlay_tags() -> set[str]:
     return {t for t in tags if not t.startswith("sha256-")}
 
 
+_BASELINE_CACHE: tuple[list[dict], str, str] | None = None
+
+
+def _baseline_cells() -> tuple[list[dict], str, str]:
+    """The newest trustworthy desktop-contract-baseline artifact, once.
+
+    contract_results() and omissions_results() read the same all.json — the
+    sweep records both axes from one image pull — so download it once per
+    invocation rather than once per axis.
+    """
+    global _BASELINE_CACHE
+    if _BASELINE_CACHE is not None:
+        return _BASELINE_CACHE
+    runs = gh_json(
+        "run", "list", "--repo", REPO, "--workflow", "desktop-contract-sweep.yml",
+        "--limit", "10", "--json", "databaseId,createdAt,status,conclusion",
+    ) or []
+    for run in runs:
+        if run.get("status") != "completed" or run.get("conclusion") != "success":
+            continue
+        run_id, date = str(run["databaseId"]), run["createdAt"][:10]
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                subprocess.run(
+                    ["gh", "run", "download", run_id, "--repo", REPO,
+                     "--name", "desktop-contract-baseline", "--dir", tmp],
+                    capture_output=True, text=True, check=True,
+                )
+            except subprocess.CalledProcessError:
+                continue
+            all_json = Path(tmp) / "all.json"
+            if not all_json.exists():
+                continue
+            _BASELINE_CACHE = (json.loads(all_json.read_text()), date, run_id)
+            return _BASELINE_CACHE
+    _BASELINE_CACHE = ([], "", "")
+    return _BASELINE_CACHE
+
+
+def omissions_results() -> dict[str, tuple[str, str, str]]:
+    """Per-cell no_silent_omissions verdict from the sweep's baseline.
+
+    Same artifact as contract_results(), different field: the sweep runs
+    checks/verify-package-wishlist.sh against every published image it pulls
+    (green criterion 8). Cells from artifacts that predate the field, and
+    cells whose image was never read (missing/error/lost), score untested —
+    absence of evidence, per the same #1730 rule as everywhere else.
+    """
+    cells, date, run_id = _baseline_cells()
+    out: dict[str, tuple[str, str, str]] = {}
+    for c in cells:
+        verdict = c.get("omissions_status")
+        if verdict in ("pass", "fail"):
+            out[c["cell"]] = (
+                "success" if verdict == "pass" else "failure", date, run_id
+            )
+    return out
+
+
 def contract_results() -> dict[str, tuple[str, str, str]]:
     """Newest per-cell verdict from desktop-contract-sweep.yml (tunaOS#858).
 
@@ -329,37 +388,8 @@ def contract_results() -> dict[str, tuple[str, str, str]]:
     translated to success/failure here, so callers can tell "no image
     published" apart from "published and broken" if they need to.
     """
-    runs = gh_json(
-        "run", "list", "--repo", REPO, "--workflow", "desktop-contract-sweep.yml",
-        "--limit", "10", "--json", "databaseId,createdAt,status,conclusion",
-    ) or []
-    for run in runs:
-        # The workflow's own conclusion (not the per-cell jobs') is a real
-        # signal here: `collate` fails the run if the baseline does not
-        # reconcile (see its "every cell must be accounted for" check), so a
-        # non-success run's artifact — if it even uploaded one — is not
-        # trustworthy data to read as a baseline.
-        if run.get("status") != "completed" or run.get("conclusion") != "success":
-            continue
-        run_id, date = str(run["databaseId"]), run["createdAt"][:10]
-        with tempfile.TemporaryDirectory() as tmp:
-            try:
-                subprocess.run(
-                    ["gh", "run", "download", run_id, "--repo", REPO,
-                     "--name", "desktop-contract-baseline", "--dir", tmp],
-                    capture_output=True, text=True, check=True,
-                )
-            except subprocess.CalledProcessError:
-                # Artifact expired (30/90-day retention) or this particular
-                # run predates the artifact existing — try the next-newest
-                # successful run rather than giving up on the whole section.
-                continue
-            all_json = Path(tmp) / "all.json"
-            if not all_json.exists():
-                continue
-            cells = json.loads(all_json.read_text())
-            return {c["cell"]: (c["status"], date, run_id) for c in cells}
-    return {}
+    cells, date, run_id = _baseline_cells()
+    return {c["cell"]: (c["status"], date, run_id) for c in cells}
 
 
 def load_green_criteria(path: Path = GREEN_CRITERIA) -> list[dict]:
@@ -446,7 +476,8 @@ def composite_verdict(verdicts: list[str]) -> str:
     return "pass"
 
 
-def composite_section(criteria, stage, contract, luks, smoke, lifecycle):
+def composite_section(criteria, stage, contract, luks, smoke, lifecycle,
+                      omissions):
     """The bar itself: one table scored against the blocking criteria.
 
     Per-criterion applicability follows each axis's own denominator, exactly
@@ -475,6 +506,9 @@ def composite_section(criteria, stage, contract, luks, smoke, lifecycle):
             )
             per_cell["lifecycle"] = _axis_from_results(
                 lifecycle, f"{variant}:{flavor}"
+            )
+            per_cell["no_silent_omissions"] = _axis_from_results(
+                omissions, f"{variant}:{flavor}"
             )
         if flavor in isos.get(variant, set()):
             per_cell["iso"] = _axis_from_results(smoke, f"{variant}:{flavor}")
@@ -544,6 +578,29 @@ def composite_section(criteria, stage, contract, luks, smoke, lifecycle):
     # The escaped square renders literally otherwise.
     lines = [l.replace("\u2b1c", UNTESTED) for l in lines]
     return lines, green, total
+
+
+def omissions_section(lmatrix, omissions) -> list[str]:
+    """Green criterion 8 as its own axis section (see omissions_results)."""
+    om_key = lambda v, d: f"{v}:{d}"                   # noqa: E731
+    total, tested, passed = tally(lmatrix, omissions, om_key)
+    return [
+        "## Silent omissions",
+        "",
+        f"**{passed} of {total}** cells clean "
+        f"({tested} read, {total - tested} never read).",
+        "",
+        (
+            "Green criterion 8 (`no_silent_omissions`): the sweep runs "
+            "`checks/verify-package-wishlist.sh` against every published image "
+            "it pulls — the same gate new builds pass at build time — so an "
+            "image shipping a silently-skipped package outside "
+            "`package-miss-allowlist.txt` reads ❌ here even if it was "
+            "published before the gate existed. A cell whose image was not "
+            "read (no image, pull error, job lost) is ⬜, not clean."
+        ),
+        "",
+    ] + desktop_table(lmatrix, omissions, om_key) + [""]
 
 
 def cell(results: dict, key: str, in_matrix: bool) -> str:
@@ -713,11 +770,15 @@ def build() -> str:
     # First, because everything below is an input to it: this is the section
     # that composes the axes into the one claim the word "green" now makes.
     lifecycle = latest_results("bootc-lifecycle.yml", r":")
+    omissions = omissions_results()
     composite_lines, _, _ = composite_section(
         load_green_criteria(), build_stage_results(), contract, luks, smoke,
-        lifecycle,
+        lifecycle, omissions,
     )
     out += composite_lines
+
+    out += omissions_section(lmatrix, omissions)
+
 
     # ── LUKS ────────────────────────────────────────────────────────────────
     total, tested, passed = tally(lmatrix, luks, luks_key)

--- a/tests/test_composite_green_scoring.py
+++ b/tests/test_composite_green_scoring.py
@@ -28,7 +28,8 @@ CRITERIA = yaml.safe_load(
 # this set that graduates to blocking turns every cell ⬜ (loud), never green
 # (silent) — test_blocking_criteria_are_scoreable below is the tripwire that
 # makes the graduation a conscious wiring decision instead of a surprise.
-SCOREABLE = {"builds", "boots", "desktop", "install", "iso", "lifecycle"}
+SCOREABLE = {"builds", "boots", "desktop", "install", "iso", "lifecycle",
+             "no_silent_omissions"}
 
 
 def test_composite_verdict_orders_fail_over_untested_over_pass() -> None:
@@ -61,7 +62,7 @@ def test_blocking_criteria_are_scoreable() -> None:
 def test_offline_composite_covers_the_full_matrix() -> None:
     """With no CI data at all: nothing green, every published cell counted,
     and the total agrees with the README denominator (build_image cells)."""
-    lines, green, total = gms.composite_section(CRITERIA, {}, {}, {}, {}, {})
+    lines, green, total = gms.composite_section(CRITERIA, {}, {}, {}, {}, {}, {})
     assert green == 0
     cfg = gms._matrix("build_image", desktops_only=False)
     assert total == sum(len(f) for f in cfg.values())
@@ -71,7 +72,7 @@ def test_offline_composite_covers_the_full_matrix() -> None:
 def test_composite_scores_a_promoted_gated_cell_green_iff_blocking_pass() -> None:
     stage = {"albacore": {"jobs": {("gnome", "Promote"): "success",
                                    ("gnome", "Gate"): "failure"}, "date": "x"}}
-    lines, green, total = gms.composite_section(CRITERIA, stage, {}, {}, {}, {})
+    lines, green, total = gms.composite_section(CRITERIA, stage, {}, {}, {}, {}, {})
     blocking = {c["id"] for c in CRITERIA if c["enforcement"] == "blocking"}
     if blocking == {"builds"}:
         # A failing Gate is advisory today: the cell is still composite-green.

--- a/tests/test_matrix_status_config.py
+++ b/tests/test_matrix_status_config.py
@@ -216,6 +216,13 @@ class OverlayTagsNetworkLayer(unittest.TestCase):
 class ContractResultsArtifactDownload(unittest.TestCase):
     """desktop-contract-sweep.yml's baseline artifact, not job conclusions."""
 
+    def setUp(self):
+        # contract_results() and omissions_results() share one download via
+        # _baseline_cells()'s module-level cache; a prior test's data must not
+        # satisfy this test's call without its mocks ever running.
+        gms._BASELINE_CACHE = None
+        self.addCleanup(setattr, gms, "_BASELINE_CACHE", None)
+
     def _run(self, status="completed"):
         return {"databaseId": 1, "createdAt": "2026-08-06T00:00:00Z",
                 "status": status, "conclusion": "success"}

--- a/tests/test_omissions_manifest_is_read_on_a_schedule.py
+++ b/tests/test_omissions_manifest_is_read_on_a_schedule.py
@@ -1,0 +1,95 @@
+"""W5 of docs/GREEN-MASTER-PLAN.md: the omissions manifest is finally read.
+
+Every image writes /usr/share/tunaos/missing-on-*.txt; until now nothing read
+it on a schedule, so a package silently skipped in an already-published image
+stayed invisible (the tunaOS#858 class — published, no desktop). The sweep now
+runs the SAME gate the build runs (verify-package-wishlist.sh) against every
+image it pulls: one multi-GB pull, two axes.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SWEEP = ROOT / ".github" / "workflows" / "desktop-contract-sweep.yml"
+spec = importlib.util.spec_from_file_location(
+    "gms", ROOT / "scripts" / "gen-matrix-status.py"
+)
+gms = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gms)
+
+
+def test_sweep_runs_the_same_gate_the_build_runs() -> None:
+    body = SWEEP.read_text(encoding="utf-8")
+    assert "verify-package-wishlist.sh" in body, (
+        "the omissions read must be the build gate itself, not a "
+        "reimplementation that can drift from it"
+    )
+    assert "TUNAOS_WISHLIST_ALLOWLIST" in body
+    assert "package-miss-allowlist.txt" in body
+
+
+def test_sweep_mirrors_the_hummingbird_skip() -> None:
+    """The gate skips hummingbird at build time (bootstrap gap is measured by
+    its own tooling); the published-image read must skip for the same
+    recorded reason, not fail those cells for a decision already made."""
+    assert "IS_HUMMINGBIRD" in SWEEP.read_text(encoding="utf-8")
+
+
+def test_result_json_carries_the_omissions_verdict() -> None:
+    body = SWEEP.read_text(encoding="utf-8")
+    assert "omissions_status" in body
+    assert "omissions_reason" in body
+    # A lost job's synthesized row must score untested, not clean.
+    assert body.count('omissions_status: "untested"') >= 1
+
+
+def test_omissions_results_translates_only_real_verdicts() -> None:
+    """pass→success, fail→failure; artifacts predating the field, and cells
+    whose image was never read, yield nothing — cell() then renders ⬜."""
+    gms._BASELINE_CACHE = (
+        [
+            {"cell": "a:gnome", "status": "pass", "omissions_status": "pass"},
+            {"cell": "b:kde", "status": "fail", "omissions_status": "fail"},
+            {"cell": "c:xfce", "status": "missing",
+             "omissions_status": "untested"},
+            {"cell": "d:niri", "status": "pass"},  # pre-field artifact
+        ],
+        "2026-08-17", "1",
+    )
+    try:
+        got = gms.omissions_results()
+    finally:
+        gms._BASELINE_CACHE = None
+    assert got == {
+        "a:gnome": ("success", "2026-08-17", "1"),
+        "b:kde": ("failure", "2026-08-17", "1"),
+    }
+
+
+def test_composite_scores_the_omissions_axis() -> None:
+    """An unallowlisted omission on an otherwise-perfect cell must show in
+    the composite the moment no_silent_omissions graduates to blocking —
+    and today (advisory) must not block."""
+    criteria = [
+        {"id": "builds", "enforcement": "blocking"},
+        {"id": "no_silent_omissions", "enforcement": "blocking"},
+    ]
+    stage = {"albacore": {"jobs": {("gnome", "Promote"): "success"},
+                          "date": "x"}}
+    omissions = {"albacore:gnome": ("failure", "x", "1")}
+    _, green, _ = gms.composite_section(
+        criteria, stage, {}, {}, {}, {}, omissions
+    )
+    assert green == 0, "a cell shipping silent omissions must not be green"
+
+
+def test_criterion_is_now_advisory_with_a_named_assertion() -> None:
+    import yaml
+    criteria = yaml.safe_load(
+        (ROOT / ".github" / "green-criteria.yml").read_text()
+    )["criteria"]
+    c = next(c for c in criteria if c["id"] == "no_silent_omissions")
+    assert c["enforcement"] == "advisory"
+    assert "desktop-contract-sweep" in c["asserted_by"]


### PR DESCRIPTION
## What

W5 of docs/GREEN-MASTER-PLAN.md — green criterion 8 (`no_silent_omissions`) goes from "written into every image; read by nothing on a schedule" to measured daily against what users actually pull.

Every image writes `/usr/share/tunaos/missing-on-*.txt`, and since the wishlist gate landed, *new* builds fail on unallowlisted misses — but nothing ever read the manifest from **published** images, so an already-shipped image carrying a silently-skipped package stayed invisible (the #858 class: published, no desktop).

## How — one pull, two axes

The desktop contract sweep already pulls every published desktop image daily. It now runs the **same gate the build runs** — `checks/verify-package-wishlist.sh`, mounted together with the committed allowlist — against each image it pulls, instead of funding a second 52-image fleet. `IS_HUMMINGBIRD` is mirrored from the build context, so hummingbird cells skip for the same recorded reason they skip at build time.

- **desktop-contract-sweep.yml**: `omissions_status`/`omissions_reason` recorded per cell in `result.json` → `all.json`; a lost job synthesizes `untested`, never clean; the collate summary gains the axis with a table of failing cells.
- **gen-matrix-status.py**: `contract_results()` and the new `omissions_results()` share one artifact download (`_baseline_cells()` cache); a new **Silent omissions** section renders the axis; the composite from #1827 scores it — artifacts predating the field score untested.
- **green-criteria.yml**: `no_silent_omissions` graduates `unimplemented → advisory` with the assertion named. Making it *blocking* later is a one-line edit; the composite and both README numbers tighten automatically (#1827's graduation tripwire covers it).
- **MATRIX-STATUS.md**: committed sections re-rendered offline from the same code; the structural drift check compares shape and the next scheduled refresh fills live values.

## Tests

`test_omissions_manifest_is_read_on_a_schedule.py` (6): the read is the build gate itself, not a reimplementation that can drift; the hummingbird skip is mirrored; lost-is-untested; verdict translation drops pre-field artifacts; the composite refuses a cell shipping silent omissions the moment the criterion blocks (and does not block while advisory); the graduation is pinned. `ContractResultsArtifactDownload` gains a cache reset so the shared download cannot leak between tests.

Full suite: **477 passed.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_