### PR TITLE
feat(lifecycle): wire the sweep into the scoreboard; advisory on first-sweep evidence (W2)

### DIFF
--- a/.github/green-criteria.yml
+++ b/.github/green-criteria.yml
@@ -117,15 +117,23 @@ criteria:
     proves: >-
       A deployed system can bootc upgrade to a newer build, rebase across
       streams, resolve aliases, and roll back off a bad deployment.
-    asserted_by: .github/workflows/bootc-lifecycle.yml
-    enforcement: unimplemented
+    asserted_by: >-
+      .github/workflows/bootc-lifecycle.yml (weekly, Thu 05:00 UTC; red runs
+      auto-retried once by rerun-infra-failures.yml when the failure is
+      infra-classified) — cell verdicts feed the scoreboard worst-of-arches
+    enforcement: advisory
     status_2026_08_17: "0 of 52 cells (0 tested, 52 never tested)"
+    status_2026_08_17_pm: >-
+      advisory. First full sweep (run 32040213366): 168 jobs, 133 passed,
+      43 of 53 arm64 clean; every failure mapped to a known class (#1819,
+      #1820, #1823, unpublished hummingbird images) with no new class.
+      Advisory until a second consecutive weekly sweep holds the shape,
+      then graduate.
     notes: >-
-      Has never run for a single cell. For a bootc OS the update transaction is
-      the product: an image that installs perfectly and cannot upgrade, or
-      cannot roll back off a bad deployment, has failed at the thing
-      immutability is sold on. Every user meets upgrade repeatedly and the ISO
-      once.
+      For a bootc OS the update transaction is the product: an image that
+      installs perfectly and cannot upgrade, or cannot roll back off a bad
+      deployment, has failed at the thing immutability is sold on. Every user
+      meets upgrade repeatedly and the ISO once.
 
   - id: parity
     name: Package set matches the upstream reference

--- a/.github/workflows/rerun-infra-failures.yml
+++ b/.github/workflows/rerun-infra-failures.yml
@@ -35,6 +35,11 @@ on:
       - Build Sailfin
       - Build Skipjack
       - Build Yellowfin
+      # The weekly lifecycle sweep fails the same two infra ways the
+      # nightlies do (GHCR/podman on hosted runners), and its 08-13 red run
+      # sat unnoticed for four days because nothing triaged it (W2). Same
+      # rule as above: one classified re-run, never a loop.
+      - Bootc Lifecycle
     types: [completed]
   workflow_dispatch:
     inputs:

--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -63,10 +63,18 @@ against today's config) yet no downstream job materialised. Verification run
       bonito-rawhide → #1823, hummingbird desktops → images not yet
       published by the factory. The update transaction demonstrably works
       matrix-wide where images exist.
-- [ ] Wire results into MATRIX-STATUS (already scaffolded) and W1.
-- [ ] Then: weekly cadence is already scheduled; make the cron survive
-      (the 08-13 failure went unnoticed for four days — add it to the red-run
-      triage the same way nightlies are).
+- [x] Wire results into MATRIX-STATUS (already scaffolded) and W1 — the
+      scaffold had a latent key mismatch (raw job names like
+      "yellowfin:gnome (amd64)" / "BETA guppy:gnome (amd64)" vs the
+      composite's "variant:flavor" lookup), so all 168 real verdicts
+      rendered ⬜; lifecycle_results() now normalises names and merges arch
+      legs worst-of. Criterion flipped unimplemented → advisory on the
+      first-sweep evidence; graduate after a second consecutive clean-shape
+      weekly sweep.
+- [x] Then: weekly cadence is already scheduled; make the cron survive —
+      Bootc Lifecycle added to rerun-infra-failures.yml's roster, so an
+      infra-classified red sweep gets one classified re-run instead of
+      sitting unnoticed for four days like 08-13 did.
 
 ### W3. Boot gate mandatory where CI can test it *(criterion 3)*
 

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -66,7 +66,7 @@ it.
 
 ## Composite green — the bar
 
-Scored against `.github/green-criteria.yml`: a cell is green only when every **blocking** criterion applicable to it has a current affirmative result; a criterion that was skipped, never tested, or unasserted renders ⬜ and does not count as satisfied. Blocking today: `builds`, `boots`. Advisory (measured in the sections below, not yet biting): `desktop`, `install`, `parity`, `no_silent_omissions`, `rebuildable`. Unimplemented: `iso`, `lifecycle`, `arch_honesty`. Graduating a criterion is an edit to `enforcement:` in that file — this table and the README count tighten with no code change.
+Scored against `.github/green-criteria.yml`: a cell is green only when every **blocking** criterion applicable to it has a current affirmative result; a criterion that was skipped, never tested, or unasserted renders ⬜ and does not count as satisfied. Blocking today: `builds`, `boots`. Advisory (measured in the sections below, not yet biting): `desktop`, `install`, `lifecycle`, `parity`, `no_silent_omissions`, `rebuildable`, `arch_honesty`. Unimplemented: `iso`. Graduating a criterion is an edit to `enforcement:` in that file — this table and the README count tighten with no code change.
 
 **0 of 142** published cells are composite-green.
 

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -519,6 +519,36 @@ def _axis_from_results(results: dict, key: str) -> str:
     return _stage_verdict(hit[0] if hit else None)
 
 
+# bootc-lifecycle job names carry an arch suffix, and the smoke-tier jobs a
+# BETA prefix: "yellowfin:gnome (amd64)", "BETA guppy:gnome (amd64)". The
+# composite and the Lifecycle section key cells as plain "variant:flavor".
+_LIFECYCLE_NAME = re.compile(
+    r"^(?:BETA\s+)?(?P<cell>[a-z0-9-]+:[a-z0-9-]+)\s+\([a-z0-9]+\)$"
+)
+
+
+def lifecycle_results() -> dict[str, tuple[str, str, str]]:
+    """Cell-keyed lifecycle verdicts, worst-of-arches.
+
+    The wiring below was written before Bootc Lifecycle had ever run, and
+    the first real sweep (run 32040213366, 168 jobs) proved the raw job
+    names never matched a cell lookup: every cell rendered ⬜ while 133
+    passes sat in the run. Normalise the names here, and merge a cell's
+    arch legs pessimistically — one green leg must not mask a red one, for
+    the same reason never-tested is not green.
+    """
+    merged: dict[str, tuple[str, str, str]] = {}
+    for name, hit in latest_results("bootc-lifecycle.yml", r":").items():
+        m = _LIFECYCLE_NAME.match(name)
+        if not m:
+            continue
+        cell = m.group("cell")
+        prev = merged.get(cell)
+        if prev is None or (prev[0] == "success" and hit[0] == "failure"):
+            merged[cell] = hit
+    return merged
+
+
 def composite_verdict(verdicts: list[str]) -> str:
     """Compose per-criterion verdicts under green-criteria.yml's rule.
 
@@ -883,7 +913,7 @@ def build() -> str:
     # ── Composite ───────────────────────────────────────────────────────────
     # First, because everything below is an input to it: this is the section
     # that composes the axes into the one claim the word "green" now makes.
-    lifecycle = latest_results("bootc-lifecycle.yml", r":")
+    lifecycle = lifecycle_results()
     omissions = omissions_results()
     parity = parity_results()
     composite_lines, _, _ = composite_section(

--- a/tests/test_matrix_status_config.py
+++ b/tests/test_matrix_status_config.py
@@ -448,3 +448,41 @@ class MainCliDispatch(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class LifecycleResultsNormalisation(unittest.TestCase):
+    """W2: the lifecycle scaffold was written before the workflow ever ran,
+    and the first real sweep (run 32040213366) proved its keys never matched
+    — latest_results returns raw job names ("yellowfin:gnome (amd64)",
+    "BETA guppy:gnome (amd64)") while the composite looks up
+    "variant:flavor". 168 verdicts rendered as 168 ⬜."""
+
+    def _with_raw(self, raw):
+        with mock.patch.object(gms, "latest_results", return_value=raw):
+            return gms.lifecycle_results()
+
+    def test_real_job_names_normalise_to_cells(self):
+        got = self._with_raw({
+            "yellowfin:gnome (amd64)": ("success", "2026-08-17", "1"),
+            "BETA guppy:gnome (amd64)": ("success", "2026-08-17", "1"),
+            "flounder:kde-nvidia (amd64)": ("failure", "2026-08-17", "1"),
+        })
+        self.assertEqual(got["yellowfin:gnome"][0], "success")
+        self.assertEqual(got["guppy:gnome"][0], "success")
+        self.assertEqual(got["flounder:kde-nvidia"][0], "failure")
+
+    def test_arch_legs_merge_worst_of(self):
+        # One green leg must not mask a red one — same spirit as
+        # never-tested-is-not-green. Order-independent on purpose.
+        for first, second in (("success", "failure"), ("failure", "success")):
+            got = self._with_raw({
+                "bonito-rawhide:gnome (amd64)": (first, "2026-08-17", "1"),
+                "bonito-rawhide:gnome (arm64)": (second, "2026-08-17", "1"),
+            })
+            self.assertEqual(got["bonito-rawhide:gnome"][0], "failure")
+
+    def test_non_cell_jobs_are_ignored(self):
+        got = self._with_raw({
+            "Generate matrix": ("success", "2026-08-17", "1"),
+        })
+        self.assertEqual(got, {})


### PR DESCRIPTION
Closes W2's last two boxes, prompted by re-reading the master plan.

## The key mismatch nobody could have seen until the workflow ran

The MATRIX-STATUS scaffold for lifecycle predates the workflow ever completing a run. The first real sweep ([32040213366](https://github.com/tuna-os/tunaOS/actions/runs/32040213366), 168 jobs) proved its lookup never matched: `latest_results` keys by **raw job name** — `yellowfin:gnome (amd64)`, `BETA guppy:gnome (amd64)` — while the composite and the `## Bootc Lifecycle` section look up plain `variant:flavor`. All 133 passes rendered as ⬜.

`lifecycle_results()` now normalises the names and merges a cell's arch legs **worst-of** — one green leg must not mask a red one, for the same reason never-tested is not green. Three unit tests use the real sweep's exact name shapes (arch suffixes, BETA prefix, non-cell jobs ignored, order-independent worst-of).

## Criterion: unimplemented → advisory

With weekly data actually flowing, the criterion's "has never run for a single cell" was false. Flipped to `advisory` with the measured baseline (133/168; 43/53 arm64 clean; every failure in a known class — #1819, #1820, #1823, unpublished hummingbird images — none new), and an explicit graduation gate: a second consecutive clean-shape weekly sweep. The committed MATRIX-STATUS enforcement sentence is re-rendered from the same code path — which also catches up `arch_honesty`, advisory since W8 but still listed as unimplemented in the committed text.

## Cron survival

`Bootc Lifecycle` joins `rerun-infra-failures.yml`'s roster: its hosted-runner failure modes are the same two infra classes the nightlies get one classified re-run for, and its 08-13 red run sat unnoticed for four days because nothing triaged it.

71 tests across the matrix-status/criteria/composite/README surface pass; yamllint clean.

With this, **W1, W2, W3, W5, W6, and W8 are fully boxed**; open remainder: W1's per-cell provenance stretch box, W4 (ISO axis, externally blocked on #1772), W7's createrepo_c audit (queued behind RFC 011's branch), and W9 (GPU runners — infra).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_