### PR TITLE
fix(gate): base-Gate evidence must survive sudo ownership and the timeout path

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -1460,7 +1460,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          pkgs=(just jq qemu-system-x86 qemu-utils ovmf socat)
+          pkgs=(just jq qemu-system-x86 qemu-utils ovmf socat imagemagick)
           if sudo sh -c 'command -v podman' >/dev/null 2>&1; then
             echo "podman already present: $(sudo sh -c 'command -v podman')"
           else
@@ -1482,6 +1482,14 @@ jobs:
             --contract base \
             --output verify-out \
             --timeout 600
+
+      # Same lesson the desktop Gate carries above: iso-e2e runs under sudo,
+      # so QEMU's screendump lands root-owned in verify-out and the upload
+      # dies on EACCES — which is how sailfin run 32068513822 lost the ONE
+      # serial log that would explain why the base marker never arrived.
+      - name: Make evidence uploadable
+        if: always()
+        run: sudo chown -R "$USER:$(id -gn)" verify-out 2>/dev/null || true
 
       - name: Upload boot evidence
         if: always()

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -1320,7 +1320,7 @@ wait_for_paint() {
 		attempt=$((attempt + 1))
 		screenshot "$label"
 		if screenshot_sane "$label"; then
-			echo "==> ${label} painted on attempt ${attempt} (stddev=${SCREENSHOT_STDDEV})"
+			echo "==> ${label} painted on attempt ${attempt} (stddev=${SCREENSHOT_STDDEV:-unmeasured})"
 			return 0
 		fi
 		sleep 15
@@ -1330,7 +1330,11 @@ wait_for_paint() {
 	if screenshot_sane "$label"; then
 		return 0
 	fi
-	echo "==> ${label} still blank after ${cap}s (stddev=${SCREENSHOT_STDDEV}) — the serial marker, not pixels, is the gate" >&2
+	# :-unmeasured, not a bare expansion: screenshot_sane's early returns (no
+	# ImageMagick, no capture) never set SCREENSHOT_STDDEV, and under set -u a
+	# bare reference here killed the base Gate's TIMEOUT path before it could
+	# print any diagnostics (sailfin run 32068513822, line-1323 crash).
+	echo "==> ${label} still blank after ${cap}s (stddev=${SCREENSHOT_STDDEV:-unmeasured}) — the serial marker, not pixels, is the gate" >&2
 	return 1
 }
 

--- a/tests/test_boot_gate_blocks_green.py
+++ b/tests/test_boot_gate_blocks_green.py
@@ -117,3 +117,32 @@ def test_readme_updater_scores_boots_with_the_same_scope() -> None:
     )
     assert '"boots,builds"' in body, "guard must accept the graduated set"
     assert "gate=" in body
+
+
+def test_base_gate_evidence_survives_sudo_and_timeouts() -> None:
+    """Sailfin run 32068513822, the base Gate's first real boot: the 600s
+    timeout crashed on an unbound SCREENSHOT_STDDEV before printing any
+    diagnostics, and the root-owned screendump made the artifact upload die
+    on EACCES — losing the one serial log that says why the marker never
+    arrived. Evidence collection must survive both failure modes."""
+    doc = yaml.safe_load(WORKFLOW)
+    steps = doc["jobs"]["verify_boot_base"]["steps"]
+    names = [s.get("name", "") for s in steps]
+    assert "Make evidence uploadable" in names, (
+        "verify-out is root-owned (iso-e2e runs under sudo); without a chown "
+        "the upload EACCESes and the evidence is lost"
+    )
+    chown = next(s for s in steps if s.get("name") == "Make evidence uploadable")
+    assert chown.get("if") == "always()", "evidence matters MOST on failure"
+    assert names.index("Make evidence uploadable") < names.index("Upload boot evidence")
+    install = next(s for s in steps if s.get("name") == "Install dependencies")
+    assert "imagemagick" in install["run"], (
+        "without ImageMagick every screenshot is unjudgeable and the paint "
+        "poll burns its full cap"
+    )
+    harness = (ROOT / "scripts" / "iso-e2e.sh").read_text(encoding="utf-8")
+    assert "${SCREENSHOT_STDDEV:-" in harness, (
+        "screenshot_sane's early returns never set SCREENSHOT_STDDEV; a bare "
+        "expansion under set -u kills the timeout path before diagnostics"
+    )
+    assert "(stddev=${SCREENSHOT_STDDEV})" not in harness


### PR DESCRIPTION
The base Gate's first real boot (sailfin run [32068513822](https://github.com/tuna-os/tunaOS/actions/runs/32068513822), running post-#1853 so the flag finally parsed) timed out waiting 600s for `TUNAOS_BASE_CONTRACT_*` — and then destroyed its own evidence twice over:

1. **The timeout path crashed before printing diagnostics**: `iso-e2e.sh: line 1323: SCREENSHOT_STDDEV: unbound variable`. `screenshot_sane`'s early returns (no ImageMagick on the runner, no capture) never set the variable, and `set -u` killed the script at `wait_for_paint`'s bare expansion. Both echo sites now default-expand (`:-unmeasured`), with a comment naming the run.
2. **The artifact upload died on `EACCES: verify-out/10-ready.ppm`** — iso-e2e runs under sudo, so QEMU's screendump landed root-owned, and the upload lost the *one serial log that would say why the marker never arrived*. The desktop Gate already carries this exact lesson (its chown dates from an earlier round); the base Gate job now has the same `Make evidence uploadable` `if: always()` step, plus `imagemagick` in its dependency list so screenshots are judgeable at all.

**Deliberately not concluded here:** whether the sailfin base genuinely fails its contract (never reaches `multi-user` running/degraded, or `bootc status` breaks) or the marker plumbing has a gap on openSUSE. That's precisely what the next run's *surviving* serial log answers — this PR is what makes that answer reachable.

New test (`test_base_gate_evidence_survives_sudo_and_timeouts`) pins all three: the chown step (`always()`, ordered before upload), imagemagick in the base Gate deps, and no bare `SCREENSHOT_STDDEV` expansion anywhere in the harness. shellcheck/yamllint clean; the boot-gate suite is 8/8.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_