### PR TITLE
fix(gate): identify early desktop-contract exits

### DIFF
--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -12,7 +12,14 @@ marker_emitted=0
 emit_fail_on_early_exit() {
 	local rc=$?
 	if [[ "$mode" == --runtime && "$rc" -ne 0 && "$marker_emitted" -eq 0 ]]; then
-		echo "TUNAOS_DESKTOP_CONTRACT_FAIL desktop=${desktop} reason=early_exit rc=${rc}" | tee /dev/ttyS0 2>/dev/null || true
+		# The static assertions run before the runtime summary block below.  Keep
+		# their failure actionable in a serial-only Gate: without this, the
+		# harness only gets `early_exit rc=1` and cannot distinguish a missing
+		# session, portal, keyring, or display-manager unit.
+		local line="${BASH_LINENO[0]:-unknown}"
+		local command="${BASH_COMMAND:-unknown}"
+		printf 'TUNAOS_DESKTOP_CONTRACT_FAIL desktop=%s reason=early_exit rc=%s line=%s command=%q\n' \
+			"${desktop}" "${rc}" "${line}" "${command}" | tee /dev/ttyS0 2>/dev/null || true
 	fi
 }
 trap emit_fail_on_early_exit EXIT
@@ -92,12 +99,12 @@ require_any_user_unit() {
 
 # xfce's greeter is the one desktop piece NO other gate can see missing.
 # xfce.sh installs its DM stack via install_available: lightdm first, greetd
-# as the fallback — and greetd's stock config runs `agreety --cmd /bin/sh`,
+# as the fallback â and greetd's stock config runs `agreety --cmd /bin/sh`,
 # a text prompt into a bare shell. If gtkgreet (or cage, its kiosk host)
 # fails to land, xfce.sh deliberately leaves that stock config in place, the
 # installed system still reaches graphical.target with an ACTIVE
 # display-manager.service, and both the runtime contract's dm check and the
-# LUKS gate read green — xfce.sh's own comment documents the blindness.
+# LUKS gate read green â xfce.sh's own comment documents the blindness.
 # So assert the greeter statically, on exactly the branch xfce.sh's enable
 # logic takes: greetd is this image's DM if and only if lightdm did not land.
 xfce_greetd_greeter_contract() {
@@ -107,13 +114,13 @@ xfce_greetd_greeter_contract() {
 	require_command cage
 	local greetd_conf="${TUNAOS_VERIFY_ROOT:-}/etc/greetd/config.toml"
 	if ! grep -qs 'gtkgreet' "$greetd_conf"; then
-		echo "greetd is the display manager but ${greetd_conf} does not launch gtkgreet — stock agreety boots users to a text prompt, not a login screen" >&2
+		echo "greetd is the display manager but ${greetd_conf} does not launch gtkgreet â stock agreety boots users to a text prompt, not a login screen" >&2
 		if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then return 0; fi
 		exit 1
 	fi
 }
 
-# PORTAL/KEYRING/GVFS PATHS — measured, one container per packaging family.
+# PORTAL/KEYRING/GVFS PATHS â measured, one container per packaging family.
 # Never add a glob you have not seen resolve on a real distro: an invented
 # pattern that matches nothing turns a working desktop red, which is exactly
 # what '/usr/lib/*/gvfs/gvfsd' did to sailfin and marlin.
@@ -122,7 +129,7 @@ xfce_greetd_greeter_contract() {
 #   Fedora / EL     /usr/libexec/gvfsd             /usr/libexec/...
 #   Debian/Ubuntu   /usr/libexec/gvfsd AND         /usr/libexec/...
 #                   /usr/lib/gvfs/gvfsd
-#                   (package is gvfs-daemons, NOT gvfs — plain gvfs ships
+#                   (package is gvfs-daemons, NOT gvfs â plain gvfs ships
 #                    only libgvfsdbus.so, so probing gvfs finds nothing)
 #   openSUSE        /usr/libexec/gvfs/gvfsd        /usr/libexec/...
 #   Arch            /usr/lib/gvfsd                 /usr/lib/...
@@ -136,7 +143,7 @@ gnome)
 	# Ubuntu names its GNOME session `ubuntu.desktop`, not `gnome*.desktop`.
 	# Measured on the published grouper:gnome: /usr/share/wayland-sessions
 	# contains exactly `ubuntu.desktop`, /usr/share/xsessions does not exist,
-	# and gnome-shell IS installed — so the old glob reported a working GNOME
+	# and gnome-shell IS installed â so the old glob reported a working GNOME
 	# desktop as broken. A contract that fails a healthy image is worse than no
 	# contract: it trains people to ignore it.
 	require_any_glob \
@@ -147,7 +154,7 @@ gnome)
 	# Session-can-start is not the same as desktop-is-usable, and the gap
 	# between them is exactly how sailfin:gnome shipped. openSUSE's
 	# patterns-gnome-gnome provides gnome-shell, a wayland session and gdm
-	# — every check above — while providing no file manager, no portal
+	# â every check above â while providing no file manager, no portal
 	# backend, no keyring and no gvfs. It passed this gate with 192
 	# packages against yellowfin:gnome's 576 (tunaos-packages#132).
 	#
@@ -158,16 +165,16 @@ gnome)
 	# do not mount (gvfs).
 	#
 	# Deliberately scoped to GNOME. Every one was verified present in
-	# yellowfin:gnome and albacore:gnome before being made mandatory — a
+	# yellowfin:gnome and albacore:gnome before being made mandatory â a
 	# requirement that has not been checked against a known-good image
 	# turns working builds red instead of catching broken ones. Extend to
 	# kde/xfce/niri/cosmic the same way: measure a healthy image first.
 	require_command nautilus
-	# One glob per packaging family — see the measured table above the case.
+	# One glob per packaging family â see the measured table above the case.
 	# openSUSE (/usr/libexec/gvfs/gvfsd, owned by gvfs-1.60.1 on Tumbleweed)
 	# and Arch (/usr/lib/gvfsd) were the two real paths missing: sailfin:gnome
 	# installed gvfs, gvfs-backends and gvfs-fuse and still failed this gate.
-	# NB Debian does NOT use a multiarch triplet here — measured, it is plain
+	# NB Debian does NOT use a multiarch triplet here â measured, it is plain
 	# /usr/lib/gvfs/gvfsd (plus /usr/libexec/gvfsd), so no /usr/lib/*/ arm is
 	# needed and none is kept.
 	require_any_glob \
@@ -192,7 +199,7 @@ gnome)
 		exit 1
 	fi
 	# dconf compiled database: every keyfile dir /etc/dconf/db/<name>.d/ must have
-	# a compiled /etc/dconf/db/<name>. Iterate instead of hardcoding local/gdm —
+	# a compiled /etc/dconf/db/<name>. Iterate instead of hardcoding local/gdm â
 	# distros ship their own keyfile dirs (ibus.d on Arch) already compiled by
 	# package postinst; hardcoding local/gdm fails those falsely.
 	for _dcf_dir in /etc/dconf/db/*.d; do
@@ -218,8 +225,8 @@ kde)
 	# NO terminal, because patterns-kde-kde resolves to the shell only.
 	# dolphin and konsole are the two the user cannot work without, and they
 	# are the only KDE applications listed EXPLICITLY in every manifest
-	# section that builds KDE — kde.yaml apt/fedora/el10/zypper/emerge plus
-	# kde-arch.yaml and kde-debian.yaml — so requiring them cannot redden a
+	# section that builds KDE â kde.yaml apt/fedora/el10/zypper/emerge plus
+	# kde-arch.yaml and kde-debian.yaml â so requiring them cannot redden a
 	# variant that is building correctly. Deliberately NOT asserted:
 	# xdg-desktop-portal-kde (absent from the emerge list, and guppy builds
 	# KDE) and plasma6-nm/kwallet (nowhere explicit; they arrive as
@@ -235,14 +242,14 @@ niri)
 	require_unit greetd
 	# niri is only a compositor: it has no portal, no secret store and no
 	# shell of its own. sailfin:niri shipped `niri` and `greetd` and nothing
-	# else. The shell itself cannot be asserted — Fedora and EL10 use DMS
+	# else. The shell itself cannot be asserted â Fedora and EL10 use DMS
 	# (quickshell) while openSUSE uses the wlroots stack (waybar/fuzzel),
 	# because quickshell and dms are not built for the opensuse-tumbleweed
 	# target yet: it IS declared in manifests/package-factory.yaml, but has no
 	# cells in the package build gate (tunaos-packages#139). Revisit when it
 	# does. The portal and the keyring ARE common:
 	# both are explicit in every niri section that builds (fedora, el10,
-	# zypper, pacman). Accept the gtk backend alongside gnome — a variant may
+	# zypper, pacman). Accept the gtk backend alongside gnome â a variant may
 	# reasonably ship only the former.
 	require_any_glob \
 		'/usr/libexec/xdg-desktop-portal-gnome' '/usr/lib/xdg-desktop-portal-gnome' \
@@ -260,7 +267,7 @@ cosmic)
 	#
 	# cosmic-files and xdg-desktop-portal-cosmic are explicit, non-optional
 	# entries in manifests/desktops/cosmic.yaml's apt, fedora and zypper
-	# sections, and in cosmic-arch.yaml's pacman section — the same bar
+	# sections, and in cosmic-arch.yaml's pacman section â the same bar
 	# dolphin/konsole (kde) and thunar (xfce) were required on ("explicit in
 	# every manifest section that builds"). Without a file manager COSMIC is
 	# not merely sparse, it is unusable the same way sailfin:gnome was
@@ -271,7 +278,7 @@ cosmic)
 	# (cosmic.yaml's el10.copr section), and install-desktop.sh installs
 	# every copr block with `|| true` (the exact "COPR packages" step,
 	# distinct from the regular `dnf_retry -y install` used for fedora/apt/
-	# zypper/pacman, which has no such fallback) — a flaky COPR there can
+	# zypper/pacman, which has no such fallback) â a flaky COPR there can
 	# legitimately produce a build that has always shipped correctly. The
 	# condition below reproduces install-desktop.sh's own _TD_OS="el10"
 	# fallback exactly (dnf-based, not Fedora, not Hummingbird) rather than
@@ -281,19 +288,19 @@ cosmic)
 	# Binary path for cosmic-files confirmed live (mdapi.fedoraproject.org
 	# rawhide file list, 2026-08-08): /usr/bin/cosmic-files, so a plain PATH
 	# check is correct. xdg-desktop-portal-cosmic confirmed the same way:
-	# /usr/libexec/xdg-desktop-portal-cosmic on Fedora — matching this same
+	# /usr/libexec/xdg-desktop-portal-cosmic on Fedora â matching this same
 	# file's already-twice-measured portal convention (libexec on Fedora/EL/
 	# Debian/Ubuntu/openSUSE, lib on Arch, see the table above the case
 	# statement), which xdg-desktop-portal-cosmic packaging follows for the
 	# same reason its sibling backends (-gnome, -gtk) do: all three build
 	# from the same upstream xdg-desktop-portal libexecdir convention per
 	# distro. Not independently re-measured on Ubuntu/openSUSE/Arch in this
-	# change (no zstd tooling available to read their repodata here) — recorded
+	# change (no zstd tooling available to read their repodata here) â recorded
 	# so the next person knows which half of this is live-verified and which
 	# is carried over from an already-established pattern, same as this
 	# file's own stated rule asks for.
 	if [[ "${PKG_MGR:-}" == "dnf" && "${IS_FEDORA:-false}" != true && "${IS_HUMMINGBIRD:-false}" != true ]]; then
-		echo "info: skipping cosmic-files/xdg-desktop-portal-cosmic on the el10 family — cosmic.yaml sources them from a best-effort COPR here (tunaOS#916)"
+		echo "info: skipping cosmic-files/xdg-desktop-portal-cosmic on the el10 family â cosmic.yaml sources them from a best-effort COPR here (tunaOS#916)"
 	else
 		require_command cosmic-files
 		require_any_glob \
@@ -315,16 +322,16 @@ xfce)
 	require_any_glob '/usr/share/xsessions/*xfce*.desktop' '/usr/share/wayland-sessions/*xfce*.desktop'
 	require_any_unit gdm gdm3 lightdm greetd
 	# sailfin:xfce shipped a session with no file manager thumbnails, no
-	# gvfs and NO portal at all — Flatpak file dialogs were simply broken.
+	# gvfs and NO portal at all â Flatpak file dialogs were simply broken.
 	# thunar and xdg-desktop-portal-gtk are explicit in every xfce section
 	# that builds (fedora, el10, apt, zypper, pacman). NOT asserted:
-	# xfce4-terminal — Debian gets it via the `xfce4` metapackage's
+	# xfce4-terminal â Debian gets it via the `xfce4` metapackage's
 	# Recommends, which an apt build may legitimately not install.
 	require_command thunar
 	require_any_glob \
 		'/usr/libexec/xdg-desktop-portal-gtk' '/usr/lib/xdg-desktop-portal-gtk'
 
-	# xfwl4 reads xfwm4's THEME DATA and panics without it — not a warning, a
+	# xfwl4 reads xfwm4's THEME DATA and panics without it â not a warning, a
 	# hard abort before the session exists:
 	#
 	#   xfwl4::backend::udev: Using renderD128 as primary GPU
@@ -334,7 +341,7 @@ xfce)
 	#
 	# yellowfin:xfce in installer-smoke run 31183217981 booted to a console of
 	# that backtrace: no desktop, no installer, nothing to screenshot. It reads
-	# like the GPU-less runner limitation and is not — the same log line says a
+	# like the GPU-less runner limitation and is not â the same log line says a
 	# render node WAS found.
 	#
 	# xfce.sh already pulls xfwm4 for this reason, but through
@@ -360,7 +367,7 @@ pantheon)
 	# gurnard only: Pantheon comes exclusively from ppa:elementary-os/stable
 	# (manifests/desktops/pantheon.yaml). Until 2026-08-07 this case did not
 	# exist, so gurnard:pantheon sailed through the LUKS gates with
-	# desktop_contract=absent — a green cell whose desktop was never proven
+	# desktop_contract=absent â a green cell whose desktop was never proven
 	# (run 31074188677, found by the full-matrix contract audit). The asserts
 	# mirror what the manifest actually installs, nothing invented: `gala` is
 	# the compositor package and its binary keeps that name, the session
@@ -372,7 +379,7 @@ pantheon)
 	# settings 8.1.0+r419, dpkg -c, 2026-08-07): xsessions/pantheon.desktop
 	# and wayland-sessions/pantheon-wayland.desktop. The first run of this
 	# contract (31187758113) failed here and the failure was REAL: no package
-	# in the manifest shipped any session entry at all — the greeter had
+	# in the manifest shipped any session entry at all â the greeter had
 	# nothing to launch. pantheon-xsession-settings is that package; the
 	# manifest now installs it.
 	require_any_glob '/usr/share/xsessions/pantheon*.desktop' \
@@ -401,14 +408,14 @@ if [[ "$mode" == --runtime ]]; then
 	fi
 	# NB: never check `is-active graphical.target` here. This service is
 	# WantedBy=graphical.target, and targets gain implicit After= on their
-	# wants — the target cannot become active until this script exits, so
+	# wants â the target cannot become active until this script exits, so
 	# that check self-deadlocks into a guaranteed failure. Assert the boot
 	# *default* instead; liveness comes from the display-manager check below.
 	if [[ "$(systemctl get-default 2>/dev/null)" != graphical.target ]]; then
 		report_fail default_target_not_graphical
 	fi
 	# Check the display-manager.service alias (every DM registers it) and
-	# verify its Id resolves to a DM this desktop's contract allows — robust
+	# verify its Id resolves to a DM this desktop's contract allows â robust
 	# to per-distro unit names (gdm vs gdm3, lightdm vs greetd for xfce).
 	dm_id=$(systemctl show -P Id display-manager.service 2>/dev/null || true)
 	if ! systemctl is-active --quiet display-manager.service 2>/dev/null; then
@@ -417,7 +424,7 @@ if [[ "$mode" == --runtime ]]; then
 		# structural: the DM logs to the journal, while the E2E gate can only
 		# read the serial console, so the actual error is invisible and every
 		# hypothesis costs a full image build. Ship the evidence with the
-		# failure — this is how a greetd exiting instantly on a missing
+		# failure â this is how a greetd exiting instantly on a missing
 		# greeter account looked identical to one whose greeter could not
 		# render.
 		{
@@ -439,8 +446,8 @@ if [[ "$mode" == --runtime ]]; then
 	fi
 	marker_emitted=1
 else
-	# ── Static unit-graph validation (pattern from secureblue's
-	# validate_systemd_unit_files.sh) ── catches unit typos, missing
+	# ââ Static unit-graph validation (pattern from secureblue's
+	# validate_systemd_unit_files.sh) ââ catches unit typos, missing
 	# executables and broken dependency graphs before the image ships.
 	# Warn-only by default (upstream units carry pre-existing noise on some
 	# variants); SYSTEMD_VERIFY_FATAL=1 enforces, mirroring BOOTC_LINT_FATAL.
@@ -457,7 +464,7 @@ else
 		fi
 	fi
 
-	# ── Launcher validation (pattern from ublue-os/aurora's 20-tests.sh) ──
+	# ââ Launcher validation (pattern from ublue-os/aurora's 20-tests.sh) ââ
 	# desktop-file-validate every shipped launcher; exit code only reflects
 	# errors (not warnings), but stock distro apps still carry occasional
 	# errors, so warn-only by default with DESKTOP_VALIDATE_FATAL=1 to
@@ -481,22 +488,22 @@ else
 		fi
 	fi
 
-	# ── Codec baseline ──
-	# "Codecs installed" was promised on every family and verified on none —
+	# ââ Codec baseline ââ
+	# "Codecs installed" was promised on every family and verified on none â
 	# the EL10 x86_64_v2 leg shipped ffmpeg-free only (no H.264/H.265 at
 	# all) and marlin shipped gst-plugins-ugly without gst-libav (x264
 	# ENcoder present, no mainstream DEcoder), and both were green. Two
 	# file-level proofs, both cheap and network-free:
 	#
-	# 1. The GStreamer libav plugin exists — the piece that lets totem,
+	# 1. The GStreamer libav plugin exists â the piece that lets totem,
 	#    thumbnailers and WebKit decode through libavcodec. One measured
 	#    path per packaging family (repo rule: no unmeasured globs):
 	#      rpm/openSUSE/Gentoo  /usr/lib64/gstreamer-1.0/libgstlibav.so
 	#      Arch                 /usr/lib/gstreamer-1.0/libgstlibav.so
 	#      Debian/Ubuntu        /usr/lib/<triplet>/gstreamer-1.0/libgstlibav.so
-	#      (the apt path MEASURED on ubuntu:noble — gstreamer1.0-libav ships
+	#      (the apt path MEASURED on ubuntu:noble â gstreamer1.0-libav ships
 	#      /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstlibav.so)
-	# 2. `ffmpeg -decoders` actually lists h264 — the plugin above routes
+	# 2. `ffmpeg -decoders` actually lists h264 â the plugin above routes
 	#    into libavcodec, so a free-codec libavcodec (the exact v2 failure)
 	#    is caught here even though the plugin file exists.
 	require_any_glob \
@@ -507,20 +514,20 @@ else
 	if command -v ffmpeg >/dev/null 2>&1; then
 		# NEVER pipe ffmpeg straight into `grep -q` here. grep -q exits at the
 		# first match, ffmpeg is still writing its ~30 KB decoder list, gets
-		# SIGPIPE, exits 141 — and under this script's `set -o pipefail` the
+		# SIGPIPE, exits 141 â and under this script's `set -o pipefail` the
 		# pipeline reports failure WITH the decoder present. That is not a
 		# race in practice: measured on ubuntu:noble (ffmpeg 6.1.1, h264
 		# decoder confirmed in the output), the piped form returned 141 on
 		# five out of five runs and failed gurnard:pantheon's proof build
 		# (run 31196812732) with a message blaming a "crippled libavcodec"
-		# the image did not have. Capture first, then grep the variable —
+		# the image did not have. Capture first, then grep the variable â
 		# and keep "ffmpeg would not run" distinct from "ffmpeg runs but
 		# cannot decode", because their fixes live in different places
 		# (packaging deps vs codec sourcing).
 		# Both failure branches dump the evidence that names the cause,
 		# because this check fired on guppy:xfce (run 31201546516) with a
-		# freshly source-built ffmpeg 8.1.2 whose USE line showed x264 —
-		# a build where the native h264 decoder should be unconditional —
+		# freshly source-built ffmpeg 8.1.2 whose USE line showed x264 â
+		# a build where the native h264 decoder should be unconditional â
 		# while the same check passes inside the July guppy:gnome image
 		# and against Alpine's 8.1.2. Three container reproductions of the
 		# tooling stage could not replicate it (portage tree drift), so
@@ -545,13 +552,13 @@ else
 		_ffmpeg_stderr="$(head -c 2048 "$_ffmpeg_stderr_file")"
 		rm -f "$_ffmpeg_stderr_file"
 		if ((_ffmpeg_rc != 0)); then
-			echo "ffmpeg is installed but would not run (broken dependencies?) — cannot verify codecs" >&2
+			echo "ffmpeg is installed but would not run (broken dependencies?) â cannot verify codecs" >&2
 			_ffmpeg_diag
 			if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
 				exit 1
 			fi
 		elif ! grep -q ' h264 ' <<<"$_ffmpeg_decoders"; then
-			echo "ffmpeg cannot decode h264 — a free/crippled libavcodec is installed" >&2
+			echo "ffmpeg cannot decode h264 â a free/crippled libavcodec is installed" >&2
 			_ffmpeg_diag
 			if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
 				exit 1
@@ -559,11 +566,11 @@ else
 		fi
 	fi
 
-	# ── KDE version-skew guard (pattern from ublue-os/aurora's 20-tests.sh) ──
+	# ââ KDE version-skew guard (pattern from ublue-os/aurora's 20-tests.sh) ââ
 	# Mid-compose repo skew can ship kwin/kscreen from a newer Plasma than
 	# plasma-desktop; the session then crashes at login while every package
 	# transaction "succeeded". Version equality across installed Plasma core
-	# packages is a hard invariant on rpm variants — fail the build on skew.
+	# packages is a hard invariant on rpm variants â fail the build on skew.
 	if [[ "$desktop" == kde ]] && command -v rpm >/dev/null 2>&1; then
 		if plasma_ver=$(rpm -q --qf '%{VERSION}' plasma-desktop 2>/dev/null); then
 			for pkg in kscreen kwin; do
@@ -587,16 +594,16 @@ else
 		fi
 	fi
 
-	# ── Flatpak baseline (store + browser + a remote that can serve them) ──
+	# ââ Flatpak baseline (store + browser + a remote that can serve them) ââ
 	# Asserts exactly what the build now lays down, nothing aspirational:
 	# tuna-flatpak-remote.sh bakes the Flathub remote on every base, and
 	# flatpak-preinstall.sh declares the curated set (io.github.kolunmi.Bazaar
-	# as the store, org.mozilla.firefox as the browser — Bluefin's choices)
+	# as the store, org.mozilla.firefox as the browser â Bluefin's choices)
 	# and enables flatpak-preinstall.service where the base's flatpak ships
 	# it. Guarded on flatpak existing so a hypothetical flatpak-less image is
 	# out of scope rather than red. The per-app grep list below is kept in
 	# lockstep with flatpak-preinstall.sh by
-	# tests/bats/test_build_scripts_remaining.bats — change both together.
+	# tests/bats/test_build_scripts_remaining.bats â change both together.
 	if command -v flatpak >/dev/null 2>&1; then
 		require_glob '/etc/flatpak/remotes.d/flathub.flatpakrepo'
 		require_glob '/usr/share/flatpak/preinstall.d/*.preinstall'
@@ -608,11 +615,11 @@ else
 				fi
 			fi
 		done
-		# Where the unit exists, declarations without the service are inert —
+		# Where the unit exists, declarations without the service are inert â
 		# that combination shipped: preinstall files with nothing to run them.
 		if [[ -f /usr/lib/systemd/system/flatpak-preinstall.service ]]; then
 			if ! systemctl is-enabled flatpak-preinstall.service >/dev/null 2>&1; then
-				echo "flatpak-preinstall.service is shipped but not enabled — the declared flatpaks would never install" >&2
+				echo "flatpak-preinstall.service is shipped but not enabled â the declared flatpaks would never install" >&2
 				if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
 					exit 1
 				fi
@@ -622,7 +629,7 @@ else
 		fi
 	fi
 
-	# ── Branding & Asset Contract ──
+	# ââ Branding & Asset Contract ââ
 	# Wallpapers: shipping only upstream artwork means a user sees upstream background on login.
 	if ! compgen -G "/usr/share/backgrounds/tunaos*" >/dev/null &&
 		! compgen -G "/usr/share/backgrounds/*/tunaos*" >/dev/null &&
@@ -634,7 +641,7 @@ else
 	fi
 
 	# dconf compiled database: every keyfile dir /etc/dconf/db/<name>.d/ must have
-	# a compiled /etc/dconf/db/<name>. Iterate instead of hardcoding local/gdm —
+	# a compiled /etc/dconf/db/<name>. Iterate instead of hardcoding local/gdm â
 	# distros ship their own keyfile dirs (ibus.d on Arch) already compiled by
 	# package postinst; hardcoding local/gdm fails those falsely.
 	for _dcf_dir in /etc/dconf/db/*.d; do

--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -99,12 +99,12 @@ require_any_user_unit() {
 
 # xfce's greeter is the one desktop piece NO other gate can see missing.
 # xfce.sh installs its DM stack via install_available: lightdm first, greetd
-# as the fallback â and greetd's stock config runs `agreety --cmd /bin/sh`,
+# as the fallback — and greetd's stock config runs `agreety --cmd /bin/sh`,
 # a text prompt into a bare shell. If gtkgreet (or cage, its kiosk host)
 # fails to land, xfce.sh deliberately leaves that stock config in place, the
 # installed system still reaches graphical.target with an ACTIVE
 # display-manager.service, and both the runtime contract's dm check and the
-# LUKS gate read green â xfce.sh's own comment documents the blindness.
+# LUKS gate read green — xfce.sh's own comment documents the blindness.
 # So assert the greeter statically, on exactly the branch xfce.sh's enable
 # logic takes: greetd is this image's DM if and only if lightdm did not land.
 xfce_greetd_greeter_contract() {
@@ -114,13 +114,13 @@ xfce_greetd_greeter_contract() {
 	require_command cage
 	local greetd_conf="${TUNAOS_VERIFY_ROOT:-}/etc/greetd/config.toml"
 	if ! grep -qs 'gtkgreet' "$greetd_conf"; then
-		echo "greetd is the display manager but ${greetd_conf} does not launch gtkgreet â stock agreety boots users to a text prompt, not a login screen" >&2
+		echo "greetd is the display manager but ${greetd_conf} does not launch gtkgreet — stock agreety boots users to a text prompt, not a login screen" >&2
 		if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then return 0; fi
 		exit 1
 	fi
 }
 
-# PORTAL/KEYRING/GVFS PATHS â measured, one container per packaging family.
+# PORTAL/KEYRING/GVFS PATHS — measured, one container per packaging family.
 # Never add a glob you have not seen resolve on a real distro: an invented
 # pattern that matches nothing turns a working desktop red, which is exactly
 # what '/usr/lib/*/gvfs/gvfsd' did to sailfin and marlin.
@@ -129,7 +129,7 @@ xfce_greetd_greeter_contract() {
 #   Fedora / EL     /usr/libexec/gvfsd             /usr/libexec/...
 #   Debian/Ubuntu   /usr/libexec/gvfsd AND         /usr/libexec/...
 #                   /usr/lib/gvfs/gvfsd
-#                   (package is gvfs-daemons, NOT gvfs â plain gvfs ships
+#                   (package is gvfs-daemons, NOT gvfs — plain gvfs ships
 #                    only libgvfsdbus.so, so probing gvfs finds nothing)
 #   openSUSE        /usr/libexec/gvfs/gvfsd        /usr/libexec/...
 #   Arch            /usr/lib/gvfsd                 /usr/lib/...
@@ -143,7 +143,7 @@ gnome)
 	# Ubuntu names its GNOME session `ubuntu.desktop`, not `gnome*.desktop`.
 	# Measured on the published grouper:gnome: /usr/share/wayland-sessions
 	# contains exactly `ubuntu.desktop`, /usr/share/xsessions does not exist,
-	# and gnome-shell IS installed â so the old glob reported a working GNOME
+	# and gnome-shell IS installed — so the old glob reported a working GNOME
 	# desktop as broken. A contract that fails a healthy image is worse than no
 	# contract: it trains people to ignore it.
 	require_any_glob \
@@ -154,7 +154,7 @@ gnome)
 	# Session-can-start is not the same as desktop-is-usable, and the gap
 	# between them is exactly how sailfin:gnome shipped. openSUSE's
 	# patterns-gnome-gnome provides gnome-shell, a wayland session and gdm
-	# â every check above â while providing no file manager, no portal
+	# — every check above — while providing no file manager, no portal
 	# backend, no keyring and no gvfs. It passed this gate with 192
 	# packages against yellowfin:gnome's 576 (tunaos-packages#132).
 	#
@@ -165,16 +165,16 @@ gnome)
 	# do not mount (gvfs).
 	#
 	# Deliberately scoped to GNOME. Every one was verified present in
-	# yellowfin:gnome and albacore:gnome before being made mandatory â a
+	# yellowfin:gnome and albacore:gnome before being made mandatory — a
 	# requirement that has not been checked against a known-good image
 	# turns working builds red instead of catching broken ones. Extend to
 	# kde/xfce/niri/cosmic the same way: measure a healthy image first.
 	require_command nautilus
-	# One glob per packaging family â see the measured table above the case.
+	# One glob per packaging family — see the measured table above the case.
 	# openSUSE (/usr/libexec/gvfs/gvfsd, owned by gvfs-1.60.1 on Tumbleweed)
 	# and Arch (/usr/lib/gvfsd) were the two real paths missing: sailfin:gnome
 	# installed gvfs, gvfs-backends and gvfs-fuse and still failed this gate.
-	# NB Debian does NOT use a multiarch triplet here â measured, it is plain
+	# NB Debian does NOT use a multiarch triplet here — measured, it is plain
 	# /usr/lib/gvfs/gvfsd (plus /usr/libexec/gvfsd), so no /usr/lib/*/ arm is
 	# needed and none is kept.
 	require_any_glob \
@@ -199,7 +199,7 @@ gnome)
 		exit 1
 	fi
 	# dconf compiled database: every keyfile dir /etc/dconf/db/<name>.d/ must have
-	# a compiled /etc/dconf/db/<name>. Iterate instead of hardcoding local/gdm â
+	# a compiled /etc/dconf/db/<name>. Iterate instead of hardcoding local/gdm —
 	# distros ship their own keyfile dirs (ibus.d on Arch) already compiled by
 	# package postinst; hardcoding local/gdm fails those falsely.
 	for _dcf_dir in /etc/dconf/db/*.d; do
@@ -225,8 +225,8 @@ kde)
 	# NO terminal, because patterns-kde-kde resolves to the shell only.
 	# dolphin and konsole are the two the user cannot work without, and they
 	# are the only KDE applications listed EXPLICITLY in every manifest
-	# section that builds KDE â kde.yaml apt/fedora/el10/zypper/emerge plus
-	# kde-arch.yaml and kde-debian.yaml â so requiring them cannot redden a
+	# section that builds KDE — kde.yaml apt/fedora/el10/zypper/emerge plus
+	# kde-arch.yaml and kde-debian.yaml — so requiring them cannot redden a
 	# variant that is building correctly. Deliberately NOT asserted:
 	# xdg-desktop-portal-kde (absent from the emerge list, and guppy builds
 	# KDE) and plasma6-nm/kwallet (nowhere explicit; they arrive as
@@ -242,14 +242,14 @@ niri)
 	require_unit greetd
 	# niri is only a compositor: it has no portal, no secret store and no
 	# shell of its own. sailfin:niri shipped `niri` and `greetd` and nothing
-	# else. The shell itself cannot be asserted â Fedora and EL10 use DMS
+	# else. The shell itself cannot be asserted — Fedora and EL10 use DMS
 	# (quickshell) while openSUSE uses the wlroots stack (waybar/fuzzel),
 	# because quickshell and dms are not built for the opensuse-tumbleweed
 	# target yet: it IS declared in manifests/package-factory.yaml, but has no
 	# cells in the package build gate (tunaos-packages#139). Revisit when it
 	# does. The portal and the keyring ARE common:
 	# both are explicit in every niri section that builds (fedora, el10,
-	# zypper, pacman). Accept the gtk backend alongside gnome â a variant may
+	# zypper, pacman). Accept the gtk backend alongside gnome — a variant may
 	# reasonably ship only the former.
 	require_any_glob \
 		'/usr/libexec/xdg-desktop-portal-gnome' '/usr/lib/xdg-desktop-portal-gnome' \
@@ -267,7 +267,7 @@ cosmic)
 	#
 	# cosmic-files and xdg-desktop-portal-cosmic are explicit, non-optional
 	# entries in manifests/desktops/cosmic.yaml's apt, fedora and zypper
-	# sections, and in cosmic-arch.yaml's pacman section â the same bar
+	# sections, and in cosmic-arch.yaml's pacman section — the same bar
 	# dolphin/konsole (kde) and thunar (xfce) were required on ("explicit in
 	# every manifest section that builds"). Without a file manager COSMIC is
 	# not merely sparse, it is unusable the same way sailfin:gnome was
@@ -278,7 +278,7 @@ cosmic)
 	# (cosmic.yaml's el10.copr section), and install-desktop.sh installs
 	# every copr block with `|| true` (the exact "COPR packages" step,
 	# distinct from the regular `dnf_retry -y install` used for fedora/apt/
-	# zypper/pacman, which has no such fallback) â a flaky COPR there can
+	# zypper/pacman, which has no such fallback) — a flaky COPR there can
 	# legitimately produce a build that has always shipped correctly. The
 	# condition below reproduces install-desktop.sh's own _TD_OS="el10"
 	# fallback exactly (dnf-based, not Fedora, not Hummingbird) rather than
@@ -288,19 +288,19 @@ cosmic)
 	# Binary path for cosmic-files confirmed live (mdapi.fedoraproject.org
 	# rawhide file list, 2026-08-08): /usr/bin/cosmic-files, so a plain PATH
 	# check is correct. xdg-desktop-portal-cosmic confirmed the same way:
-	# /usr/libexec/xdg-desktop-portal-cosmic on Fedora â matching this same
+	# /usr/libexec/xdg-desktop-portal-cosmic on Fedora — matching this same
 	# file's already-twice-measured portal convention (libexec on Fedora/EL/
 	# Debian/Ubuntu/openSUSE, lib on Arch, see the table above the case
 	# statement), which xdg-desktop-portal-cosmic packaging follows for the
 	# same reason its sibling backends (-gnome, -gtk) do: all three build
 	# from the same upstream xdg-desktop-portal libexecdir convention per
 	# distro. Not independently re-measured on Ubuntu/openSUSE/Arch in this
-	# change (no zstd tooling available to read their repodata here) â recorded
+	# change (no zstd tooling available to read their repodata here) — recorded
 	# so the next person knows which half of this is live-verified and which
 	# is carried over from an already-established pattern, same as this
 	# file's own stated rule asks for.
 	if [[ "${PKG_MGR:-}" == "dnf" && "${IS_FEDORA:-false}" != true && "${IS_HUMMINGBIRD:-false}" != true ]]; then
-		echo "info: skipping cosmic-files/xdg-desktop-portal-cosmic on the el10 family â cosmic.yaml sources them from a best-effort COPR here (tunaOS#916)"
+		echo "info: skipping cosmic-files/xdg-desktop-portal-cosmic on the el10 family — cosmic.yaml sources them from a best-effort COPR here (tunaOS#916)"
 	else
 		require_command cosmic-files
 		require_any_glob \
@@ -322,16 +322,16 @@ xfce)
 	require_any_glob '/usr/share/xsessions/*xfce*.desktop' '/usr/share/wayland-sessions/*xfce*.desktop'
 	require_any_unit gdm gdm3 lightdm greetd
 	# sailfin:xfce shipped a session with no file manager thumbnails, no
-	# gvfs and NO portal at all â Flatpak file dialogs were simply broken.
+	# gvfs and NO portal at all — Flatpak file dialogs were simply broken.
 	# thunar and xdg-desktop-portal-gtk are explicit in every xfce section
 	# that builds (fedora, el10, apt, zypper, pacman). NOT asserted:
-	# xfce4-terminal â Debian gets it via the `xfce4` metapackage's
+	# xfce4-terminal — Debian gets it via the `xfce4` metapackage's
 	# Recommends, which an apt build may legitimately not install.
 	require_command thunar
 	require_any_glob \
 		'/usr/libexec/xdg-desktop-portal-gtk' '/usr/lib/xdg-desktop-portal-gtk'
 
-	# xfwl4 reads xfwm4's THEME DATA and panics without it â not a warning, a
+	# xfwl4 reads xfwm4's THEME DATA and panics without it — not a warning, a
 	# hard abort before the session exists:
 	#
 	#   xfwl4::backend::udev: Using renderD128 as primary GPU
@@ -341,7 +341,7 @@ xfce)
 	#
 	# yellowfin:xfce in installer-smoke run 31183217981 booted to a console of
 	# that backtrace: no desktop, no installer, nothing to screenshot. It reads
-	# like the GPU-less runner limitation and is not â the same log line says a
+	# like the GPU-less runner limitation and is not — the same log line says a
 	# render node WAS found.
 	#
 	# xfce.sh already pulls xfwm4 for this reason, but through
@@ -367,7 +367,7 @@ pantheon)
 	# gurnard only: Pantheon comes exclusively from ppa:elementary-os/stable
 	# (manifests/desktops/pantheon.yaml). Until 2026-08-07 this case did not
 	# exist, so gurnard:pantheon sailed through the LUKS gates with
-	# desktop_contract=absent â a green cell whose desktop was never proven
+	# desktop_contract=absent — a green cell whose desktop was never proven
 	# (run 31074188677, found by the full-matrix contract audit). The asserts
 	# mirror what the manifest actually installs, nothing invented: `gala` is
 	# the compositor package and its binary keeps that name, the session
@@ -379,7 +379,7 @@ pantheon)
 	# settings 8.1.0+r419, dpkg -c, 2026-08-07): xsessions/pantheon.desktop
 	# and wayland-sessions/pantheon-wayland.desktop. The first run of this
 	# contract (31187758113) failed here and the failure was REAL: no package
-	# in the manifest shipped any session entry at all â the greeter had
+	# in the manifest shipped any session entry at all — the greeter had
 	# nothing to launch. pantheon-xsession-settings is that package; the
 	# manifest now installs it.
 	require_any_glob '/usr/share/xsessions/pantheon*.desktop' \
@@ -408,14 +408,14 @@ if [[ "$mode" == --runtime ]]; then
 	fi
 	# NB: never check `is-active graphical.target` here. This service is
 	# WantedBy=graphical.target, and targets gain implicit After= on their
-	# wants â the target cannot become active until this script exits, so
+	# wants — the target cannot become active until this script exits, so
 	# that check self-deadlocks into a guaranteed failure. Assert the boot
 	# *default* instead; liveness comes from the display-manager check below.
 	if [[ "$(systemctl get-default 2>/dev/null)" != graphical.target ]]; then
 		report_fail default_target_not_graphical
 	fi
 	# Check the display-manager.service alias (every DM registers it) and
-	# verify its Id resolves to a DM this desktop's contract allows â robust
+	# verify its Id resolves to a DM this desktop's contract allows — robust
 	# to per-distro unit names (gdm vs gdm3, lightdm vs greetd for xfce).
 	dm_id=$(systemctl show -P Id display-manager.service 2>/dev/null || true)
 	if ! systemctl is-active --quiet display-manager.service 2>/dev/null; then
@@ -424,7 +424,7 @@ if [[ "$mode" == --runtime ]]; then
 		# structural: the DM logs to the journal, while the E2E gate can only
 		# read the serial console, so the actual error is invisible and every
 		# hypothesis costs a full image build. Ship the evidence with the
-		# failure â this is how a greetd exiting instantly on a missing
+		# failure — this is how a greetd exiting instantly on a missing
 		# greeter account looked identical to one whose greeter could not
 		# render.
 		{
@@ -446,8 +446,8 @@ if [[ "$mode" == --runtime ]]; then
 	fi
 	marker_emitted=1
 else
-	# ââ Static unit-graph validation (pattern from secureblue's
-	# validate_systemd_unit_files.sh) ââ catches unit typos, missing
+	# ── Static unit-graph validation (pattern from secureblue's
+	# validate_systemd_unit_files.sh) ── catches unit typos, missing
 	# executables and broken dependency graphs before the image ships.
 	# Warn-only by default (upstream units carry pre-existing noise on some
 	# variants); SYSTEMD_VERIFY_FATAL=1 enforces, mirroring BOOTC_LINT_FATAL.
@@ -464,7 +464,7 @@ else
 		fi
 	fi
 
-	# ââ Launcher validation (pattern from ublue-os/aurora's 20-tests.sh) ââ
+	# ── Launcher validation (pattern from ublue-os/aurora's 20-tests.sh) ──
 	# desktop-file-validate every shipped launcher; exit code only reflects
 	# errors (not warnings), but stock distro apps still carry occasional
 	# errors, so warn-only by default with DESKTOP_VALIDATE_FATAL=1 to
@@ -488,22 +488,22 @@ else
 		fi
 	fi
 
-	# ââ Codec baseline ââ
-	# "Codecs installed" was promised on every family and verified on none â
+	# ── Codec baseline ──
+	# "Codecs installed" was promised on every family and verified on none —
 	# the EL10 x86_64_v2 leg shipped ffmpeg-free only (no H.264/H.265 at
 	# all) and marlin shipped gst-plugins-ugly without gst-libav (x264
 	# ENcoder present, no mainstream DEcoder), and both were green. Two
 	# file-level proofs, both cheap and network-free:
 	#
-	# 1. The GStreamer libav plugin exists â the piece that lets totem,
+	# 1. The GStreamer libav plugin exists — the piece that lets totem,
 	#    thumbnailers and WebKit decode through libavcodec. One measured
 	#    path per packaging family (repo rule: no unmeasured globs):
 	#      rpm/openSUSE/Gentoo  /usr/lib64/gstreamer-1.0/libgstlibav.so
 	#      Arch                 /usr/lib/gstreamer-1.0/libgstlibav.so
 	#      Debian/Ubuntu        /usr/lib/<triplet>/gstreamer-1.0/libgstlibav.so
-	#      (the apt path MEASURED on ubuntu:noble â gstreamer1.0-libav ships
+	#      (the apt path MEASURED on ubuntu:noble — gstreamer1.0-libav ships
 	#      /usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstlibav.so)
-	# 2. `ffmpeg -decoders` actually lists h264 â the plugin above routes
+	# 2. `ffmpeg -decoders` actually lists h264 — the plugin above routes
 	#    into libavcodec, so a free-codec libavcodec (the exact v2 failure)
 	#    is caught here even though the plugin file exists.
 	require_any_glob \
@@ -514,20 +514,20 @@ else
 	if command -v ffmpeg >/dev/null 2>&1; then
 		# NEVER pipe ffmpeg straight into `grep -q` here. grep -q exits at the
 		# first match, ffmpeg is still writing its ~30 KB decoder list, gets
-		# SIGPIPE, exits 141 â and under this script's `set -o pipefail` the
+		# SIGPIPE, exits 141 — and under this script's `set -o pipefail` the
 		# pipeline reports failure WITH the decoder present. That is not a
 		# race in practice: measured on ubuntu:noble (ffmpeg 6.1.1, h264
 		# decoder confirmed in the output), the piped form returned 141 on
 		# five out of five runs and failed gurnard:pantheon's proof build
 		# (run 31196812732) with a message blaming a "crippled libavcodec"
-		# the image did not have. Capture first, then grep the variable â
+		# the image did not have. Capture first, then grep the variable —
 		# and keep "ffmpeg would not run" distinct from "ffmpeg runs but
 		# cannot decode", because their fixes live in different places
 		# (packaging deps vs codec sourcing).
 		# Both failure branches dump the evidence that names the cause,
 		# because this check fired on guppy:xfce (run 31201546516) with a
-		# freshly source-built ffmpeg 8.1.2 whose USE line showed x264 â
-		# a build where the native h264 decoder should be unconditional â
+		# freshly source-built ffmpeg 8.1.2 whose USE line showed x264 —
+		# a build where the native h264 decoder should be unconditional —
 		# while the same check passes inside the July guppy:gnome image
 		# and against Alpine's 8.1.2. Three container reproductions of the
 		# tooling stage could not replicate it (portage tree drift), so
@@ -552,13 +552,13 @@ else
 		_ffmpeg_stderr="$(head -c 2048 "$_ffmpeg_stderr_file")"
 		rm -f "$_ffmpeg_stderr_file"
 		if ((_ffmpeg_rc != 0)); then
-			echo "ffmpeg is installed but would not run (broken dependencies?) â cannot verify codecs" >&2
+			echo "ffmpeg is installed but would not run (broken dependencies?) — cannot verify codecs" >&2
 			_ffmpeg_diag
 			if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
 				exit 1
 			fi
 		elif ! grep -q ' h264 ' <<<"$_ffmpeg_decoders"; then
-			echo "ffmpeg cannot decode h264 â a free/crippled libavcodec is installed" >&2
+			echo "ffmpeg cannot decode h264 — a free/crippled libavcodec is installed" >&2
 			_ffmpeg_diag
 			if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
 				exit 1
@@ -566,11 +566,11 @@ else
 		fi
 	fi
 
-	# ââ KDE version-skew guard (pattern from ublue-os/aurora's 20-tests.sh) ââ
+	# ── KDE version-skew guard (pattern from ublue-os/aurora's 20-tests.sh) ──
 	# Mid-compose repo skew can ship kwin/kscreen from a newer Plasma than
 	# plasma-desktop; the session then crashes at login while every package
 	# transaction "succeeded". Version equality across installed Plasma core
-	# packages is a hard invariant on rpm variants â fail the build on skew.
+	# packages is a hard invariant on rpm variants — fail the build on skew.
 	if [[ "$desktop" == kde ]] && command -v rpm >/dev/null 2>&1; then
 		if plasma_ver=$(rpm -q --qf '%{VERSION}' plasma-desktop 2>/dev/null); then
 			for pkg in kscreen kwin; do
@@ -594,16 +594,16 @@ else
 		fi
 	fi
 
-	# ââ Flatpak baseline (store + browser + a remote that can serve them) ââ
+	# ── Flatpak baseline (store + browser + a remote that can serve them) ──
 	# Asserts exactly what the build now lays down, nothing aspirational:
 	# tuna-flatpak-remote.sh bakes the Flathub remote on every base, and
 	# flatpak-preinstall.sh declares the curated set (io.github.kolunmi.Bazaar
-	# as the store, org.mozilla.firefox as the browser â Bluefin's choices)
+	# as the store, org.mozilla.firefox as the browser — Bluefin's choices)
 	# and enables flatpak-preinstall.service where the base's flatpak ships
 	# it. Guarded on flatpak existing so a hypothetical flatpak-less image is
 	# out of scope rather than red. The per-app grep list below is kept in
 	# lockstep with flatpak-preinstall.sh by
-	# tests/bats/test_build_scripts_remaining.bats â change both together.
+	# tests/bats/test_build_scripts_remaining.bats — change both together.
 	if command -v flatpak >/dev/null 2>&1; then
 		require_glob '/etc/flatpak/remotes.d/flathub.flatpakrepo'
 		require_glob '/usr/share/flatpak/preinstall.d/*.preinstall'
@@ -615,11 +615,11 @@ else
 				fi
 			fi
 		done
-		# Where the unit exists, declarations without the service are inert â
+		# Where the unit exists, declarations without the service are inert —
 		# that combination shipped: preinstall files with nothing to run them.
 		if [[ -f /usr/lib/systemd/system/flatpak-preinstall.service ]]; then
 			if ! systemctl is-enabled flatpak-preinstall.service >/dev/null 2>&1; then
-				echo "flatpak-preinstall.service is shipped but not enabled â the declared flatpaks would never install" >&2
+				echo "flatpak-preinstall.service is shipped but not enabled — the declared flatpaks would never install" >&2
 				if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
 					exit 1
 				fi
@@ -629,7 +629,7 @@ else
 		fi
 	fi
 
-	# ââ Branding & Asset Contract ââ
+	# ── Branding & Asset Contract ──
 	# Wallpapers: shipping only upstream artwork means a user sees upstream background on login.
 	if ! compgen -G "/usr/share/backgrounds/tunaos*" >/dev/null &&
 		! compgen -G "/usr/share/backgrounds/*/tunaos*" >/dev/null &&
@@ -641,7 +641,7 @@ else
 	fi
 
 	# dconf compiled database: every keyfile dir /etc/dconf/db/<name>.d/ must have
-	# a compiled /etc/dconf/db/<name>. Iterate instead of hardcoding local/gdm â
+	# a compiled /etc/dconf/db/<name>. Iterate instead of hardcoding local/gdm —
 	# distros ship their own keyfile dirs (ibus.d on Arch) already compiled by
 	# package postinst; hardcoding local/gdm fails those falsely.
 	for _dcf_dir in /etc/dconf/db/*.d; do


### PR DESCRIPTION
Refs #1801.

The Guppy GNOME Gate currently reports only `early_exit rc=1` when a static desktop requirement fails before the runtime summary block. This adds the failing shell line and safely quoted command to the serial contract marker, so the next Gate identifies the exact missing session, portal, keyring, or display-manager requirement.

Validation:
- `bash -n build_scripts/checks/verify-desktop-experience.sh`
- Static assertions covering the added line/command diagnostic fields
- `git diff --check`

This preserves the existing non-zero gate outcome; it improves failure evidence rather than weakening the contract.