### PR TITLE
docs(plan): W2 boxes 1-2 done — first full lifecycle sweep, all failures classified

### DIFF
--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -52,10 +52,17 @@ failing in 9 seconds — `generate-matrix` succeeded (the jq emits 156 cells
 against today's config) yet no downstream job materialised. Verification run
 `31999953433` dispatched 08-17 06:01Z.
 
-- [ ] Diagnose the run-2 result; fix whatever eats the matrix between
-      `generate-matrix` and the `lifecycle` job.
-- [ ] First full sweep: expect mass failure; file per-class issues, not
-      per-cell.
+- [x] Diagnose the run-2 result; fix whatever eats the matrix between
+      `generate-matrix` and the `lifecycle` job — run 2 surfaced the arm64
+      mixed-stack/stale-lock podman failure (#1556 class, all six arm64
+      cells); fixed by the guarded install + lock sweep (#1841).
+- [x] First full sweep: run 32040213366 (08-17, post-#1841) executed all
+      168 cells — 133 passed, including 43 of 53 arm64. Every failure maps
+      to a KNOWN class, no new ones: xfce cells → #1819 (7 cells,
+      roster posted), gnome-nvidia-hwe → #1820 (3 cells, roster posted),
+      bonito-rawhide → #1823, hummingbird desktops → images not yet
+      published by the factory. The update transaction demonstrably works
+      matrix-wide where images exist.
 - [ ] Wire results into MATRIX-STATUS (already scaffolded) and W1.
 - [ ] Then: weekly cadence is already scheduled; make the cron survive
       (the 08-13 failure went unnoticed for four days — add it to the red-run


### PR DESCRIPTION
Records the W2 milestone in the master plan. Run [32040213366](https://github.com/tuna-os/tunaOS/actions/runs/32040213366) — the first complete Bootc Lifecycle sweep, running post-#1841 — executed all 168 cells: **133 passed, 43 of 53 arm64 clean**, and the #1556 mixed-stack class is gone from the workflow.

Every failure maps to a known class with no new ones: xfce cells → #1819 (7 cells, roster posted on the issue), `gnome-nvidia-hwe` → #1820 (3 cells, roster posted), bonito-rawhide → #1823, hummingbird desktops → images not yet published by the package factory.

For a bootc OS this is the headline the criterion exists for: the update/rebase/rollback transaction demonstrably works matrix-wide wherever an image exists to test. Remaining W2 boxes: wiring results into MATRIX-STATUS/W1, and red-run triage for the weekly cron.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_