### PR TITLE
feat(parity): package parity on a daily cadence, fed to the board (W6)

### DIFF
--- a/.github/green-criteria.yml
+++ b/.github/green-criteria.yml
@@ -130,9 +130,16 @@ criteria:
   - id: parity
     name: Package set matches the upstream reference
     proves: The flavor ships the packages its upstream equivalent ships.
-    asserted_by: scripts/package-parity.sh
-    enforcement: unimplemented
+    asserted_by: >-
+      .github/workflows/package-parity.yml (daily) →
+      scripts/package-parity.sh --audit; verdicts feed the scoreboard via the
+      package-parity-baseline artifact
+    enforcement: advisory
     status_2026_08_17: "not scheduled"
+    status_2026_08_17_pm: >-
+      scheduled daily. First cadence asserts the desktop-vs-own-base delta
+      (the #858 no-desktop-at-all shape); the upstream-reference diff is not
+      yet asserted and this criterion stays advisory at least until it is.
 
   - id: no_silent_omissions
     name: The build tells the truth about what it shipped

--- a/.github/workflows/package-parity.yml
+++ b/.github/workflows/package-parity.yml
@@ -1,0 +1,84 @@
+name: Package Parity
+
+# Green criterion 7 (W6), first cadence: every published desktop cell's
+# package set audited against its own base daily — the shape that exposes a
+# build applying no desktop at all (#858: marlin:kde with zero KDE packages,
+# published green). Reads the tiny .packages ORAS artifacts, not the images,
+# so the whole matrix costs seconds.
+#
+# ADVISORY: this workflow succeeds even when cells are BROKEN — the verdicts
+# feed docs/MATRIX-STATUS.md and the composite through the uploaded artifact,
+# and enforcement is green-criteria.yml's job, not this job's exit code. The
+# job fails only when the audit itself cannot run (that would otherwise read
+# as 52 quiet ⬜ cells — the failure mode this whole program exists to stop).
+#
+# The against-own-base delta is the first, cheap parity assertion; diffing
+# against each variant's UPSTREAM reference (Bluefin/Aurora package sets) is
+# the second W6 box and stays open.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # After the nightlies' promotes, alongside the 08:00 contract sweep.
+    - cron: "40 8 * * *"
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install oras and yq
+        run: |
+          sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64
+          sudo chmod +x /usr/bin/yq
+          curl -fsSL https://github.com/oras-project/oras/releases/download/v1.3.0/oras_1.3.0_linux_amd64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin oras
+
+      - name: Audit every desktop against its base
+        env:
+          PARITY_JSON: parity-cells.jsonl
+        run: |
+          set -euo pipefail
+          : > "$PARITY_JSON"
+          for de in gnome kde cosmic niri xfce; do
+            echo "::group::--audit ${de}"
+            ./scripts/package-parity.sh --audit "$de" | tee -a parity-report.txt
+            echo "::endgroup::"
+          done
+          jq -s -c 'sort_by(.cell)' "$PARITY_JSON" > parity.json
+          measured=$(jq '[.[] | select(.verdict | startswith("unmeasured") | not)] | length' parity.json)
+          broken=$(jq '[.[] | select(.verdict | startswith("BROKEN"))] | length' parity.json)
+          suspect=$(jq '[.[] | select(.verdict | startswith("suspect"))] | length' parity.json)
+          # An audit that measured nothing is a broken audit, not a clean one.
+          if [[ "$measured" -eq 0 ]]; then
+            echo "::error::parity audit measured zero cells — every fetch failed; this is an audit fault, not a clean matrix"
+            exit 1
+          fi
+          {
+            echo "# Package parity (desktop vs own base)"
+            echo
+            echo "**${measured} cells measured — ${broken} BROKEN, ${suspect} suspect.**"
+            echo
+            echo '```'
+            cat parity-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$broken" -gt 0 ]]; then
+            jq -r '.[] | select(.verdict | startswith("BROKEN"))
+              | "::warning title=parity \(.cell)::\(.verdict) (delta \(.delta))"' parity.json
+          fi
+
+      - name: Upload parity baseline
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: package-parity-baseline
+          path: |
+            parity.json
+            parity-report.txt
+          retention-days: 90

--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -106,10 +106,15 @@ Every image already writes `/usr/share/tunaos/missing-on-*.txt`.
 
 ### W6. Schedule parity *(criterion 7)*
 
-- [ ] `scripts/package-parity.sh` exists; put it on a cadence against each
-      variant's upstream reference and feed W1.
-- [ ] Start advisory; graduate to blocking per-variant once the noise floor is
-      known.
+- [x] `scripts/package-parity.sh` is on a daily cadence
+      (`package-parity.yml`) and feeds W1: per-cell verdicts land in the
+      package-parity-baseline artifact, the Package parity section, and the
+      composite. First cadence = desktop-vs-own-base delta (the #858 shape);
+      the audit roster now derives from build-config so no declared variant
+      can be silently omitted.
+- [ ] Diff against each variant's UPSTREAM reference (Bluefin/Aurora package
+      sets) — the criterion's full claim; advisory until that lands and the
+      noise floor is known, then graduate per-variant.
 
 ### W7. Rebuildability beyond base pins *(criterion 9)*
 

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -66,7 +66,7 @@ it.
 
 ## Composite green — the bar
 
-Scored against `.github/green-criteria.yml`: a cell is green only when every **blocking** criterion applicable to it has a current affirmative result; a criterion that was skipped, never tested, or unasserted renders ⬜ and does not count as satisfied. Blocking today: `builds`, `boots`. Advisory (measured in the sections below, not yet biting): `desktop`, `install`, `no_silent_omissions`, `rebuildable`. Unimplemented: `iso`, `lifecycle`, `parity`, `arch_honesty`. Graduating a criterion is an edit to `enforcement:` in that file — this table and the README count tighten with no code change.
+Scored against `.github/green-criteria.yml`: a cell is green only when every **blocking** criterion applicable to it has a current affirmative result; a criterion that was skipped, never tested, or unasserted renders ⬜ and does not count as satisfied. Blocking today: `builds`, `boots`. Advisory (measured in the sections below, not yet biting): `desktop`, `install`, `parity`, `no_silent_omissions`, `rebuildable`. Unimplemented: `iso`, `lifecycle`, `arch_honesty`. Graduating a criterion is an edit to `enforcement:` in that file — this table and the README count tighten with no code change.
 
 **0 of 142** published cells are composite-green.
 
@@ -92,6 +92,27 @@ Cells outside the desktop columns (base, hwe, nvidia and friends) are in the cou
 **0 of 52** cells clean (0 read, 52 never read).
 
 Green criterion 8 (`no_silent_omissions`): the sweep runs `checks/verify-package-wishlist.sh` against every published image it pulls — the same gate new builds pass at build time — so an image shipping a silently-skipped package outside `package-miss-allowlist.txt` reads ❌ here even if it was published before the gate existed. A cell whose image was not read (no image, pull error, job lost) is ⬜, not clean.
+
+| Variant | gnome | kde | cosmic | niri | xfce |
+|---|:--:|:--:|:--:|:--:|:--:|
+| **albacore** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **bonito** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **bonito-rawhide** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **flounder** | ⬜ | ⬜ | — | — | ⬜ |
+| **flounder-sid** | ⬜ | ⬜ | — | — | ⬜ |
+| **grouper** | ⬜ | ⬜ | ⬜ | — | ⬜ |
+| **guppy** | ⬜ | ⬜ | — | — | ⬜ |
+| **hummingbird** | ⬜ | ⬜ | ⬜ | ⬜ | — |
+| **marlin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **sailfin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **skipjack** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+| **yellowfin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
+
+## Package parity
+
+**0 of 52** cells at parity (0 measured, 52 never measured).
+
+Green criterion 7 (`parity`), first cadence: every desktop's package set audited daily against its own base (`package-parity.yml` → `scripts/package-parity.sh --audit`) — the shape that exposes a build applying no desktop at all (#858). ❌ covers both BROKEN (no more packages than base) and suspect (fewer than 25 added). Diffing against each variant's upstream reference is the next step and is not yet asserted.
 
 | Variant | gnome | kde | cosmic | niri | xfce |
 |---|:--:|:--:|:--:|:--:|:--:|

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -363,6 +363,54 @@ def omissions_results() -> dict[str, tuple[str, str, str]]:
     return out
 
 
+_PARITY_CACHE: tuple[list[dict], str, str] | None = None
+
+
+def parity_results() -> dict[str, tuple[str, str, str]]:
+    """Per-cell parity verdict from package-parity.yml's baseline artifact.
+
+    ok → success; BROKEN/suspect → failure (a desktop adding fewer than the
+    floor of packages over its base is below the bar even when it isn't the
+    zero-added #858 case); unmeasured cells yield nothing — cell() renders ⬜.
+    """
+    global _PARITY_CACHE
+    if _PARITY_CACHE is None:
+        runs = gh_json(
+            "run", "list", "--repo", REPO, "--workflow", "package-parity.yml",
+            "--limit", "10", "--json", "databaseId,createdAt,status,conclusion",
+        ) or []
+        _PARITY_CACHE = ([], "", "")
+        for run in runs:
+            if run.get("status") != "completed" or run.get("conclusion") != "success":
+                continue
+            run_id, date = str(run["databaseId"]), run["createdAt"][:10]
+            with tempfile.TemporaryDirectory() as tmp:
+                try:
+                    subprocess.run(
+                        ["gh", "run", "download", run_id, "--repo", REPO,
+                         "--name", "package-parity-baseline", "--dir", tmp],
+                        capture_output=True, text=True, check=True,
+                    )
+                except subprocess.CalledProcessError:
+                    continue
+                parity_json = Path(tmp) / "parity.json"
+                if not parity_json.exists():
+                    continue
+                _PARITY_CACHE = (
+                    json.loads(parity_json.read_text()), date, run_id
+                )
+                break
+    cells, date, run_id = _PARITY_CACHE
+    out: dict[str, tuple[str, str, str]] = {}
+    for c in cells:
+        verdict = c.get("verdict", "")
+        if verdict == "ok":
+            out[c["cell"]] = ("success", date, run_id)
+        elif verdict.startswith(("BROKEN", "suspect")):
+            out[c["cell"]] = ("failure", date, run_id)
+    return out
+
+
 def contract_results() -> dict[str, tuple[str, str, str]]:
     """Newest per-cell verdict from desktop-contract-sweep.yml (tunaOS#858).
 
@@ -504,7 +552,7 @@ def criterion_scope_allows(criterion: dict, flavor: str) -> bool:
 
 
 def composite_section(criteria, stage, contract, luks, smoke, lifecycle,
-                      omissions):
+                      omissions, parity):
     """The bar itself: one table scored against the blocking criteria.
 
     Per-criterion applicability follows each axis's own denominator, exactly
@@ -539,6 +587,9 @@ def composite_section(criteria, stage, contract, luks, smoke, lifecycle,
             )
             per_cell["no_silent_omissions"] = _axis_from_results(
                 omissions, f"{variant}:{flavor}"
+            )
+            per_cell["parity"] = _axis_from_results(
+                parity, f"{variant}:{flavor}"
             )
         if flavor in isos.get(variant, set()):
             per_cell["iso"] = _axis_from_results(smoke, f"{variant}:{flavor}")
@@ -641,6 +692,29 @@ def omissions_section(lmatrix, omissions) -> list[str]:
         ),
         "",
     ] + desktop_table(lmatrix, omissions, om_key) + [""]
+
+
+def parity_section(lmatrix, parity) -> list[str]:
+    """Green criterion 7's first cadence (see parity_results)."""
+    pkey = lambda v, d: f"{v}:{d}"                     # noqa: E731
+    total, tested, passed = tally(lmatrix, parity, pkey)
+    return [
+        "## Package parity",
+        "",
+        f"**{passed} of {total}** cells at parity "
+        f"({tested} measured, {total - tested} never measured).",
+        "",
+        (
+            "Green criterion 7 (`parity`), first cadence: every desktop's "
+            "package set audited daily against its own base "
+            "(`package-parity.yml` → `scripts/package-parity.sh --audit`) — "
+            "the shape that exposes a build applying no desktop at all "
+            "(#858). ❌ covers both BROKEN (no more packages than base) and "
+            "suspect (fewer than 25 added). Diffing against each variant's "
+            "upstream reference is the next step and is not yet asserted."
+        ),
+        "",
+    ] + desktop_table(lmatrix, parity, pkey) + [""]
 
 
 def cell(results: dict, key: str, in_matrix: bool) -> str:
@@ -811,13 +885,15 @@ def build() -> str:
     # that composes the axes into the one claim the word "green" now makes.
     lifecycle = latest_results("bootc-lifecycle.yml", r":")
     omissions = omissions_results()
+    parity = parity_results()
     composite_lines, _, _ = composite_section(
         load_green_criteria(), build_stage_results(), contract, luks, smoke,
-        lifecycle, omissions,
+        lifecycle, omissions, parity,
     )
     out += composite_lines
 
     out += omissions_section(lmatrix, omissions)
+    out += parity_section(lmatrix, parity)
 
 
     # ── LUKS ────────────────────────────────────────────────────────────────

--- a/scripts/package-parity.sh
+++ b/scripts/package-parity.sh
@@ -65,15 +65,34 @@ names() { cut -f1 "$1" | LC_ALL=C sort -u; }
 # no desktop at all, which is what marlin's kde/cosmic/niri/xfce do.
 if [[ "${1:-}" == "--audit" ]]; then
 	de="${2:?usage: --audit <desktop>}"
+	# The variant roster comes from build-config when available, so the audit
+	# cannot silently omit a variant the factory declares (bonito-rawhide,
+	# flounder-sid and gurnard were missing from the old hardcoded list —
+	# exactly the absence-of-evidence hole this repo keeps refusing to dig).
+	variants=(yellowfin bonito sailfin flounder grouper marlin skipjack albacore guppy)
+	if command -v yq >/dev/null && [[ -f .github/build-config.yml ]]; then
+		mapfile -t variants < <(yq -r '.variants[].id' .github/build-config.yml)
+	fi
+	# PARITY_JSON: append one JSON object per audited cell — the machine
+	# output the scheduled workflow collates for the scoreboard (W6).
+	emit_json() {
+		[[ -n "${PARITY_JSON:-}" ]] || return 0
+		jq -nc --arg cell "$1" --arg verdict "$2" --argjson delta "$3" \
+			'{cell:$cell,verdict:$verdict,delta:$delta}' >>"$PARITY_JSON"
+	}
 	printf '%-12s %8s %8s %9s   %s\n' variant base "$de" delta verdict
 	printf -- '-%.0s' {1..72}
 	echo
-	for v in yellowfin bonito sailfin flounder grouper marlin skipjack albacore guppy; do
+	for v in "${variants[@]}"; do
 		b=$(fetch "$v:base" 2>/dev/null) || {
 			printf '%-12s   (no base)\n' "$v"
+			emit_json "$v:$de" "unmeasured: no base manifest" 0
 			continue
 		}
-		d=$(fetch "$v:$de" 2>/dev/null) || continue
+		d=$(fetch "$v:$de" 2>/dev/null) || {
+			emit_json "$v:$de" "unmeasured: no $de manifest" 0
+			continue
+		}
 		nb=$(names "$b" | wc -l)
 		nd=$(names "$d" | wc -l)
 		delta=$((nd - nb))
@@ -81,6 +100,7 @@ if [[ "${1:-}" == "--audit" ]]; then
 		((delta <= 0)) && verdict="BROKEN: no more packages than base"
 		((delta > 0 && delta < 25)) && verdict="suspect: only $delta added"
 		printf '%-12s %8d %8d %+9d   %s\n' "$v" "$nb" "$nd" "$delta" "$verdict"
+		emit_json "$v:$de" "$verdict" "$delta"
 	done
 	exit 0
 fi

--- a/tests/test_boot_gate_blocks_green.py
+++ b/tests/test_boot_gate_blocks_green.py
@@ -90,7 +90,7 @@ def test_scope_excludes_are_not_judged_and_gate_absence_is_not_green() -> None:
         ("gnome", "Promote"): "success",
         ("gnome", "Gate"): "success",            # the full bar → green
     }, "date": "x"}}
-    _, green, _ = gms.composite_section(criteria, stage, {}, {}, {}, {}, {})
+    _, green, _ = gms.composite_section(criteria, stage, {}, {}, {}, {}, {}, {})
     # gnome (promote+gate) and base-hwe (boots out of scope) are green;
     # base promoted but its gate never ran — skipped_is_not_green.
     assert green == 2

--- a/tests/test_composite_green_scoring.py
+++ b/tests/test_composite_green_scoring.py
@@ -62,7 +62,7 @@ def test_blocking_criteria_are_scoreable() -> None:
 def test_offline_composite_covers_the_full_matrix() -> None:
     """With no CI data at all: nothing green, every published cell counted,
     and the total agrees with the README denominator (build_image cells)."""
-    lines, green, total = gms.composite_section(CRITERIA, {}, {}, {}, {}, {}, {})
+    lines, green, total = gms.composite_section(CRITERIA, {}, {}, {}, {}, {}, {}, {})
     assert green == 0
     cfg = gms._matrix("build_image", desktops_only=False)
     assert total == sum(len(f) for f in cfg.values())
@@ -72,7 +72,7 @@ def test_offline_composite_covers_the_full_matrix() -> None:
 def test_composite_scores_a_promoted_gated_cell_green_iff_blocking_pass() -> None:
     stage = {"albacore": {"jobs": {("gnome", "Promote"): "success",
                                    ("gnome", "Gate"): "failure"}, "date": "x"}}
-    lines, green, total = gms.composite_section(CRITERIA, stage, {}, {}, {}, {}, {})
+    lines, green, total = gms.composite_section(CRITERIA, stage, {}, {}, {}, {}, {}, {})
     blocking = {c["id"] for c in CRITERIA if c["enforcement"] == "blocking"}
     if blocking == {"builds"}:
         # A failing Gate is advisory today: the cell is still composite-green.

--- a/tests/test_omissions_manifest_is_read_on_a_schedule.py
+++ b/tests/test_omissions_manifest_is_read_on_a_schedule.py
@@ -80,7 +80,7 @@ def test_composite_scores_the_omissions_axis() -> None:
                           "date": "x"}}
     omissions = {"albacore:gnome": ("failure", "x", "1")}
     _, green, _ = gms.composite_section(
-        criteria, stage, {}, {}, {}, {}, omissions
+        criteria, stage, {}, {}, {}, {}, omissions, {}
     )
     assert green == 0, "a cell shipping silent omissions must not be green"
 

--- a/tests/test_package_parity_is_scheduled.py
+++ b/tests/test_package_parity_is_scheduled.py
@@ -1,0 +1,78 @@
+"""W6 of docs/GREEN-MASTER-PLAN.md: parity measured daily, fed to the board.
+
+package-parity.sh existed and ran never — criterion 7 read "not scheduled".
+The workflow now audits every desktop against its own base daily (the #858
+no-desktop-at-all shape) and the verdicts flow to the composite.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "package-parity.yml"
+SCRIPT = ROOT / "scripts" / "package-parity.sh"
+spec = importlib.util.spec_from_file_location(
+    "gms", ROOT / "scripts" / "gen-matrix-status.py"
+)
+gms = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gms)
+
+
+def test_workflow_is_scheduled_and_advisory_shaped() -> None:
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    assert "schedule" in doc[True] if True in doc else "schedule" in doc["on"]
+    body = WORKFLOW.read_text()
+    assert "package-parity-baseline" in body, "the scoreboard reads this artifact"
+    assert "measured zero cells" in body, (
+        "an audit that measured nothing must fail loudly — 52 quiet ⬜ cells "
+        "is the failure mode this program exists to stop"
+    )
+
+
+def test_audit_roster_derives_from_build_config() -> None:
+    body = SCRIPT.read_text()
+    assert ".github/build-config.yml" in body, (
+        "a hardcoded variant list silently omits declared variants "
+        "(bonito-rawhide, flounder-sid and gurnard were missing)"
+    )
+    assert "PARITY_JSON" in body
+
+
+def test_parity_results_maps_verdicts() -> None:
+    gms._PARITY_CACHE = (
+        [
+            {"cell": "a:gnome", "verdict": "ok", "delta": 400},
+            {"cell": "b:kde", "verdict": "BROKEN: no more packages than base",
+             "delta": -2},
+            {"cell": "c:xfce", "verdict": "suspect: only 3 added", "delta": 3},
+            {"cell": "d:niri", "verdict": "unmeasured: no base manifest",
+             "delta": 0},
+        ],
+        "2026-08-17", "1",
+    )
+    try:
+        got = gms.parity_results()
+    finally:
+        gms._PARITY_CACHE = None
+    assert got == {
+        "a:gnome": ("success", "2026-08-17", "1"),
+        "b:kde": ("failure", "2026-08-17", "1"),
+        "c:xfce": ("failure", "2026-08-17", "1"),
+    }, "ok passes; BROKEN and suspect fail; unmeasured renders ⬜"
+
+
+def test_criterion_is_advisory_with_the_cadence_named() -> None:
+    criteria = yaml.safe_load(
+        (ROOT / ".github" / "green-criteria.yml").read_text()
+    )["criteria"]
+    c = next(c for c in criteria if c["id"] == "parity")
+    assert c["enforcement"] == "advisory"
+    assert "package-parity.yml" in c["asserted_by"]
+
+
+def test_committed_doc_carries_the_parity_section() -> None:
+    doc = (ROOT / "docs" / "MATRIX-STATUS.md").read_text()
+    assert "## Package parity" in doc


### PR DESCRIPTION
## What

W6 of docs/GREEN-MASTER-PLAN.md, first box. `scripts/package-parity.sh` existed and ran never — criterion 7 read "not scheduled". Now:

- **`package-parity.yml`** (daily, 08:40 UTC): audits every desktop cell's package set against its own base — the shape that exposes a build applying no desktop at all (#858: marlin:kde with zero KDE packages, published green). Reads the tiny `.packages` ORAS artifacts instead of pulling images, so the full matrix costs seconds. **Advisory by design**: the workflow succeeds even with BROKEN cells (enforcement is `green-criteria.yml`'s job, not an exit code) and fails only if the audit measured *zero* cells — 52 quiet ⬜ cells being the exact failure mode this program exists to stop.
- **`package-parity.sh`**: the audit roster now derives from `build-config.yml` (the hardcoded list silently omitted bonito-rawhide, flounder-sid, and gurnard — the absence-of-evidence hole again); `PARITY_JSON` emits per-cell verdicts for the workflow to collate into the `package-parity-baseline` artifact.
- **`gen-matrix-status.py`**: `parity_results()` reads the artifact (ok → pass; BROKEN *and* suspect → fail; unmeasured → ⬜); a new **Package parity** section; the composite scores the axis.
- **`green-criteria.yml`**: `parity` graduates `unimplemented → advisory` with the cadence named. The upstream-reference diff (the criterion's full claim — Bluefin/Aurora package sets) is the remaining W6 box, and the criterion stays advisory at least until it lands.

## Tests

`test_package_parity_is_scheduled.py` (5): schedule + artifact + zero-measured guard pinned; roster derives from build-config; verdict mapping (ok/BROKEN/suspect/unmeasured); criterion graduation; committed doc section. Plus composite arity updates in the three existing composite test files.

Full suite: **489 passed.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_