### PR TITLE
docs(plan): classify bonito desktops — xfce healed, gnome/niri amd64 = F44 repo skew

### DIFF
--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -246,7 +246,7 @@ Same shape as yellowfin. Additionally:
 | area | state | action |
 |---|---|---|
 | base | **promoted 08-17** after #1806 re-pin | keep |
-| desktops | were blocked behind base; tonight xfce/arm64 built, xfce/amd64 failed — **undiagnosed** | classify remaining desktop failures now base is back |
+| desktops | classified 08-18: xfce **healed on both arches**; gnome/niri amd64 fail on F44 amd64 repo skew (libxslt/libtasn1/libnotify version walls + `LIBSYSTEMD_257` symbol missing) — upstream repo inconsistency, nothing here can fix it | heals when the F44 amd64 mirrors converge; re-check next nightly |
 | *-nvidia (5) | #1725 | as above |
 
 ### bonito-rawhide (Fedora Rawhide) — 6/14 build


### PR DESCRIPTION
One-line plan sync: the bonito desktop row in `docs/GREEN-MASTER-PLAN.md` was still marked **undiagnosed** from 08-17. The 08-18 evidence classifies it:

- **xfce healed on both arches** (built amd64 + arm64 on the latest nightly).
- **gnome/niri amd64** fail on Fedora 44 amd64 repo inconsistency: version walls on libxslt/libtasn1/libnotify plus a missing `LIBSYSTEMD_257` symbol — an upstream mirror-skew class this repo cannot fix. Action recorded as re-check when the F44 amd64 mirrors converge.

No code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_