### PR TITLE
feat(hummingbird): pin desktop flavors amd64-only until the aarch64 repo converges (#1755 option A)

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -720,20 +720,36 @@ variants:
         stage: 1
         build_image: true
         build_iso: true
+      # Desktops are amd64-only until the aarch64 rebuild repo converges
+      # (#1755 option A, W8 architecture honesty). Measured 2026-08-18:
+      # hummingbird/20251124-aarch64 now EXISTS (it 404'd when #1755 was
+      # filed) but is a 1358-package seed against x86_64's 8100 — cosmic
+      # 8/22 manifest packages present, gnome 5/52, no gnome-shell/gdm and
+      # no COSMIC compositor. An arm64 desktop leg today would either 404
+      # nothing and install almost nothing (--skip-unavailable), publishing
+      # the #858 shape: an image with no desktop. Same treatment as
+      # grouper:cosmic's amd64 pin. Re-add "linux/arm64" per flavor when
+      # the aarch64 index carries that desktop's manifest set — re-measure
+      # with the method in manifests/desktops/cosmic.yaml's hummingbird
+      # section comment.
       - id: gnome
         stage: 2
+        platforms: ["linux/amd64"]
         build_image: true
         build_iso: true
       - id: kde
         stage: 2
+        platforms: ["linux/amd64"]
         build_image: true
         build_iso: true
       - id: niri
         stage: 2
+        platforms: ["linux/amd64"]
         build_image: true
         build_iso: true
       - id: cosmic
         stage: 2
+        platforms: ["linux/amd64"]
         build_image: true
         build_iso: true
 

--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -194,6 +194,12 @@ payloads, action pins.
       (tunaos-packages#414) and upstream public-hummingbird serves arm64
       with full source parity — the four guaranteed-red cells become
       buildable once the first aarch64 factory run publishes.
+      Update 08-18: the first aarch64 publish landed
+      (`hummingbird/20251124-aarch64`, 1358 packages) but is a seed with no
+      desktop coverage (cosmic 8/22, gnome 5/52, measured live). The four
+      cells are pinned `linux/amd64` per #1755 option A instead of red —
+      tests/test_hummingbird_arm64_honesty.py makes re-adding arm64 a
+      reviewed, per-desktop, measured decision as the factory converges.
 
 ### W9. Hardware capacity *(unblocks W3/W4 for 4 of 5 desktops, and NVIDIA)*
 
@@ -257,7 +263,7 @@ The fully-diagnosed one: **#1755**.
 | gnome amd64 | builds; repo lacks gnome-shell/gdm/mutter (29 of 52 pkgs missing) so the image has no real desktop | needs tunaos-packages rebuilds (#1755 §2, tunaos-packages#250) |
 | cosmic amd64 | **section landed 08-18** (#1755 option B): 22/23 pkgs re-measured against the live repo, `hummingbird:` section added to cosmic.yaml (cosmic-settings-daemon deliberately omitted — not in repo) | verify on next nightly |
 | kde/niri | no manifest section; ~50% pkg coverage | after cosmic proves the path |
-| all arm64 desktops | repo 404s — unsatisfiable by construction | W8: drop or build (#1755 option A/D) |
+| all arm64 desktops | resolved 08-18 via option A: the aarch64 repo now publishes (1358-pkg seed vs x86_64's 8100 — cosmic 8/22, gnome 5/52, no shell/gdm/compositor measured live) but cannot carry a desktop yet, so desktop flavors are pinned `linux/amd64` in build-config with the re-add condition tested | re-add arm64 per flavor when the aarch64 index carries that desktop's manifest set |
 | dconf branding failure | **deliberately left failing** — guarding it would green cells that contain no desktop | fix only after manifest sections exist |
 | convergence | tunaos-packages seed grew for the first time since 08-09 (7170→7673); reserve budget stops *between* tiers (tunaos-packages#401), cosmic/niri/kde runs lost to the 6h ceiling | in-loop deadline check (#401), tier failures layer-00/01/02/07/10/11 to classify (#402/#403/#404 candidates) |
 

--- a/tests/test_hummingbird_arm64_honesty.py
+++ b/tests/test_hummingbird_arm64_honesty.py
@@ -1,0 +1,52 @@
+"""W8 architecture honesty, hummingbird arm64 (#1755 option A).
+
+The aarch64 rebuild repo began publishing on 2026-08-18
+(hummingbird/20251124-aarch64 — it 404'd when #1755 was filed), but it is a
+1358-package seed against x86_64's 8100: measured against its live
+primary.xml, cosmic has 8 of its 22 manifest packages, gnome 5 of 52, with
+no gnome-shell, no gdm, and no COSMIC compositor. An arm64 desktop leg
+would install almost nothing under --skip-unavailable and publish the #858
+shape — an image with no desktop — so the desktop flavors are pinned
+amd64-only until per-desktop coverage exists, exactly like grouper:cosmic.
+
+This test keeps the pin deliberate: whoever re-adds linux/arm64 to a
+desktop flavor deletes that flavor from the pinned set below IN THE SAME
+CHANGE, which is the reviewable claim that the aarch64 index now carries
+that desktop's manifest set.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+PINNED_AMD64_ONLY = {"gnome", "kde", "niri", "cosmic"}
+
+
+def _hummingbird() -> dict:
+    cfg = yaml.safe_load(
+        (ROOT / ".github" / "build-config.yml").read_text(encoding="utf-8"))
+    return next(v for v in cfg["variants"] if v["id"] == "hummingbird")
+
+
+def test_desktop_flavors_are_amd64_only_until_the_aarch64_repo_converges():
+    hb = _hummingbird()
+    for flavor in hb["flavors"]:
+        if flavor["id"] in PINNED_AMD64_ONLY:
+            assert flavor.get("platforms") == ["linux/amd64"], (
+                f"hummingbird:{flavor['id']} declares "
+                f"{flavor.get('platforms', hb['platforms'])} — re-adding "
+                f"arm64 requires measuring the desktop's manifest set "
+                f"against the live aarch64 index and removing the flavor "
+                f"from PINNED_AMD64_ONLY in the same change")
+
+
+def test_base_keeps_both_arches():
+    """base needs no rebuild repo and promotes on both arches — the pin is
+    about desktop package coverage, not the variant."""
+    hb = _hummingbird()
+    base = next(f for f in hb["flavors"] if f["id"] == "base")
+    assert base.get("platforms", hb["platforms"]) == [
+        "linux/amd64", "linux/arm64"]


### PR DESCRIPTION
Closes out W8's hummingbird-arm64 question with fresh measurement instead of the stale #1755 one.

## Measured today

`hummingbird/20251124-aarch64` **now serves** (it 404'd when #1755 was filed — the aarch64 factory leg from tunaos-packages#414 has published). But it is a **1358-package seed** against x86_64's 8100: checked against its live `primary.xml`, cosmic has **8 of its 22** manifest packages, gnome **5 of 52** — no gnome-shell, no gdm, no COSMIC compositor. An arm64 desktop leg today would install almost nothing under `--skip-unavailable` and publish the #858 shape: an image with no desktop.

## Change

- The four desktop flavors (gnome/kde/niri/cosmic) get `platforms: ["linux/amd64"]` — same treatment as grouper:cosmic's amd64 pin. Four guaranteed-red cells become *not offered*, honestly. `base` keeps both arches (needs no rebuild repo; promotes on both nightly).
- `tests/test_hummingbird_arm64_honesty.py` pins the decision: re-adding `linux/arm64` to a flavor requires removing it from the pinned set in the same change — so convergence is a reviewed, per-desktop, measured claim, with the re-measurement method referenced in the config comment.
- Plan's W8 box and hummingbird row updated with the measurement.

Refs #1755, #1754; tunaos-packages#414.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_