### PR TITLE
fix(sailfin): verify Packman ownership after the dup — version order is not the invariant

### DIFF
--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -183,6 +183,38 @@ if [[ "${_TD_OS}" == "zypper" ]]; then
 			zypper --non-interactive --gpg-auto-import-keys refresh --force || true
 			sleep $((attempt * 5))
 		done
+
+		# The dup is VERSION-driven, and that is not enough. Run 32047331620
+		# (gnome amd64): the desktop transaction upgraded ffmpeg to
+		# openSUSE's newer 9.0.1 build, the dup printed "Nothing to do" —
+		# there was no higher Packman version to move to — and the codec
+		# baseline still failed on the crippled decoder set. Ownership is
+		# the invariant, not version order: verify the vendor on the named
+		# multimedia set and force any openSUSE-owned member back to
+		# Packman, downgrades allowed.
+		_td_pm_lost=()
+		for _td_pkg in ffmpeg libavcodec-full gstreamer-plugins-good \
+			gstreamer-plugins-bad gstreamer-plugins-ugly \
+			gstreamer-plugins-libav vlc-codecs; do
+			rpm -q "$_td_pkg" >/dev/null 2>&1 || continue
+			rpm -q --qf '%{VENDOR}\n' "$_td_pkg" | grep -qi packman ||
+				_td_pm_lost+=("$_td_pkg")
+		done
+		if ((${#_td_pm_lost[@]} > 0)); then
+			echo "Packman lost ownership of: ${_td_pm_lost[*]} — forcing it back (tunaOS#1832)"
+			attempt=0
+			until zypper --non-interactive install -y --oldpackage \
+				--allow-vendor-change --force-resolution \
+				--from packman-essentials "${_td_pm_lost[@]}"; do
+				attempt=$((attempt + 1))
+				if ((attempt >= 3)); then
+					echo "ERROR: could not force the multimedia stack back to Packman (tunaOS#1832)" >&2
+					exit 1
+				fi
+				zypper --non-interactive --gpg-auto-import-keys refresh --force || true
+				sleep $((attempt * 5))
+			done
+		fi
 	fi
 fi
 

--- a/tests/test_sailfin_keeps_packman_codecs.py
+++ b/tests/test_sailfin_keeps_packman_codecs.py
@@ -41,3 +41,20 @@ def test_base_stage_still_installs_packman_first() -> None:
     """The re-assert complements the base install, it does not replace it."""
     assert "packman-essentials" in BASE
     assert "--allow-vendor-change" in BASE
+
+
+def test_ownership_is_verified_not_inferred_from_the_dup() -> None:
+    """Run 32047331620 proved the dup alone is insufficient: the desktop
+    transaction upgraded ffmpeg to openSUSE's NEWER crippled build, the dup
+    said "Nothing to do" (no higher Packman version existed), and the codec
+    baseline still failed. The script must check the installed VENDOR on the
+    multimedia set and force openSUSE-owned members back to Packman, with
+    downgrades allowed — version order is not the invariant, ownership is."""
+    assert "rpm -q --qf '%{VENDOR}" in SCRIPT
+    assert "--oldpackage" in SCRIPT
+    assert "--from packman-essentials" in SCRIPT
+    assert "force the multimedia stack back to Packman" in SCRIPT
+    # The vendor check must come AFTER the dup — it is the fallback for the
+    # case the dup cannot handle, not a replacement for it.
+    assert SCRIPT.index("dup --from packman-essentials") \
+        < SCRIPT.index("rpm -q --qf '%{VENDOR}")


### PR DESCRIPTION
The sailfin validation run ([32047331620](https://github.com/tuna-os/tunaOS/actions/runs/32047331620), post-#1840 re-dispatch) closed the loop on the codec fix and exposed the deeper layer.

## What the run proved

Good news first: **sailfin base built on both arches, manifested, signed, and promoted** — first promotion in days. Then all five desktop amd64 legs failed the codec baseline, and the log shows the #1840 re-assert **ran exactly as designed and did nothing**:

```
+ zypper --non-interactive dup --from packman-essentials --allow-vendor-change
Computing distribution upgrade...
Nothing to do.
...
ffmpeg cannot decode h264 — a free/crippled libavcodec is installed
codec_diag: configure --disable-decoder='h264,hevc,vc1,prores_raw,vvc'
```

The desktop transaction had upgraded ffmpeg to openSUSE's **newer** 9.0.1 build. `dup --from` is *version-driven*: with no higher Packman version to move to, it does nothing — `--allow-vendor-change` only permits a switch, it doesn't motivate one. On fast-moving Tumbleweed, openSUSE's build being newer than Packman's is a normal state, so the #1840 fix works only on the days the version race happens to go the other way.

## The fix

Ownership is the invariant, not version order. After the dup, check `rpm -q --qf '%{VENDOR}'` on the named multimedia set (ffmpeg, libavcodec-full, gstreamer-plugins-{good,bad,ugly,libav}, vlc-codecs) and force any openSUSE-owned member back to Packman with `zypper install --oldpackage --force-resolution --allow-vendor-change --from packman-essentials` — downgrades allowed, three retries, loud `exit 1` if it cannot. The dup stays (it's the cheap path when Packman is ahead); the vendor check is the fallback for the case it cannot handle.

## Verification

- New test pins the mechanism: vendor check present, `--oldpackage` present, and placed **after** the dup
- All 4 sailfin codec tests pass; shellcheck clean; the build-scripts BATS suite unchanged
- After merge I'll dispatch `build-sailfin.yml` once more — the codec_diag lines in verify-desktop-experience.sh are the end-to-end assertion

Refs #1832.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_