### PR TITLE
ci(refresh): arm auto-merge on the automation PRs so status updates land unattended

### DIFF
--- a/.github/workflows/matrix-status.yml
+++ b/.github/workflows/matrix-status.yml
@@ -129,6 +129,24 @@ jobs:
             echo "PR already open for $BRANCH — force-push refreshed it."
           fi
 
+          # Arm auto-merge so the refresh lands without a human. A PR opened
+          # with the Actions token triggers no pull_request workflows, so its
+          # own checks sit at "Expected" forever and the PR reads as waiting
+          # for approval — but this repo merges through a MERGE QUEUE, and
+          # the queue runs its required checks itself on the merge group
+          # (queue-initiated, so the bot-token workflow-trigger limitation
+          # does not apply there). Arming auto-merge is therefore sufficient:
+          # the PR enqueues immediately, the group checks run, and the
+          # refresh merges — measured on every auto-merged PR of 2026-08-18,
+          # each of which enqueued before its PR-level checks finished.
+          # Re-armed on every refresh because a merge clears auto-merge and
+          # the next refresh opens a fresh PR.
+          pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [[ -n "$pr" ]]; then
+            gh pr merge --auto --merge "$pr" ||
+              echo "::warning::could not arm auto-merge on #$pr — the refresh will wait for a human"
+          fi
+
       - name: Summary
         if: always()
         run: |

--- a/.github/workflows/update-build-status.yml
+++ b/.github/workflows/update-build-status.yml
@@ -109,3 +109,15 @@ jobs:
             echo "PR already open for $BRANCH -- force-push refreshed it."
           fi
 
+          # Arm auto-merge so the snapshot lands without a human — same
+          # mechanism and rationale as matrix-status.yml: bot-opened PRs
+          # trigger no pull_request checks, but the merge queue runs its
+          # required checks on the merge group itself, so arming is all the
+          # PR needs to enqueue and merge. Re-armed every refresh because a
+          # merge clears it.
+          pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [[ -n "$pr" ]]; then
+            gh pr merge --auto --merge "$pr" ||
+              echo "::warning::could not arm auto-merge on #$pr — the refresh will wait for a human"
+          fi
+


### PR DESCRIPTION
Fixes the "automation PRs wait for a human" problem for both status refreshers (matrix-status, README build status).

**Why they stall:** a PR opened with the Actions token triggers no `pull_request` workflows — its checks sit at "Expected" forever, and the PR reads as waiting for approval. **Why arming is sufficient:** main merges through a merge queue, and the queue runs its required checks itself on the merge group; queue-initiated runs are exempt from the bot-token trigger limitation. Measured on every auto-merged PR of 2026-08-18 — each enqueued the moment auto-merge was armed, before its own PR checks finished, and merged on the group's checks.

So the fix is one step in each workflow after create-or-refresh: `gh pr merge --auto --merge`, re-armed every refresh (a merge clears auto-merge; the next refresh opens a fresh PR). Failure to arm degrades to today's behavior with a loud `::warning::` instead of silence.

Deliberately **not** auto-merged: the weekly upstream-snapshots PR — its body asks for a human skim to spot porting candidates before the baseline moves.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_