### PR TITLE
fix(sailfin): the codec invariant lives in the libraries, not the openSUSE package names

### DIFF
--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -184,35 +184,59 @@ if [[ "${_TD_OS}" == "zypper" ]]; then
 			sleep $((attempt * 5))
 		done
 
-		# The dup is VERSION-driven, and that is not enough. Run 32047331620
-		# (gnome amd64): the desktop transaction upgraded ffmpeg to
-		# openSUSE's newer 9.0.1 build, the dup printed "Nothing to do" —
-		# there was no higher Packman version to move to — and the codec
-		# baseline still failed on the crippled decoder set. Ownership is
-		# the invariant, not version order: verify the vendor on the named
-		# multimedia set and force any openSUSE-owned member back to
-		# Packman, downgrades allowed.
+		# The dup is VERSION-driven, and that is not enough — but the first
+		# forced-install attempt (run 32047331620 follow-up, 32052422745)
+		# also taught us WHICH packages matter. The Packman codec model on
+		# openSUSE keeps the distro's ffmpeg/gstreamer packages
+		# openSUSE-vendored; full decoding comes from Packman's LIBRARY
+		# complements. Essentials carries NO package literally named
+		# `ffmpeg` (measured against the live index 2026-08-17: only
+		# ffmpeg-3..8 and libavcodecNN), so forcing the openSUSE names was
+		# a no-op: 'ffmpeg' not found in package names → "already
+		# installed" → Nothing to do → crippled decoders survive.
+		#
+		# The invariant: every installed libavcodecNN (the soname the
+		# ffmpeg binary actually loads decoders from) plus the
+		# gstreamer *-codecs complements and vlc-codecs must be
+		# Packman-vendored. Force any that are not, downgrades allowed.
 		_td_pm_lost=()
-		for _td_pkg in ffmpeg libavcodec-full gstreamer-plugins-good \
-			gstreamer-plugins-bad gstreamer-plugins-ugly \
-			gstreamer-plugins-libav vlc-codecs; do
-			rpm -q "$_td_pkg" >/dev/null 2>&1 || continue
+		while IFS= read -r _td_pkg; do
+			[[ -n "$_td_pkg" ]] || continue
 			rpm -q --qf '%{VENDOR}\n' "$_td_pkg" | grep -qi packman ||
 				_td_pm_lost+=("$_td_pkg")
+		done < <(rpm -qa --qf '%{NAME}\n' 'libavcodec*' 2>/dev/null)
+		for _td_pkg in gstreamer-plugins-bad-codecs \
+			gstreamer-plugins-ugly-codecs vlc-codecs; do
+			if ! rpm -q "$_td_pkg" >/dev/null 2>&1; then
+				# The complement is not installed at all — that is the same
+				# hole with a different spelling.
+				_td_pm_lost+=("$_td_pkg")
+			elif ! rpm -q --qf '%{VENDOR}\n' "$_td_pkg" | grep -qi packman; then
+				_td_pm_lost+=("$_td_pkg")
+			fi
 		done
 		if ((${#_td_pm_lost[@]} > 0)); then
-			echo "Packman lost ownership of: ${_td_pm_lost[*]} — forcing it back (tunaOS#1832)"
+			echo "Packman must own the codec libraries; forcing: ${_td_pm_lost[*]} (tunaOS#1832)"
 			attempt=0
 			until zypper --non-interactive install -y --oldpackage \
 				--allow-vendor-change --force-resolution \
 				--from packman-essentials "${_td_pm_lost[@]}"; do
 				attempt=$((attempt + 1))
 				if ((attempt >= 3)); then
-					echo "ERROR: could not force the multimedia stack back to Packman (tunaOS#1832)" >&2
+					echo "ERROR: could not force the codec libraries back to Packman (tunaOS#1832)" >&2
 					exit 1
 				fi
 				zypper --non-interactive --gpg-auto-import-keys refresh --force || true
 				sleep $((attempt * 5))
+			done
+			# Assert, don't hope: a second no-op here means the force above
+			# quietly failed and the codec baseline will fail later anyway —
+			# fail HERE, where the zypper output is still on screen.
+			for _td_pkg in "${_td_pm_lost[@]}"; do
+				rpm -q --qf '%{VENDOR}\n' "$_td_pkg" | grep -qi packman || {
+					echo "ERROR: ${_td_pkg} still not Packman-vendored after the forced install (tunaOS#1832)" >&2
+					exit 1
+				}
 			done
 		fi
 	fi

--- a/tests/test_sailfin_keeps_packman_codecs.py
+++ b/tests/test_sailfin_keeps_packman_codecs.py
@@ -44,16 +44,25 @@ def test_base_stage_still_installs_packman_first() -> None:
 
 
 def test_ownership_is_verified_not_inferred_from_the_dup() -> None:
-    """Run 32047331620 proved the dup alone is insufficient: the desktop
-    transaction upgraded ffmpeg to openSUSE's NEWER crippled build, the dup
-    said "Nothing to do" (no higher Packman version existed), and the codec
-    baseline still failed. The script must check the installed VENDOR on the
-    multimedia set and force openSUSE-owned members back to Packman, with
-    downgrades allowed — version order is not the invariant, ownership is."""
+    """Run 32047331620 proved the dup alone is insufficient (openSUSE's
+    NEWER ffmpeg → "Nothing to do"), and run 32052422745 proved which
+    packages the check must target: Packman Essentials carries NO package
+    named `ffmpeg` (measured live 2026-08-17 — only ffmpeg-3..8 and
+    libavcodecNN), so forcing the openSUSE package names was a no-op
+    ('not found in package names'). The invariant is that the LIBRARY
+    complements are Packman-vendored: every installed libavcodecNN, the
+    gstreamer *-codecs packages, and vlc-codecs."""
     assert "rpm -q --qf '%{VENDOR}" in SCRIPT
     assert "--oldpackage" in SCRIPT
     assert "--from packman-essentials" in SCRIPT
-    assert "force the multimedia stack back to Packman" in SCRIPT
+    # The corrected target set: libraries, not the openSUSE binary names.
+    assert "'libavcodec*'" in SCRIPT
+    assert "gstreamer-plugins-bad-codecs" in SCRIPT
+    assert "gstreamer-plugins-ugly-codecs" in SCRIPT
+    assert "vlc-codecs" in SCRIPT
+    # And it must assert the outcome, not hope: a post-force vendor
+    # re-check that fails the build where the zypper output is on screen.
+    assert "still not Packman-vendored after the forced install" in SCRIPT
     # The vendor check must come AFTER the dup — it is the fallback for the
     # case the dup cannot handle, not a replacement for it.
     assert SCRIPT.index("dup --from packman-essentials") \


### PR DESCRIPTION
Run [32052422745](https://github.com/tuna-os/tunaOS/actions/runs/32052422745) (post-#1850) closed the second loop on the sailfin codec chain. The vendor check fired correctly, the forced install ran — **and was a no-op**:

```
'ffmpeg' not found in package names. Trying capabilities.
'ffmpeg' is already installed.
...
Nothing to do.
```

## Why

Packman Essentials carries **no package named `ffmpeg`**. I pulled the live index (2026-08-17, 497 packages): it ships versioned `ffmpeg-3`…`ffmpeg-8`, the `libavcodecNN` library packages (`libavcodec62` included), `gstreamer-plugins-{bad,ugly}-codecs`, and `vlc-codecs`. That's the openSUSE+Packman codec model: the distro's `ffmpeg`/gstreamer packages stay openSUSE-vendored, and decoding capability comes from Packman's **library complements** — which is where the h264 decoders `verify-desktop-experience.sh` exercises actually live. #1850's check was aimed at names Packman doesn't publish, so `--from packman-essentials` had nothing to match.

## Fix

The ownership check now targets the real invariant:
- every **installed `libavcodecNN`** must be Packman-vendored (globbed from the rpmdb, so soname bumps like 61→62 are covered automatically)
- `gstreamer-plugins-bad-codecs`, `gstreamer-plugins-ugly-codecs`, `vlc-codecs` must be **installed and** Packman-vendored — absent is the same hole with a different spelling
- the forced install aims at those names, and a **post-force vendor re-check fails the build immediately** (with the zypper output still on screen) instead of three minutes later in the codec baseline

Test updated to pin the corrected target set and the post-force assertion. shellcheck clean; all 4 codec tests pass.

After merge I'll dispatch `build-sailfin.yml` — third validation round, and this time the check aims where Packman actually publishes.

Refs #1832.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_