### PR TITLE
fix(sailfin): re-assert Packman codecs after the desktop install (#1832)

### DIFF
--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -157,6 +157,33 @@ if [[ "${_TD_OS}" == "zypper" ]]; then
 	}
 	zypper --non-interactive --gpg-auto-import-keys refresh || true
 	_td_zypper_install_retry "${_TD_ZYPPER_PKGS[@]}"
+
+	# Re-assert the Packman multimedia stack AFTER the desktop transaction
+	# (tunaOS#1832). The base stage installs Packman's full-codec ffmpeg with
+	# --allow-vendor-change, but the desktop install can pull a NEWER
+	# openSUSE-vendor ffmpeg through a dependency bump — vendor stickiness
+	# does not survive a version-forced upgrade — and openSUSE's build
+	# compiles the h264/hevc/vc1 decoders out. Every sailfin desktop then
+	# failed the codec baseline deterministically:
+	#
+	#   ffmpeg cannot decode h264 — a free/crippled libavcodec is installed
+	#   configure --disable-decoder='h264,hevc,vc1,prores_raw,vvc'
+	#
+	# The dup is a no-op when Packman already owns the stack, so this is
+	# idempotent, and the codec baseline in verify-desktop-experience.sh
+	# remains the assertion that it worked.
+	if zypper --non-interactive repos packman-essentials >/dev/null 2>&1; then
+		attempt=0
+		until zypper --non-interactive dup --from packman-essentials --allow-vendor-change; do
+			attempt=$((attempt + 1))
+			if ((attempt >= 3)); then
+				echo "ERROR: could not re-assert Packman multimedia after the desktop install (tunaOS#1832)" >&2
+				exit 1
+			fi
+			zypper --non-interactive --gpg-auto-import-keys refresh --force || true
+			sleep $((attempt * 5))
+		done
+	fi
 fi
 
 # ── Emerge path ────────────────────────────────────────────────────────────────

--- a/tests/test_sailfin_keeps_packman_codecs.py
+++ b/tests/test_sailfin_keeps_packman_codecs.py
@@ -1,0 +1,43 @@
+"""tunaOS#1832: every sailfin desktop failed the codec baseline.
+
+The base stage installs Packman's full-codec ffmpeg (--allow-vendor-change),
+but the desktop transaction can pull a NEWER openSUSE-vendor ffmpeg through a
+dependency bump — vendor stickiness does not survive a version-forced upgrade
+— and openSUSE's build compiles the h264/hevc/vc1 decoders out. Measured on
+nightly 31987555325, all five desktops, all three in-job attempts:
+
+    ffmpeg cannot decode h264 — a free/crippled libavcodec is installed
+    configure --disable-decoder='h264,hevc,vc1,prores_raw,vvc'
+
+install-desktop.sh's zypper path now re-asserts Packman after its install.
+"""
+from __future__ import annotations
+
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = (ROOT / "build_scripts" / "desktop" /
+          "install-desktop.sh").read_text(encoding="utf-8")
+BASE = (ROOT / "Containerfile.opensuse").read_text(encoding="utf-8")
+
+
+def test_desktop_stage_reasserts_packman_after_its_transaction() -> None:
+    assert "dup --from packman-essentials --allow-vendor-change" in SCRIPT
+    # It must come AFTER the desktop package install, or the install can
+    # undo it again — the exact bug this fixes.
+    assert SCRIPT.index('_td_zypper_install_retry "${_TD_ZYPPER_PKGS[@]}"') \
+        < SCRIPT.index("dup --from packman-essentials")
+
+
+def test_reassert_is_guarded_and_loud() -> None:
+    # Only when the repo exists (local/dev builds without Packman must not
+    # break), and a failed re-assert fails the build rather than shipping a
+    # crippled codec stack for the Gate to find later.
+    assert "zypper --non-interactive repos packman-essentials" in SCRIPT
+    assert "could not re-assert Packman multimedia" in SCRIPT
+
+
+def test_base_stage_still_installs_packman_first() -> None:
+    """The re-assert complements the base install, it does not replace it."""
+    assert "packman-essentials" in BASE
+    assert "--allow-vendor-change" in BASE


### PR DESCRIPTION
## What

Unblocks all five sailfin desktop cells (#1832 — the Phase 0 classification of "sailfin amd64 desktops undiagnosed").

Every sailfin desktop failed the codec baseline deterministically (nightly [31987555325](https://github.com/tuna-os/tunaOS/actions/runs/31987555325), all five cells, all three in-job attempts):

```
ffmpeg cannot decode h264 — a free/crippled libavcodec is installed
configure --disable-decoder='h264,hevc,vc1,prores_raw,vvc'
```

## Why the base-stage Packman install wasn't enough

`Containerfile.opensuse` already adds Packman Essentials and installs the full-codec ffmpeg with `--allow-vendor-change`. But the **desktop transaction can pull a newer openSUSE-vendor ffmpeg through a dependency bump** — zypper's vendor stickiness does not survive a version-forced upgrade — and openSUSE's build compiles the patent-encumbered decoders out. The failing images carried ffmpeg 9.0.1 (SUSE) over Packman's build.

## Fix

`install-desktop.sh`'s zypper path re-runs `zypper dup --from packman-essentials --allow-vendor-change` **after** its package install:

- a no-op when Packman already owns the stack (idempotent)
- guarded on the repo existing, so local/dev builds without Packman keep working
- **loud on failure** — a build that cannot restore its codec stack fails there, instead of shipping for the Gate to find later
- the codec baseline in `verify-desktop-experience.sh` remains the assertion that it worked

## Tests

`test_sailfin_keeps_packman_codecs.py` (3): the re-assert exists and comes *after* the install (the ordering is the bug), is guarded and loud, and complements — not replaces — the base-stage install. Full suite: **495 passed.**

After merge I'll dispatch build-sailfin.yml to validate the five cells end-to-end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_