### PR TITLE
chore(iso): adopt Tacklebox customize diagnostics

### DIFF
--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -48,7 +48,7 @@ downloads:
   # runs, and the boot dies in emergency on `overlayfs: failed to resolve
   # '/run/rootfsbase'`. Proven both ways by named runs: broken at
   # tacklebox 30629145076, booting to login at 30630284339.
-  tacklebox: "4fa604115dfa2e6356c68bde85a191c6620ebea1"
+  tacklebox: "dca2b63c1c647dca46d2866eb8dcb8864e4ab0b0"
 
   # Zirconium's mkosi.extra payload, fetched as a source tarball by
   # build_scripts/install-zirconium.sh (niri stages only). Pinned to a commit


### PR DESCRIPTION
## Summary

- update the pinned `tuna-os/tacklebox` revision to upstream commit `dca2b63`
- bring the fix from tuna-os/tacklebox#230 into source-built ISO jobs: streamed customize output, per-script progress markers, and an internal 30-minute customize cap
- retain TunaOS's existing outer 80-minute guard as defense in depth

## Why

tuna-os/tunaOS#1772's AMD64 ISO failure became a silent job cancellation because the pinned Tacklebox revision discarded customize output in quiet mode and left the nested container unbounded. The upstream fix is merged; this one-line pin update makes it reachable from `scripts/lib/common.sh`.

The new revision is a descendant of the existing pin (49 commits ahead, 0 behind), so it preserves the live-boot and dracut-floor fixes documented beside the pin.

## Validation

- verified the updated reference is a descendant of the existing pinned commit
- verified the branch changes only `image-versions.yaml`
- upstream regression coverage in tuna-os/tacklebox#230 covers streamed execution, the default timeout, overrides, and script markers

Refs tuna-os/tunaOS#1772