### PR TITLE
fix(sailfin): pin the ffmpeg CLI to the stream Packman ships; gates dump serial on silent timeout

### DIFF
--- a/Containerfile.opensuse
+++ b/Containerfile.opensuse
@@ -90,6 +90,18 @@ ENV BASE_IMAGE=${BASE_IMAGE} \
 # volume opens, until it dropped to the emergency shell (defect 8 of
 # tunaOS#953, run 30733919804). The GNOME pattern pulls cryptsetup in later,
 # but the initramfs is built here, and no other flavor's package set does.
+#
+# ffmpeg-8, NOT the unversioned `ffmpeg` name (tunaOS#1832, nightly
+# 32091072257): Tumbleweed flipped `ffmpeg` to the 9.x stream, whose openSUSE
+# build compiles the h264/hevc/vc1 decoders out — and Packman publishes no
+# 9.x yet (measured against the live Essentials index 2026-08-18: newest CLI
+# is ffmpeg-8 8.1.2, newest soname libavcodec62). Installing the unversioned
+# name therefore hands /usr/bin/ffmpeg to a binary that cannot decode h264 no
+# matter what the Packman dup below does to the libraries. ffmpeg-8 resolves
+# from packman-essentials directly (priority 90 beats the distro's 99 at
+# equal versions), keeps the CLI on the stream Packman actually ships full
+# codecs for, and install-desktop.sh's vendor check asserts the ownership.
+# Move back to the unversioned name when Packman publishes the 9.x stream.
 RUN set -eu; \
     retry_zypper() { \
       attempt=1; \
@@ -119,7 +131,7 @@ RUN set -eu; \
     retry_zypper --non-interactive --gpg-auto-import-keys refresh && \
     retry_zypper --non-interactive dup --from packman-essentials --allow-vendor-change && \
     retry_zypper --non-interactive install -y \
-        ffmpeg \
+        ffmpeg-8 \
         gstreamer-plugins-good \
         gstreamer-plugins-bad \
         gstreamer-plugins-ugly \

--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -199,12 +199,20 @@ if [[ "${_TD_OS}" == "zypper" ]]; then
 		# ffmpeg binary actually loads decoders from) plus the
 		# gstreamer *-codecs complements and vlc-codecs must be
 		# Packman-vendored. Force any that are not, downgrades allowed.
+		# 'ffmpeg-[0-9]' also covers the CLI: openSUSE's versioned ffmpeg-N
+		# packages exist in both repos, and only Packman's build ships the
+		# h264/hevc decoders — an openSUSE-vendored ffmpeg-8 is the same
+		# crippled stack with a working library underneath it. (The
+		# unversioned `ffmpeg` name is deliberately not installed at all —
+		# see Containerfile.opensuse; if a dependency ever drags it in, the
+		# availability gate below surfaces it as TUNAOS_CODEC_GAP because
+		# Packman publishes no package of that name.)
 		_td_pm_lost=()
 		while IFS= read -r _td_pkg; do
 			[[ -n "$_td_pkg" ]] || continue
 			rpm -q --qf '%{VENDOR}\n' "$_td_pkg" | grep -qi packman ||
 				_td_pm_lost+=("$_td_pkg")
-		done < <(rpm -qa --qf '%{NAME}\n' 'libavcodec*' 2>/dev/null)
+		done < <(rpm -qa --qf '%{NAME}\n' 'libavcodec*' 'ffmpeg-[0-9]' 'ffmpeg' 2>/dev/null)
 		for _td_pkg in gstreamer-plugins-bad-codecs \
 			gstreamer-plugins-ugly-codecs vlc-codecs; do
 			if ! rpm -q "$_td_pkg" >/dev/null 2>&1; then

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -3030,6 +3030,21 @@ disk)
 	wait_for_paint "10-ready" || true
 	if [[ "$rc" -eq 2 ]]; then
 		echo "ERROR: ${DISK_CONTRACT} contract marker was not emitted" >&2
+		# Answer WHY in the job log itself, not only in an artifact a human
+		# must download: every base Gate on 2026-08-18's nightlies timed out
+		# with a painted VGA screen and this branch as the only in-log
+		# evidence (sailfin run 32091072257, bonito-rawhide 32090947417).
+		# An EMPTY serial log means the console karg routing is broken (the
+		# markers went to the screen the Gate photographs); a serial log
+		# with kernel printk but no marker means the contract unit itself
+		# never ran or never reached the console. The tail makes the two
+		# distinguishable at a glance.
+		if [[ -s "$SERIAL_LOG" ]]; then
+			echo "==> serial log captured $(wc -c <"$SERIAL_LOG") bytes; last 120 lines:" >&2
+			tail -n 120 "$SERIAL_LOG" | sed 's/^/serial| /' >&2
+		else
+			echo "==> serial log is EMPTY — nothing reached ${SERIAL_LOG}: the guest's console= routing never targeted the serial port the Gate captures" >&2
+		fi
 	fi
 	exit "$rc"
 	;;

--- a/tests/test_boot_gate_blocks_green.py
+++ b/tests/test_boot_gate_blocks_green.py
@@ -146,3 +146,15 @@ def test_base_gate_evidence_survives_sudo_and_timeouts() -> None:
         "expansion under set -u kills the timeout path before diagnostics"
     )
     assert "(stddev=${SCREENSHOT_STDDEV})" not in harness
+
+
+def test_marker_timeout_dumps_the_serial_tail_into_the_job_log() -> None:
+    """2026-08-18 nightlies: every base Gate timed out marker-less with the
+    only evidence in a download-only artifact — the job log said nothing
+    about WHY. On rc=2 the disk mode now prints the serial tail directly
+    (or states the log is EMPTY, which means the guest's console= routing
+    never targeted the serial port), so the next silent gate is
+    classifiable from the job log alone."""
+    script = (ROOT / "scripts" / "iso-e2e.sh").read_text(encoding="utf-8")
+    assert "serial log is EMPTY" in script
+    assert 'tail -n 120 "$SERIAL_LOG"' in script

--- a/tests/test_sailfin_keeps_packman_codecs.py
+++ b/tests/test_sailfin_keeps_packman_codecs.py
@@ -87,3 +87,18 @@ def test_unpublished_soname_generations_are_surfaced_not_fatal() -> None:
     # The force and the post-force assert both operate on the filtered set,
     # so the assert can never demand a package the force was never given.
     assert SCRIPT.count('"${_td_force[@]}"') >= 2
+
+
+def test_the_ffmpeg_cli_is_pinned_to_the_stream_packman_ships() -> None:
+    """Nightly 32091072257: Tumbleweed flipped the unversioned `ffmpeg` name
+    to the 9.x stream (decoders compiled out) while Packman's newest CLI is
+    ffmpeg-8 — so installing `ffmpeg` hands /usr/bin/ffmpeg to a binary that
+    cannot decode h264 regardless of what happens to the libraries, and the
+    codec baseline fails on every desktop. The base installs the versioned
+    stream Packman actually ships, and the vendor check owns the CLI too."""
+    assert "ffmpeg-8 \\\n" in BASE
+    # the unversioned name must NOT be in the base install list
+    import re
+    assert not re.search(r"^\s+ffmpeg \\\\$", BASE, re.M)
+    # the ownership check covers the CLI glob alongside the sonames
+    assert "'ffmpeg-[0-9]'" in SCRIPT


### PR DESCRIPTION
Two evidence-driven fixes from tonight's nightlies (sailfin run 32091072257, bonito-rawhide run 32090947417).

## 1. Sailfin codec chain, layer four (#1832)

The #1858 availability gate worked exactly as designed — `TUNAOS_CODEC_GAP` emitted for `libavcodec63`, only the Packman-published set forced — and that exposed the real remaining break: **Tumbleweed flipped the unversioned `ffmpeg` name to the 9.x stream** (openSUSE build, `--disable-decoder='h264,hevc,vc1,…'`), and Packman publishes no 9.x yet. Measured against the live Essentials index tonight: newest CLI is `ffmpeg-8` 8.1.2, newest soname `libavcodec62`. So the base's explicit `ffmpeg` install handed `/usr/bin/ffmpeg` to a binary that cannot decode h264 regardless of the library layer, and the codec baseline correctly failed all five amd64 desktops.

- `Containerfile.opensuse` installs **`ffmpeg-8`** (resolves from packman-essentials — priority 90 beats the distro's 99 at equal versions), with the full rationale and a revert note for when Packman ships 9.x.
- `install-desktop.sh`'s ownership check now covers the CLI packages (`ffmpeg-[0-9]`, plus any dep-dragged unversioned `ffmpeg`, which the availability gate surfaces as a gap since Packman has no such name) alongside the sonames.

## 2. Base Gates: answer "why" in the job log

Every base Gate in tonight's matrix timed out marker-less with a painted text screen and silent serial — and the only evidence was a download-only artifact. On marker-timeout, disk mode now prints the serial tail into the job log, or states the log is EMPTY — which cleanly distinguishes *console routing never reached the serial port* from *the contract unit never ran*. The next nightly answers the open TUNAOS_BASE_CONTRACT question in-log.

## Verification

- `bash -n` both scripts; 15/15 across the two test files (new pins: ffmpeg-8 + CLI coverage; serial-dump behavior).
- gnome **arm64** passed tonight's nightly on the same codec path, consistent with the amd64-repo stream flip being the cause.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_