### PR TITLE
fix(iso): guarded podman install + stale lock cleanup on the #1556 surface

### DIFF
--- a/.github/workflows/reusable-build-artifacts.yml
+++ b/.github/workflows/reusable-build-artifacts.yml
@@ -99,10 +99,25 @@ jobs:
       - name: Maximize build space
         uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6 # main as of 2026-02-11
 
+      # Do NOT apt-install podman on a runner that already has one (the Gate's
+      # rule in reusable-build-image.yml, proven again by bootc-lifecycle run
+      # 32040213366: after #1841 applied this guard, all 53 arm64 legs ran
+      # podman cleanly — the failures left were missing images, not
+      # "crun: unknown version"). The stale-lock sweep is the second half of
+      # the same fix: a leftover /dev/shm/libpod_lock sized by a different
+      # podman build fails lock init with ERANGE mid-pre-pull — the #1556
+      # signature this workflow's arm64 ISO cells die with.
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y just podman jq rclone golang-go git systemd-boot-efi mtools squashfs-tools xorriso dosfstools gdisk e2fsprogs btrfs-progs
+          pkgs=(just jq rclone golang-go git systemd-boot-efi mtools squashfs-tools xorriso dosfstools gdisk e2fsprogs btrfs-progs)
+          if sudo sh -c 'command -v podman' >/dev/null 2>&1; then
+            echo "podman already present: $(sudo sh -c 'command -v podman') ($(sudo podman --version))"
+          else
+            pkgs+=(podman)
+          fi
+          sudo apt-get install -y "${pkgs[@]}"
+          sudo rm -f /dev/shm/libpod_lock /dev/shm/libpod_rootless_lock_* || true
 
       - name: Setup rootless podman (subuid/subgid for runner)
         run: |

--- a/tests/test_lifecycle_arm64_podman_is_not_a_mixed_stack.py
+++ b/tests/test_lifecycle_arm64_podman_is_not_a_mixed_stack.py
@@ -28,3 +28,18 @@ def test_podman_is_never_apt_installed_over_a_preinstalled_one() -> None:
 
 def test_stale_lock_segments_are_cleared() -> None:
     assert BODY.count("rm -f /dev/shm/libpod_lock") == 2
+
+
+# The ISO surface — where #1556 was originally filed. Lifecycle run
+# 32040213366 validated the guard on all 53 arm64 legs (zero mixed-stack or
+# lock-init failures), so the same treatment applies to the workflow whose
+# arm64 tacklebox pre-pull first showed the signature.
+ARTIFACTS = (ROOT / ".github" / "workflows" /
+             "reusable-build-artifacts.yml").read_text(encoding="utf-8")
+
+
+def test_iso_surface_carries_the_same_guard() -> None:
+    assert "podman already present" in ARTIFACTS
+    assert "rm -f /dev/shm/libpod_lock" in ARTIFACTS
+    # The one unconditional install line this workflow used to carry.
+    assert "apt-get install -y just podman" not in ARTIFACTS


### PR DESCRIPTION
The evidence-gated follow-up promised in #1841. That PR's validation run just completed: bootc-lifecycle run [32040213366](https://github.com/tuna-os/tunaOS/actions/runs/32040213366) executed **all 168 cells with the guarded install — 53 arm64 legs ran podman cleanly, zero occurrences of `crun: unknown version` or the `libpod_lock` ERANGE**. The 10 arm64 failures that remain are bonito-rawhide/hummingbird cells whose images were never promoted; a spot-check (bonito-rawhide:gnome arm64) shows the job pulled and ran the image fine and failed a *real* content assertion (`libgstlibav.so` missing — the #1810 gstreamer/ffmpeg skew shipping through, which is exactly what lifecycle validation exists to catch).

With the fix class validated, this applies the same treatment to `reusable-build-artifacts.yml` — the workflow whose arm64 tacklebox pre-pull is where #1556 was originally filed. Its unconditional `apt-get install -y just podman …` becomes the Gate's guarded pattern (skip podman when the runner already ships one under `/usr/local`) plus the stale `/dev/shm/libpod_lock*` sweep.

`tests/test_lifecycle_arm64_podman_is_not_a_mixed_stack.py` now covers this surface as well: the guard and lock sweep must be present, and the old unconditional install line must not return.

Refs #1556 — I'll comment there with the validation evidence once this merges, and the next arm64 ISO run decides whether #1556 can close.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_