### PR TITLE
fix(nvidia): recreate the rpmdb dir in the upper layer — the rebuild's rename is what overlayfs refuses

### DIFF
--- a/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
+++ b/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
@@ -92,6 +92,24 @@ else
 	# the transaction below was never going to succeed — fail here with the
 	# discriminating signature in the log instead of 300 INSERT errors later.
 	echo "==> rebuilding the inherited rpmdb before the swap (copy-up guard, tunaOS#1823/#1725)"
+	# The bare rebuild was not enough — run 32143809963 answered with the
+	# discriminating signature this guard was built to produce:
+	#   error: failed to replace old database with new database!
+	# and ZERO "malformed" lines. The rebuild reads and rewrites the db
+	# fine; it dies at its final step, a directory RENAME over the dbpath —
+	# which still lives in a LOWER overlay layer, and overlayfs refuses
+	# cross-layer directory renames (EXDEV). The same mechanism is what
+	# corrupts sqlite's writes in the plain install transaction (#1823).
+	# So recreate the directory natively in the upper layer first: the
+	# copy lands in the upper layer, the rm whiteouts the lower dir, and
+	# the mv is then a same-device rename. Every subsequent rpm write —
+	# the rebuild's replace included — is upper-layer-native.
+	_rpmdb_dir="$(rpm --eval '%_dbpath' 2>/dev/null || true)"
+	if [[ -n "$_rpmdb_dir" && -d "$_rpmdb_dir" ]]; then
+		cp -a "$_rpmdb_dir" "${_rpmdb_dir}.tbox-copyup"
+		rm -rf "$_rpmdb_dir"
+		mv "${_rpmdb_dir}.tbox-copyup" "$_rpmdb_dir"
+	fi
 	rpm --rebuilddb
 	echo "TUNAOS_RPMDB_PROBE=rebuilt-pre-swap"
 

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -417,6 +417,7 @@ STUB
 echo "rpm \$*" >> "${BATS_TEST_TMPDIR}/tool.log"
 case "\$*" in
   *"-q kernel"*) echo "$1"; exit 0 ;;
+  *"--eval"*) echo "${BATS_TEST_TMPDIR}/rpmdb"; exit 0 ;;
 esac
 exit 0
 STUB
@@ -438,6 +439,11 @@ make_swap_fixture() {
   for p in kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra; do
     touch "${BATS_TEST_TMPDIR}/kernel-rpms/${p}-${AKMODS_KVER}.rpm"
   done
+  # The rpmdb dir the stubbed `rpm --eval %_dbpath` names; the copy-up
+  # guard round-trips it (cp -a → rm -rf → mv), and the sentinel proves
+  # the contents survive the trip.
+  mkdir -p "${BATS_TEST_TMPDIR}/rpmdb"
+  echo sentinel > "${BATS_TEST_TMPDIR}/rpmdb/rpmdb.sqlite"
 }
 
 run_swap() {
@@ -495,6 +501,21 @@ run_swap() {
   [ -n "$rebuild_line" ]
   [ -n "$first_erase_line" ]
   [ "$rebuild_line" -lt "$first_erase_line" ]
+}
+
+@test "kernel-swap recreates the rpmdb dir in the upper layer before rebuilding it" {
+  # Run 32143809963: the bare rebuild died at 'failed to replace old
+  # database with new database' — overlayfs refuses the rebuild's final
+  # directory rename while the dbpath is a lower-layer dir (EXDEV). The
+  # guard must round-trip the directory (cp -a → rm -rf → mv) so every
+  # later write is same-device, and must not lose the db doing it.
+  make_swap_stubs "6.12.0-250.el10.x86_64"
+  make_swap_fixture
+  run_swap
+  [ "$status" -eq 0 ]
+  [ -d "${BATS_TEST_TMPDIR}/rpmdb" ]
+  [ "$(cat "${BATS_TEST_TMPDIR}/rpmdb/rpmdb.sqlite")" = "sentinel" ]
+  [ ! -e "${BATS_TEST_TMPDIR}/rpmdb.tbox-copyup" ]
 }
 
 @test "kernel-swap replaces a mismatched kernel with the akmods one" {


### PR DESCRIPTION
The #1877 copy-up guard did exactly what it was built to do: run 32143809963 (albacore base-nvidia) produced the **discriminating verdict** for #1823 on a stable EL10 base. `rpm --rebuilddb` reads and rewrites the inherited db cleanly, then dies at its final step:

```
error: failed to replace old database with new database!
error: replace files in /usr/share/rpm with files from /usr/share/rpmrebuilddb.35 to recover
```

— with **zero** `malformed` lines anywhere in the log. So the db is *not* malformed at rest, and the failure isn't mid-transaction mmap corruption either: the rebuild ends in a **directory rename over the dbpath**, which still lives in a lower overlay layer, and overlayfs refuses cross-layer directory renames (EXDEV). That's the mechanism behind the whole #1823 class — the plain install transaction's sqlite writes fail against the same lower-layer directory.

**Fix:** round-trip the rpmdb directory before any rpm write in the swap branch — `cp -a` to a sibling (lands in the upper layer), `rm -rf` the original (whiteouts the lower dir), `mv` back (same-device rename). Every subsequent rpm write, the rebuild's replace included, is then upper-layer-native. Guarded by `-d` so environments whose rpm answers no dbpath skip the round-trip.

New bats test pins the round-trip (dir survives, sentinel content intact, no `.tbox-copyup` leftover); the ordering test from #1877 still holds. **41/41 pass.**

If this reading is right, every RPM-path `*-nvidia` cell (albacore/yellowfin/skipjack — ~15 build cells) unblocks at the kernel swap, and the same trick is the candidate fix for bonito-rawhide's stage-2 (#1823). Verdict on the next nightly's nvidia legs (task tracking continues on #1725/#1823).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_