### PR TITLE
fix(rawhide): port the proven rpmdb upper-layer round-trip to stage-2 (#1823)

### DIFF
--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -760,12 +760,32 @@ install_rawhide_tolerant() {
 # can kill a green pinned-Fedora build would cost more than it measures.
 rawhide_rpmdb_probe() {
 	[[ "$(detect_fedora_ver)" == "rawhide" ]] || return 0
-	echo "::notice title=rpmdb probe (tunaOS#1823)::rebuilding the rpmdb inherited from the Rawhide base before the first stage-2 rpm write"
+	# tunaOS#1823, PROVEN FIX ported from the nvidia overlay (run
+	# 32339591457, 2026-08-20): the sqlite corruption class is rpm writing
+	# into a db directory that still lives in a LOWER overlay layer.
+	# Recreating the resolved directory natively in the upper layer (copy
+	# lands upper, rm whiteouts the lower dir, mv is a same-device rename)
+	# made albacore's base-nvidia kernel swap — previously 100% red on the
+	# malformed-db storm — build clean end to end. Same shape here, before
+	# the first stage-2 rpm write on the inherited Rawhide base.
+	local _rpmdb_path _rpmdb_dir
+	_rpmdb_path="$(rpm --eval '%_dbpath' 2>/dev/null || true)"
+	_rpmdb_dir="$(readlink -f "$_rpmdb_path" 2>/dev/null || true)"
+	if [[ -n "$_rpmdb_dir" && -d "$_rpmdb_dir" ]]; then
+		echo "::notice title=rpmdb copy-up (tunaOS#1823)::${_rpmdb_path} resolves to ${_rpmdb_dir}; recreating it in the upper layer before the first stage-2 rpm write"
+		cp -a "$_rpmdb_dir" "${_rpmdb_dir}.tbox-copyup"
+		rm -rf "$_rpmdb_dir"
+		mv "${_rpmdb_dir}.tbox-copyup" "$_rpmdb_dir"
+	fi
+	# The rebuild stays advisory-only: its replace step ends in directory
+	# renames that fail under this overlay even against an upper-native
+	# dir (measured twice on the nvidia surface) — the round-trip above is
+	# the fix, the stage-2 transaction that follows is the verdict.
 	if rpm --rebuilddb; then
 		echo "TUNAOS_RPMDB_PROBE=rebuilt"
 	else
-		echo "TUNAOS_RPMDB_PROBE=rebuild-failed"
-		echo "::warning title=rpmdb probe (tunaOS#1823)::rpm --rebuilddb itself failed — the base image's rpmdb is malformed at rest, not corrupted by the stage-2 transaction"
+		echo "TUNAOS_RPMDB_PROBE=rebuild-failed-nonfatal"
+		echo "::warning title=rpmdb probe (tunaOS#1823)::rpm --rebuilddb failed (rename beside the dbpath); proceeding — the stage-2 transaction is the real verdict"
 	fi
 	return 0
 }

--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -275,10 +275,21 @@ the overlay kernel swap with rpmdb sqlite corruption ("database disk image
 is malformed" on every INSERT while installing kernel-6.12.0-257.el10),
 i.e. the same rpmdb-under-buildah-overlay class as #1823, on a second
 variant surface. Count EL10 nvidia cells under #1823 until it resolves.
-Copy-up guard landed same day: 10-kernel-swap.sh now runs `rpm
---rebuilddb` before its first destructive write, forcing the inherited
-sqlite db through overlay copy-up — probe and candidate fix in one, per
-the #1823 protocol. Verify on the next nightly's nvidia legs.*
+**RESOLVED on the EL10 surface, three rounds of evidence (08-18→08-20):**
+round 1 (#1877, bare `rpm --rebuilddb`) produced the discriminating
+signature — clean rebuild, replace REFUSED, zero malformed; round 2
+(#1909, literal-path directory round-trip) killed the malformed storm but
+the rebuild's rename still failed; round 3 (#1912, `readlink -f` the
+dbpath + round-trip the RESOLVED directory + rebuild demoted to advisory)
+went GREEN: albacore base-nvidia run 32339591457 logged the resolution
+(`/usr/share/rpm` is a real dir there — symlink hypothesis refuted for
+EL10), the kernel transaction completed with no malformed and
+`TUNAOS_NVIDIA_CONTRACT_OK`. Root cause: rpm writing into a db directory
+still in a lower overlay layer; the upper-layer round-trip is the whole
+fix, the rebuild was only ever the probe. Ported to bonito-rawhide's
+stage-2 the same day (`rawhide_rpmdb_probe` in lib.sh now round-trips
+before rebuilding) — verify on the next bonito-rawhide nightly's desktop
+legs, then #1823 closes.*
 
 ### yellowfin (AlmaLinux Kitten 10) — 12/20 build
 | area | state | action |

--- a/tests/bats/test_rawhide_rpmdb_probe.bats
+++ b/tests/bats/test_rawhide_rpmdb_probe.bats
@@ -29,6 +29,7 @@ setup() {
 #!/usr/bin/env bash
 case "$1" in
   -E) printf '%s\n' "${RPM_E_OUT:-45}" ;;
+  --eval) printf '%s\n' "${RPM_DBPATH_OUT:-}" ;;
   --rebuilddb)
     echo invoked >> "${REBUILD_LOG}"
     exit "${REBUILD_RC:-0}"
@@ -70,14 +71,30 @@ run_probe() {
   [ "$(wc -l < "$REBUILD_LOG")" -eq 0 ]
 }
 
-@test "a failed rebuild warns with the at-rest diagnosis but does not fail the build" {
-  # If --rebuilddb itself dies, the base wrote a malformed db — that is the
-  # most valuable outcome the probe can report, and the transaction that
-  # follows is still the real verdict.
+@test "a failed rebuild warns but does not fail the build" {
+  # Re-diagnosed on the nvidia surface (run 32339591457): the rebuild's
+  # replace step ends in directory renames that fail under the overlay
+  # even against an upper-native dir — it is not evidence of a malformed
+  # source db. The round-trip is the fix; the transaction that follows is
+  # the real verdict, so a rebuild failure only warns.
   REBUILD_RC=1 run_probe
   [ "$status" -eq 0 ]
-  [[ "$output" == *"TUNAOS_RPMDB_PROBE=rebuild-failed"* ]]
-  [[ "$output" == *"malformed at rest"* ]]
+  [[ "$output" == *"TUNAOS_RPMDB_PROBE=rebuild-failed-nonfatal"* ]]
+  [[ "$output" == *"real verdict"* ]]
+}
+
+@test "the resolved rpmdb dir is round-tripped into the upper layer first" {
+  # The proven #1823 fix (albacore base-nvidia went red→green on it):
+  # recreate the resolved db directory natively in the upper layer before
+  # the first rpm write. The sentinel proves the contents survive the
+  # cp -a → rm -rf → mv round trip; no .tbox-copyup residue remains.
+  mkdir -p "${BATS_TEST_TMPDIR}/rpmdb"
+  echo sentinel > "${BATS_TEST_TMPDIR}/rpmdb/rpmdb.sqlite"
+  RPM_DBPATH_OUT="${BATS_TEST_TMPDIR}/rpmdb" run_probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"recreating it in the upper layer"* ]]
+  [ "$(cat "${BATS_TEST_TMPDIR}/rpmdb/rpmdb.sqlite")" = "sentinel" ]
+  [ ! -e "${BATS_TEST_TMPDIR}/rpmdb.tbox-copyup" ]
 }
 
 @test "stage-2 calls the probe before its first rpm write" {


### PR DESCRIPTION
**Albacore base-nvidia went red→green** on run 32339591457 with #1912's guard — the first successful base-nvidia build ever, closing the EL10 surface of #1823 with full evidence: the log's resolution line shows `/usr/share/rpm` is a **real directory** there (symlink hypothesis refuted, printed not inferred), the upper-layer round-trip ran, the advisory rebuild still couldn't do its rename (`rebuild-failed-nonfatal` — proving the demotion was load-bearing), and the kernel transaction completed clean through `TUNAOS_NVIDIA_CONTRACT_OK`.

Root cause, now settled: rpm writing into a db directory that still lives in a **lower overlay layer**. The upper-layer round-trip (cp-sibling → whiteout → same-device rename) is the whole fix; the rebuild was only ever the probe.

This PR ports the identical trick to #1823's remaining surface — `rawhide_rpmdb_probe` (stage-2 on the inherited Rawhide base) now resolves the dbpath, round-trips the real directory before the first stage-2 rpm write, and keeps the rebuild advisory with the corrected diagnosis (its rename endgame fails under the overlay even against an upper-native dir; it was never evidence of a malformed source db).

Probe bats suite updated: the failed-rebuild test asserts the new nonfatal marker and diagnosis, plus a new round-trip test (sentinel survives, no residue) — 5/5. Plan's nvidia note carries the three-round resolution record (#1877 → #1909 → #1912). Verify on the next bonito-rawhide nightly's desktop legs, then #1823 closes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_