### PR TITLE
fix(hummingbird): ship dconf in the cosmic image so the branding keyfiles can compile

### DIFF
--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -122,6 +122,16 @@ packages:
 
   fedora:
     packages:
+      # dconf is explicit, not assumed: the TunaOS branding keyfiles in
+      # /etc/dconf/db/distro.d need `dconf update` at build time, and
+      # verify-branding fails the build if the compiled db is missing. Full
+      # Fedora pulls dconf transitively so this line is a no-op there, but
+      # hummingbird's minimal rebuild does not (its cosmic chain never
+      # requires it — measured on the 2026-08-18 redispatch, where the image
+      # had keyfiles, no dconf binary, and TUNAOS_BRANDING_FAIL). The package
+      # is in the 20251124 hummingbird index. Listed in BOTH sections so the
+      # wiring test's pinned diff (exactly cosmic-settings-daemon) holds.
+      - dconf
       - cosmic-session
       - cosmic-comp
       - cosmic-panel
@@ -174,6 +184,10 @@ packages:
         baseurl: https://repo.tunaos.org/hummingbird/20251124-x86_64/
         priority: 5
     packages:
+      # See the fedora list's dconf note — needed here for real (the rebuild
+      # never pulls it transitively), mirrored there to keep the lists' diff
+      # pinned to exactly cosmic-settings-daemon.
+      - dconf
       - cosmic-session
       - cosmic-comp
       - cosmic-panel


### PR DESCRIPTION
The redispatched hummingbird run (32118324213) got further than any run before it: the amd64 base leg built and promoted (the nightly's had hung 4h in runner setup), the new cosmic manifest section installed, and the desktop-experience contract **passed** for the first time. The build then died at the very last check with `TUNAOS_BRANDING_FAIL variant=hummingbird failures=1`: the TunaOS keyfiles in `/etc/dconf/db/distro.d` were present but `/etc/dconf/db/distro` was never compiled — the image has no `dconf` binary, so `install-desktop.sh`'s own `dconf update` (guarded by `command -v dconf`) silently skipped.

Root cause: full Fedora pulls `dconf` transitively, hummingbird's minimal rebuild does not — nothing in the cosmic chain requires it. The package **is** in the 20251124 x86_64 index (verified against the live primary.xml).

Fix: list `dconf` explicitly in **both** the `fedora` and `hummingbird` cosmic package sections — a no-op on full Fedora, the missing binary on hummingbird — so `tests/bats/test_hummingbird_desktop_wiring.bats`'s pinned list-diff (exactly `cosmic-settings-daemon`) still holds. All 7 wiring bats tests pass locally.

This was the plan's "dconf branding failure — deliberately left failing, fix only after manifest sections exist" item; the cosmic section landing (#1859) and the contract passing on this run satisfied that condition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_