### PR TITLE
docs: slim the README to a front page, move detail into docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,39 @@ TunaOS builds **bootc-based desktop operating systems** with atomic updates and 
 
 [Visit tunaos.org](https://tunaos.org/) or read the [launch announcement](https://tunaos.org/blog/modern-enterprise-linux-desktops-with-tunaos).
 
-### Features
-
 - **Modern Desktops**: GNOME, KDE Plasma, COSMIC, Niri, and XFCE — equal first-class options across distribution bases
 - **Up-to-Date Desktop Stack**: Fresh desktop features and updates backported to Enterprise and community bases
 - **Homebrew**: Baked into the image — all your CLI apps and fonts are just a `brew` command away
 - **Flathub by Default**: Full Flathub access out of the box — get any Flatpak available on the net
-- **HWE Option**: Hardware Enablement kernel for newer hardware support
-- **NVIDIA Option**: NVIDIA drivers and CUDA for graphics and AI workflows
+- **HWE and NVIDIA Options**: Hardware Enablement kernels and NVIDIA drivers + CUDA as image tags
 
-## Images and variants
+## Choose your image
 
-TunaOS provides a variety of bootc-based operating system images. Use the table below to choose your base distribution and desktop environment.
+| Variant | Base OS | Registry Path | Desktops | Architectures |
+| :--- | :--- | :--- | :--- | :--- |
+| 🐠 **Yellowfin** | AlmaLinux Kitten 10 | `ghcr.io/tuna-os/yellowfin` | GNOME, KDE, COSMIC, Niri | x86_64, x86_64/v2, arm64 |
+| 🐟 **Albacore** | AlmaLinux 10 (RHEL 10) | `ghcr.io/tuna-os/albacore` | GNOME, KDE, COSMIC, Niri | x86_64, x86_64/v2, arm64 |
+| 🍣 **Skipjack** | CentOS Stream 10 | `ghcr.io/tuna-os/skipjack` | GNOME, KDE, COSMIC, Niri | x86_64, arm64 |
+| 🎣 **Bonito** | Fedora 44 | `ghcr.io/tuna-os/bonito` | GNOME, KDE, COSMIC, Niri | x86_64, arm64 |
+| 🐦 **Hummingbird** | Fedora Hummingbird (experimental) | `ghcr.io/tuna-os/hummingbird` | Base, GNOME, KDE, COSMIC, Niri | x86_64, arm64 |
+| 🔒 **Redfin** | Red Hat Enterprise Linux 10 | *Local-Build Only* | GNOME, KDE, COSMIC, Niri, XFCE | x86_64, arm64 |
+| 🐟 **Grouper** | Ubuntu 26.04 | `ghcr.io/tuna-os/grouper` | GNOME, KDE, Niri, XFCE | x86_64 |
+| 🐟 **Gurnard** | Ubuntu 24.04 (Noble Numbat, experimental) | `ghcr.io/tuna-os/gurnard` | Base, Pantheon | x86_64, arm64 |
+| 🚀 **Marlin** | Arch Linux (Rolling) | `ghcr.io/tuna-os/marlin` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
+| 🐡 **Flounder** | Debian 13 (Trixie) | `ghcr.io/tuna-os/flounder` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
+| ☢️ **Flounder Sid** | Debian Sid (Unstable) | `ghcr.io/tuna-os/flounder:*-sid` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
+| 🐉 **Bonito Rawhide** | Fedora Rawhide | `ghcr.io/tuna-os/bonito:*-rawhide` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64, arm64 |
+| 🦈 **Sailfin** | openSUSE Tumbleweed | `ghcr.io/tuna-os/sailfin` | GNOME, KDE, Niri, XFCE | x86_64 |
+| 🌈 **Guppy** | Gentoo Linux | `ghcr.io/tuna-os/guppy` | GNOME, KDE | x86_64 |
 
-### Live build matrix
+Tags are `<desktop>[-hardware]` — e.g. `yellowfin:gnome-hwe`,
+`albacore:kde-nvidia`. Full tag reference: [docs/IMAGE-TAGS.md](docs/IMAGE-TAGS.md).
+Hardware requirements and ARM laptop status: [docs/HARDWARE.md](docs/HARDWARE.md).
+
+> [!NOTE]
+> **Redfin (RHEL 10)** is local-build only due to EULA restrictions. To build it locally, run `just build redfin <desktop>` (see [rhel-setup.md](docs/rhel-setup.md)).
+
+## Live build matrix
 
 <!-- build-status:start -->
 
@@ -64,210 +83,24 @@ _Generated from the latest conclusive main-branch build for each variant (cancel
 
 <!-- build-status:end -->
 
-| Variant | Base OS | Registry Path | Desktops | Architectures |
-| :--- | :--- | :--- | :--- | :--- |
-| 🐠 **Yellowfin** | AlmaLinux Kitten 10 | `ghcr.io/tuna-os/yellowfin` | GNOME, KDE, COSMIC, Niri | x86_64, x86_64/v2, arm64 |
-| 🐟 **Albacore** | AlmaLinux 10 (RHEL 10) | `ghcr.io/tuna-os/albacore` | GNOME, KDE, COSMIC, Niri | x86_64, x86_64/v2, arm64 |
-| 🍣 **Skipjack** | CentOS Stream 10 | `ghcr.io/tuna-os/skipjack` | GNOME, KDE, COSMIC, Niri | x86_64, arm64 |
-| 🎣 **Bonito** | Fedora 44 | `ghcr.io/tuna-os/bonito` | GNOME, KDE, COSMIC, Niri | x86_64, arm64 |
-| 🐦 **Hummingbird** | Fedora Hummingbird (experimental) | `ghcr.io/tuna-os/hummingbird` | Base, GNOME, KDE, COSMIC, Niri | x86_64, arm64 |
-| 🔒 **Redfin** | Red Hat Enterprise Linux 10 | *Local-Build Only* | GNOME, KDE, COSMIC, Niri, XFCE | x86_64, arm64 |
-| 🐟 **Grouper** | Ubuntu 26.04 | `ghcr.io/tuna-os/grouper` | GNOME, KDE, Niri, XFCE | x86_64 |
-| 🐟 **Gurnard** | Ubuntu 24.04 (Noble Numbat, experimental) | `ghcr.io/tuna-os/gurnard` | Base, Pantheon | x86_64, arm64 |
-| 🚀 **Marlin** | Arch Linux (Rolling) | `ghcr.io/tuna-os/marlin` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
-| 🐡 **Flounder** | Debian 13 (Trixie) | `ghcr.io/tuna-os/flounder` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
-| ☢️ **Flounder Sid** | Debian Sid (Unstable) | `ghcr.io/tuna-os/flounder:*-sid` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
-| 🐉 **Bonito Rawhide** | Fedora Rawhide | `ghcr.io/tuna-os/bonito:*-rawhide` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64, arm64 |
-| 🦈 **Sailfin** | openSUSE Tumbleweed | `ghcr.io/tuna-os/sailfin` | GNOME, KDE, Niri, XFCE | x86_64 |
-| 🌈 **Guppy** | Gentoo Linux | `ghcr.io/tuna-os/guppy` | GNOME, KDE | x86_64 |
+## Get started
 
-> [!NOTE]
-> **Redfin (RHEL 10)** is local-build only due to EULA restrictions. To build it locally, run `just build redfin <desktop>` (see [rhel-setup.md](docs/rhel-setup.md)).
+- **Install from an ISO:** [📦 tunaos.org/download](https://tunaos.org/download)
+- **Build your own ISO in the browser:** [🛠️ tunaos.org/iso-builder](https://tunaos.org/iso-builder)
+- **Switch an existing bootc system:**
 
-### Suffix Rules (Image Tags)
+  ```bash
+  sudo bootc switch ghcr.io/tuna-os/yellowfin:gnome
+  ```
 
-Image tags are constructed as `<desktop>[-hardware]`:
-
-1. **Desktop Suffixes**:
-   * `gnome`: GNOME (stable)
-   * `kde`: KDE Plasma
-   * `cosmic`: COSMIC Desktop
-   * `niri`: Niri (tiling Wayland compositor)
-   * `xfce`: XFCE (Wayland experimental)
-   * `pantheon`: Pantheon desktop (elementary OS) — Gurnard variant, experimental
-   * `base`: Plain system image with no desktop environment pre-installed (available for most variants)
-
-2. **Hardware Suffixes** (append to any desktop suffix):
-   * *(none)*: Standard generic kernel build
-   * `-hwe`: Hardware Enablement (newer kernel stack)
-   * `-nvidia`: NVIDIA drivers + CUDA pre-configured
-   * `-nvidia-hwe`: NVIDIA drivers on HWE kernel stack
-
-*Example tags:* `yellowfin:gnome-hwe`, `albacore:kde-nvidia`, `marlin:cosmic`
-
----
-
-## System requirements
-
-| Component | Minimum | Recommended |
-|-----------|---------|-------------|
-| **CPU** | x86_64, ARM64 | x86_64, ARM64 |
-| **RAM** | 4 GB | 8 GB+ |
-| **Storage** | 20 GB | 50 GB+ |
-
-### Supported hardware (ARM laptops)
-
-| Hardware | Status | Docs |
-|----------|--------|------|
-| Snapdragon X Elite (e.g. Lenovo ThinkPad X13s) | Supported via [Bonito](https://tunaos.org/docs/bonito) (ARM64) | [Snapdragon X Elite FAQ](https://tunaos.org/docs/faq); the dedicated [bonito-x13s](https://tunaos.org/docs/bonito-x13s) / [dakota-x13s](https://tunaos.org/docs/dakota-x13s) pages are archived |
-| Apple Silicon (M1, M2) | In progress via [Asahi Linux](https://asahilinux.org/) — see note below | [bootc-installer-asahi](https://github.com/tuna-os/bootc-installer-asahi) |
-| Apple Silicon (M3 and newer) | Not supported (no Asahi support for M3+ yet) | — |
-
-> **Apple Silicon status.** [ROADMAP.md](ROADMAP.md) is the canonical source
-> and lists Apple Silicon support as 🟡 **in progress**
-> ([#781](https://github.com/tuna-os/tunaOS/issues/781)), so this row says the
-> same thing rather than a flat "Supported". Concretely, what exists today:
-> the `-asahi` images build and are gated in CI (Bonito & Grouper, 36/36
-> verified, [#776](https://github.com/tuna-os/tunaOS/issues/776)), and the
-> installer track has D0–D2 and D4 done. What does not exist yet: the D3
-> macOS installer app, any tagged release of `bootc-installer-asahi`, and any
-> validation on real Apple hardware — that repo's deepest test is qemu +
-> U-Boot, which it describes as "the deepest fidelity achievable without
-> Apple hardware". Installing today means driving the Asahi installer path
-> by hand. If you have M1/M2 hardware to test on, #781 is the place to help.
-
----
-
-## Installation
-
-### Use a pre-built ISO
-
-Browse the currently published installation media on the download page:
-
-**[📦 tunaos.org/download](https://tunaos.org/download)**
-
-### Build your own ISO or VM image
-
-**In your browser — no tools, no root, nothing uploaded:**
-
-**[🛠️ tunaos.org/iso-builder](https://tunaos.org/iso-builder)** — point it
-at any TunaOS image (or your own bootc image), pick your flatpaks, and it
-authors a bootable live ISO entirely in WebAssembly using the same
-[tacklebox](https://github.com/tuna-os/tacklebox) engine CI uses.
-[User guide](https://tunaos.org/docs/iso-builder).
-
-**Or locally with [tacklebox](https://github.com/tuna-os/tacklebox):**
-
-```bash
-# ISO (requires root)
-sudo tacklebox build --iso tunaos-yellowfin-gnome.iso \
-  --bootable-environment-image ghcr.io/tuna-os/yellowfin:gnome \
-  --bootable-environment-desktop gnome \
-  --output-base .build/iso
-```
-
-Or use the included helper script:
-
-```bash
-sudo ./scripts/build-iso-tacklebox.sh yellowfin gnome ghcr gnome
-```
-
-For QCOW2 VM images, use bootc directly:
-
-```bash
-# QCOW2 (VM image)
-sudo bootc image build-to-qcow2 \
-  --output-format qcow2 \
-  ghcr.io/tuna-os/yellowfin:gnome
-```
-
-### Switch an existing system
-
-If you're already running a compatible bootc system:
-
-```bash
-sudo bootc switch ghcr.io/tuna-os/yellowfin:gnome
-```
-
-### Verifying downloads
-
-TunaOS images and ISOs are keylessly signed (Sigstore Cosign, GitHub Actions
-OIDC identity — no project key or password) and published with SBOMs, so you
-can verify what you're running instead of trusting the download blindly.
-
-**ISOs** ship with a `.iso.sha256` checksum and a `.iso.sigstore.json`
-verification bundle alongside the image:
-
-```bash
-sha256sum --check --strict tunaos-example.iso.sha256
-
-cosign verify-blob tunaos-example.iso \
-  --bundle tunaos-example.iso.sigstore.json \
-  --certificate-identity \
-    "https://github.com/tuna-os/tunaOS/.github/workflows/reusable-build-artifacts.yml@refs/heads/main" \
-  --certificate-oidc-issuer \
-    "https://token.actions.githubusercontent.com"
-```
-
-**Container images** are signed by digest, with a signed SPDX SBOM
-attestation attached to each platform image:
-
-```bash
-digest=$(skopeo inspect docker://ghcr.io/tuna-os/yellowfin:gnome | jq -r .Digest)
-cosign verify "ghcr.io/tuna-os/yellowfin@${digest}" \
-  --certificate-identity \
-    "https://github.com/tuna-os/tunaOS/.github/workflows/reusable-build-image.yml@refs/heads/main" \
-  --certificate-oidc-issuer \
-    "https://token.actions.githubusercontent.com"
-```
-
-Full commands, the SBOM-attestation example, and the exact trust boundary
-(which identities/issuers are accepted and why) are in
-[docs/VERIFY-ARTIFACTS.md](docs/VERIFY-ARTIFACTS.md).
-
-## Container registry authentication
-
-Images are published on GitHub Container Registry (GHCR). To pull images with `bootc` or `podman`:
-
-```bash
-# Authenticate to GHCR (requires a GitHub personal access token with read:packages scope)
-echo "$GITHUB_TOKEN" | podman login ghcr.io -u YOUR_USERNAME --password-stdin
-
-# Or use the GitHub CLI
-gh auth token | podman login ghcr.io -u YOUR_USERNAME --password-stdin
-```
-
-See [GitHub Container Registry docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for more details.
-
-### Troubleshooting: `501 Unsupported client range` on pull
-
-TunaOS images publish as `zstd:chunked` for faster delta pulls, but GHCR's
-blob CDN doesn't support the multi-range HTTP requests that chunked pulls
-use. Most `podman`/`bootc` builds fall back to a normal full-blob pull
-automatically, but some do not and hard-fail with:
-
-```
-Error: copying system image from manifest list: partial pull of blob sha256:...:
-read zstd:chunked manifest: fetching partial blob: received unexpected HTTP status: 501 Unsupported client range
-```
-
-If you hit this, disable partial/chunked pulls client-side in
-`/etc/containers/storage.conf`:
-
-```toml
-[storage.options.pull_options]
-enable_partial_images = "false"
-```
-
-Tracked in [tuna-os/tunaos#579](https://github.com/tuna-os/tunaos/issues/579).
+Building media locally, verifying signatures and SBOMs, registry
+authentication, and pull troubleshooting: [docs/INSTALL.md](docs/INSTALL.md).
 
 ## Contributing
 
-Contributions welcome! See [`CONTRIBUTING.md`](CONTRIBUTING.md) for:
-- Development environment setup
-- Build workflow and pre-commit checklist
-- Pull request guidelines
-- Architecture overview
+Contributions welcome! See [`CONTRIBUTING.md`](CONTRIBUTING.md) for development
+environment setup, the build workflow and pre-commit checklist, pull request
+guidelines, and an architecture overview.
 
 ## Community and support
 
@@ -275,60 +108,23 @@ Contributions welcome! See [`CONTRIBUTING.md`](CONTRIBUTING.md) for:
 - [m] **Chat**: [#tunaos:reilly.asia](https://matrix.to/#/%23tunaos:reilly.asia)
 - 🎮 **Discord:** [TunaOS](https://discord.gg/MXSTqB8Nv)
 
-Related Communities:
-- 🎮 **Discord:** [Universal Blue Community](https://discord.gg/WEu6BdFEtp)
-- 💬 **AlmaLinux Atomic SIG:** [AlmaLinux Atomic SIG](https://chat.almalinux.org/almalinux/channels/sigatomic)
+Related communities: [Universal Blue Discord](https://discord.gg/WEu6BdFEtp) ·
+[AlmaLinux Atomic SIG](https://chat.almalinux.org/almalinux/channels/sigatomic)
 
 ## Documentation
 
-### Project Docs
+Start here:
+
 - [User Guide](docs/USER-GUIDE.md) — choosing an image, installing, updating, rolling back, apps, encryption
-- [Developer Guide](docs/DEVELOPER-GUIDE.md) — the whole pipeline and its plumbing, with diagrams: matrix, build stages, package factories, quality machinery
-- [TunaOS Blog](https://tunaos.org/blog/modern-enterprise-linux-desktops-with-tunaos) — launch announcement and design philosophy comparison
-- [Vision](VISION.md) — project philosophy: erasing the mystique of the Linux distribution
-- [Goal](GOAL.md) — current objective: LUKS E2E fisherman migration
-- [Contributor Guide](CONTRIBUTING.md) — how to set up, build, and contribute
-- [Roll Your Own Guide](docs/ROLL_YOUR_OWN.md) — build your own custom TunaOS variant
-- [Agent Guide](docs/AGENT_GUIDE.md) — complete architecture and contributor reference
-- [Build Pipeline](docs/build-pipeline.md) — CI/CD workflow overview
-- [Build Pipeline Reference](docs/PIPELINE.md) — the build matrix, verification gates, and publish flow in detail
-- [mkosi Investigation](docs/mkosi-investigation.md) — mkosi as a build backend and DDI output: findings, not a production change (#999)
-- [Testing Guide](docs/TESTING.md) — ISO end-to-end test harness
-- [Secure Boot](docs/SECURE-BOOT.md) — which variants support Secure Boot out of the box
-- [Disk Encryption & TPM2](docs/LUKS-TPM.md) — LUKS2 passphrase setup and TPM2 auto-unlock
-- [CI/CD Spec](docs/CI_SPEC.md) — target/aspirational workflow spec; see Build Pipeline above for what's actually deployed
-- [CI Troubleshooting Playbook](docs/ci-troubleshooting.md) — quick reference for diagnosing recurring CI failures
-- [Improvement Plan](docs/IMPROVEMENT_PLAN.md) — roadmap and development progress
-- [Redfin Setup](docs/rhel-setup.md) — RHEL 10 local-build instructions
-- [Developer Docs](https://tunaos.org/docs/tunaos/building) — build and contribution guide
-
-### Policies & Planning
+- [Developer Guide](docs/DEVELOPER-GUIDE.md) — the whole pipeline and its plumbing, with diagrams
+- [Installation](docs/INSTALL.md) — building media, verification, registry access
+- [Hardware Support](docs/HARDWARE.md) — requirements and ARM laptop status
+- [Matrix Status](docs/MATRIX-STATUS.md) — which variant×desktop cells are verified, per quality axis
 - [Roadmap](ROADMAP.md) — project direction and feature status
-- [Q3 2026 Checkpoint](Q3_CHECKPOINT-2026-08-22.md) — decision sheet for the Q3 "Expand Coverage" milestone (#1299)
-- [Variant Lifecycle Policy](VARIANT-LIFECYCLE.md) — Stable/Beta/Alpha admission gates and deprecation rules
-- [RFC Process](RFC-PROCESS.md) — how RFCs are proposed, reviewed, and decided
-- [Package Sourcing Policy](PACKAGE-SOURCING.md) — package origin rules, Tideforge-first, and allowlist (#1319)
-- [Issue Triage Policy](TRIAGE-POLICY.md) — triage states and SLAs (draft, #1195)
-- [Fedora Base Currency Policy](FEDORA-BASE-POLICY.md) — adopted N+rawhide sequencing for Fedora-based variants (#1171)
-- [Versioning](VERSIONING.md) — tag scheme and stability tiers
-- [Migration Guide](MIGRATION.md) — switching from other distros
-- [Security Policy](SECURITY.md) — vulnerability reporting and supported versions
-- [Branch Protection](docs/BRANCH-PROTECTION.md) — rulesets and required CI audit (#1167)
-- [Branch Hygiene](docs/BRANCH-HYGIENE.md) — branch lifecycle, naming rules, and stale branch triage (#1530)
-- [Q3 Checkpoint Policy](docs/Q3_CHECKPOINT-2026-08-22.md) — decision integrity and merge-eligible scoring rule (#1683)
-- [Adopters](ADOPTERS.md) — organizations using TunaOS
-- [Adoption Metrics](ADOPTION-METRICS.md) — how adoption is measured and reported (#1174)
-- [Code of Conduct](CODE_OF_CONDUCT.md) — community standards
+- [Vision](VISION.md) — project philosophy
 
-### Community & Governance
-- [Community](COMMUNITY.md) — contribution ladder, metrics, communication
-- [Maintainers](MAINTAINERS.md) — maintainer playbook and bus factor plan
-
-### External Resources
-- [AlmaLinux Kitten 10 Differences](https://wiki.almalinux.org/development/almalinux-os-kitten-10.html#how-is-almalinux-os-kitten-different-from-centos-stream)
-- [Project Bluefin Documentation](https://docs.projectbluefin.io)
-- [Universal Blue](https://universal-blue.org/)
-- [bootc](https://github.com/bootc-dev/bootc)
+The full index — every guide, policy, and planning doc — is at
+[docs/README.md](docs/README.md).
 
 ---
 
@@ -347,17 +143,9 @@ Related Communities:
 
 ---
 
-### 🤖 Powered by KubeStellar / Hive
-
-This repository and many of the [tuna-os](https://github.com/tuna-os) repositories are developed and maintained using **[Hive](https://hive.tunaos.org)** — an AI-driven development platform orchestrated via [KubeStellar](https://kubestellar.io/).
-
-Hive deploys a suite of specialized AI agents (guide, architect, sec-check, quality, ci-maintainer, strategist) onto a local Kubernetes cluster. These agents triage issues, implement fixes, review PRs, manage CI pipelines, and maintain documentation — all working autonomously through GitHub.
-
-<img width="100" alt="Hive" src="https://avatars.githubusercontent.com/in/3942065" />
-
-Every commit, PR, and issue in this repo benefits from multi-agent collaboration coordinated through Hive.
-
-*Learn more: [hive.tunaos.org](https://hive.tunaos.org) | [KubeStellar](https://kubestellar.io/)*
+This repository and many of the [tuna-os](https://github.com/tuna-os) repos are
+developed and maintained with **[Hive](https://hive.tunaos.org)**, an AI-driven
+development platform orchestrated via [KubeStellar](https://kubestellar.io/).
 
 ---
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -1,0 +1,35 @@
+# Hardware support
+
+System requirements and per-platform hardware status. For which *image* fits
+your hardware (HWE kernels, NVIDIA, ARM), see the
+[User Guide](USER-GUIDE.md) and the tag reference in
+[IMAGE-TAGS.md](IMAGE-TAGS.md).
+
+## System requirements
+
+| Component | Minimum | Recommended |
+|-----------|---------|-------------|
+| **CPU** | x86_64, ARM64 | x86_64, ARM64 |
+| **RAM** | 4 GB | 8 GB+ |
+| **Storage** | 20 GB | 50 GB+ |
+
+## Supported hardware (ARM laptops)
+
+| Hardware | Status | Docs |
+|----------|--------|------|
+| Snapdragon X Elite (e.g. Lenovo ThinkPad X13s) | Supported via [Bonito](https://tunaos.org/docs/bonito) (ARM64) | [Snapdragon X Elite FAQ](https://tunaos.org/docs/faq); the dedicated [bonito-x13s](https://tunaos.org/docs/bonito-x13s) / [dakota-x13s](https://tunaos.org/docs/dakota-x13s) pages are archived |
+| Apple Silicon (M1, M2) | In progress via [Asahi Linux](https://asahilinux.org/) — see note below | [bootc-installer-asahi](https://github.com/tuna-os/bootc-installer-asahi) |
+| Apple Silicon (M3 and newer) | Not supported (no Asahi support for M3+ yet) | — |
+
+> **Apple Silicon status.** [ROADMAP.md](../ROADMAP.md) is the canonical source
+> and lists Apple Silicon support as 🟡 **in progress**
+> ([#781](https://github.com/tuna-os/tunaOS/issues/781)), so this row says the
+> same thing rather than a flat "Supported". Concretely, what exists today:
+> the `-asahi` images build and are gated in CI (Bonito & Grouper, 36/36
+> verified, [#776](https://github.com/tuna-os/tunaOS/issues/776)), and the
+> installer track has D0–D2 and D4 done. What does not exist yet: the D3
+> macOS installer app, any tagged release of `bootc-installer-asahi`, and any
+> validation on real Apple hardware — that repo's deepest test is qemu +
+> U-Boot, which it describes as "the deepest fidelity achievable without
+> Apple hardware". Installing today means driving the Asahi installer path
+> by hand. If you have M1/M2 hardware to test on, #781 is the place to help.

--- a/docs/IMAGE-TAGS.md
+++ b/docs/IMAGE-TAGS.md
@@ -1,0 +1,31 @@
+# Image tag reference
+
+Image tags are constructed as `<desktop>[-hardware]`, against the variant's
+registry path (see the variant table in the [README](../README.md)).
+
+## Desktop suffixes
+
+* `gnome`: GNOME (stable)
+* `kde`: KDE Plasma
+* `cosmic`: COSMIC Desktop
+* `niri`: Niri (tiling Wayland compositor)
+* `xfce`: XFCE (Wayland experimental)
+* `pantheon`: Pantheon desktop (elementary OS) — Gurnard variant, experimental
+* `base`: Plain system image with no desktop environment pre-installed
+  (available for most variants)
+
+## Hardware suffixes
+
+Append to any desktop suffix:
+
+* *(none)*: Standard generic kernel build
+* `-hwe`: Hardware Enablement (newer kernel stack)
+* `-nvidia`: NVIDIA drivers + CUDA pre-configured
+* `-nvidia-hwe`: NVIDIA drivers on HWE kernel stack
+
+*Example tags:* `yellowfin:gnome-hwe`, `albacore:kde-nvidia`, `marlin:cosmic`
+
+Some variants also publish stream-suffixed tags on a sibling variant's path:
+`ghcr.io/tuna-os/bonito:*-rawhide` (Fedora Rawhide) and
+`ghcr.io/tuna-os/flounder:*-sid` (Debian Sid). The full tag scheme and
+stability tiers are in [VERSIONING.md](../VERSIONING.md).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,129 @@
+# Installing TunaOS
+
+Everything below the quick start that used to live on the front page: building
+your own media, switching an existing system, verifying what you downloaded,
+and registry authentication. For choosing an image, day-2 updates, rollbacks
+and apps, start with the [User Guide](USER-GUIDE.md).
+
+## Use a pre-built ISO
+
+Browse the currently published installation media on the download page:
+
+**[📦 tunaos.org/download](https://tunaos.org/download)**
+
+## Build your own ISO or VM image
+
+**In your browser — no tools, no root, nothing uploaded:**
+
+**[🛠️ tunaos.org/iso-builder](https://tunaos.org/iso-builder)** — point it
+at any TunaOS image (or your own bootc image), pick your flatpaks, and it
+authors a bootable live ISO entirely in WebAssembly using the same
+[tacklebox](https://github.com/tuna-os/tacklebox) engine CI uses.
+[User guide](https://tunaos.org/docs/iso-builder).
+
+**Or locally with [tacklebox](https://github.com/tuna-os/tacklebox):**
+
+```bash
+# ISO (requires root)
+sudo tacklebox build --iso tunaos-yellowfin-gnome.iso \
+  --bootable-environment-image ghcr.io/tuna-os/yellowfin:gnome \
+  --bootable-environment-desktop gnome \
+  --output-base .build/iso
+```
+
+Or use the included helper script:
+
+```bash
+sudo ./scripts/build-iso-tacklebox.sh yellowfin gnome ghcr gnome
+```
+
+For QCOW2 VM images, use bootc directly:
+
+```bash
+# QCOW2 (VM image)
+sudo bootc image build-to-qcow2 \
+  --output-format qcow2 \
+  ghcr.io/tuna-os/yellowfin:gnome
+```
+
+## Switch an existing system
+
+If you're already running a compatible bootc system:
+
+```bash
+sudo bootc switch ghcr.io/tuna-os/yellowfin:gnome
+```
+
+## Verifying downloads
+
+TunaOS images and ISOs are keylessly signed (Sigstore Cosign, GitHub Actions
+OIDC identity — no project key or password) and published with SBOMs, so you
+can verify what you're running instead of trusting the download blindly.
+
+**ISOs** ship with a `.iso.sha256` checksum and a `.iso.sigstore.json`
+verification bundle alongside the image:
+
+```bash
+sha256sum --check --strict tunaos-example.iso.sha256
+
+cosign verify-blob tunaos-example.iso \
+  --bundle tunaos-example.iso.sigstore.json \
+  --certificate-identity \
+    "https://github.com/tuna-os/tunaOS/.github/workflows/reusable-build-artifacts.yml@refs/heads/main" \
+  --certificate-oidc-issuer \
+    "https://token.actions.githubusercontent.com"
+```
+
+**Container images** are signed by digest, with a signed SPDX SBOM
+attestation attached to each platform image:
+
+```bash
+digest=$(skopeo inspect docker://ghcr.io/tuna-os/yellowfin:gnome | jq -r .Digest)
+cosign verify "ghcr.io/tuna-os/yellowfin@${digest}" \
+  --certificate-identity \
+    "https://github.com/tuna-os/tunaOS/.github/workflows/reusable-build-image.yml@refs/heads/main" \
+  --certificate-oidc-issuer \
+    "https://token.actions.githubusercontent.com"
+```
+
+Full commands, the SBOM-attestation example, and the exact trust boundary
+(which identities/issuers are accepted and why) are in
+[VERIFY-ARTIFACTS.md](VERIFY-ARTIFACTS.md).
+
+## Container registry authentication
+
+Images are published on GitHub Container Registry (GHCR). To pull images with
+`bootc` or `podman`:
+
+```bash
+# Authenticate to GHCR (requires a GitHub personal access token with read:packages scope)
+echo "$GITHUB_TOKEN" | podman login ghcr.io -u YOUR_USERNAME --password-stdin
+
+# Or use the GitHub CLI
+gh auth token | podman login ghcr.io -u YOUR_USERNAME --password-stdin
+```
+
+See [GitHub Container Registry docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
+for more details.
+
+### Troubleshooting: `501 Unsupported client range` on pull
+
+TunaOS images publish as `zstd:chunked` for faster delta pulls, but GHCR's
+blob CDN doesn't support the multi-range HTTP requests that chunked pulls
+use. Most `podman`/`bootc` builds fall back to a normal full-blob pull
+automatically, but some do not and hard-fail with:
+
+```
+Error: copying system image from manifest list: partial pull of blob sha256:...:
+read zstd:chunked manifest: fetching partial blob: received unexpected HTTP status: 501 Unsupported client range
+```
+
+If you hit this, disable partial/chunked pulls client-side in
+`/etc/containers/storage.conf`:
+
+```toml
+[storage.options.pull_options]
+enable_partial_images = "false"
+```
+
+Tracked in [tuna-os/tunaos#579](https://github.com/tuna-os/tunaos/issues/579).

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,37 @@ user-facing site:
 | [IMPROVEMENT_PLAN.md](IMPROVEMENT_PLAN.md) | Historical record of the May 2026 sprint + remaining roadmap items |
 | [agents/](agents/) | Hive agent guides (issue-tracker, triage-labels, domain) |
 | [adr/](adr/) | Architecture Decision Records |
+| [USER-GUIDE.md](USER-GUIDE.md) | Choosing an image, installing, updating, rolling back, apps, encryption |
+| [DEVELOPER-GUIDE.md](DEVELOPER-GUIDE.md) | The whole pipeline and its plumbing, with diagrams |
+| [INSTALL.md](INSTALL.md) | Building media locally, artifact verification, registry auth, pull troubleshooting |
+| [HARDWARE.md](HARDWARE.md) | System requirements and ARM laptop support status |
+| [IMAGE-TAGS.md](IMAGE-TAGS.md) | Image tag reference: desktop and hardware suffixes |
+| [GREEN-CRITERIA.md](GREEN-CRITERIA.md) | What "green" means for a cell — the criteria behind the composite score |
+| [GREEN-MASTER-PLAN.md](GREEN-MASTER-PLAN.md) | The workstreams driving the matrix to green |
+| [build-pipeline.md](build-pipeline.md) | CI/CD workflow overview |
+| [ci-troubleshooting.md](ci-troubleshooting.md) | Quick reference for diagnosing recurring CI failures |
+
+## Policies & planning (repo root)
+
+These live at the repository root rather than in this folder:
+
+- [ROADMAP.md](../ROADMAP.md) — project direction and feature status
+- [VISION.md](../VISION.md) — project philosophy
+- [GOAL.md](../GOAL.md) — current objective
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — how to set up, build, and contribute
+- [VARIANT-LIFECYCLE.md](../VARIANT-LIFECYCLE.md) — Stable/Beta/Alpha admission gates and deprecation rules
+- [RFC-PROCESS.md](../RFC-PROCESS.md) — how RFCs are proposed, reviewed, and decided
+- [PACKAGE-SOURCING.md](../PACKAGE-SOURCING.md) — package origin rules, Tideforge-first, and allowlist (#1319)
+- [TRIAGE-POLICY.md](../TRIAGE-POLICY.md) — triage states and SLAs (draft, #1195)
+- [FEDORA-BASE-POLICY.md](../FEDORA-BASE-POLICY.md) — adopted N+rawhide sequencing for Fedora-based variants (#1171)
+- [VERSIONING.md](../VERSIONING.md) — tag scheme and stability tiers
+- [MIGRATION.md](../MIGRATION.md) — switching from other distros
+- [SECURITY.md](../SECURITY.md) — vulnerability reporting and supported versions
+- [ADOPTERS.md](../ADOPTERS.md) / [ADOPTION-METRICS.md](../ADOPTION-METRICS.md) — who uses TunaOS and how adoption is measured
+- [COMMUNITY.md](../COMMUNITY.md) — contribution ladder, metrics, communication
+- [MAINTAINERS.md](../MAINTAINERS.md) — maintainer playbook and bus factor plan
+- [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) — community standards
+- [Q3_CHECKPOINT-2026-08-22.md](../Q3_CHECKPOINT-2026-08-22.md) — decision sheet for the Q3 "Expand Coverage" milestone (#1299)
 
 For current project priorities see [ROADMAP.md](../ROADMAP.md). For how to build
 and contribute see [CONTRIBUTING.md](../CONTRIBUTING.md).


### PR DESCRIPTION
Per the maintainer: the README is far too long and complicated — move things to docs.

## What changed

The front page drops from ~370 to ~155 lines. It keeps identity + badges, the variant table (the "choose your image" decision), the live build matrix (same generated block — the `build-status` markers and refresh pipeline are untouched), a short get-started section, and a curated eight-link documentation list.

Everything else **moved, nothing deleted**:

- **`docs/INSTALL.md`** (new) — building ISOs/qcow2 locally, `bootc switch`, signature/SBOM verification, GHCR authentication, and the `501 Unsupported client range` workaround
- **`docs/HARDWARE.md`** (new) — system requirements, ARM laptop support table, and the carefully-sourced Apple Silicon status note (kept verbatim, links re-rooted)
- **`docs/IMAGE-TAGS.md`** (new) — desktop and hardware tag suffix reference
- **`docs/README.md`** — absorbs the full documentation index, including the root-level policy/planning links the front page used to carry, so nothing loses discoverability

## Verification

- All relative links in the five touched files resolve (checked by script)
- `tests/test_readme_build_status_refresh.py` (7) and `tests/bats/test_build_status_classification.bats` (7) pass — the refresh script still targets the same markers

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_