### PR TITLE
fix(nvidia): rebuild the inherited rpmdb before the kernel swap's first write

### DIFF
--- a/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
+++ b/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
@@ -73,6 +73,28 @@ if [[ "$INSTALLED_VERSION" == "$CACHED_VERSION" ]]; then
 	echo "==> kernels already aligned; no swap needed"
 else
 	echo "==> swapping image kernel to the akmods-matched ${CACHED_VERSION}"
+
+	# tunaOS#1823 on the EL10 surface (tunaOS#1725): on 2026-08-18 every EL10
+	# *-nvidia leg died right below with sqlite error 11 — "database disk
+	# image is malformed" on every INSERT of the kernel install transaction
+	# (albacore run 32090745718, all five legs, 3/3 buildah attempts) — the
+	# same error class bonito-rawhide hits in stage-2. The rpmdb this stage
+	# inherits is a sqlite file in a LOWER overlay layer; rpm mmaps it, and
+	# overlayfs copy-up under an mmap'd write is the known corruption shape.
+	# Rebuilding the db first forces the whole database through copy-up into
+	# THIS layer before the first write touches it. This is lib.sh's
+	# rawhide_rpmdb_probe graduating per its own protocol on a stable base:
+	# rebuild outcome + transaction outcome discriminate the two #1823
+	# readings, and if the copy-up reading is right, it fixes the swap
+	# outright. Deliberately FATAL on rebuild failure (unlike the rawhide
+	# probe, which runs on green pinned builds): every cell that reaches this
+	# branch is red today, and a db that cannot even rebuild at rest means
+	# the transaction below was never going to succeed — fail here with the
+	# discriminating signature in the log instead of 300 INSERT errors later.
+	echo "==> rebuilding the inherited rpmdb before the swap (copy-up guard, tunaOS#1823/#1725)"
+	rpm --rebuilddb
+	echo "TUNAOS_RPMDB_PROBE=rebuilt-pre-swap"
+
 	# Always remove these packages as kernel cache provides signed versions
 	# (bluefin-lts kernel-swap.sh, verbatim reasoning).
 	PKGS=("${KERNEL_NAME}" "${KERNEL_NAME}-core" "${KERNEL_NAME}-modules" "${KERNEL_NAME}-modules-core" "${KERNEL_NAME}-modules-extra" "${KERNEL_NAME}-uki-virt")

--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -232,7 +232,11 @@ the current failure is not semodule — all five albacore nvidia legs die in
 the overlay kernel swap with rpmdb sqlite corruption ("database disk image
 is malformed" on every INSERT while installing kernel-6.12.0-257.el10),
 i.e. the same rpmdb-under-buildah-overlay class as #1823, on a second
-variant surface. Count EL10 nvidia cells under #1823 until it resolves.*
+variant surface. Count EL10 nvidia cells under #1823 until it resolves.
+Copy-up guard landed same day: 10-kernel-swap.sh now runs `rpm
+--rebuilddb` before its first destructive write, forcing the inherited
+sqlite db through overlay copy-up — probe and candidate fix in one, per
+the #1823 protocol. Verify on the next nightly's nvidia legs.*
 
 ### yellowfin (AlmaLinux Kitten 10) — 12/20 build
 | area | state | action |

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -469,9 +469,32 @@ run_swap() {
   run_swap
   [ "$status" -eq 0 ]
   [[ "$output" == *"no swap needed"* ]]
-  # No erase and no kernel install happened.
+  # No erase and no kernel install happened — and no rebuilddb either: the
+  # copy-up guard exists to protect rpm WRITES, and the aligned branch
+  # makes none, so running it there would only add risk to green cells.
   ! grep -q 'rpm --erase' "${BATS_TEST_TMPDIR}/tool.log"
   ! grep -q 'dnf -y install' "${BATS_TEST_TMPDIR}/tool.log"
+  ! grep -q -- '--rebuilddb' "${BATS_TEST_TMPDIR}/tool.log"
+}
+
+@test "kernel-swap rebuilds the inherited rpmdb before its first destructive write" {
+  # tunaOS#1823 on EL10 (#1725): the swap's rpm --erase/-ivh run against a
+  # sqlite rpmdb inherited from a lower overlay layer, and every EL10
+  # *-nvidia leg died in that transaction with "database disk image is
+  # malformed" (albacore run 32090745718). The guard must force the db
+  # through copy-up BEFORE the first write — rebuilddb after an erase has
+  # already corrupted the db protects nothing, so the ORDER is the contract.
+  make_swap_stubs "6.12.0-250.el10.x86_64"
+  make_swap_fixture
+  run_swap
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TUNAOS_RPMDB_PROBE=rebuilt-pre-swap"* ]]
+  local rebuild_line first_erase_line
+  rebuild_line="$(grep -n -- '--rebuilddb' "${BATS_TEST_TMPDIR}/tool.log" | head -1 | cut -d: -f1)"
+  first_erase_line="$(grep -n -- '--erase' "${BATS_TEST_TMPDIR}/tool.log" | head -1 | cut -d: -f1)"
+  [ -n "$rebuild_line" ]
+  [ -n "$first_erase_line" ]
+  [ "$rebuild_line" -lt "$first_erase_line" ]
 }
 
 @test "kernel-swap replaces a mismatched kernel with the akmods one" {


### PR DESCRIPTION
Targets the largest tractable red cluster on the build axis: every EL10 `*-nvidia` leg dies in the overlay kernel swap with sqlite error 11 — `database disk image is malformed` on every INSERT of the kernel install transaction (albacore run 32090745718, all five legs, 3/3 buildah attempts). That's the same class bonito-rawhide hits in stage-2 (#1823), reported on #1725 this morning.

**Mechanism:** the overlay stage inherits `rpmdb.sqlite` from a lower overlay layer; rpm mmaps it, and overlayfs copy-up under an mmap'd write is the known sqlite corruption shape. `rpm --rebuilddb` before the swap's first destructive write forces the whole database through copy-up into the overlay's own layer.

**Probe and fix in one**, per #1823's own graduation protocol (`build_scripts/lib.sh` `rawhide_rpmdb_probe`):
- rebuild fails → the db is malformed at rest — the crisp discriminating signature, logged before failure instead of 300 INSERT errors later
- rebuild ok, transaction ok → copy-up was the cause; the nvidia cells go green
- rebuild ok, transaction still fails → corruption happens during the write itself; #1823 gets its answer either way

**Deliberately fatal** on rebuild failure, unlike the rawhide probe: every cell reaching the swap branch is red today, so this cannot break a green cell. Scoped to the swap branch only — the aligned branch makes no rpm writes, and the new bats test pins both the ordering (rebuild before the first erase) and the aligned branch staying rebuild-free. All 40 tests in `test_nvidia_overlay.bats` pass.

Verdict arrives with the next nightly's nvidia legs; plan updated with the verify note.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_