### PR TITLE
feat(green): graduate no_silent_omissions advisory → blocking (0 drop)

### DIFF
--- a/.github/green-criteria.yml
+++ b/.github/green-criteria.yml
@@ -188,9 +188,14 @@ criteria:
       build_scripts/checks/verify-package-wishlist.sh — at build time as a
       gate, and daily against every published image by
       .github/workflows/desktop-contract-sweep.yml (omissions read)
-    enforcement: advisory
+    enforcement: blocking
     status_2026_08_17: "written into every image; read by nothing on a schedule"
     status_2026_08_17_pm: "scheduled: the contract sweep reads the manifest from every image it pulls and scores it against package-miss-allowlist.txt"
+    status_2026_08_19: >-
+      graduated advisory → blocking. The composite green count did not drop
+      (63 → 63): every composite-green cell already carries an affirmative
+      omissions verdict, so the flip only makes an existing check bite instead
+      of leaving it advisory. First of the Part 3 Phase 4 graduations.
     notes: >-
       Distinct from `parity`. Parity asks whether the set matches upstream;
       this asks whether the build admitted what it silently skipped.


### PR DESCRIPTION
First of the Part 3 Phase 4 graduations from `GREEN-MASTER-PLAN.md`: flip one advisory criterion to blocking at a time, stating the number drop.\n\n**This PR:** `no_silent_omissions` `advisory` → `blocking`.\n\n**Number drop: 0** (composite green stays **63 → 63**).\n\nWhy zero: the desktop-contract-sweep reads the omissions manifest from every published desktop image daily, and every composite-green cell already carries an affirmative omissions verdict (48 pass / 4 untested, and the 4 untested are not composite-green). The flip therefore only makes an existing, already-passing check *bite* — it cannot green a cell that was never verified, which is the point.\n\nRemaining advisory criteria and their measured drops (for the PRs that follow): `desktop` −3, `lifecycle` −4, `parity` −6, `install` −12.\n\nTests: `pytest tests/test_green_criteria.py tests/test_composite_green_scoring.py tests/test_boot_gate_blocks_green.py` — 25 passed.