### PR TITLE
fix(lifecycle): guarded podman install + stale lock cleanup on arm64 (#1556 surface)

### DIFF
--- a/.github/scripts/update-build-status.sh
+++ b/.github/scripts/update-build-status.sh
@@ -164,7 +164,7 @@ fi
 
 {
 	echo
-	echo "**Built ${total_green}/${total_cells} · composite green ${composite_green}/${total_cells} (${percent}%)** — of the remainder, **${total_failing} failing** and **${total_unreached} never reached** (no job asserted them). The two are reported separately on purpose: a never-reached cell is untested, not broken. Composite green is scored against [\\`.github/green-criteria.yml\\`](.github/green-criteria.yml) (blocking today: \\`builds\\` + \\`boots\\` — a cell must promote AND pass its boot Gate; the full per-axis board is [docs/MATRIX-STATUS.md](docs/MATRIX-STATUS.md)). This is a point-in-time CI snapshot, not a support-tier promise."
+	echo "**Built ${total_green}/${total_cells} · composite green ${composite_green}/${total_cells} (${percent}%)** — of the remainder, **${total_failing} failing** and **${total_unreached} never reached** (no job asserted them). The two are reported separately on purpose: a never-reached cell is untested, not broken. Composite green is scored against [\`.github/green-criteria.yml\`](.github/green-criteria.yml) (blocking today: \`builds\` + \`boots\` — a cell must promote AND pass its boot Gate; the full per-axis board is [docs/MATRIX-STATUS.md](docs/MATRIX-STATUS.md)). This is a point-in-time CI snapshot, not a support-tier promise."
 	echo
 	echo "$end"
 } >>"$tmp_table"

--- a/.github/workflows/bootc-lifecycle.yml
+++ b/.github/workflows/bootc-lifecycle.yml
@@ -104,10 +104,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # podman handled like the boot Gate does it (reusable-build-image.yml):
+      # never apt-install over a preinstalled /usr/local podman — the mixed
+      # stack cannot start containers ("crun: unknown version"). On the
+      # ubuntu-24.04-arm runners this ALSO fixes tunaOS#1556: two podman
+      # builds sharing /dev/shm/libpod_lock with different lock counts is
+      # exactly how "failed to open 2048 locks in /libpod_lock: numerical
+      # result out of range" killed all 6 arm64 cells of run 31999953433
+      # before any test content ran. The stale-segment removal is defensive
+      # for the case where the runner image itself already initialized the
+      # segment: podman re-creates it with its own count on next use.
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends podman skopeo jq
+          pkgs=(skopeo jq)
+          if sudo sh -c 'command -v podman' >/dev/null 2>&1; then
+            echo "podman already present: $(sudo sh -c 'command -v podman') ($(sudo podman --version))"
+          else
+            pkgs+=(podman)
+          fi
+          sudo apt-get install -y --no-install-recommends "${pkgs[@]}"
+          sudo rm -f /dev/shm/libpod_lock /dev/shm/libpod_rootless_lock_* || true
 
       - name: Log in to GHCR
         run: |
@@ -204,10 +221,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # podman handled like the boot Gate does it (reusable-build-image.yml):
+      # never apt-install over a preinstalled /usr/local podman — the mixed
+      # stack cannot start containers ("crun: unknown version"). On the
+      # ubuntu-24.04-arm runners this ALSO fixes tunaOS#1556: two podman
+      # builds sharing /dev/shm/libpod_lock with different lock counts is
+      # exactly how "failed to open 2048 locks in /libpod_lock: numerical
+      # result out of range" killed all 6 arm64 cells of run 31999953433
+      # before any test content ran. The stale-segment removal is defensive
+      # for the case where the runner image itself already initialized the
+      # segment: podman re-creates it with its own count on next use.
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends podman skopeo jq
+          pkgs=(skopeo jq)
+          if sudo sh -c 'command -v podman' >/dev/null 2>&1; then
+            echo "podman already present: $(sudo sh -c 'command -v podman') ($(sudo podman --version))"
+          else
+            pkgs+=(podman)
+          fi
+          sudo apt-get install -y --no-install-recommends "${pkgs[@]}"
+          sudo rm -f /dev/shm/libpod_lock /dev/shm/libpod_rootless_lock_* || true
 
       - name: Log in to GHCR
         run: |

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -203,9 +203,13 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
 @test "disk gate requires the desktop contract marker" {
   # The gate wakes on either marker (both prove the contract service ran)
   # but only OK passes; FAIL surfaces its reason lines and exits nonzero.
+  # --contract selects the marker prefix; desktop is the default and base
+  # cells assert TUNAOS_BASE_CONTRACT instead.
   run grep -F 'TUNAOS_DESKTOP_CONTRACT_(OK|FAIL)' "${REPO_ROOT}/scripts/iso-e2e.sh"
   [ "$status" -eq 0 ]
-  grep -qF 'desktop experience contract FAILED' "${REPO_ROOT}/scripts/iso-e2e.sh"
+  grep -qF 'CONTRACT_PREFIX="TUNAOS_DESKTOP_CONTRACT"' "${REPO_ROOT}/scripts/iso-e2e.sh"
+  grep -qF 'CONTRACT_PREFIX="TUNAOS_BASE_CONTRACT"' "${REPO_ROOT}/scripts/iso-e2e.sh"
+  grep -qF 'contract FAILED:' "${REPO_ROOT}/scripts/iso-e2e.sh"
 }
 
 @test "runtime contract never asserts graphical.target is active" {

--- a/tests/bats/test_build_status_classification.bats
+++ b/tests/bats/test_build_status_classification.bats
@@ -22,14 +22,18 @@ setup() {
   BIN="${BATS_TEST_TMPDIR}/bin"
   mkdir -p "$BIN"
 
-  # yq: one variant, four flavors. The script only ever asks for the flavor
-  # list and the (id, emoji) pairs.
+  # yq: one variant, four flavors. The script asks for the flavor list, the
+  # (id, emoji) pairs, and — since the composite count — the green-criteria
+  # blocking set and the boots scope. The excludes cases must precede the
+  # generic *flavors* one: their queries also contain the word "flavors".
   cat > "${BIN}/yq" <<'STUB'
 #!/usr/bin/env bash
 for arg in "$@"; do
   case "$arg" in
-    *flavors*) printf 'green\nbroken\nskipped\nabsent\n'; exit 0 ;;
-    *emoji*)   printf 'sailfin\t🦈\n'; exit 0 ;;
+    *excludes_flavor*) exit 0 ;;
+    *enforcement*)     printf 'boots,builds\n'; exit 0 ;;
+    *flavors*)         printf 'green\nbroken\nskipped\nabsent\n'; exit 0 ;;
+    *emoji*)           printf 'sailfin\t🦈\n'; exit 0 ;;
   esac
 done
 exit 0

--- a/tests/test_lifecycle_arm64_podman_is_not_a_mixed_stack.py
+++ b/tests/test_lifecycle_arm64_podman_is_not_a_mixed_stack.py
@@ -1,0 +1,30 @@
+"""tunaOS#1556 (lifecycle surface): the arm64 cells died before any test ran.
+
+Run 31999953433 lost all six arm64 cells to
+
+    Error: failed to open 2048 locks in /libpod_lock: numerical result out of range
+
+bootc-lifecycle.yml apt-installed podman unconditionally — the exact
+mixed-stack mistake reusable-build-image.yml's Gate documents ("crun: unknown
+version") — and two podman builds sharing /dev/shm/libpod_lock with different
+lock counts is what ERANGE looks like. Both lifecycle jobs now use the Gate's
+guarded install and clear any stale lock segment.
+"""
+from __future__ import annotations
+
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+BODY = (ROOT / ".github" / "workflows" /
+        "bootc-lifecycle.yml").read_text(encoding="utf-8")
+
+
+def test_podman_is_never_apt_installed_over_a_preinstalled_one() -> None:
+    assert "sudo apt-get install -y --no-install-recommends podman" not in BODY
+    assert BODY.count("podman already present") == 2, (
+        "both lifecycle jobs must carry the guarded install"
+    )
+
+
+def test_stale_lock_segments_are_cleared() -> None:
+    assert BODY.count("rm -f /dev/shm/libpod_lock") == 2


### PR DESCRIPTION
## What

Run [31999953433](https://github.com/tuna-os/tunaOS/actions/runs/31999953433) — the first real Bootc Lifecycle run — lost **all six arm64 cells** before any test content ran:

```
Error: failed to open 2048 locks in /libpod_lock: numerical result out of range
```

## Diagnosis

`bootc-lifecycle.yml` apt-installed podman **unconditionally** — the exact mixed-stack mistake `reusable-build-image.yml`'s Gate documents from its own incident ("crun: unknown version", run 30594521039): newer runner images ship podman under `/usr/local`, apt adds Ubuntu's on top, and the two builds end up sharing state. Two podman builds sharing `/dev/shm/libpod_lock` with **different lock counts** is precisely what the ERANGE "failed to open 2048 locks" failure looks like.

## Fix

Both lifecycle jobs now:
- use the Gate's **guarded install** (apt-install podman only when none is present), and
- defensively **clear stale lock segments** (`/dev/shm/libpod_lock*`) so podman re-creates them with its own count — covering the case where the runner image itself already initialized the segment.

This addresses the **lifecycle surface** of #1556. If the next lifecycle run proves it out on arm64, the same treatment applies to the ISO pre-pull path where the issue was first filed — I'll follow up there with evidence rather than speculatively.

## Tests

`test_lifecycle_arm64_podman_is_not_a_mixed_stack.py` (2): the unconditional install is gone from both jobs; the cleanup is present in both. Full suite: **497 passed.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_