### PR TITLE
docs: user guide and developer guide, with the plumbing drawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ Related Communities:
 ## Documentation
 
 ### Project Docs
+- [User Guide](docs/USER-GUIDE.md) — choosing an image, installing, updating, rolling back, apps, encryption
+- [Developer Guide](docs/DEVELOPER-GUIDE.md) — the whole pipeline and its plumbing, with diagrams: matrix, build stages, package factories, quality machinery
 - [TunaOS Blog](https://tunaos.org/blog/modern-enterprise-linux-desktops-with-tunaos) — launch announcement and design philosophy comparison
 - [Vision](VISION.md) — project philosophy: erasing the mystique of the Linux distribution
 - [Goal](GOAL.md) — current objective: LUKS E2E fisherman migration

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -1,0 +1,333 @@
+# TunaOS Developer Guide
+
+How the whole thing actually works — every pipe, every gate, and why each one
+exists. The [User Guide](USER-GUIDE.md) tells people what to run; this
+document tells you what happens between a commit and a user's `bootc upgrade`.
+
+TunaOS is a fork-of-ideas from the [Universal Blue](https://universal-blue.org/)
+family — [Bluefin](https://projectbluefin.io) (GNOME),
+[Aurora](https://getaurora.dev) (KDE),
+[Zirconium](https://github.com/zirconium-dev/zirconium) (Niri). We consume
+their artifacts directly where we can (`ghcr.io/projectbluefin/common`,
+`ghcr.io/ublue-os/brew`, `ublue-os/akmods` for NVIDIA, the Zirconium source
+tree for our Niri stack) and re-derive their patterns where we can't, because
+our defining feature — the same desktop on *thirteen different bases* — means
+most of their Fedora-only plumbing needs a base-agnostic equivalent here.
+
+---
+
+## 1. The map
+
+Four repositories and two artifact stores make up the machine:
+
+```mermaid
+flowchart LR
+    subgraph sources["Source repositories"]
+        T["tuna-os/tunaOS<br/>image definitions + CI"]
+        P["tuna-os/tunaos-packages<br/>package factories"]
+        I["tuna-os/iso-builder"]
+        F["fisherman + installer frontends<br/>(bootc-installer, tuna-installer-*)"]
+    end
+    subgraph stores["Artifact stores"]
+        G["ghcr.io/tuna-os/*<br/>OS images (signed, SBOM-attested)"]
+        R["repo.tunaos.org (R2)<br/>RPM/DEB repositories"]
+    end
+    U["upstreams<br/>projectbluefin/common · ublue-os/brew<br/>ublue-os/akmods · zirconium-dev/zirconium"]
+
+    P -->|"publishes repos"| R
+    R -->|"dnf/apt/emerge at build time"| T
+    U -->|"layers & sources"| T
+    T -->|"build, sign, promote"| G
+    G -->|"images"| I
+    I -->|"ISOs"| F
+    F -->|"installs"| G
+```
+
+- **tunaOS** (this repo) turns base OS images + package repos into desktop
+  images and publishes them to GHCR.
+- **tunaos-packages** builds the packages the bases don't have (see §5) and
+  publishes RPM/DEB repos to R2.
+- **iso-builder** wraps published images into live ISOs (via the externally
+  pinned `tacklebox`, contract in [TACKLEBOX-CONTRACT.md](TACKLEBOX-CONTRACT.md)).
+- **fisherman** (Go, shared with Bluefin) + the GUI frontends do disk
+  installs; [INSTALLER-FRONTENDS.md](INSTALLER-FRONTENDS.md) tracks their
+  parity matrix.
+
+## 2. The build matrix: 142 cells
+
+Everything CI does is driven by **`.github/build-config.yml`**: 13 variants ×
+their flavors (5 desktops + `base` + hardware tiers) × declared platforms
+(amd64 / amd64-v2 / arm64). A **cell** is one `(variant, flavor)` pair —
+`yellowfin:gnome`, `bonito:kde-nvidia` — and there are 142 of them with
+`build_image: true`. Every scoreboard, gate, and denominator in the project
+derives from this file, on purpose: a flavor that isn't declared here doesn't
+exist, and tests enforce that the workflows regenerate from it rather than
+drift.
+
+Flavors stack in a strict DAG — hardware layers go **on top of** desktop
+images, never the reverse, so a desktop is built exactly once per variant:
+
+```mermaid
+flowchart TD
+    base --> gnome & kde & cosmic & niri & xfce
+    base --> basehwe["base-hwe"] & basenvidia["base-nvidia"]
+    gnome --> gnomehwe["gnome-hwe"] & gnomenvidia["gnome-nvidia"]
+    kde --> kdehwe["kde-hwe"] & kdenvidia["kde-nvidia"]
+    gnomehwe --> gnh["gnome-nvidia-hwe"]
+```
+
+Stage 1 builds `base`; stage 2 fans out desktops (decoupled from a fully
+green multi-arch base by #1729, so one dead architecture cannot strand every
+desktop); stages 3–4 apply `Containerfile.overlay` hardware layers.
+
+## 3. A cell's journey: `reusable-build-image.yml`
+
+Each per-variant workflow (`build-<variant>.yml`) calls `build-variant.yml`,
+which fans each cell into the reusable pipeline. This is the heart of CI:
+
+```mermaid
+flowchart LR
+    B["build_push<br/>per-arch image build<br/>+ rechunk (chunkah)"] --> M["Manifest<br/>multi-arch manifest<br/>→ :tag-testing"]
+    M --> S["Sign<br/>cosign"]
+    M --> SB["Generate SBOM<br/>syft, memory-bounded<br/>(manifest fallback)"]
+    M --> GT["Gate<br/>qcow2 via bootc install<br/>boot + verify in QEMU"]
+    S --> PR["Promote<br/>:tag-testing → :tag"]
+    GT -.->|"advisory today"| PR
+    PR --> AT["Attest SBOM<br/>in-toto attestation"]
+```
+
+The load-bearing details, each one paid for with a real incident:
+
+- **Two tags per cell.** Builds land on `:<tag>-testing`; **Promote** copies
+  to the published `:<tag>` only after the pipeline is satisfied. Users only
+  ever pull promoted tags.
+- **Rechunk**: `chunkah` re-layers the image into ostree-friendly chunks so
+  `bootc upgrade` downloads deltas, not the world — same technique as
+  Bluefin.
+- **SBOM generation is memory-bounded** (`systemd-run --scope -p MemoryMax`
+  with a runner-derived cap) because syft OOM-killed entire runners on
+  Gentoo-sized package inventories; if the scan still dies, an SPDX document
+  is synthesized from the image's own package manifest
+  (`scripts/packages_to_spdx.py`) so Promote never ships unattested.
+- **The Gate** builds a real disk from the image (`just qcow2` →
+  `bootc install to-disk --via-loopback`) and boots it in QEMU
+  (`scripts/iso-e2e.sh`). It is advisory per cell today; making it blocking
+  where CI can boot (gnome + base cells — the rest need a DRM render node
+  hosted runners lack) is workstream W3 of
+  [GREEN-MASTER-PLAN.md](GREEN-MASTER-PLAN.md).
+- **Retries with judgement**: promotion `skopeo` copies, GHCR pushes and
+  cosign calls retry with backoff; a Sigstore outage downgrades attestation
+  rather than blocking Promote (#1560).
+
+### Inside the image build
+
+Per-family Containerfiles (`Containerfile.el10`, `.debian`, `.ubuntu`,
+`.arch`, `.gentoo`, `.opensuse`, `.final`, `.overlay`) all execute the same
+numbered pipeline from `build_scripts/`:
+
+- **`lib.sh`** is the shared vocabulary. The functions worth knowing:
+  - `install_available` / `apt_install_available` — install what the repo
+    set can resolve, and **record every miss** via
+    `record_package_wishlist` into `/usr/share/tunaos/missing-on-*.txt`
+    inside the image. Misses are tolerated at install time and judged later
+    (see §6) — that split is deliberate.
+  - `install_rawhide_tolerant` — Rawhide-only `--skip-broken` retry for the
+    RPM Fusion multimedia skew; strict on every pinned release. Rawhide is
+    detected from os-release (`detect_fedora_ver`), because `rpm -E %fedora`
+    expands to a number even on Rawhide.
+  - `safe_enable` / `safe_disable` — unit toggles that tolerate
+    absent-on-this-variant units.
+- **`manifests/desktops/<desktop>.yaml`** declares each desktop's package
+  sets per base family (`required` = contract surface, `optional` =
+  best-effort), consumed by `install-desktop.sh`. The Niri stack is built
+  from the pinned Zirconium source (`install-zirconium.sh`,
+  `image-versions.yaml`).
+- **`build_scripts/checks/`** are the in-build gates:
+  `verify-desktop-experience.sh` (the desktop contract — sessions, DM,
+  portals actually present) and `verify-package-wishlist.sh` (every recorded
+  miss must be declared acceptable in `package-miss-allowlist.txt`, or the
+  build fails — silent omissions are how marlin:kde once shipped with no
+  wayland-sessions at all, #858).
+- **`system_files/`** is the plain-file overlay (branding, defaults,
+  `00-tunaos.toml` bootc install config).
+
+### Local development
+
+```bash
+just build yellowfin gnome        # build an image locally
+just qcow2 ghcr.io/tuna-os/yellowfin:gnome-testing   # disk image from any ref
+just run-qcow2 yellowfin gnome    # boot it in QEMU
+just check                        # linters
+just test                         # pytest + bats
+```
+
+One sharp edge, fixed but worth knowing: recipes live in imported `just/`
+modules, and **the working directory of an imported recipe depends on the
+just version** (apt's 1.21.0 runs them from `just/`, 1.25+ from the repo
+root). Every module recipe therefore begins with
+`cd {{ justfile_directory() }}`, and a test sweep keeps it that way — don't
+remove those lines.
+
+The test suite (`tests/`, pytest + bats) is unusual on purpose: most tests
+pin *workflow behavior* — YAML structure, generated files, gate semantics —
+because this repo's product is largely its pipeline. If you change the
+pipeline's shape, expect a test to tell you which document or generator you
+also need to update.
+
+## 4. Nightly operations
+
+| UTC | What |
+| --- | --- |
+| 22:20 | `check-base-image-pins` — every pinned base digest must still resolve (#1788: upstream GC'd three at once) |
+| 01:00 | All 13 `build-<variant>.yml` nightlies (scheduler drift up to ~90 min is normal) |
+| 08:00 | Desktop contract sweep — pulls every **published** desktop image; §6 |
+| 13:30 | README build-status refresh → automation PR |
+| on cell movement | MATRIX-STATUS regeneration → automation PR |
+
+`main` only accepts merge-queue changes, so every automation pushes a branch
+and opens a PR (direct pushes bounce off the rule). Automation PRs use one
+long-lived branch each, force-pushed, so there's never more than one open.
+
+## 5. The package factories: `tunaos-packages`
+
+The variants only work because someone builds the packages their bases lack.
+That someone is [tunaos-packages](https://github.com/tuna-os/tunaos-packages):
+
+```mermaid
+flowchart TD
+    subgraph factories["tunaos-packages"]
+        X["EL10 XFCE factory<br/>(mock, distributed tiers)"]
+        GN["GNOME 49/50/51 factories<br/>(mock, per-release)"]
+        H["Hummingbird desktop factory<br/>(runtime-gap, 673 pkgs)"]
+        TF["tideforge<br/>(DEB builds for grouper/flounder)"]
+        BH["Gentoo binhost<br/>(guppy binary packages)"]
+    end
+    R2["repo.tunaos.org (R2)"]
+    UP["upstream repos<br/>(Fedora, RPM Fusion,<br/>public-hummingbird, COPRs)"]
+    X & GN & H & TF & BH --> R2
+    UP -.->|"buildroot inputs"| factories
+    R2 --> tunaOS["tunaOS image builds"]
+```
+
+Design rules that hold across all factories:
+
+- **Builds are tiered** topological orders over the real BuildRequires graph,
+  computed — not hand-maintained — and the workflows that run them are
+  *generated* from the build orders (tests enforce regeneration).
+- **Publishing is gated on having built something.** A run that compiled
+  zero packages must not re-sign and re-upload the old repo as if it were
+  fresh (`INCIDENT-repo-wipe-gnome.md` is the origin story; every R2 writer
+  now carries the refuse-to-publish-empty guard).
+- **Repos are regenerated fully**, not `createrepo_c --update`-patched —
+  stale metadata entries once served checksums for RPMs that no longer
+  existed (the gtkgreet drift class).
+- **The Hummingbird factory tracks its upstream automatically.** Its build
+  order is *the runtime gap*: everything the desktops need minus everything
+  `public-hummingbird` already ships (measured by
+  `measure-hummingbird-gap.py`, `membership: runtime` in the catalog).
+  Build-only tools come from the buildroot's inherited Rawhide fallback. A
+  daily **gap-drift detector** re-measures whenever upstream publishes a new
+  repo revision and opens a PR with the adds/drops — when upstream adopts a
+  package we build, it drops out of our order and upstream's build wins by
+  repo priority (our `.fc43` dist tag intentionally sorts below their
+  `.hum1`, so we can never shadow them).
+
+## 6. The quality machinery: how "green" is kept honest
+
+This is the part most forks of Universal Blue don't have, and the part this
+project considers its real product. The bar is defined in
+**`.github/green-criteria.yml`** — ten criteria, each with an explicit
+`enforcement` (`blocking` / `advisory` / `unimplemented`), and a composite
+rule: *a cell is green only when every blocking criterion has a current
+affirmative result; skipped or never-tested never counts.*
+
+```mermaid
+flowchart LR
+    subgraph evidence["Evidence producers"]
+        BLD["nightly builds<br/>(Promote, Gate)"]
+        SWEEP["contract sweep 08:00<br/>desktop contract +<br/>omissions manifest read"]
+        LUKS["LUKS E2E<br/>(install axis)"]
+        ISO["installer smoke<br/>(ISO axis)"]
+        LC["bootc-lifecycle<br/>(upgrade/rollback axis)"]
+        PIN["pin check 22:20<br/>(rebuildable axis)"]
+    end
+    CRIT[".github/green-criteria.yml<br/>enforcement per criterion"]
+    GEN["scripts/gen-matrix-status.py<br/>composite scorer"]
+    MS["docs/MATRIX-STATUS.md<br/>Composite green — the bar"]
+    RM["README<br/>Built X/142 · composite green Y/142"]
+
+    evidence --> GEN
+    CRIT --> GEN
+    GEN --> MS
+    CRIT --> RM
+```
+
+The important properties:
+
+- **Enforcement is data, not code.** Graduating a criterion from advisory to
+  blocking is a one-line edit to `green-criteria.yml`; the composite table
+  and the README count tighten automatically. A criterion made blocking
+  without a wired per-cell assertion fails the test suite with instructions
+  — a raised bar can never silently render as a blank board.
+- **Absence of evidence is never failure, and never success.** Skipped,
+  missing, cancelled, and lost all render ⬜ and count against green — the
+  #1730 rule, applied uniformly.
+- **Published images are re-checked, not trusted.** The 08:00 sweep pulls
+  every published desktop image and runs the *same* scripts the build ran:
+  the desktop contract, and the omissions gate against
+  `/usr/share/tunaos/missing-on-*.txt` — so an image published before a gate
+  existed still gets judged by it.
+- **The scoreboard is generated, and its honesty is tested** — down to
+  details like "a flavor removed from build-config keeps its last verdict
+  visible but leaves the denominator", and "the README refresh opens a PR
+  because direct pushes to main bounce".
+
+Where each axis stands today, per cell, is
+[MATRIX-STATUS.md](MATRIX-STATUS.md); the plan for driving all of it to
+blocking is [GREEN-MASTER-PLAN.md](GREEN-MASTER-PLAN.md).
+
+## 7. Troubleshooting CI — the classes we've already met
+
+Before debugging a red run from scratch, check it against the catalogue:
+[ci-troubleshooting.md](ci-troubleshooting.md) and the *Failures that look
+like successes* section of [MATRIX-STATUS.md](MATRIX-STATUS.md). Highlights:
+
+- A **cancelled run is not a verdict** — superseded runs get skipped by
+  every reader; never count them as failures.
+- **`continue-on-error` masks step outcomes in the jobs API** — read raw
+  logs (the signed blob URL from the logs API) when a step's real exit
+  matters.
+- **Job names are load-bearing**: the matrix readers key on
+  `<variant> / <flavor> / <Stage>` names. Renaming jobs breaks scoreboards.
+- **Infra flakes get retried by classification** (#1731), not by hand.
+
+## 8. Repository tour
+
+| Path | What lives there |
+| :--- | :--- |
+| `.github/build-config.yml` | The matrix — single source of truth |
+| `.github/green-criteria.yml` | The bar |
+| `.github/workflows/` | Per-variant entries, `build-variant.yml`, `reusable-build-image.yml`, sweeps and refreshers |
+| `Containerfile.*` | Per-family image definitions |
+| `build_scripts/` | The numbered build pipeline, `lib.sh`, `checks/`, `desktop/` |
+| `manifests/desktops/*.yaml` | Desktop package contracts per base family |
+| `system_files/` | Plain-file overlay shipped into every image |
+| `just/` + `Justfile` | Local dev entry points (build, qcow2, VMs, tests) |
+| `scripts/` | Pipeline tooling: matrix generator, parity, iso-e2e, SPDX synthesis |
+| `tests/` | Pytest + bats — largely pipeline-behavior pins |
+| `docs/` | You are here; [PIPELINE.md](PIPELINE.md) is the quick reference |
+
+## 9. Contributing flow
+
+1. Branch; `main` is merge-queue only.
+2. Make the change *and* the change's paper trail: if you touched the
+   pipeline's shape, a generator, a gate, or the matrix, there is a test or
+   a generated document that must move with it — CI will tell you which.
+3. `just check && just test` locally.
+4. PR; the queue runs the required checks and merges.
+
+The house style, learned the hard way and enforced by review: **measure,
+don't assume** (comments in this codebase cite run IDs); **loud beats
+silent** (a gate that can't score must fail, not skip); and **absence of
+evidence is not evidence of absence** — if your change makes something stop
+being checked, say so in the scoreboard, don't let it render green.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1,0 +1,221 @@
+# TunaOS User Guide
+
+Everything you need to run TunaOS day to day: picking an image, installing it,
+staying updated, rolling back, and getting apps — plus what our quality labels
+actually promise you.
+
+TunaOS stands on the shoulders of the [Universal Blue](https://universal-blue.org/)
+family: [Bluefin](https://projectbluefin.io) (GNOME),
+[Aurora](https://getaurora.dev) (KDE), and
+[Zirconium](https://github.com/zirconium-dev/zirconium) (Niri). Their
+documentation applies to TunaOS more often than not, because we ship the same
+image-based model, the same Homebrew and Flathub integration, and — for Niri —
+literally the same desktop stack. When this guide is thin somewhere, the
+[Bluefin documentation](https://docs.projectbluefin.io) is the best second
+read. What TunaOS adds is *choice of base*: the same desktop experience on
+Enterprise Linux, Fedora, Debian, Ubuntu, Arch, openSUSE, or Gentoo.
+
+---
+
+## 1. What kind of OS this is
+
+TunaOS images are **bootc-based**: the operating system is delivered as a
+container image, and your installed system atomically updates to each new
+image. That means:
+
+- **Updates are atomic.** An update either fully applies or doesn't happen.
+  There is no half-updated system to debug.
+- **Rollback is built in.** The previous deployment stays on disk; one
+  command (or one boot-menu pick) returns to it.
+- **The OS is the same everywhere.** Your installation is bit-for-bit the
+  image we test in CI, not a package soup that drifted from it.
+- **You don't `dnf install` onto the base.** Apps come from Flatpak,
+  Homebrew, or containers (see §6). Changing the base OS means switching to
+  a different image — which is cheap and reversible.
+
+If you have used Fedora Silverblue, Bluefin, or Aurora, you already know this
+model. If not, Bluefin's
+[introduction](https://docs.projectbluefin.io/introduction) explains the
+philosophy well.
+
+## 2. Choosing your image
+
+A TunaOS image is named `<variant>:<desktop>[-hardware]`.
+
+### The variant — which base OS
+
+| Variant | Base OS | Cadence & character |
+| :--- | :--- | :--- |
+| 🐠 **yellowfin** | AlmaLinux Kitten 10 | Enterprise base, slightly fresher than Albacore |
+| 🐟 **albacore** | AlmaLinux 10 (RHEL-compatible) | The long-stability pick |
+| 🍣 **skipjack** | CentOS Stream 10 | Upstream of RHEL, rolling-ish enterprise |
+| 🎣 **bonito** | Fedora 44 | Fedora cadence, broad hardware |
+| 🐉 **bonito-rawhide** | Fedora Rawhide | Fedora's dev branch; expect breakage |
+| 🐡 **flounder** | Debian 13 (Trixie) | Debian stable |
+| ☢️ **flounder-sid** | Debian Sid | Debian unstable |
+| 🐟 **grouper** | Ubuntu 26.04 | Ubuntu LTS-next |
+| 🐟 **gurnard** | Ubuntu 24.04 + Pantheon | Experimental |
+| 🚀 **marlin** | Arch Linux | Rolling |
+| 🦈 **sailfin** | openSUSE Tumbleweed | Rolling |
+| 🌈 **guppy** | Gentoo | Binary-package Gentoo, the adventurous pick |
+| 🐦 **hummingbird** | Fedora Hummingbird | Experimental next-gen Fedora base |
+| 🔒 **redfin** | RHEL 10 | Local-build only (EULA) — see [rhel-setup.md](rhel-setup.md) |
+
+### The desktop — `gnome`, `kde`, `cosmic`, `niri`, `xfce`
+
+All desktops are first-class across bases (where the base can support them).
+`base` is the no-desktop server-style image. Our Niri desktop is the
+[Zirconium](https://github.com/zirconium-dev/zirconium) stack, built from the
+same source Zirconium ships on Fedora.
+
+### The hardware suffix — optional
+
+- `-hwe` — Hardware Enablement kernel for newer hardware
+- `-nvidia` — NVIDIA drivers + CUDA (via [Universal Blue akmods](https://github.com/ublue-os/akmods))
+- `-nvidia-hwe` — both
+- `-asahi` — Apple Silicon (select variants; see [ASAHI-HARDWARE-TIERS.md](ASAHI-HARDWARE-TIERS.md))
+
+So `ghcr.io/tuna-os/albacore:kde-nvidia` is AlmaLinux 10 + KDE Plasma +
+NVIDIA. The full, live per-cell status of every combination is in the
+[README build matrix](../README.md) and [MATRIX-STATUS.md](MATRIX-STATUS.md).
+
+### What "green" promises — read this once
+
+Historically, a green cell meant "the image built and was published". We have
+deliberately raised that bar: [GREEN-CRITERIA.md](GREEN-CRITERIA.md) defines
+what full green means — builds, desktop present, boots, installs, updates and
+rolls back, honest about omissions — and the README now reports **built** and
+**composite green** separately. A variant can be built-green and still carry
+known gaps on the harder criteria; the scoreboard tells you which. Pick
+yellowfin/albacore gnome or kde if you want the most-proven cells today.
+
+## 3. Installing
+
+### Option A — ISO installer
+
+Download an ISO for your variant/desktop (where published), write it to a USB
+stick, boot it, and follow the installer. TunaOS installers run
+[fisherman](https://github.com/projectbluefin/fisherman) under a GUI frontend
+and support encrypted installs (see §7).
+
+### Option B — from any existing bootc system
+
+Already on Bluefin, Aurora, Silverblue-bootc, or another TunaOS image? Switch
+in place:
+
+```bash
+sudo bootc switch ghcr.io/tuna-os/yellowfin:gnome
+sudo systemctl reboot
+```
+
+Your home directory and local data are untouched; the OS beneath you is
+replaced atomically. Switching back is the same command with the old image.
+
+### Option C — VM / cloud
+
+Every image can be turned into a disk image locally:
+
+```bash
+git clone https://github.com/tuna-os/tunaOS && cd tunaOS
+just qcow2 ghcr.io/tuna-os/bonito:kde     # produces bonito.qcow2
+just run-qcow2 bonito kde                  # boots it under QEMU
+```
+
+## 4. Staying updated
+
+Updates arrive as new image builds (nightly CI). Apply them with:
+
+```bash
+sudo bootc upgrade
+```
+
+or let the built-in automatic updater fetch and stage them; the update
+activates on the next reboot. Nothing changes out from under a running
+system.
+
+Check what you're on and what's staged:
+
+```bash
+sudo bootc status
+```
+
+## 5. Rollback and rebasing
+
+**Roll back** to the previous deployment — one command, or pick the previous
+entry in the boot menu:
+
+```bash
+sudo bootc rollback
+sudo systemctl reboot
+```
+
+**Rebase** to a different desktop, hardware tier, or even a different base —
+it's the same `bootc switch` from §3. Common moves:
+
+```bash
+# same base, different desktop
+sudo bootc switch ghcr.io/tuna-os/albacore:niri
+
+# same everything, add NVIDIA
+sudo bootc switch ghcr.io/tuna-os/albacore:kde-nvidia
+
+# hop bases entirely (Alma -> Fedora), keeping your data
+sudo bootc switch ghcr.io/tuna-os/bonito:kde
+```
+
+Cross-base hops are supported by the model but are the least-tested path —
+treat them as an experiment, and know `bootc rollback` is always there.
+
+## 6. Apps: Flatpak, Homebrew, containers
+
+- **Graphical apps** come from **Flathub**, enabled out of the box:
+  `flatpak install flathub org.mozilla.firefox` or use your desktop's
+  software center.
+- **CLI tools** come from **Homebrew**, baked into the image the same way
+  Bluefin does it (`ghcr.io/ublue-os/brew`): `brew install ripgrep`.
+- **Development environments** work great in containers: `distrobox` /
+  `toolbox` give you a mutable Fedora/Ubuntu/anything userland with your
+  home directory mounted. Bluefin's
+  [devcontainer guidance](https://docs.projectbluefin.io) applies unchanged.
+
+The one thing you *don't* do is layer packages onto the base with the host
+package manager — the base is the image.
+
+## 7. Disk encryption and secure boot
+
+- Installers support **LUKS full-disk encryption** with optional **TPM2
+  auto-unlock**; a recovery key is generated and shown during install. Keep
+  it. Details: [LUKS-TPM.md](LUKS-TPM.md).
+- Secure Boot state and expectations: [SECURE-BOOT.md](SECURE-BOOT.md).
+
+## 8. Verifying what you run
+
+Every published image is signed with cosign and carries an attested SBOM:
+
+```bash
+cosign verify ghcr.io/tuna-os/yellowfin:gnome \
+  --certificate-identity-regexp 'github.com/tuna-os/tunaOS' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+More in [VERIFY-ARTIFACTS.md](VERIFY-ARTIFACTS.md).
+
+## 9. When something goes wrong
+
+1. **Roll back first** (`sudo bootc rollback` + reboot). An image-based OS
+   makes "get back to a working system" a one-liner — use it, then debug.
+2. Check your cell in [MATRIX-STATUS.md](MATRIX-STATUS.md): if the axis that
+   bit you is ❌ or ⬜ there, it's known territory.
+3. Search [issues](https://github.com/tuna-os/tunaOS/issues); file one with
+   `bootc status` output and your image ref if it's new.
+4. Ask in [Discord](https://discord.gg/MXSTqB8Nv).
+
+## 10. Further reading
+
+- [Bluefin documentation](https://docs.projectbluefin.io) — the model, apps,
+  devcontainers; most of it applies here
+- [Aurora](https://getaurora.dev) — the KDE sibling upstream
+- [Zirconium](https://github.com/zirconium-dev/zirconium) — our Niri stack
+- [bootc documentation](https://bootc-dev.github.io/bootc/) — the underlying
+  technology
+- [DEVELOPER-GUIDE.md](DEVELOPER-GUIDE.md) — how all of this is built


### PR DESCRIPTION
## What

Two new top-level guides, linked from the README's Documentation section.

### docs/USER-GUIDE.md

What to run and how to live with it: the bootc image model in plain terms, choosing among the variants × desktops × hardware tiers, all three install paths (ISO, `bootc switch` from any bootc system, local qcow2), updates / rollback / rebasing, apps via Flathub + Homebrew + distrobox, LUKS/TPM and cosign verification — and an honest section on what the raised green bar does and does not promise, pointing at the composite scoreboard.

Leans on the upstream family deliberately, per the ask: **Bluefin's documentation is named as the best second read**, **Aurora** as the KDE sibling, and **Zirconium** as the literal source of our Niri stack.

### docs/DEVELOPER-GUIDE.md

How it all works, commit to `bootc upgrade`, with **mermaid diagrams** for the parts prose does badly:

1. the four-repo / two-store map (tunaOS · tunaos-packages · iso-builder · fisherman → GHCR · repo.tunaos.org)
2. the flavor DAG (hardware layers on top of desktops, never the reverse)
3. the cell pipeline (`build_push → Manifest → Sign / SBOM / Gate → Promote → Attest`)
4. the package-factory flow (EL10 XFCE, GNOME 49/50/51, hummingbird runtime-gap + drift detector, tideforge, Gentoo binhost)
5. the quality-machinery loop (evidence producers → `green-criteria.yml` enforcement → composite scoreboard → README numbers)

Load-bearing details are documented **with their incident provenance**: testing-vs-published tags, chunkah rechunking, the memory-bounded SBOM with manifest fallback, the wishlist/omissions gates (#858), the just-version working-directory trap (#1811/#1818), refuse-to-publish-empty, and the #1730 absence-of-evidence rule — so the guide teaches the *why*, not just the *what*.

## Verification

- Every relative link in both guides checked to resolve against the tree
- Mermaid blocks are GitHub-native (no external assets)
- Full suite: **477 passed**

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_