### PR TITLE
feat(hummingbird): wire the cosmic desktop — 22/23 packages already in the repo (#1755 option B)

### DIFF
--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -230,7 +230,7 @@ The fully-diagnosed one: **#1755**.
 |---|---|---|
 | base | **promotes on both arches** | keep |
 | gnome amd64 | builds; repo lacks gnome-shell/gdm/mutter (29 of 52 pkgs missing) so the image has no real desktop | needs tunaos-packages rebuilds (#1755 §2, tunaos-packages#250) |
-| cosmic amd64 | **cheapest real win in the matrix**: 22/23 pkgs already in repo, fails only for want of a `hummingbird:` manifest section | write the section (#1755 option B) |
+| cosmic amd64 | **section landed 08-18** (#1755 option B): 22/23 pkgs re-measured against the live repo, `hummingbird:` section added to cosmic.yaml (cosmic-settings-daemon deliberately omitted — not in repo) | verify on next nightly |
 | kde/niri | no manifest section; ~50% pkg coverage | after cosmic proves the path |
 | all arm64 desktops | repo 404s — unsatisfiable by construction | W8: drop or build (#1755 option A/D) |
 | dconf branding failure | **deliberately left failing** — guarding it would green cells that contain no desktop | fix only after manifest sections exist |

--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -146,6 +146,58 @@ packages:
       - xdg-desktop-portal-cosmic
       - pop-icon-theme
 
+  # ── Hummingbird (Fedora rebuild) ───────────────────────────────────
+  # The cheapest real win in the matrix (#1755 §4): the rebuild repo carries
+  # 22 of cosmic's 23 Fedora packages, and the cell was red purely because no
+  # section named them. Re-measured 2026-08-18 against the live primary.xml
+  # (8100 packages): everything below resolves.
+  #
+  # NOT an alias of the fedora list (unlike gnome.yaml's section, which IS
+  # `*fedora_gnome_packages`): the repo has no `cosmic-settings-daemon` — the
+  # single gap — and hummingbird installs run --skip-unavailable, so listing
+  # it would record a permanent, known omission every night instead of a
+  # decision. Same treatment as the zypper section's cosmic-settings note
+  # above: do not list what the repository cannot supply. Re-add it (or
+  # restore the alias outright) when tunaos-packages rebuilds it —
+  # tests/bats/test_hummingbird_desktop_wiring.bats pins that the difference
+  # between this list and fedora's is exactly that one package, so the two
+  # cannot drift silently.
+  #
+  # Snapshot pin, not `current/$basearch/`: same status as gnome.yaml's
+  # section — the floating alias does not exist on repo.tunaos.org yet
+  # (tuna-os/tunaos-packages#365), and the x86_64-only path is the only one
+  # published (#1755 §3), which is fine because this section is only read on
+  # the amd64 leg's dnf path.
+  hummingbird:
+    repos:
+      - name: tunaos-hummingbird
+        baseurl: https://repo.tunaos.org/hummingbird/20251124-x86_64/
+        priority: 5
+    packages:
+      - cosmic-session
+      - cosmic-comp
+      - cosmic-panel
+      - cosmic-app-library
+      - cosmic-applets
+      - cosmic-bg
+      - cosmic-files
+      - cosmic-idle
+      - cosmic-launcher
+      - cosmic-notifications
+      - cosmic-osd
+      - cosmic-randr
+      - cosmic-screenshot
+      - cosmic-settings
+      # cosmic-settings-daemon deliberately absent — see the section comment.
+      - cosmic-term
+      - cosmic-wallpapers
+      - cosmic-workspaces
+      - cosmic-greeter
+      - cosmic-icon-theme
+      - greetd
+      - xdg-desktop-portal-cosmic
+      - pop-icon-theme
+
   el10:
     # cosmic-greeter hard-requires fprintd-pam, which CentOS Stream 10 only
     # builds for x86_64 -- that gap is why aarch64 cosmic was pinned off in

--- a/tests/bats/test_hummingbird_desktop_wiring.bats
+++ b/tests/bats/test_hummingbird_desktop_wiring.bats
@@ -71,16 +71,39 @@ yq_bin() { command -v yq; }
 	[ "$output" -ge 1 ]
 }
 
-# Only gnome is wired on purpose. kde uses `groups:` and niri uses `copr:`,
-# and their Hummingbird package sets (384 and 310 sources) do not exist yet —
-# inventing sections for repositories that 404 would be guesswork. This test
-# records that as a deliberate boundary so its absence is not read as an
-# oversight.
+# Only gnome and cosmic are wired on purpose. kde uses `groups:` and niri
+# uses `copr:`, and their Hummingbird package sets (~47-50% repo coverage,
+# #1755 §4) do not exist yet — inventing sections for packages the repo
+# cannot supply would be guesswork. This test records that as a deliberate
+# boundary so their absence is not read as an oversight.
 @test "only the desktops whose hummingbird packages exist are wired" {
 	[ -n "$(yq_bin)" ] || skip "yq not available"
 	local d
-	for d in kde niri cosmic; do
+	for d in kde niri; do
 		run yq -r '.packages.hummingbird // "absent"' "${REPO_ROOT}/manifests/desktops/${d}.yaml"
 		[ "$output" = "absent" ] || [ "$output" = "null" ]
 	done
+}
+
+# cosmic joined gnome on 2026-08-18 (#1755 option B): 22 of its 23 Fedora
+# packages resolve against the live repo (re-measured, 8100-package
+# primary.xml), the gap being exactly cosmic-settings-daemon. Its section is
+# a literal list, NOT the fedora alias gnome uses — listing the missing
+# daemon under --skip-unavailable would turn a decision into a nightly
+# omission. This test IS the drift guard the alias would have been: the
+# difference between the two lists must be exactly that one package, in that
+# direction, so either list changing alone fails loudly here.
+@test "cosmic's hummingbird list is fedora's minus exactly cosmic-settings-daemon" {
+	[ -n "$(yq_bin)" ] || skip "yq not available"
+	local cosmic_yaml="${REPO_ROOT}/manifests/desktops/cosmic.yaml"
+	run yq -r '.packages.hummingbird.repos[0].baseurl' "$cosmic_yaml"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"hummingbird/20251124-x86_64"* ]]
+	local fedora hummingbird diff
+	fedora="$(yq -r '.packages.fedora.packages[]' "$cosmic_yaml" | sort)"
+	hummingbird="$(yq -r '.packages.hummingbird.packages[]' "$cosmic_yaml" | sort)"
+	[ -n "$fedora" ]
+	[ -n "$hummingbird" ]
+	diff="$(comm -3 <(echo "$fedora") <(echo "$hummingbird") | tr -d '\t')"
+	[ "$diff" = "cosmic-settings-daemon" ]
 }


### PR DESCRIPTION
Implements **option B from #1755** — "the cheapest real win in the matrix". `hummingbird:cosmic` has been red purely because `manifests/desktops/cosmic.yaml` had no `hummingbird:` section, so `install-desktop.sh` resolved nothing and the image shipped no desktop.

## Measurement (re-done tonight, not inherited from the issue)

Pulled the live repo's `primary.xml` (`hummingbird/20251124-x86_64`, now **8100 packages**, up from 7168 at #1755's measurement): all 23 of cosmic's Fedora packages resolve **except `cosmic-settings-daemon`** — the same single gap the issue measured.

## Design choice: literal list, not the fedora alias

gnome.yaml's section aliases `*fedora_gnome_packages`. Cosmic's deliberately does not: the repo lacks exactly one package and hummingbird installs run `--skip-unavailable`, so aliasing the full list would turn a reviewed decision into a permanent nightly omission on the `no_silent_omissions` axis. Same precedent as this manifest's own zypper section (openSUSE's missing `cosmic-settings`): do not list what the repository cannot supply.

The drift risk the alias would have prevented is carried by a test instead: `test_hummingbird_desktop_wiring.bats` now pins that the difference between the fedora and hummingbird lists is **exactly** `cosmic-settings-daemon`, in that direction — either list changing alone fails loudly.

## Changes

- `manifests/desktops/cosmic.yaml` — `hummingbird:` section (repo pin mirrors gnome.yaml's, same #365 snapshot-alias caveat; 22 packages; the omission documented in place).
- `tests/bats/test_hummingbird_desktop_wiring.bats` — cosmic moves out of the deliberately-not-wired boundary (its premise, "packages do not exist yet", is measured false); new test pins repo path + one-package diff. 7/7 pass.
- `docs/GREEN-MASTER-PLAN.md` — hummingbird cosmic row updated; verification lands on the next nightly.

Refs #1755, #1754.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_