### PR TITLE
fix(nvidia): resolve the symlinked dbpath and demote the rebuild to advisory (#1823 round 2)

### DIFF
--- a/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
+++ b/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
@@ -104,14 +104,33 @@ else
 	# copy lands in the upper layer, the rm whiteouts the lower dir, and
 	# the mv is then a same-device rename. Every subsequent rpm write —
 	# the rebuild's replace included — is upper-layer-native.
-	_rpmdb_dir="$(rpm --eval '%_dbpath' 2>/dev/null || true)"
+	# Round 2 (nightly 32323650607): the round-trip ran and the rebuild
+	# STILL failed — now at "could not move new database in place" AND
+	# "could also not restore old database", with `malformed` gone
+	# entirely. Every failing operation is a rename beside the dbpath.
+	# On bootc/ostree images %_dbpath (/usr/share/rpm) is typically a
+	# SYMLINK into /usr/lib/sysimage/rpm, so round-tripping the literal
+	# path round-trips the symlink and leaves the real directory in the
+	# lower layer. Resolve first, round-trip the real directory.
+	_rpmdb_path="$(rpm --eval '%_dbpath' 2>/dev/null || true)"
+	_rpmdb_dir="$(readlink -f "$_rpmdb_path" 2>/dev/null || true)"
 	if [[ -n "$_rpmdb_dir" && -d "$_rpmdb_dir" ]]; then
+		echo "==> rpmdb: ${_rpmdb_path} resolves to ${_rpmdb_dir}; recreating it in the upper layer"
 		cp -a "$_rpmdb_dir" "${_rpmdb_dir}.tbox-copyup"
 		rm -rf "$_rpmdb_dir"
 		mv "${_rpmdb_dir}.tbox-copyup" "$_rpmdb_dir"
 	fi
-	rpm --rebuilddb
-	echo "TUNAOS_RPMDB_PROBE=rebuilt-pre-swap"
+	# The rebuild is now ADVISORY: its endgame is a pair of directory
+	# renames beside a possibly-symlinked dbpath — exactly the step
+	# measured failing twice — while the round-trip above is the actual
+	# copy-up fix. The kernel transaction below is the real verdict; do
+	# not let the probe kill the patient.
+	if rpm --rebuilddb; then
+		echo "TUNAOS_RPMDB_PROBE=rebuilt-pre-swap"
+	else
+		echo "TUNAOS_RPMDB_PROBE=rebuild-failed-nonfatal"
+		echo "::warning title=rpmdb rebuild (tunaOS#1823)::rpm --rebuilddb failed (rename beside the dbpath); proceeding — the kernel transaction below is the real verdict"
+	fi
 
 	# Always remove these packages as kernel cache provides signed versions
 	# (bluefin-lts kernel-swap.sh, verbatim reasoning).

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -518,6 +518,29 @@ run_swap() {
   [ ! -e "${BATS_TEST_TMPDIR}/rpmdb.tbox-copyup" ]
 }
 
+@test "kernel-swap resolves a symlinked dbpath and round-trips the real directory" {
+  # Round 2 of tunaOS#1823 (nightly 32323650607): the round-trip ran and
+  # the rebuild still died at 'could not move new database in place' —
+  # because on bootc/ostree images %_dbpath is a SYMLINK into
+  # /usr/lib/sysimage/rpm, so round-tripping the literal path moved the
+  # symlink and left the real directory in the lower layer. The guard
+  # must readlink -f first and round-trip what the path resolves to.
+  make_swap_stubs "6.12.0-250.el10.x86_64"
+  make_swap_fixture
+  rm -rf "${BATS_TEST_TMPDIR}/rpmdb"
+  mkdir -p "${BATS_TEST_TMPDIR}/sysimage-rpm"
+  echo sentinel > "${BATS_TEST_TMPDIR}/sysimage-rpm/rpmdb.sqlite"
+  ln -s "${BATS_TEST_TMPDIR}/sysimage-rpm" "${BATS_TEST_TMPDIR}/rpmdb"
+  run_swap
+  [ "$status" -eq 0 ]
+  # The REAL directory was round-tripped and survived intact...
+  [ "$(cat "${BATS_TEST_TMPDIR}/sysimage-rpm/rpmdb.sqlite")" = "sentinel" ]
+  [ ! -e "${BATS_TEST_TMPDIR}/sysimage-rpm.tbox-copyup" ]
+  # ...and the symlink still points at it.
+  [ -L "${BATS_TEST_TMPDIR}/rpmdb" ]
+  [ "$(cat "${BATS_TEST_TMPDIR}/rpmdb/rpmdb.sqlite")" = "sentinel" ]
+}
+
 @test "kernel-swap replaces a mismatched kernel with the akmods one" {
   make_swap_stubs "6.12.0-250.el10.x86_64"  # the first-contact Kitten kernel
   make_swap_fixture


### PR DESCRIPTION
Round 2 of the #1823 drive, from tonight's albacore nightly (32323650607, first with #1909): the round-trip **ran** — `cp -a` / `rm -rf` / `mv` all executed — and `rpm --rebuilddb` *still* failed, now at

```
error: could not move new database in place
error: could also not restore old database from /usr/share/rpmold.40
```

with `malformed` **gone entirely** from the log. Every failing operation is a rename *beside the dbpath*. The missed detail: on bootc/ostree images `%_dbpath` (`/usr/share/rpm`) is a **symlink** into `/usr/lib/sysimage/rpm` — so #1909's round-trip moved the symlink and left the real directory in the lower layer.

Two changes:
- **`readlink -f` the dbpath** and round-trip what it resolves to, with the resolution printed into the log (so the next log answers the symlink question directly instead of leaving it inferred).
- **The rebuild is now advisory.** Its endgame is a pair of directory renames beside a possibly-symlinked dbpath — exactly the step measured failing on two consecutive runs — while the round-trip is the actual copy-up fix and the kernel install transaction below is the real verdict. The probe marker records `rebuilt-pre-swap` vs `rebuild-failed-nonfatal` so the log still discriminates.

New bats test pins the symlink shape (real directory round-tripped and intact, symlink still pointing at it); 42/42 pass.

Progress markers across the three rounds: `malformed`-storm → clean rebuild that can't rename → (expected next) transaction succeeding against an upper-layer-native real directory.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_