### PR TITLE
fix(sailfin): only force codec sonames Packman actually publishes (#1832)

### DIFF
--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -215,12 +215,33 @@ if [[ "${_TD_OS}" == "zypper" ]]; then
 				_td_pm_lost+=("$_td_pkg")
 			fi
 		done
-		if ((${#_td_pm_lost[@]} > 0)); then
-			echo "Packman must own the codec libraries; forcing: ${_td_pm_lost[*]} (tunaOS#1832)"
+		# A soname generation Packman has not published cannot be forced
+		# from packman-essentials. During a Tumbleweed ffmpeg major
+		# transition the openSUSE build is briefly the ONLY build — run
+		# 32068513822 killed all five amd64 desktops because openSUSE
+		# shipped libavcodec63 (ffmpeg 9) while Packman's newest is
+		# libavcodec62, so the forced install was a no-op and the assert
+		# below (correctly) refused to hope. Failing the image for that
+		# gap goes red on something no change in this repository can fix:
+		# force what Packman offers, surface the rest with a greppable
+		# marker, and let the codec baseline in
+		# verify-desktop-experience.sh keep asserting that the primary
+		# ffmpeg stack still decodes h264 (it links the Packman soname).
+		_td_force=()
+		for _td_pkg in "${_td_pm_lost[@]}"; do
+			if zypper --non-interactive search --match-exact --type package \
+				--repo packman-essentials "$_td_pkg" >/dev/null 2>&1; then
+				_td_force+=("$_td_pkg")
+			else
+				echo "TUNAOS_CODEC_GAP: ${_td_pkg} is not Packman-vendored and packman-essentials publishes no build to force; its consumers decode with openSUSE's crippled build until Packman catches up (tunaOS#1832)"
+			fi
+		done
+		if ((${#_td_force[@]} > 0)); then
+			echo "Packman must own the codec libraries; forcing: ${_td_force[*]} (tunaOS#1832)"
 			attempt=0
 			until zypper --non-interactive install -y --oldpackage \
 				--allow-vendor-change --force-resolution \
-				--from packman-essentials "${_td_pm_lost[@]}"; do
+				--from packman-essentials "${_td_force[@]}"; do
 				attempt=$((attempt + 1))
 				if ((attempt >= 3)); then
 					echo "ERROR: could not force the codec libraries back to Packman (tunaOS#1832)" >&2
@@ -232,7 +253,7 @@ if [[ "${_TD_OS}" == "zypper" ]]; then
 			# Assert, don't hope: a second no-op here means the force above
 			# quietly failed and the codec baseline will fail later anyway —
 			# fail HERE, where the zypper output is still on screen.
-			for _td_pkg in "${_td_pm_lost[@]}"; do
+			for _td_pkg in "${_td_force[@]}"; do
 				rpm -q --qf '%{VENDOR}\n' "$_td_pkg" | grep -qi packman || {
 					echo "ERROR: ${_td_pkg} still not Packman-vendored after the forced install (tunaOS#1832)" >&2
 					exit 1

--- a/tests/test_sailfin_keeps_packman_codecs.py
+++ b/tests/test_sailfin_keeps_packman_codecs.py
@@ -67,3 +67,23 @@ def test_ownership_is_verified_not_inferred_from_the_dup() -> None:
     # case the dup cannot handle, not a replacement for it.
     assert SCRIPT.index("dup --from packman-essentials") \
         < SCRIPT.index("rpm -q --qf '%{VENDOR}")
+
+
+def test_unpublished_soname_generations_are_surfaced_not_fatal() -> None:
+    """Run 32068513822 killed all five amd64 desktops: Tumbleweed shipped
+    libavcodec63 (ffmpeg 9) while Packman Essentials' newest build is
+    libavcodec62, so the forced install was a no-op ('already installed')
+    and the post-force assert failed — on a gap no change in this
+    repository can close. A generation Packman does not publish cannot be
+    forced from packman-essentials: it must be surfaced with a greppable
+    marker, and only the Packman-published subset forced and asserted."""
+    assert "TUNAOS_CODEC_GAP" in SCRIPT
+    # Availability is measured against the live repo, per package, before
+    # any forcing happens.
+    assert "--match-exact" in SCRIPT
+    assert "--repo packman-essentials" in SCRIPT
+    assert SCRIPT.index("TUNAOS_CODEC_GAP") \
+        < SCRIPT.index("Packman must own the codec libraries")
+    # The force and the post-force assert both operate on the filtered set,
+    # so the assert can never demand a package the force was never given.
+    assert SCRIPT.count('"${_td_force[@]}"') >= 2


### PR DESCRIPTION
## What happened

Validation run [32068513822](https://github.com/tuna-os/tunaOS/actions/runs/32068513822) killed **all five amd64 desktop legs** on the post-force vendor assert from #1854. Reading the gnome amd64 log:

- The dup itself **worked**: Packman's `libavcodec62-8.1.2-…pm.54` replaced the openSUSE build in the base layer.
- But Tumbleweed has moved to a dual-ffmpeg world: the desktop transaction pulls in `libavcodec63` (ffmpeg 9.0.1) from openSUSE OSS as a dependency.
- Packman Essentials publishes `libavcodec57/60/61/62` and **no 63** (measured against the live index). The forced install was a no-op (`'libavcodec63' is already installed`), and the post-force assert correctly refused to hope — then failed the build.

The invariant "every installed libavcodecNN must be Packman-vendored" is unsatisfiable during a distro ffmpeg major transition, and failing the image for it goes red on something no change in this repository can fix — the same reasoning as the `arch_honesty` criterion.

## The fix

Before forcing, the check now measures availability per package against `packman-essentials` (`zypper search --match-exact --repo packman-essentials`):

- The Packman-published subset is forced and hard-asserted exactly as before — the #1854 behavior is unchanged where Packman can actually supply the package.
- A generation Packman has not published yet is surfaced with a greppable `TUNAOS_CODEC_GAP` marker instead of `exit 1`.

The functional backstop is unchanged: the codec baseline in `verify-desktop-experience.sh` still asserts the primary ffmpeg stack decodes h264, and that stack links the Packman soname (`libavcodec62`).

## Verification

- `bash -n` clean; `tests/test_sailfin_keeps_packman_codecs.py` 5/5 (new test pins the availability gate, the marker, and that force + assert operate on the same filtered set).
- gnome **arm64** passed on the same run, consistent with the gap being an amd64-repo transition artifact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_