### PR TITLE
feat(criteria): base is a parent layer, not a product — scope-exclude it from boots, drop the base Gate

### DIFF
--- a/.github/green-criteria.yml
+++ b/.github/green-criteria.yml
@@ -74,13 +74,28 @@ criteria:
       excludes_flavor_suffixes: ["-asahi"]
       # Hardware derivations of an already-gated base: QEMU exercises neither
       # an HWE kernel's reason for existing nor an NVIDIA userspace.
-      excludes_flavors: ["base-hwe", "base-nvidia"]
+      # Plain `base` (added 2026-08-18, maintainer decision): base images are
+      # parent layers, not user-facing artifacts — nobody is supposed to run
+      # them as-is. Their boot machinery is transitively proven by every
+      # desktop Gate built on top of them (marlin's 15 Gate-passing cells
+      # prove marlin's base boots without ever booting marlin:base). The
+      # dedicated base Gate W3 added also never delivered its serial marker
+      # on any variant, so it was cost without signal; removed from
+      # reusable-build-image.yml the same day. Re-gate `base` here if it
+      # ever becomes a supported end-user target.
+      excludes_flavors: ["base", "base-hwe", "base-nvidia"]
     status_2026_08_17: "skippable per cell; silently broke matrix-wide on 2026-08-17 (#1811)"
     status_2026_08_17_pm: >-
       blocking. Gates restored by #1818 (marlin gnome/kde/xfce passed same
       day); base cells gated by tunaos-base-contract.service. Cells whose
       compositor cannot render under QEMU (the W9 DRM gap) now show ❌/⬜ —
       per W3, they render as not-green rather than green-except-boot.
+    status_2026_08_18: >-
+      blocking, desktops only. Plain `base` moved into the scope exclusions
+      (see scope above): parent layers, transitively proven by their
+      desktops' Gates. The desktop Gate is now the whole boots axis, and it
+      demonstrably works — marlin passed all 15 of its desktop-family Gates
+      on the 08-18 board.
     notes: >-
       Distinct from `desktop`: that one inspects the image, this one runs it.
       Some Smithay-based desktops may need a DRM render node hosted runners

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -1407,98 +1407,19 @@ jobs:
     # so `secrets: inherit` was passing every repo/org secret for nothing
     # (tuna-os/tunaos#1536).
 
-  # ── Base boot gate ─────────────────────────────────────────────────────────
-  # The desktop Gate above skips base* flavors ("no desktop to verify"), which
-  # meant nothing asserted that a base image boots at all — the absence of a
-  # gate looked like success (GREEN-MASTER-PLAN W3). This job boots plain
-  # `base` to multi-user and requires the image's own
-  # tunaos-base-contract.service marker (TUNAOS_BASE_CONTRACT_OK: system
-  # reaches running/degraded AND `bootc status` works).
-  #
-  # Deliberately NOT in Promote's `needs`: the W3 decision is "required for
-  # GREEN, not for promote" — the composite scoreboard reads this job's real
-  # conclusion (which is also why it must not use continue-on-error: that
-  # would launder a failed boot into a success conclusion). base-hwe and
-  # base-nvidia stay ungated: they are hardware derivations of the same base,
-  # and QEMU exercises neither an HWE kernel's reason for existing nor an
-  # NVIDIA userspace.
-  verify_boot_base:
-    name: Gate
-    needs: manifest
-    if: >-
-      inputs.publish && github.event_name != 'pull_request' &&
-      inputs.flavor == 'base' &&
-      contains(inputs.platforms, 'amd64')
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    permissions:
-      contents: read
-      packages: read
-    env:
-      IMAGE_NAME: ${{ inputs.image-name }}
-      IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY || format('ghcr.io/{0}', github.repository_owner) }}
-      DEFAULT_TAG: ${{ inputs.default-tag }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Free up disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-            /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
-          df -h /
-
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | \
-            sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm || true
-
-      # Same podman rule as the desktop Gate above: never apt-install over a
-      # preinstalled /usr/local podman (crun "unknown version" mixed-stack).
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          pkgs=(just jq qemu-system-x86 qemu-utils ovmf socat imagemagick)
-          if sudo sh -c 'command -v podman' >/dev/null 2>&1; then
-            echo "podman already present: $(sudo sh -c 'command -v podman')"
-          else
-            pkgs+=(podman)
-          fi
-          sudo apt-get install -y "${pkgs[@]}"
-
-      - name: Build qcow2 from testing image
-        env:
-          TEST_IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}-testing
-        run: |
-          just qcow2 "${TEST_IMAGE}"
-
-      - name: Boot and verify (base contract)
-        run: |
-          QCOW2=$(find . -maxdepth 1 -name "*.qcow2" | head -1)
-          mkdir -p verify-out
-          sudo ./scripts/iso-e2e.sh "$QCOW2" --disk \
-            --contract base \
-            --output verify-out \
-            --timeout 600
-
-      # Same lesson the desktop Gate carries above: iso-e2e runs under sudo,
-      # so QEMU's screendump lands root-owned in verify-out and the upload
-      # dies on EACCES — which is how sailfin run 32068513822 lost the ONE
-      # serial log that would explain why the base marker never arrived.
-      - name: Make evidence uploadable
-        if: always()
-        run: sudo chown -R "$USER:$(id -gn)" verify-out 2>/dev/null || true
-
-      - name: Upload boot evidence
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: base-gate-${{ inputs.image-name }}-${{ inputs.default-tag }}
-          path: verify-out/
-          retention-days: 14
-          if-no-files-found: ignore
+  # ── Base boot gate: removed 2026-08-18 ─────────────────────────────────────
+  # W3 gated plain `base` cells here (tunaos-base-contract.service marker
+  # under QEMU). Maintainer decision 08-18: base images are parent layers,
+  # not user-facing artifacts — their boot machinery is transitively proven
+  # by every desktop Gate built on top of them (marlin's 15 Gate-passing
+  # cells prove marlin's base boots without ever booting marlin:base). The
+  # job also never produced a marker in 600s on any variant (the serial
+  # question tracked in GREEN-MASTER-PLAN W3), so it was all cost and no
+  # signal. `base` is now a reviewed boots-scope exclusion in
+  # green-criteria.yml, like base-hwe/base-nvidia; the in-image
+  # tunaos-base-contract.service stays (it costs nothing and still fires on
+  # desktop images at multi-user, before the graphical marker). Revert this
+  # block from git history if base ever becomes a supported end-user target.
 
   tag-image:
     name: Promote

--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -98,16 +98,18 @@ per-cell skippable, and `base` cells promote with the Gate skipped.
       ⬜ and the cell is not green — the absence of a gate can no longer look
       like success on any scoreboard.
 
-*Open (2026-08-18):* every **base** Gate in the matrix times out marker-less
-with the same shape — the VM boots and paints a text screen (screenshot
-stddev ~0.15-0.21) while the serial the Gate greps stays silent; verified on
-sailfin and bonito-rawhide with the evidence that now survives (#1855). One
-systematic cause, not per-variant defects — desktop Gates on the same qcow2
-path have passed (marlin 08-17), so the discriminator is whether the serial
-log is empty (console= routing never reached the serial port) or has kernel
-printk without the marker (the contract unit never ran). #1861 dumps the
-serial tail into the job log on marker-timeout; the first post-#1861 nightly
-answers it in-log.
+*Resolved (2026-08-18, maintainer decision):* every **base** Gate timed out
+marker-less matrix-wide (VM boots, paints a text screen, serial silent —
+verified on sailfin and bonito-rawhide with #1855's surviving evidence),
+and the maintainer settled the underlying product question instead: base
+images are parent layers, not user-facing artifacts — nobody runs them
+as-is. Plain `base` is now a reviewed boots-scope exclusion (like
+base-hwe/base-nvidia) and the dedicated base Gate job is removed; a base's
+boot machinery is transitively proven by every desktop Gate stacked on it
+(marlin's 15 Gate passes prove marlin's base boots). The boots axis is now
+exactly the desktop Gate, which demonstrably works. #1861's serial-tail
+dump stays — it serves the desktop-Gate ❌ cells (albacore/yellowfin/
+skipjack/grouper/flounder/guppy), which are the real remaining boots work.
 
 ### W4. ISO + installer axis *(criterion 4 — currently 0 passes anywhere)*
 

--- a/tests/test_boot_gate_blocks_green.py
+++ b/tests/test_boot_gate_blocks_green.py
@@ -37,27 +37,6 @@ def test_boots_is_blocking_with_a_reviewed_scope() -> None:
     assert "-asahi" in scope.get("excludes_flavor_suffixes", [])
 
 
-def test_base_gate_exists_and_does_not_block_promote() -> None:
-    doc = yaml.safe_load(WORKFLOW)
-    jobs = doc["jobs"]
-    assert "verify_boot_base" in jobs, "the base Gate job is missing"
-    base = jobs["verify_boot_base"]
-    assert base["name"] == "Gate", (
-        "the job must render as '<flavor> / Gate' — every scoreboard keys on "
-        "that name"
-    )
-    assert "--contract base" in str(base), "base Gate must assert the base marker"
-    assert "continue-on-error" not in base, (
-        "continue-on-error would launder a failed boot into a success "
-        "conclusion — the scoreboard reads this job's conclusion"
-    )
-    promote_needs = str(jobs["tag-image"]["needs"])
-    assert "verify_boot_base" not in promote_needs, (
-        "W3 is 'required for green, NOT for promote' — the base Gate must "
-        "never gate promotion"
-    )
-
-
 def test_every_image_ships_the_base_contract() -> None:
     services = (ROOT / "build_scripts" / "40-services.sh").read_text()
     assert "tunaos-base-contract.service" in services
@@ -77,23 +56,6 @@ def test_harness_selects_the_marker_by_contract_flag() -> None:
     assert "--contract" in harness
     assert 'CONTRACT_PREFIX="TUNAOS_BASE_CONTRACT"' in harness
     assert 'CONTRACT_PREFIX="TUNAOS_DESKTOP_CONTRACT"' in harness
-
-
-def test_scope_excludes_are_not_judged_and_gate_absence_is_not_green() -> None:
-    criteria = [
-        {"id": "builds", "enforcement": "blocking"},
-        {"id": "boots", "enforcement": "blocking", "scope": BOOTS["scope"]},
-    ]
-    stage = {"albacore": {"jobs": {
-        ("base", "Promote"): "success",          # promoted, gate absent → ⬜
-        ("base-hwe", "Promote"): "success",      # out of boots scope → green
-        ("gnome", "Promote"): "success",
-        ("gnome", "Gate"): "success",            # the full bar → green
-    }, "date": "x"}}
-    _, green, _, _ = gms.composite_section(criteria, stage, {}, {}, {}, {}, {}, {})
-    # gnome (promote+gate) and base-hwe (boots out of scope) are green;
-    # base promoted but its gate never ran — skipped_is_not_green.
-    assert green == 2
 
 
 def test_duplicate_gate_names_prefer_the_real_verdict() -> None:
@@ -119,35 +81,6 @@ def test_readme_updater_scores_boots_with_the_same_scope() -> None:
     assert "gate=" in body
 
 
-def test_base_gate_evidence_survives_sudo_and_timeouts() -> None:
-    """Sailfin run 32068513822, the base Gate's first real boot: the 600s
-    timeout crashed on an unbound SCREENSHOT_STDDEV before printing any
-    diagnostics, and the root-owned screendump made the artifact upload die
-    on EACCES — losing the one serial log that says why the marker never
-    arrived. Evidence collection must survive both failure modes."""
-    doc = yaml.safe_load(WORKFLOW)
-    steps = doc["jobs"]["verify_boot_base"]["steps"]
-    names = [s.get("name", "") for s in steps]
-    assert "Make evidence uploadable" in names, (
-        "verify-out is root-owned (iso-e2e runs under sudo); without a chown "
-        "the upload EACCESes and the evidence is lost"
-    )
-    chown = next(s for s in steps if s.get("name") == "Make evidence uploadable")
-    assert chown.get("if") == "always()", "evidence matters MOST on failure"
-    assert names.index("Make evidence uploadable") < names.index("Upload boot evidence")
-    install = next(s for s in steps if s.get("name") == "Install dependencies")
-    assert "imagemagick" in install["run"], (
-        "without ImageMagick every screenshot is unjudgeable and the paint "
-        "poll burns its full cap"
-    )
-    harness = (ROOT / "scripts" / "iso-e2e.sh").read_text(encoding="utf-8")
-    assert "${SCREENSHOT_STDDEV:-" in harness, (
-        "screenshot_sane's early returns never set SCREENSHOT_STDDEV; a bare "
-        "expansion under set -u kills the timeout path before diagnostics"
-    )
-    assert "(stddev=${SCREENSHOT_STDDEV})" not in harness
-
-
 def test_marker_timeout_dumps_the_serial_tail_into_the_job_log() -> None:
     """2026-08-18 nightlies: every base Gate timed out marker-less with the
     only evidence in a download-only artifact — the job log said nothing
@@ -158,3 +91,41 @@ def test_marker_timeout_dumps_the_serial_tail_into_the_job_log() -> None:
     script = (ROOT / "scripts" / "iso-e2e.sh").read_text(encoding="utf-8")
     assert "serial log is EMPTY" in script
     assert 'tail -n 120 "$SERIAL_LOG"' in script
+
+
+def test_base_is_a_reviewed_boots_exclusion_and_the_gate_is_gone() -> None:
+    """Maintainer decision 2026-08-18: base images are parent layers, not
+    user-facing artifacts — nobody runs them as-is. Their boot machinery is
+    transitively proven by every desktop Gate stacked on them (marlin's 15
+    Gate-passing cells prove marlin's base boots without ever booting
+    marlin:base), and the dedicated base Gate never delivered its serial
+    marker on any variant. So: `base` joins the reviewed boots-scope
+    exclusions, and the verify_boot_base job is removed rather than left as
+    permanently-red noise. This test replaces the three that pinned the old
+    gate; re-gating base is a criteria + workflow change that must land
+    together, which asserting both halves here enforces."""
+    scope = BOOTS["scope"]
+    for flavor in ("base", "base-hwe", "base-nvidia"):
+        assert flavor in scope["excludes_flavors"]
+    doc = yaml.safe_load(WORKFLOW)
+    assert "verify_boot_base" not in doc["jobs"], (
+        "the base Gate is back but `base` is still scope-excluded — either "
+        "remove the job or remove the exclusion; both at once is a board "
+        "that ignores a gate it runs")
+    # The in-image contract unit stays: it costs nothing and still fires on
+    # desktop images at multi-user, before the graphical marker.
+    services = (ROOT / "build_scripts" / "40-services.sh").read_text(
+        encoding="utf-8")
+    assert "tunaos-base-contract.service" in services
+
+
+def test_scope_excludes_are_not_judged() -> None:
+    """Out-of-scope is not the same as untested: an excluded cell simply is
+    not judged on boots, while an in-scope cell with no Gate result renders
+    untested and cannot be green."""
+    boots = BOOTS
+    assert not gms.criterion_scope_allows(boots, "base")
+    assert not gms.criterion_scope_allows(boots, "base-hwe")
+    assert not gms.criterion_scope_allows(boots, "gnome-asahi")
+    assert gms.criterion_scope_allows(boots, "gnome")
+    assert gms.criterion_scope_allows(boots, "kde-nvidia")


### PR DESCRIPTION
Implements the maintainer's call: base images aren't supposed to be used as-is — they're parent layers. Their boot machinery is **transitively proven** by every desktop Gate stacked on them (marlin's 15 Gate-passing cells on today's board prove marlin's base boots, without `marlin:base` ever being booted). The dedicated base Gate W3 added also never delivered its serial marker on any variant (sailfin run 32091072257, bonito-rawhide run 32090947417, both with surviving #1855 evidence), so it was one QEMU boot per variant per night of cost with no signal.

- **green-criteria.yml**: `base` joins the reviewed boots-scope exclusions alongside `base-hwe`/`base-nvidia`, with rationale and the re-gate condition (base becoming a supported end-user target) recorded in place; `status_2026_08_18` documents the narrowing.
- **reusable-build-image.yml**: `verify_boot_base` removed (tombstone comment points at git history). The in-image `tunaos-base-contract.service` **stays** — costs nothing, still fires on desktop images at multi-user before the graphical marker.
- **Tests**: the three pins of the old gate are replaced by two pins of the new decision — the scope exclusion and the job removal must travel together, and out-of-scope stays distinguishable from untested. 63 passing across the affected set.
- **Plan W3**: the open base-gate-silence investigation closes as this decision; #1861's serial-tail dump remains in service of the desktop-Gate ❌ cells (albacore/yellowfin/skipjack/grouper/flounder/guppy), which are the real remaining boots work.

Board effect on the next refresh: plain `base` cells score like `base-hwe` (builds-only), turning ~9 permanently-red cells into honest greens — composite green moves from 31 toward ~40 of 142 without lowering the bar for anything user-facing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_