### PR TITLE
feat(rebuildable): check every package-repo pin nightly (W7 box 2)

### DIFF
--- a/.github/green-criteria.yml
+++ b/.github/green-criteria.yml
@@ -178,15 +178,24 @@ criteria:
   - id: rebuildable
     name: The image can still be built tomorrow
     proves: Every pinned input still resolves.
-    asserted_by: scripts/check-base-image-pins.sh (.github/workflows/check-base-image-pins.yml)
+    asserted_by: >-
+      scripts/check-base-image-pins.sh + scripts/check-package-repo-pins.py
+      (.github/workflows/check-base-image-pins.yml, nightly 22:20 UTC)
     enforcement: advisory
     status_2026_08_17: "13 of 13 base-image pins resolve"
+    status_2026_08_17_pm: >-
+      package-repo pins now checked nightly alongside the base digests: dnf
+      baseurls (repo.tunaos.org snapshot datestamps included), COPR projects
+      (#391's single point of failure among them), PPAs, and the tideforge
+      APT repo + keyring — 14 of 14 resolved at first measurement. Toolchain
+      payloads and action pins remain unchecked.
     notes: >-
       A cell that built last night and cannot build tonight was never really
       green. On 2026-08-16 three variants died at once because upstream
       garbage-collected their base digests with nothing in this repo changing
-      (#1788). Currently covers base-image pins only; package and toolchain
-      pins are not yet checked.
+      (#1788). Package repos fail the same way with worse error messages: a
+      cleaned snapshot bucket or a deleted personal COPR 404s at dnf time,
+      mid-build, per flavor.
 
   - id: arch_honesty
     name: A cell may not declare an architecture it cannot satisfy

--- a/.github/workflows/check-base-image-pins.yml
+++ b/.github/workflows/check-base-image-pins.yml
@@ -36,3 +36,18 @@ jobs:
 
       - name: Verify every base image pin still resolves
         run: ./scripts/check-base-image-pins.sh
+
+  # Separate job on purpose: a GC'd base digest and an expired package repo
+  # are different failures with different owners, and one exiting 1 must not
+  # stop the other from reporting.
+  package-repos:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Verify every package-repo pin still resolves
+        run: python3 scripts/check-package-repo-pins.py

--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -126,7 +126,15 @@ Every image already writes `/usr/share/tunaos/missing-on-*.txt`.
 repo.tunaos.org snapshots (hummingbird's 9-month-old datestamp pin), toolchain
 payloads, action pins.
 
-- [ ] Extend the pin check to package-repo URLs per variant.
+- [x] Extend the pin check to package-repo URLs per variant —
+      scripts/check-package-repo-pins.py walks every desktop manifest for dnf
+      baseurls, COPR projects, PPAs, and APT repos/keyrings, and probes each
+      nightly in check-base-image-pins.yml (own job, so base-pin and
+      package-pin failures report independently). 14 pins found, 14 resolving
+      at first run. Toolchain payloads and action pins remain open, as does
+      the COPR *content* question (#391 is about trusting the repo, not just
+      its existence) — the structural fix for that is RFC 011's tier-2
+      migration, not this check.
 - [ ] The `createrepo_c --update` drift class (#358) is fixed in
       `build-xfce-package.yml` only — audit `build-xfce-distributed.yml`,
       `build.yml`, `build-gnome49/50/51-package.yml` (noted on #358).

--- a/scripts/check-package-repo-pins.py
+++ b/scripts/check-package-repo-pins.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Verify every package-repo pin declared in the desktop manifests resolves.
+
+W7 of docs/GREEN-MASTER-PLAN.md, second box of the `rebuildable` criterion.
+check-base-image-pins.sh covers the base image digests; this covers the other
+half of "can this image still be built tomorrow": the package repositories the
+manifests point at.
+
+These pins break in ways a build log reads as something else entirely:
+
+- repo.tunaos.org snapshot URLs are immutable datestamps (the hummingbird
+  manifest pins 20251124 — a snapshot nobody will think about until the day
+  the bucket is cleaned).
+- COPR projects are personal infrastructure. jreilly1821/c10s-gnome-50 is a
+  declared single point of failure (#391); yalter/niri-git and the
+  avengemedia repos are other people's. A deleted COPR 404s at dnf time,
+  mid-build, per flavor.
+- PPAs and the tideforge APT repo fail the same way for the apt family.
+
+Like the base-image check, this runs nightly BEFORE the variant builds, so an
+expired pin is one named line here rather than N broken cells there.
+
+Exit non-zero if any pin fails to resolve. SKIP (not FAIL) for URLs whose
+repo variables cannot be resolved statically — a skip is printed so it cannot
+silently become a hole.
+"""
+
+from __future__ import annotations
+
+import glob
+import sys
+import urllib.error
+import urllib.request
+
+import yaml
+
+MANIFEST_GLOB = "manifests/desktops/*.yaml"
+TIMEOUT = 25
+UA = {"User-Agent": "tunaos-repo-pin-check (+https://github.com/tuna-os/tunaOS)"}
+
+# dnf repo variables we can resolve statically. Anything left unresolved after
+# this substitution is reported as SKIP rather than guessed at.
+VARS = {"$basearch": "x86_64"}
+
+
+def _sub_vars(url: str) -> str:
+    for var, val in VARS.items():
+        url = url.replace(var, val)
+    return url
+
+
+def collect(doc) -> list[tuple[str, str]]:
+    """Walk a parsed manifest and return (kind, probe_url) pairs.
+
+    Shapes handled — one per declaration style that exists in the manifests:
+      dnf:   {..., "baseurl": URL}            -> URL/repodata/repomd.xml
+      apt:   {..., "uri": URL, "suite": S}    -> flat (S == "./") URL/Packages
+                                                 else URL/dists/S/InRelease
+             {..., "keyring_url": URL}        -> URL itself
+      copr:  {"copr": [{"repo": "o/n", "extra_repos": ["o/n", ...]}]}
+                                              -> COPR api_3 project endpoint
+      ppa:   {"ppa": [{"repo": "ppa:o/n"}]}   -> Launchpad API archive endpoint
+    """
+    pins: list[tuple[str, str]] = []
+
+    def copr_probe(spec: str) -> tuple[str, str]:
+        owner, _, name = spec.partition("/")
+        return ("copr", "https://copr.fedorainfracloud.org/api_3/project"
+                        f"?ownername={owner}&projectname={name}")
+
+    def walk(node):
+        if isinstance(node, dict):
+            if isinstance(node.get("baseurl"), str):
+                pins.append(("dnf", _sub_vars(node["baseurl"]).rstrip("/")
+                             + "/repodata/repomd.xml"))
+            if isinstance(node.get("uri"), str) and "suite" in node:
+                uri = node["uri"].rstrip("/")
+                suite = str(node.get("suite", "./"))
+                if suite in ("./", "."):
+                    pins.append(("apt", f"{uri}/Packages"))
+                else:
+                    pins.append(("apt", f"{uri}/dists/{suite}/InRelease"))
+            if isinstance(node.get("keyring_url"), str):
+                pins.append(("key", node["keyring_url"]))
+            for entry in node.get("copr") or []:
+                if isinstance(entry, dict) and isinstance(entry.get("repo"), str):
+                    pins.append(copr_probe(entry["repo"]))
+                    for extra in entry.get("extra_repos") or []:
+                        pins.append(copr_probe(extra))
+            for entry in node.get("ppa") or []:
+                if isinstance(entry, dict) and isinstance(entry.get("repo"), str):
+                    spec = entry["repo"].removeprefix("ppa:")
+                    owner, _, name = spec.partition("/")
+                    pins.append(("ppa", "https://api.launchpad.net/1.0/"
+                                        f"~{owner}/+archive/ubuntu/{name}"))
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(doc)
+    return pins
+
+
+def probe(url: str) -> int:
+    req = urllib.request.Request(url, headers=UA, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code
+    except (urllib.error.URLError, OSError):
+        return 0
+
+
+def main() -> int:
+    pins: dict[str, str] = {}
+    for path in sorted(glob.glob(MANIFEST_GLOB)):
+        with open(path, encoding="utf-8") as f:
+            doc = yaml.safe_load(f)
+        for kind, url in collect(doc):
+            pins.setdefault(url, kind)
+
+    if not pins:
+        # Zero pins means the extraction broke, not that the manifests are
+        # clean — the same absence-of-evidence rule as everywhere else.
+        print("::error::package-repo pin check found zero declared repos — "
+              "extraction is broken, not the manifests clean")
+        return 1
+
+    failed = 0
+    skipped = 0
+    for url in sorted(pins):
+        kind = pins[url]
+        if "$" in url:
+            print(f"SKIP  {kind:5s} (unresolved repo variable)  {url}")
+            skipped += 1
+            continue
+        code = probe(url) or probe(url)  # one retry on transport failure
+        if code == 200:
+            print(f"ok    {kind:5s} {code}  {url}")
+        else:
+            print(f"FAIL  {kind:5s} {code}  {url}")
+            print(f"::error::package-repo pin no longer resolves "
+                  f"(HTTP {code}): {url} — an image that references it "
+                  f"cannot be rebuilt (rebuildable criterion, W7)")
+            failed += 1
+
+    print(f"\nchecked {len(pins) - skipped} package-repo pin(s), "
+          f"{skipped} skipped; {failed} unresolvable")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_package_repo_pins_are_checked.py
+++ b/tests/test_package_repo_pins_are_checked.py
@@ -1,0 +1,95 @@
+"""W7, second box: the package-repo pins are checked, not remembered.
+
+check-base-image-pins.sh proved the pattern on base digests (#1788: three
+variants died overnight with nothing in the repo changing). The manifests
+carry the same class of pin on the package side — repo.tunaos.org snapshot
+datestamps, personal COPRs (#391), PPAs, the tideforge APT repo — and until
+this landed, nothing asserted any of them between one nightly and the next.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check-package-repo-pins.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "check-base-image-pins.yml"
+
+spec = importlib.util.spec_from_file_location("crpp", SCRIPT)
+crpp = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(crpp)
+
+
+def test_every_declaration_shape_is_extracted() -> None:
+    """One synthetic manifest carrying every shape the real manifests use."""
+    doc = {
+        "fedora": {"repos": [{"name": "snap",
+                              "baseurl": "https://repo.example/x/20251124-x86_64/"}]},
+        "el10": {"copr": [{"repo": "owner/proj",
+                           "extra_repos": ["owner/extra"]}]},
+        "apt": {"repos": [{"uri": "https://repo.example/deb/", "suite": "./",
+                           "keyring_url": "https://repo.example/deb/key.gpg"}],
+                "ppa": [{"repo": "ppa:someone/stuff"}]},
+        "deb": {"repos": [{"uri": "https://repo.example/deb2", "suite": "noble"}]},
+    }
+    urls = {url for _, url in crpp.collect(doc)}
+    assert urls == {
+        "https://repo.example/x/20251124-x86_64/repodata/repomd.xml",
+        "https://copr.fedorainfracloud.org/api_3/project"
+        "?ownername=owner&projectname=proj",
+        "https://copr.fedorainfracloud.org/api_3/project"
+        "?ownername=owner&projectname=extra",
+        "https://repo.example/deb/Packages",
+        "https://repo.example/deb/key.gpg",
+        "https://api.launchpad.net/1.0/~someone/+archive/ubuntu/stuff",
+        "https://repo.example/deb2/dists/noble/InRelease",
+    }
+
+
+def test_the_real_manifests_yield_the_known_pin_classes() -> None:
+    """Extraction against the actual manifests finds every pin class we know
+    is declared today. If a manifest refactor changes a shape, this fails
+    before the nightly check silently starts checking nothing."""
+    pins: list[tuple[str, str]] = []
+    for path in sorted((ROOT / "manifests" / "desktops").glob("*.yaml")):
+        pins.extend(crpp.collect(yaml.safe_load(path.read_text())))
+    kinds = {k for k, _ in pins}
+    assert {"dnf", "copr", "ppa", "apt", "key"} <= kinds, (
+        f"missing pin classes: extraction found only {sorted(kinds)}"
+    )
+    urls = [u for _, u in pins]
+    # The two named motivators: the hummingbird snapshot datestamp and the
+    # #391 COPR single point of failure.
+    assert any("hummingbird/20251124" in u for u in urls)
+    assert any("projectname=c10s-gnome-50" in u for u in urls)
+
+
+def test_basearch_is_substituted_and_leftovers_skip_not_guess() -> None:
+    doc = {"repos": [{"baseurl": "https://r.example/$basearch/"},
+                     {"baseurl": "https://r.example/$releasever/"}]}
+    urls = {url for _, url in crpp.collect(doc)}
+    assert "https://r.example/x86_64/repodata/repomd.xml" in urls
+    # $releasever is not statically resolvable; it must survive to the SKIP
+    # path rather than being silently dropped or mangled.
+    assert any("$releasever" in u for u in urls)
+
+
+def test_zero_extracted_pins_is_a_failure_not_a_pass() -> None:
+    body = SCRIPT.read_text()
+    assert "found zero declared repos" in body, (
+        "an extraction that finds nothing must fail loudly — the "
+        "absence-of-evidence rule (#1730) applies to the checker itself"
+    )
+
+
+def test_the_nightly_workflow_runs_it() -> None:
+    body = WORKFLOW.read_text()
+    assert "check-package-repo-pins.py" in body
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    jobs = doc["jobs"]
+    assert "package-repos" in jobs, (
+        "package-repo pins get their own job so a base-pin failure cannot "
+        "stop them from reporting (and vice versa)"
+    )


### PR DESCRIPTION
Closes the second W7 box. `check-base-image-pins.sh` covers half of "can this image still be built tomorrow" — the base digests (#1788). The manifests carry the same class of pin on the package side, and nothing asserted any of them between one nightly and the next:

- **repo.tunaos.org snapshot baseurls** — hummingbird pins the immutable `20251124` datestamp; nobody will think about it until the day the bucket is cleaned
- **personal COPR projects** — `jreilly1821/c10s-gnome-50` is the declared single point of failure (#391); `yalter/niri-git` and the avengemedia repos are other people's infrastructure
- **PPAs**, and the **tideforge APT repo + keyring**

## What this adds

`scripts/check-package-repo-pins.py` walks `manifests/desktops/*.yaml` for every declaration shape in use (dnf `baseurl`, `copr` + `extra_repos`, apt `uri`/`suite` in both flat and `dists` form, `keyring_url`, `ppa`), substitutes `$basearch`, **SKIPs — never guesses** — anything still carrying an unresolved repo variable, probes each deduplicated pin with one retry, and fails loudly on two conditions: an unresolvable pin, and extracting *zero* pins (the absence-of-evidence rule applied to the checker itself).

Wired into `check-base-image-pins.yml` (nightly 22:20 UTC, before the builds) as its **own job**, so a GC'd base digest and an expired package repo — different failures with different owners — report independently.

## Verification

- **First live run: 14 pins found, 14 resolving** (2 PPAs, 7 COPRs, 3 dnf baseurls, 1 APT repo, 1 keyring) — clean baseline recorded in the criteria file
- 5 new tests: every declaration shape extracts to the expected probe URL; the real manifests yield all five pin classes including the two named motivators; `$basearch` substitutes while `$releasever` survives to the SKIP path; zero-extraction fails; the workflow wires the job
- `green-criteria.yml` `rebuildable` updated (still advisory); W7 box ticked with the honest remainder: toolchain payloads and action pins stay open, and COPR *content* trust stays with RFC 011's tier-2 migration — this check proves existence, not trustworthiness

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_