### PR TITLE
fix(iso): bound stalled tacklebox builds

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -218,6 +218,18 @@ tunaos_run_tacklebox() {
 	local recipe_file="${1:?recipe_file required}"
 	local out_dir="${2:?out_dir required}"
 	local iso_out="${3:?iso_out required}"
+	# Tacklebox currently reports a live-customize phase only as
+	# "running N script(s)". If a nested operation stalls, the surrounding
+	# 90-minute Actions job used to end as a bare cancellation with neither an
+	# actionable error nor its later diagnostic steps (#1772). Bound the whole
+	# invocation below that job limit so the failure says what happened and the
+	# workflow still has time to upload its evidence. Workflows with a reviewed
+	# longer budget may override this, but an unbounded value is never accepted.
+	local timeout_seconds="${TUNAOS_TACKLEBOX_TIMEOUT_SECONDS:-4800}"
+	[[ "$timeout_seconds" =~ ^[1-9][0-9]*$ ]] || {
+		echo "ERROR: TUNAOS_TACKLEBOX_TIMEOUT_SECONDS must be a positive integer" >&2
+		return 2
+	}
 
 	local tacklebox_image="${TACKLEBOX_IMAGE:-ghcr.io/tuna-os/tacklebox:latest}"
 	local from_source="${TACKLEBOX_FROM_SOURCE:-0}"
@@ -273,10 +285,23 @@ tunaos_run_tacklebox() {
 			"$tacklebox_image")
 	fi
 
-	"${tb[@]}" build "$(realpath "$recipe_file")" \
+	local -a build_cmd=("${tb[@]}" build "$(realpath "$recipe_file")" \
 		--iso "$(realpath "$iso_out")" \
 		--output-base "$(realpath "$out_dir")" \
-		--yes
+		--yes)
+
+	echo "==> Running tacklebox with a ${timeout_seconds}s deadline" >&2
+	if timeout --foreground --kill-after=120 "$timeout_seconds" "${build_cmd[@]}"; then
+		return 0
+	else
+		local rc=$?
+		if [[ "$rc" -eq 124 || "$rc" -eq 137 ]]; then
+			echo "::error::tacklebox exceeded its ${timeout_seconds}s deadline; " \
+				"see tunaOS#1772 and the workflow diagnostics below" >&2
+			podman ps -a 2>&1 || true
+		fi
+		return "$rc"
+	fi
 }
 
 # ── bootc storage backend detection (tunaOS#954) ──────────────────────────

--- a/tests/bats/test_build_iso_tacklebox.bats
+++ b/tests/bats/test_build_iso_tacklebox.bats
@@ -362,6 +362,14 @@ JSON
   [ "$TACKLEBOX_IMAGE" = "quay.io/custom/tacklebox:dev" ]
 }
 
+@test "tacklebox invocation has a bounded, overrideable deadline" {
+	SCRIPT_PATH="${REPO_ROOT:-$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)}/scripts/lib/common.sh"
+	grep -q 'TUNAOS_TACKLEBOX_TIMEOUT_SECONDS:-4800' "$SCRIPT_PATH"
+	grep -q 'timeout --foreground --kill-after=120' "$SCRIPT_PATH"
+	grep -q 'tunaOS#1772' "$SCRIPT_PATH"
+	grep -q 'must be a positive integer' "$SCRIPT_PATH"
+}
+
 # ── Variant matrix ─────────────────────────────────────────────────────────
 
 @test "variants: all four variants produce valid output dirs" {


### PR DESCRIPTION
Addresses the local harness portion of #1772.

Tacklebox can leave CI at `[customize] running N script(s)` until Actions cancels the outer 90-minute job, skipping the useful diagnostic/upload steps. The shared runner now imposes a default 80-minute foreground deadline (overrideable only with a positive `TUNAOS_TACKLEBOX_TIMEOUT_SECONDS`), kills a stalled process group, emits a classified error, and prints the remaining Podman containers.

This does not claim to fix the upstream stall; it converts the silent cancellation into actionable evidence while leaving reviewed longer workflows able to override the deadline.

Validation:
- `bash -n scripts/lib/common.sh`
- `bash -n scripts/build-iso-tacklebox.sh`
- Regression assertions for the deadline wiring
- `git diff --check`

Bats is unavailable in this workspace; CI runs the added Bats test.