### PR TITLE
fix(gate): iso-e2e.sh actually parses --contract — the base Gate died on its own flag

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -198,6 +198,13 @@ while [[ $# -gt 0 ]]; do
 		TIMEOUT="$2"
 		shift 2
 		;;
+	--contract)
+		# --disk only: which in-image contract marker gates the boot.
+		# 'desktop' waits for TUNAOS_DESKTOP_CONTRACT_*, 'base' for
+		# TUNAOS_BASE_CONTRACT_*. Validated where disk mode reads it.
+		DISK_CONTRACT="$2"
+		shift 2
+		;;
 	--live-marker)
 		LIVE_MARKER="$2"
 		shift 2

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -210,6 +210,10 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
   grep -qF 'CONTRACT_PREFIX="TUNAOS_DESKTOP_CONTRACT"' "${REPO_ROOT}/scripts/iso-e2e.sh"
   grep -qF 'CONTRACT_PREFIX="TUNAOS_BASE_CONTRACT"' "${REPO_ROOT}/scripts/iso-e2e.sh"
   grep -qF 'contract FAILED:' "${REPO_ROOT}/scripts/iso-e2e.sh"
+  # The FLAG must be parsed, not just the mapping present: the base Gate's
+  # first sailfin run (32047331620) died in 0.05s on 'Unknown flag:
+  # --contract' because the disk-mode logic landed without a parser case.
+  grep -qE '^\s+--contract\)' "${REPO_ROOT}/scripts/iso-e2e.sh"
 }
 
 @test "runtime contract never asserts graphical.target is active" {


### PR DESCRIPTION
The W3 base gate's first real outing (sailfin run [32047331620](https://github.com/tuna-os/tunaOS/actions/runs/32047331620), base/Gate job) failed in 0.05 seconds:

```
Unknown flag: --contract
```

Textbook decorative-plumbing bug, and it's mine: the disk-mode `DISK_CONTRACT`/`CONTRACT_PREFIX` logic landed in W3, `reusable-build-image.yml` passes `--contract base`, and the tests asserted the prefix mappings exist — but the argument **parser** never got a `--contract` case, so every base Gate invocation exits 1 at the catch-all before QEMU even starts.

## Fix

- Add the `--contract` case to the parser (value validated where disk mode already reads it: `desktop` or `base`, hard error otherwise)
- The bats test now asserts the parser case itself (`--contract\)`) — not just the mapping — so the flag can't silently regress into decoration again

## Impact

Every base-cell Gate ❌ since the W3 merge is this bug, not a contract failure. Base rows in the composite recover on the next builds; sailfin base (which promoted today) gets its first *real* `TUNAOS_BASE_CONTRACT` verdict on the validation run already queued.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_