### PR TITLE
docs(user-guide): restructure after the upstream family's documentation

### DIFF
--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -7,6 +7,7 @@ document tells you what happens between a commit and a user's `bootc upgrade`.
 TunaOS is a fork-of-ideas from the [Universal Blue](https://universal-blue.org/)
 family — [Bluefin](https://projectbluefin.io) (GNOME),
 [Aurora](https://getaurora.dev) (KDE),
+[Bazzite](https://bazzite.gg) (gaming),
 [Zirconium](https://github.com/zirconium-dev/zirconium) (Niri). We consume
 their artifacts directly where we can (`ghcr.io/projectbluefin/common`,
 `ghcr.io/ublue-os/brew`, `ublue-os/akmods` for NVIDIA, the Zirconium source

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1,19 +1,32 @@
 # TunaOS User Guide
 
-Everything you need to run TunaOS day to day: picking an image, installing it,
-staying updated, rolling back, and getting apps — plus what our quality labels
-actually promise you.
+Everything you need to run TunaOS day to day: picking an image, installing
+it, staying updated, rolling back, and getting apps — plus what our quality
+labels actually promise you.
 
-TunaOS stands on the shoulders of the [Universal Blue](https://universal-blue.org/)
-family: [Bluefin](https://projectbluefin.io) (GNOME),
-[Aurora](https://getaurora.dev) (KDE), and
-[Zirconium](https://github.com/zirconium-dev/zirconium) (Niri). Their
-documentation applies to TunaOS more often than not, because we ship the same
-image-based model, the same Homebrew and Flathub integration, and — for Niri —
-literally the same desktop stack. When this guide is thin somewhere, the
-[Bluefin documentation](https://docs.projectbluefin.io) is the best second
-read. What TunaOS adds is *choice of base*: the same desktop experience on
-Enterprise Linux, Fedora, Debian, Ubuntu, Arch, openSUSE, or Gentoo.
+## Is TunaOS for you?
+
+TunaOS is for people who want their operating system to behave like firmware:
+updated automatically, rolled back trivially, and otherwise invisible. Apps
+come from Flathub and Homebrew; development happens in containers; the OS
+itself is a signed image we build, test, and publish nightly.
+
+TunaOS stands on the shoulders of the
+[Universal Blue](https://universal-blue.org/) family, and we would rather
+point you at their excellent documentation than re-explain what we share:
+
+| If you are… | Read alongside this guide |
+| :--- | :--- |
+| new to image-based Linux, or a GNOME user | [Bluefin docs](https://docs.projectbluefin.io) — the model, apps, day-2 admin |
+| a KDE Plasma user | [Aurora docs](https://docs.getaurora.dev) — the KDE workstation experience |
+| here to game | [Bazzite](https://bazzite.gg) — the family's gaming specialist (see §8) |
+| a Niri user | [Zirconium](https://github.com/zirconium-dev/zirconium) — literally the stack we ship |
+| a developer | [Bluefin DX docs](https://docs.projectbluefin.io/bluefin-dx) — devcontainers, Podman, pet containers (see §9) |
+
+What TunaOS adds to the family is *choice of base*: the same desktop
+experience on Enterprise Linux, Fedora, Debian, Ubuntu, Arch, openSUSE, or
+Gentoo — where Bluefin, Aurora, and Bazzite are Fedora-based, TunaOS lets you
+pick the foundation and keep the experience.
 
 ---
 
@@ -29,14 +42,14 @@ image. That means:
   command (or one boot-menu pick) returns to it.
 - **The OS is the same everywhere.** Your installation is bit-for-bit the
   image we test in CI, not a package soup that drifted from it.
-- **You don't `dnf install` onto the base.** Apps come from Flatpak,
-  Homebrew, or containers (see §6). Changing the base OS means switching to
-  a different image — which is cheap and reversible.
+- **You don't install packages onto the base.** Apps come from Flatpak,
+  Homebrew, or containers (§7). Changing the base OS means switching to a
+  different image — which is cheap and reversible (§6).
 
-If you have used Fedora Silverblue, Bluefin, or Aurora, you already know this
-model. If not, Bluefin's
+If you have used Silverblue, Bluefin, Aurora, or Bazzite, you already know
+this model. If not, Bluefin's
 [introduction](https://docs.projectbluefin.io/introduction) explains the
-philosophy well.
+philosophy better than we could.
 
 ## 2. Choosing your image
 
@@ -49,7 +62,7 @@ A TunaOS image is named `<variant>:<desktop>[-hardware]`.
 | 🐠 **yellowfin** | AlmaLinux Kitten 10 | Enterprise base, slightly fresher than Albacore |
 | 🐟 **albacore** | AlmaLinux 10 (RHEL-compatible) | The long-stability pick |
 | 🍣 **skipjack** | CentOS Stream 10 | Upstream of RHEL, rolling-ish enterprise |
-| 🎣 **bonito** | Fedora 44 | Fedora cadence, broad hardware |
+| 🎣 **bonito** | Fedora 44 | Fedora cadence — closest cousin to Bluefin/Aurora |
 | 🐉 **bonito-rawhide** | Fedora Rawhide | Fedora's dev branch; expect breakage |
 | 🐡 **flounder** | Debian 13 (Trixie) | Debian stable |
 | ☢️ **flounder-sid** | Debian Sid | Debian unstable |
@@ -66,42 +79,43 @@ A TunaOS image is named `<variant>:<desktop>[-hardware]`.
 All desktops are first-class across bases (where the base can support them).
 `base` is the no-desktop server-style image. Our Niri desktop is the
 [Zirconium](https://github.com/zirconium-dev/zirconium) stack, built from the
-same source Zirconium ships on Fedora.
+same pinned source Zirconium ships on Fedora.
 
 ### The hardware suffix — optional
 
 - `-hwe` — Hardware Enablement kernel for newer hardware
-- `-nvidia` — NVIDIA drivers + CUDA (via [Universal Blue akmods](https://github.com/ublue-os/akmods))
+- `-nvidia` — NVIDIA drivers + CUDA (via [Universal Blue akmods](https://github.com/ublue-os/akmods), the same driver packaging Bazzite and Aurora use)
 - `-nvidia-hwe` — both
 - `-asahi` — Apple Silicon (select variants; see [ASAHI-HARDWARE-TIERS.md](ASAHI-HARDWARE-TIERS.md))
 
 So `ghcr.io/tuna-os/albacore:kde-nvidia` is AlmaLinux 10 + KDE Plasma +
-NVIDIA. The full, live per-cell status of every combination is in the
+NVIDIA. The live per-cell status of every combination is in the
 [README build matrix](../README.md) and [MATRIX-STATUS.md](MATRIX-STATUS.md).
 
 ### What "green" promises — read this once
 
 Historically, a green cell meant "the image built and was published". We have
 deliberately raised that bar: [GREEN-CRITERIA.md](GREEN-CRITERIA.md) defines
-what full green means — builds, desktop present, boots, installs, updates and
-rolls back, honest about omissions — and the README now reports **built** and
-**composite green** separately. A variant can be built-green and still carry
-known gaps on the harder criteria; the scoreboard tells you which. Pick
-yellowfin/albacore gnome or kde if you want the most-proven cells today.
+what full green means — builds, desktop present, boots, installs, updates
+and rolls back, honest about omissions — and the README reports **built**
+and **composite green** separately. A variant can be built-green and still
+carry known gaps on the harder criteria; the scoreboard tells you which.
+Pick yellowfin/albacore gnome or kde if you want the most-proven cells
+today.
 
 ## 3. Installing
 
 ### Option A — ISO installer
 
-Download an ISO for your variant/desktop (where published), write it to a USB
-stick, boot it, and follow the installer. TunaOS installers run
-[fisherman](https://github.com/projectbluefin/fisherman) under a GUI frontend
-and support encrypted installs (see §7).
+Download an ISO for your variant/desktop (where published), write it to a
+USB stick, boot it, and follow the installer. TunaOS installers run
+[fisherman](https://github.com/projectbluefin/fisherman) under a GUI
+frontend and support encrypted installs (§10).
 
 ### Option B — from any existing bootc system
 
-Already on Bluefin, Aurora, Silverblue-bootc, or another TunaOS image? Switch
-in place:
+Already on Bluefin, Aurora, Bazzite, Silverblue-bootc, or another TunaOS
+image? Switch in place:
 
 ```bash
 sudo bootc switch ghcr.io/tuna-os/yellowfin:gnome
@@ -121,36 +135,76 @@ just qcow2 ghcr.io/tuna-os/bonito:kde     # produces bonito.qcow2
 just run-qcow2 bonito kde                  # boots it under QEMU
 ```
 
-## 4. Staying updated
+## 4. Day-2 administration
 
-Updates arrive as new image builds (nightly CI). Apply them with:
+This section mirrors Bluefin's
+[administration guide](https://docs.projectbluefin.io/administration) — same
+model, same habits — with TunaOS specifics called out.
+
+### Updates
+
+Updates arrive as new image builds from nightly CI, and are applied
+automatically by **[uupd](https://github.com/ublue-os/uupd)** (the Universal
+Blue updater, running on a systemd timer) — the same updater Bluefin and
+Aurora use. It also keeps Flatpaks and Homebrew current. Staged updates
+activate on the next reboot; nothing changes under a running system.
+
+Update manually any time:
 
 ```bash
-sudo bootc upgrade
+sudo bootc upgrade          # fetch + stage the newest image
+sudo bootc status           # what you're on, what's staged
 ```
 
-or let the built-in automatic updater fetch and stage them; the update
-activates on the next reboot. Nothing changes out from under a running
-system.
+(We deliberately ship uupd instead of bootc's own
+`bootc-fetch-apply-updates.timer`, which is masked in our images — one
+updater, not two.)
 
-Check what you're on and what's staged:
+### ujust — the task runner
 
-```bash
-sudo bootc status
-```
+Like the rest of the family, TunaOS ships **`ujust`**: curated just recipes
+for common admin tasks. Run `ujust` with no arguments to list what's
+available on your image.
 
-## 5. Rollback and rebasing
+### Tailscale, out of the box
 
-**Roll back** to the previous deployment — one command, or pick the previous
-entry in the boot menu:
+`tailscaled` is enabled by default, same as Aurora: `sudo tailscale up` and
+you're on your tailnet. Prefer another VPN? `sudo tailscale down` and use
+NetworkManager as usual.
+
+### Changing system defaults
+
+bootc keeps the OS in an immutable `/usr`; **your** configuration lives in
+`/etc` and wins over the image's defaults (shipped under `/usr/etc`). Drop
+overrides into `/etc` — systemd units, dconf keys, sysctl — and they persist
+across updates. `sudo ostree admin config-diff` shows everything you've
+changed from stock.
+
+### Why there is no package layering
+
+Bluefin documents `rpm-ostree` layering as a last resort; TunaOS images are
+**bootc-native across seven different package ecosystems**, so host-level
+layering isn't offered at all. The intended paths are, in order: Flatpak →
+Homebrew → distrobox/toolbox container → build your own image
+([ROLL_YOUR_OWN.md](ROLL_YOUR_OWN.md) — the equivalent of Universal Blue's
+custom-image story). That last option is the escape hatch that makes the
+first three acceptable.
+
+## 5. Rollback
+
+One command, or pick the previous entry in the boot menu:
 
 ```bash
 sudo bootc rollback
 sudo systemctl reboot
 ```
 
-**Rebase** to a different desktop, hardware tier, or even a different base —
-it's the same `bootc switch` from §3. Common moves:
+An image-based OS makes "get back to a working system" a one-liner. Use it
+first, debug second.
+
+## 6. Rebasing — desktop, hardware, or entire base
+
+Rebasing is the same `bootc switch` from §3. Common moves:
 
 ```bash
 # same base, different desktop
@@ -159,36 +213,58 @@ sudo bootc switch ghcr.io/tuna-os/albacore:niri
 # same everything, add NVIDIA
 sudo bootc switch ghcr.io/tuna-os/albacore:kde-nvidia
 
-# hop bases entirely (Alma -> Fedora), keeping your data
+# hop bases entirely (Alma → Fedora), keeping your data
 sudo bootc switch ghcr.io/tuna-os/bonito:kde
 ```
 
 Cross-base hops are supported by the model but are the least-tested path —
 treat them as an experiment, and know `bootc rollback` is always there.
 
-## 6. Apps: Flatpak, Homebrew, containers
+## 7. Apps: Flatpak, Homebrew, containers
 
-- **Graphical apps** come from **Flathub**, enabled out of the box:
-  `flatpak install flathub org.mozilla.firefox` or use your desktop's
-  software center.
+- **Graphical apps** come from **Flathub**, enabled out of the box — via
+  your desktop's software center (GNOME Software / KDE Discover) or
+  `flatpak install flathub org.mozilla.firefox`.
 - **CLI tools** come from **Homebrew**, baked into the image the same way
   Bluefin does it (`ghcr.io/ublue-os/brew`): `brew install ripgrep`.
-- **Development environments** work great in containers: `distrobox` /
-  `toolbox` give you a mutable Fedora/Ubuntu/anything userland with your
-  home directory mounted. Bluefin's
-  [devcontainer guidance](https://docs.projectbluefin.io) applies unchanged.
+- **Everything else** works great in containers: `distrobox` / `toolbox`
+  give you a mutable Fedora/Ubuntu/Arch/anything userland with your home
+  directory mounted — the family's answer to "but I need `apt install`".
 
-The one thing you *don't* do is layer packages onto the base with the host
-package manager — the base is the image.
+## 8. Gaming
 
-## 7. Disk encryption and secure boot
+For serious gaming on this family of operating systems, the honest answer
+is: **[Bazzite](https://bazzite.gg)** is the specialist — Steam Gaming Mode,
+Proton tuning, HDR/VRR, handheld support — and if gaming is your primary
+use, run Bazzite. On TunaOS, the basics work the family way: install Steam,
+Lutris, or Heroic from Flathub, and NVIDIA users pick a `-nvidia` image
+(§2). Bazzite's documentation on Proton, controllers, and per-game tuning
+largely applies to any Flathub Steam install, and is the best reference for
+those topics on our Fedora-based variants too.
+
+## 9. For developers
+
+The [Bluefin DX](https://docs.projectbluefin.io/bluefin-dx) philosophy —
+develop in containers, keep the host boring — is the intended workflow on
+TunaOS as well:
+
+- **Devcontainers** in VS Code or JetBrains against Podman (preinstalled on
+  all variants).
+- **Pet containers** via distrobox for a long-lived mutable shell.
+- **Kubernetes/cloud tooling** via Homebrew (`brew install kubectl helm k9s …`).
+
+TunaOS does not currently ship a separate `-dx` image tier; the container
+tooling above is present in the standard images. For hacking on TunaOS
+itself, see the [Developer Guide](DEVELOPER-GUIDE.md).
+
+## 10. Disk encryption and secure boot
 
 - Installers support **LUKS full-disk encryption** with optional **TPM2
   auto-unlock**; a recovery key is generated and shown during install. Keep
   it. Details: [LUKS-TPM.md](LUKS-TPM.md).
-- Secure Boot state and expectations: [SECURE-BOOT.md](SECURE-BOOT.md).
+- Secure Boot state and expectations per variant: [SECURE-BOOT.md](SECURE-BOOT.md).
 
-## 8. Verifying what you run
+## 11. Verifying what you run
 
 Every published image is signed with cosign and carries an attested SBOM:
 
@@ -200,22 +276,28 @@ cosign verify ghcr.io/tuna-os/yellowfin:gnome \
 
 More in [VERIFY-ARTIFACTS.md](VERIFY-ARTIFACTS.md).
 
-## 9. When something goes wrong
+## 12. When something goes wrong
 
-1. **Roll back first** (`sudo bootc rollback` + reboot). An image-based OS
-   makes "get back to a working system" a one-liner — use it, then debug.
-2. Check your cell in [MATRIX-STATUS.md](MATRIX-STATUS.md): if the axis that
-   bit you is ❌ or ⬜ there, it's known territory.
+1. **Roll back first** (`sudo bootc rollback` + reboot), then debug.
+2. Check your cell in [MATRIX-STATUS.md](MATRIX-STATUS.md): if the axis
+   that bit you is ❌ or ⬜ there, it's known territory.
 3. Search [issues](https://github.com/tuna-os/tunaOS/issues); file one with
    `bootc status` output and your image ref if it's new.
 4. Ask in [Discord](https://discord.gg/MXSTqB8Nv).
 
-## 10. Further reading
+**FAQ, in brief.** *Can I install .rpm/.deb files?* Not on the host — use
+distrobox, or build your own image. *Do I lose data on rebase?* No; `/home`
+and `/etc` persist. *How current are images?* Built nightly; uupd applies
+them automatically. *Is my exact combination tested?* Check the composite
+scoreboard — we publish exactly what is and isn't proven, per cell.
 
-- [Bluefin documentation](https://docs.projectbluefin.io) — the model, apps,
-  devcontainers; most of it applies here
-- [Aurora](https://getaurora.dev) — the KDE sibling upstream
+## 13. Further reading
+
+- [Bluefin documentation](https://docs.projectbluefin.io) — the model,
+  administration, DX; most of it applies here
+- [Aurora documentation](https://docs.getaurora.dev) — the KDE sibling
+- [Bazzite](https://bazzite.gg) — gaming on this family
 - [Zirconium](https://github.com/zirconium-dev/zirconium) — our Niri stack
-- [bootc documentation](https://bootc-dev.github.io/bootc/) — the underlying
-  technology
+- [bootc documentation](https://bootc-dev.github.io/bootc/) — the
+  underlying technology
 - [DEVELOPER-GUIDE.md](DEVELOPER-GUIDE.md) — how all of this is built


### PR DESCRIPTION
## What

Reworks the User Guide with **docs.projectbluefin.io**, **docs.getaurora.dev**, and **bazzite.gg** as the structural models, per maintainer direction — and with every TunaOS-specific claim verified against the tree rather than imported from upstream prose.

- **"Is TunaOS for you?"** opener (Bluefin's framing), with a read-alongside table routing readers to the right upstream: Bluefin for the model and day-2 habits, Aurora for KDE, Bazzite for gaming, Zirconium for Niri, Bluefin DX for developer workflow. TunaOS's own pitch is sharpened to what we uniquely add: choice of base.
- **Day-2 administration** section mirroring Bluefin's administration guide, with our *actual* facilities: `uupd` on a timer with `bootc-fetch-apply-updates.timer` deliberately masked (verified in `build_scripts/40-services.sh`), `ujust` recipes, Tailscale enabled by default (as Aurora ships it), `/etc`-over-`/usr/etc` overrides, and an honest "why there is no package layering" adapted for a bootc-native seven-ecosystem project — escape hatch: ROLL_YOUR_OWN.
- **Gaming** section that says the honest thing: Bazzite is the family's specialist and the right answer if gaming is primary; Flathub Steam + `-nvidia` images cover the basics here, and Bazzite's Proton/controller documentation applies broadly.
- **Developers** section aligned to the Bluefin DX philosophy (devcontainers, pet containers, Homebrew cloud tooling), noting plainly that we ship no separate `-dx` tier.
- Brief **FAQ** in troubleshooting, upstream-docs style.
- Developer Guide: Bazzite added to the family roster in the intro.

All relative links verified to resolve.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_