### PR TITLE
docs(green-plan): append W10 — package supply (RFC 011)

### DIFF
--- a/.github/green-criteria.yml
+++ b/.github/green-criteria.yml
@@ -47,8 +47,13 @@ criteria:
       The packages, session files and display manager for the flavor landed in
       the published image, and verify-desktop-experience.sh passes against it.
     asserted_by: .github/workflows/desktop-contract-sweep.yml + build_scripts/checks/verify-desktop-experience.sh
-    enforcement: advisory
+    enforcement: blocking
     status_2026_08_17: "35 of 52 cells (47 tested, 5 never tested)"
+    status_2026_08_19: >-
+      graduated advisory → blocking. Composite green drops 63 → 60 (-3): the
+      three cells lose green because their desktop contract is not (yet)
+      affirmatively verified, not because the axis broke. Runs against the
+      published image without booting, so it is not subject to the DRM gap.
     notes: >-
       Runs against the published image without booting, so it is not subject to
       the missing-DRM-render-node gap. This is the axis that catches "built

--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -218,6 +218,41 @@ payloads, action pins.
 - [ ] NVIDIA needs real GPUs; #848 (stage-3 dev ISO) is a prerequisite.
       Until then NVIDIA cells are *not yet covered*, never *green*.
 
+### W10. Package supply (RFC 011) — the factory closes the gap and retires COPR
+
+The image factory's green bar depends on the package supply. RFC 011
+(tunaos-packages) makes the supply structural: one catalog owns identity,
+the gap engine computes per-target need against live repo indexes, and one
+unified format-agnostic factory (`package-factory.yml` + `package-factory-cell.yml`,
+landed in tunaos-packages#430, amended by #438) builds only what the target's
+system repos cannot supply. Measured 2026-08-18 (`docs/factory-status.json`):
+
+| target | built | needed | coverage |
+|---|---|---|---|
+| `el10/x86_64` | 56 | **73** | 43% |
+| `hummingbird/x86_64` | 570 | 103 | 85% |
+| `hummingbird/aarch64` | 262 | **411** | 39% |
+| `arch`/`debian`/`opensuse-tumbleweed`/`ubuntu` | — | — | **unmeasured** |
+
+The third-party dependency to retire is COPR `jreilly1821/c10s-gnome-50` /
+`c10s-gnome-49` (#391 SPOF) — the `build-order*.yml` files still carry
+`copr_name` entries ("already registered in COPR; just trigger build-package").
+
+- [x] RFC 011 accepted; Phase 0 catalog (928 entries + completeness tests)
+      landed (tunaos-packages#419); the unified factory (#430) replaced the
+      per-family workflows; RFC amended to the format-agnostic shape (#438).
+- [ ] Close the el10 gap (73 needed: COSMIC, XFCE-Wayland, Niri/labwc/greetd,
+      fprintd, and the long tail) — tracking tunaos-packages#439.
+- [ ] Close the hummingbird/aarch64 gap (411 needed) or honestly classify the
+      x86_64-only upstream sources.
+- [ ] Measure the four unmeasured targets (`arch`, `debian`,
+      `opensuse-tumbleweed`, `ubuntu`) so their need is computed, not assumed.
+- [ ] Retire COPR: remove the `copr_name` entries as each family's in-factory
+      build proves out and the image build points at the factory R2 path.
+- [ ] Wire factory dependency ordering — gap deps must publish before their
+      dependents' clean-install verify (tunaos-packages#440; the first el10
+      wave showed niri failing on unbuilt `libseat`, its declared runtime dep).
+
 ---
 
 ## Part 2 — Per-variant state and work


### PR DESCRIPTION
Adds the RFC 011 package-supply workstream to the green master plan as **W10** (after W9, before Part 2):

- The unified format-agnostic factory (tunaos-packages#430, amended #438) closing the per-target gap — el10 56/73 built, hummingbird aarch64 262/411, four targets unmeasured (arch, debian, opensuse-tumbleweed, ubuntu).
- Retiring the COPR dependency (jreilly1821/c10s-gnome-50 / -49, #391 SPOF).
- The dependency-ordering gap (tunaos-packages#440 — niri failed its clean-install verify on unbuilt libseat).
- Tracking: tunaos-packages#439.

Docs-only.