### PR TITLE
probe(rawhide): rebuild the inherited rpmdb before stage-2's first write (#1823)

### DIFF
--- a/build_scripts/20-packages.sh
+++ b/build_scripts/20-packages.sh
@@ -26,6 +26,9 @@ if [[ "$PKG_MGR" == "apt" ]]; then
 fi
 # ── dnf (RPM) path continues below ────────────────────────────────────
 
+# Before the first rpm write of stage-2: the #1823 probe (no-op off Rawhide).
+rawhide_rpmdb_probe
+
 # Install OS-specific branding
 if [[ $IS_FEDORA == true ]]; then
 	dnf_retry -y install fedora-logos

--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -740,6 +740,36 @@ install_rawhide_tolerant() {
 	return 0
 }
 
+# tunaOS#1823 probe: stage-2 on a fresh Rawhide base fails with sqlite error
+# 11 ("database disk image is malformed") on every RPM install once the
+# transaction is large — small overlays pass, desktop-sized ones fail, both
+# arches, across all dnf retries and full build attempts. Rebuilding the
+# rpmdb inherited from the base layer BEFORE the first stage-2 rpm write is
+# the cheap discriminating experiment the issue asks for:
+#
+#   rebuild FAILS                        -> the base's rpmdb is malformed at
+#                                           rest (base rpm wrote a bad db)
+#   rebuild ok, transaction then ok      -> inherited-db/overlayfs-copy-up
+#                                           was the problem; probe graduates
+#                                           to a fix
+#   rebuild ok, transaction still fails  -> corruption happens DURING the
+#                                           transaction (sqlite-on-overlayfs)
+#
+# Deliberately a no-op off Rawhide, and never fails the build itself: the
+# transaction that follows is the real verdict either way, and a probe that
+# can kill a green pinned-Fedora build would cost more than it measures.
+rawhide_rpmdb_probe() {
+	[[ "$(detect_fedora_ver)" == "rawhide" ]] || return 0
+	echo "::notice title=rpmdb probe (tunaOS#1823)::rebuilding the rpmdb inherited from the Rawhide base before the first stage-2 rpm write"
+	if rpm --rebuilddb; then
+		echo "TUNAOS_RPMDB_PROBE=rebuilt"
+	else
+		echo "TUNAOS_RPMDB_PROBE=rebuild-failed"
+		echo "::warning title=rpmdb probe (tunaOS#1823)::rpm --rebuilddb itself failed — the base image's rpmdb is malformed at rest, not corrupted by the stage-2 transaction"
+	fi
+	return 0
+}
+
 # systemctl enable wrapper that tolerates the unit-not-present case.
 # Build scripts run in a multi-stage container build where some units may
 # only exist on certain variants (e.g. tailscaled on EL10 but not on EL9).

--- a/tests/bats/test_rawhide_rpmdb_probe.bats
+++ b/tests/bats/test_rawhide_rpmdb_probe.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# rawhide_rpmdb_probe() — tunaOS#1823.
+#
+# Stage-2 on a fresh Rawhide base fails with "database disk image is
+# malformed" (sqlite error 11) on every RPM install once the transaction is
+# desktop-sized; small overlays pass; both arches; survives all retries. The
+# probe rebuilds the rpmdb inherited from the base BEFORE stage-2's first rpm
+# write, and its marker discriminates the three hypotheses in the issue.
+#
+# Runs the REAL functions extracted verbatim from build_scripts/lib.sh (the
+# extract-and-run technique of test_install_rawhide_tolerant.bats) against
+# mocked rpm.
+
+REPO_ROOT="${REPO_ROOT:-$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)}"
+LIB="${REPO_ROOT}/build_scripts/lib.sh"
+
+setup() {
+  BIN="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "$BIN"
+
+  FN_PROBE="$(awk '/^rawhide_rpmdb_probe\(\)/,/^}/' "$LIB")"
+  FN_DETECT="$(awk '/^detect_fedora_ver\(\)/,/^}/' "$LIB")"
+  [[ -n "$FN_PROBE" ]]
+  [[ -n "$FN_DETECT" ]]
+
+  # Mock rpm: `-E %fedora` prints RPM_E_OUT; `--rebuilddb` exits
+  # REBUILD_RC and records that it was invoked.
+  cat > "${BIN}/rpm" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  -E) printf '%s\n' "${RPM_E_OUT:-45}" ;;
+  --rebuilddb)
+    echo invoked >> "${REBUILD_LOG}"
+    exit "${REBUILD_RC:-0}"
+    ;;
+esac
+STUB
+  chmod +x "${BIN}/rpm"
+
+  REBUILD_LOG="${BATS_TEST_TMPDIR}/rebuilds"
+  : > "$REBUILD_LOG"
+  export REBUILD_LOG
+
+  OS_RELEASE="${BATS_TEST_TMPDIR}/os-release"
+  printf 'PRETTY_NAME="Fedora Linux Rawhide (Prerelease)"\n' > "$OS_RELEASE"
+  export OS_RELEASE
+}
+
+run_probe() {
+  PATH="${BIN}:$PATH" run bash -c "
+    set -euo pipefail
+    ${FN_DETECT}
+    ${FN_PROBE}
+    rawhide_rpmdb_probe
+  "
+}
+
+@test "on rawhide, the inherited rpmdb is rebuilt and the marker says so" {
+  run_probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TUNAOS_RPMDB_PROBE=rebuilt"* ]]
+  [ "$(wc -l < "$REBUILD_LOG")" -eq 1 ]
+}
+
+@test "off rawhide, the probe is a no-op — pinned Fedora never pays for it" {
+  printf 'PRETTY_NAME="Fedora Linux 44 (Container Image)"\n' > "$OS_RELEASE"
+  RPM_E_OUT=44 run_probe
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"TUNAOS_RPMDB_PROBE"* ]]
+  [ "$(wc -l < "$REBUILD_LOG")" -eq 0 ]
+}
+
+@test "a failed rebuild warns with the at-rest diagnosis but does not fail the build" {
+  # If --rebuilddb itself dies, the base wrote a malformed db — that is the
+  # most valuable outcome the probe can report, and the transaction that
+  # follows is still the real verdict.
+  REBUILD_RC=1 run_probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TUNAOS_RPMDB_PROBE=rebuild-failed"* ]]
+  [[ "$output" == *"malformed at rest"* ]]
+}
+
+@test "stage-2 calls the probe before its first rpm write" {
+  # The probe must precede every dnf/rpm invocation on the dnf path of
+  # 20-packages.sh, or it measures nothing.
+  script="${REPO_ROOT}/build_scripts/20-packages.sh"
+  probe_line="$(grep -n '^rawhide_rpmdb_probe' "$script" | head -1 | cut -d: -f1)"
+  [ -n "$probe_line" ]
+  first_write="$(grep -nE 'dnf_retry|dnf -y|rpm -[iU]' "$script" | head -1 | cut -d: -f1)"
+  [ -n "$first_write" ]
+  [ "$probe_line" -lt "$first_write" ]
+}


### PR DESCRIPTION
The cheap discriminating experiment #1823 asks for. Stage-2 on the fresh bonito-rawhide base fails with sqlite error 11 ("database disk image is malformed") on every RPM install once the transaction is desktop-sized — small overlays pass, both arches fail identically, and it survives all dnf retries and full build attempts, so the corruption is in the image's rpmdb, not the repo metadata.

## What this adds

`rawhide_rpmdb_probe()` in `lib.sh`, called at the top of `20-packages.sh`'s dnf path — before the first stage-2 rpm write. It runs `rpm --rebuilddb` on the rpmdb inherited from the base layer, and its outcome discriminates the issue's three hypotheses:

| Probe outcome | Diagnosis |
|---|---|
| rebuild **fails** | the base's rpmdb is malformed **at rest** — base rpm wrote a bad db |
| rebuild ok, transaction then **succeeds** | inherited-db / overlayfs copy-up was the problem → probe graduates to a fix |
| rebuild ok, transaction **still fails** | corruption happens **during** the transaction (sqlite-on-overlayfs) |

The marker `TUNAOS_RPMDB_PROBE=<rebuilt|rebuild-failed>` in the build log carries the answer for the next triage pass.

Scoped to Rawhide via `detect_fedora_ver()` (pinned Fedora never pays for it) and never fails the build itself — the transaction that follows is the real verdict either way.

## Verification

- 4 bats tests using the repo's extract-and-run pattern against mocked `rpm`: fires on rawhide, no-op off it, a failed rebuild warns with the at-rest diagnosis without killing the build, and the call site precedes every `dnf_retry`/`dnf -y`/`rpm -iU` line in `20-packages.sh`
- shellcheck clean on both touched scripts; the existing rawhide-tolerance suite still passes

Tonight's 01:00Z nightly runs the probe on the real failing cells — I'm deliberately not adding a manual dispatch on top of the currently starved runner pool. I'll read the markers from the nightly and update #1823 with the verdict.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_