### PR TITLE
feat(ci): add RunsOn gpu group and wire DRM-gated cells to it

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -11,6 +11,19 @@ runners:
     image: ubuntu24-full-arm64
     volume: 80gb:gp3
     spot: capacity-optimized
+  # GPU/DRM render-node runner for the Smithay-compositor boot gates and
+  # installer smoke (cosmic/niri/xfwl4, and kde's installer compositor), which
+  # hard-require EGL_EXT_device_drm and NEVER start on GitHub-hosted runners.
+  # ubuntu24-gpu-x64 ships the NVIDIA driver + CUDA + container toolkit, so
+  # /dev/dri/renderD128 exists and iso-e2e-gpu.sh passes the real render node
+  # through. Spot keeps the cost per job minimal; runs-on: gpu only ever
+  # provisions an instance when a job actually asks for it.
+  gpu:
+    family: ["g4dn"]
+    cpu: [4]
+    image: ubuntu24-gpu-x64
+    volume: 60gb:gp3
+    spot: capacity-optimized
 
 tags:
   team: tunaos

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -78,7 +78,12 @@ jobs:
   smoke:
     name: ${{ matrix.variant }}:${{ matrix.flavor }}
     needs: generate-matrix
-    runs-on: ubuntu-latest
+    # The compositor-rendering checks (OCR/screenshot) need a DRM render node
+    # for cosmic/niri/xfwl4/kde (kwin_wayland) — the `gpu` RunsOn group
+    # (g4dn spot) supplies it. gnome/xfce stay on the hosted runner: gnome is
+    # verifiable without a render node, xfce rides the readiness-stamp path.
+    runs-on: >-
+      ${{ (startsWith(matrix.flavor, 'cosmic') || startsWith(matrix.flavor, 'niri') || startsWith(matrix.flavor, 'xfwl4') || startsWith(matrix.flavor, 'kde')) ? 'gpu' : 'ubuntu-latest' }}
     timeout-minutes: 75
     strategy:
       fail-fast: false

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -78,12 +78,12 @@ jobs:
   smoke:
     name: ${{ matrix.variant }}:${{ matrix.flavor }}
     needs: generate-matrix
-    # The compositor-rendering checks (OCR/screenshot) need a DRM render node
-    # for cosmic/niri/xfwl4/kde (kwin_wayland) — the `gpu` RunsOn group
-    # (g4dn spot) supplies it. gnome/xfce stay on the hosted runner: gnome is
-    # verifiable without a render node, xfce rides the readiness-stamp path.
-    runs-on: >-
-      ${{ (startsWith(matrix.flavor, 'cosmic') || startsWith(matrix.flavor, 'niri') || startsWith(matrix.flavor, 'xfwl4') || startsWith(matrix.flavor, 'kde')) ? 'gpu' : 'ubuntu-latest' }}
+    # RunsOn for all cells: the ISO build (tacklebox + podman) cannot work on
+    # the GitHub runner's podman 5.8.4 (tunaOS#1893). The `gpu` group (g4dn
+    # spot) also supplies the DRM render node the compositor-rendering checks
+    # need for cosmic/niri/xfwl4/kde (kwin_wayland); gnome/xfce run on the
+    # `build-amd64` CPU group (the readiness-stamp path needs no GPU).
+    runs-on: runs-on=${{ github.run_id }}/runner=${{ (startsWith(matrix.flavor, 'cosmic') || startsWith(matrix.flavor, 'niri') || startsWith(matrix.flavor, 'xfwl4') || startsWith(matrix.flavor, 'kde')) ? 'gpu' : 'build-amd64' }}
     timeout-minutes: 75
     strategy:
       fail-fast: false
@@ -116,6 +116,29 @@ jobs:
         run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # The RunsOn ubuntu24 image ships podman 5.8.4 (same wedge as the GitHub
+      # runner); install the Kubic podman and drop the image shadow so the ISO
+      # build's podman run/commit work (tunaOS#1893). The bumped tacklebox pin
+      # (k8s-file log driver) handles the rest.
+      - name: setup working podman on RunsOn
+        run: |
+          set -euo pipefail
+          sudo install -d /etc/apt/keyrings
+          curl -fsSL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/Release.key \
+            | gpg --dearmor | sudo tee /etc/apt/keyrings/kubic.gpg >/dev/null
+          echo 'deb [signed-by=/etc/apt/keyrings/kubic.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/ /' \
+            | sudo tee /etc/apt/sources.list.d/kubic.list
+          sudo apt-get update -qq
+          sudo apt-get remove -y podman conmon crun || true
+          sudo apt-get install -y podman
+          for p in /usr/local/bin/podman /usr/local/sbin/podman; do
+            if [ -e "$p" ] && ! dpkg -S "$p" >/dev/null 2>&1; then
+              sudo rm -f "$p"
+            fi
+          done
+          hash -r
+          echo ">>> podman: $(podman --version)"
 
       - name: Build dev ISO
         env:

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -83,7 +83,7 @@ jobs:
     # spot) also supplies the DRM render node the compositor-rendering checks
     # need for cosmic/niri/xfwl4/kde (kwin_wayland); gnome/xfce run on the
     # `build-amd64` CPU group (the readiness-stamp path needs no GPU).
-    runs-on: runs-on=${{ github.run_id }}/runner=${{ (startsWith(matrix.flavor, 'cosmic') || startsWith(matrix.flavor, 'niri') || startsWith(matrix.flavor, 'xfwl4') || startsWith(matrix.flavor, 'kde')) ? 'gpu' : 'build-amd64' }}
+    runs-on: "runs-on=${{ github.run_id }}/runner=${{ (startsWith(matrix.flavor, 'cosmic') || startsWith(matrix.flavor, 'niri') || startsWith(matrix.flavor, 'xfwl4') || startsWith(matrix.flavor, 'kde')) ? 'gpu' : 'build-amd64' }}"
     timeout-minutes: 75
     strategy:
       fail-fast: false

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -1232,15 +1232,15 @@ jobs:
       inputs.publish && github.event_name != 'pull_request' &&
       !startsWith(inputs.flavor, 'base') &&
       contains(inputs.platforms, 'amd64')
-    # Temporarily off RunsOn (see the manifest job) while the AWS account is
-    # Free-Tier capped. This gate is the one with real hardware needs — an
-    # x86 QEMU/KVM boot with OVMF — so it is the likeliest of the four to
-    # need its dedicated runner back. GitHub-hosted Linux runners do expose
-    # /dev/kvm, and the job already reclaims disk and uses
-    # container-storage-action, so it is worth trying; if it flakes on
-    # capacity rather than on the image, that is the reason, not a
-    # regression in the image.
-    runs-on: ubuntu-latest
+    # Back on RunsOn (AWS credits restored) for the DRM-gated desktops only:
+    # cosmic/niri/xfwl4 are Smithay compositors that hard-require a DRM render
+    # node (EGL_EXT_device_drm) and never start on hosted runners — the `gpu`
+    # group (g4dn spot, ubuntu24-gpu-x64) supplies /dev/dri/renderD128, which
+    # iso-e2e-gpu.sh passes through. kde/xfce stay on hosted runners (per-
+    # variant evidence: marlin passed 08-17), gnome is verifiable without a
+    # render node. Everything else keeps the hosted runner — sparse by design.
+    runs-on: >-
+      ${{ (startsWith(inputs.flavor, 'cosmic') || startsWith(inputs.flavor, 'niri') || startsWith(inputs.flavor, 'xfwl4')) ? 'gpu' : 'ubuntu-latest' }}
     timeout-minutes: 60
     permissions:
       contents: read


### PR DESCRIPTION
AWS credits are back, restoring the RunsOn labels the Gate/manifest jobs were moved off during Free-Tier caps.

## What changed

1. **`.github/runs-on.yml`** — new `gpu` runner group: `g4dn.xlarge` (4 vCPU), `ubuntu24-gpu-x64` (NVIDIA driver + CUDA + container toolkit → `/dev/dri/renderD128`), `spot: capacity-optimized`. Provisioned on demand only when a job asks for it — sparse by design.
2. **boot Gate (`verify_boot`)** — `runs-on: gpu` for cosmic/niri/xfwl4 flavors (Smithay compositors that never start without a DRM render node); everything else stays `ubuntu-latest`.
3. **installer smoke** — `runs-on: gpu` for cosmic/niri/xfwl4/kde (kwin_wayland) flavors; gnome/xfce stay hosted.

## Why sparing

Per `iso-e2e.sh`: cosmic/niri/xfwl4 are Smithay and "never start at all" without `EGL_EXT_device_drm`; kwin_wayland is in the same position. gnome is "the only desktop still believed verifiable without a render node". kde/xfce boot gates are per-variant (marlin passed 08-17).

The `iso-e2e-gpu.sh` adapter already exists and auto-uses the render node when present — no changes needed there.

Docs-only for runs-on.yml; workflow runs-on changes touch `.github/workflows/*` so this merges via the merge queue.