### PR TITLE
fix(rpmdb): salvage the completed rebuild file-level — rpm's own recovery instruction (#1823 round 4)

### DIFF
--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -777,15 +777,30 @@ rawhide_rpmdb_probe() {
 		rm -rf "$_rpmdb_dir"
 		mv "${_rpmdb_dir}.tbox-copyup" "$_rpmdb_dir"
 	fi
-	# The rebuild stays advisory-only: its replace step ends in directory
-	# renames that fail under this overlay even against an upper-native
-	# dir (measured twice on the nvidia surface) — the round-trip above is
-	# the fix, the stage-2 transaction that follows is the verdict.
+	# The rebuild's rename endgame fails under this overlay even against
+	# an upper-native dir (measured twice on the nvidia surface) — but a
+	# db corrupted AT REST by an earlier stage's writes needs the
+	# rebuild's PRODUCT, and rpm builds it fine before throwing it away
+	# at the rename, printing its own recovery instruction ("replace
+	# files in ... with files from .../rpmrebuilddb.NN"). Same salvage as
+	# 10-kernel-swap.sh: file-level swap, no directory rename needed.
+	local _rpmdb_parent _rebuilt
+	_rpmdb_parent="${_rpmdb_dir%/*}"
+	rm -rf "${_rpmdb_parent}"/rpmrebuilddb.* "${_rpmdb_parent}"/rpmold.* 2>/dev/null || true
 	if rpm --rebuilddb; then
 		echo "TUNAOS_RPMDB_PROBE=rebuilt"
 	else
-		echo "TUNAOS_RPMDB_PROBE=rebuild-failed-nonfatal"
-		echo "::warning title=rpmdb probe (tunaOS#1823)::rpm --rebuilddb failed (rename beside the dbpath); proceeding — the stage-2 transaction is the real verdict"
+		_rebuilt="$(ls -d "${_rpmdb_parent}"/rpmrebuilddb.* 2>/dev/null | head -1 || true)"
+		if [[ -n "$_rpmdb_dir" && -d "$_rpmdb_dir" && -n "$_rebuilt" && -d "$_rebuilt" ]]; then
+			echo "::notice title=rpmdb salvage (tunaOS#1823)::salvaging the completed rebuild file-level from ${_rebuilt}"
+			rm -rf "${_rpmdb_dir:?}"/*
+			cp -a "$_rebuilt"/. "$_rpmdb_dir"/
+			rm -rf "$_rebuilt" "${_rpmdb_parent}"/rpmold.*
+			echo "TUNAOS_RPMDB_PROBE=rebuilt-salvaged"
+		else
+			echo "TUNAOS_RPMDB_PROBE=rebuild-failed-nonfatal"
+			echo "::warning title=rpmdb probe (tunaOS#1823)::rpm --rebuilddb failed and left no rebuilt db to salvage; proceeding — the stage-2 transaction is the real verdict"
+		fi
 	fi
 	return 0
 }

--- a/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
+++ b/build_scripts/overlay/overrides/nvidia/10-kernel-swap.sh
@@ -120,16 +120,35 @@ else
 		rm -rf "$_rpmdb_dir"
 		mv "${_rpmdb_dir}.tbox-copyup" "$_rpmdb_dir"
 	fi
-	# The rebuild is now ADVISORY: its endgame is a pair of directory
-	# renames beside a possibly-symlinked dbpath — exactly the step
-	# measured failing twice — while the round-trip above is the actual
-	# copy-up fix. The kernel transaction below is the real verdict; do
-	# not let the probe kill the patient.
+	# Round 4 (run 32339591457): base-nvidia went green on the round-trip
+	# alone, but the DESKTOP legs inherit an rpmdb their stage-2 build
+	# already corrupted at rest (1678 malformed-on-READ lines), so the
+	# transaction needs the REBUILD's product — and rpm's rebuild reads
+	# and rewrites the corrupt db fine, then throws the result away when
+	# its directory-rename endgame fails under the overlay, printing its
+	# own recovery instruction:
+	#   error: replace files in /usr/share/rpm with files from
+	#          /usr/share/rpmrebuilddb.NN to recover
+	# So do exactly that: when the rename fails, salvage the completed
+	# rebuild with a FILE-level swap, which needs no directory rename at
+	# all. Stale rebuild/old dirs are cleared first so the salvage can
+	# only pick up the rebuild that just ran.
+	_rpmdb_parent="${_rpmdb_dir%/*}"
+	rm -rf "${_rpmdb_parent}"/rpmrebuilddb.* "${_rpmdb_parent}"/rpmold.* 2>/dev/null || true
 	if rpm --rebuilddb; then
 		echo "TUNAOS_RPMDB_PROBE=rebuilt-pre-swap"
 	else
-		echo "TUNAOS_RPMDB_PROBE=rebuild-failed-nonfatal"
-		echo "::warning title=rpmdb rebuild (tunaOS#1823)::rpm --rebuilddb failed (rename beside the dbpath); proceeding — the kernel transaction below is the real verdict"
+		_rebuilt="$(ls -d "${_rpmdb_parent}"/rpmrebuilddb.* 2>/dev/null | head -1 || true)"
+		if [[ -n "$_rpmdb_dir" && -d "$_rpmdb_dir" && -n "$_rebuilt" && -d "$_rebuilt" ]]; then
+			echo "==> salvaging the completed rebuild file-level from ${_rebuilt} (rpm's own recovery instruction)"
+			rm -rf "${_rpmdb_dir:?}"/*
+			cp -a "$_rebuilt"/. "$_rpmdb_dir"/
+			rm -rf "$_rebuilt" "${_rpmdb_parent}"/rpmold.*
+			echo "TUNAOS_RPMDB_PROBE=rebuilt-salvaged"
+		else
+			echo "TUNAOS_RPMDB_PROBE=rebuild-failed-nonfatal"
+			echo "::warning title=rpmdb rebuild (tunaOS#1823)::rpm --rebuilddb failed and left no rebuilt db to salvage; proceeding — the kernel transaction below is the real verdict"
+		fi
 	fi
 
 	# Always remove these packages as kernel cache provides signed versions

--- a/tests/bats/test_nvidia_overlay.bats
+++ b/tests/bats/test_nvidia_overlay.bats
@@ -418,6 +418,15 @@ echo "rpm \$*" >> "${BATS_TEST_TMPDIR}/tool.log"
 case "\$*" in
   *"-q kernel"*) echo "$1"; exit 0 ;;
   *"--eval"*) echo "${BATS_TEST_TMPDIR}/rpmdb"; exit 0 ;;
+  *"--rebuilddb"*)
+    # Real rpm leaves the completed rebuild dir behind when its rename
+    # endgame fails; the salvage path picks that up.
+    if [[ "\${TUNAOS_TEST_REBUILD_RC:-0}" != 0 ]]; then
+      mkdir -p "${BATS_TEST_TMPDIR}/rpmrebuilddb.42"
+      echo rebuilt > "${BATS_TEST_TMPDIR}/rpmrebuilddb.42/rpmdb.sqlite"
+    fi
+    exit "\${TUNAOS_TEST_REBUILD_RC:-0}"
+    ;;
 esac
 exit 0
 STUB
@@ -539,6 +548,24 @@ run_swap() {
   # ...and the symlink still points at it.
   [ -L "${BATS_TEST_TMPDIR}/rpmdb" ]
   [ "$(cat "${BATS_TEST_TMPDIR}/rpmdb/rpmdb.sqlite")" = "sentinel" ]
+}
+
+@test "kernel-swap salvages a completed rebuild file-level when rpm's rename fails" {
+  # Round 4 of tunaOS#1823 (run 32339591457): the desktop-nvidia legs
+  # inherit a db their stage-2 already corrupted at rest, so the
+  # transaction NEEDS the rebuild's product — and rpm builds it, then
+  # throws it away at the failing rename, printing 'replace files in ...
+  # with files from .../rpmrebuilddb.NN to recover'. The guard must do
+  # exactly that: a file-level swap, no directory rename involved.
+  make_swap_stubs "6.12.0-250.el10.x86_64"
+  make_swap_fixture
+  TUNAOS_TEST_REBUILD_RC=1 run_swap
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TUNAOS_RPMDB_PROBE=rebuilt-salvaged"* ]]
+  # The db dir now holds the rebuilt content, not the pre-rebuild one...
+  [ "$(cat "${BATS_TEST_TMPDIR}/rpmdb/rpmdb.sqlite")" = "rebuilt" ]
+  # ...and no rebuild residue remains beside it.
+  [ ! -e "${BATS_TEST_TMPDIR}/rpmrebuilddb.42" ]
 }
 
 @test "kernel-swap replaces a mismatched kernel with the akmods one" {

--- a/tests/bats/test_rawhide_rpmdb_probe.bats
+++ b/tests/bats/test_rawhide_rpmdb_probe.bats
@@ -32,6 +32,12 @@ case "$1" in
   --eval) printf '%s\n' "${RPM_DBPATH_OUT:-}" ;;
   --rebuilddb)
     echo invoked >> "${REBUILD_LOG}"
+    # Real rpm leaves the completed rebuild dir behind when its rename
+    # endgame fails; the salvage path picks that up.
+    if [[ "${REBUILD_RC:-0}" != 0 && -n "${RPM_DBPATH_OUT:-}" ]]; then
+      mkdir -p "${RPM_DBPATH_OUT%/*}/rpmrebuilddb.42"
+      echo rebuilt > "${RPM_DBPATH_OUT%/*}/rpmrebuilddb.42/rpmdb.sqlite"
+    fi
     exit "${REBUILD_RC:-0}"
     ;;
 esac
@@ -95,6 +101,19 @@ run_probe() {
   [[ "$output" == *"recreating it in the upper layer"* ]]
   [ "$(cat "${BATS_TEST_TMPDIR}/rpmdb/rpmdb.sqlite")" = "sentinel" ]
   [ ! -e "${BATS_TEST_TMPDIR}/rpmdb.tbox-copyup" ]
+}
+
+@test "a failed rebuild with a completed product is salvaged file-level" {
+  # tunaOS#1823 round 4: a db corrupted at rest by an earlier stage needs
+  # the rebuild's PRODUCT, and rpm builds it before the rename fails —
+  # its own error text says to replace the files by hand. The probe does.
+  mkdir -p "${BATS_TEST_TMPDIR}/rpmdb"
+  echo corrupt > "${BATS_TEST_TMPDIR}/rpmdb/rpmdb.sqlite"
+  RPM_DBPATH_OUT="${BATS_TEST_TMPDIR}/rpmdb" REBUILD_RC=1 run_probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TUNAOS_RPMDB_PROBE=rebuilt-salvaged"* ]]
+  [ "$(cat "${BATS_TEST_TMPDIR}/rpmdb/rpmdb.sqlite")" = "rebuilt" ]
+  [ ! -e "${BATS_TEST_TMPDIR}/rpmrebuilddb.42" ]
 }
 
 @test "stage-2 calls the probe before its first rpm write" {


### PR DESCRIPTION
Run 32339591457 split the #1823 class in two:

- **base-nvidia: GREEN** on the upper-layer round-trip alone — its inherited db is clean, and the cell **promoted** for the first time ever.
- **Every desktop-nvidia leg: still red** — those inherit an rpmdb their *stage-2 build already corrupted at rest* (1,678 malformed-on-**READ** lines; bogus failed deps for coreutils/dracut coming from a garbage `Requirename` table). A corrupt-at-rest db needs the rebuild's *product* — and rpm builds it fine, then throws it away when its directory-rename endgame fails under the overlay, printing its own recovery instruction:

```
error: replace files in /usr/share/rpm with files from /usr/share/rpmrebuilddb.NN to recover
```

**This PR does exactly what rpm asks.** Both guard sites (`10-kernel-swap.sh` and `rawhide_rpmdb_probe`) now salvage the completed rebuild with a **file-level swap** into the round-tripped db dir when the rename fails — no directory rename involved — clearing stale `rpmrebuilddb.*`/`rpmold.*` dirs beforehand so only the fresh product can be picked up. Marker: `rebuilt-salvaged`.

Bonus: the failing bats run caught a real `set -euo pipefail` bug in the salvage lookup (an unmatched `ls` glob killed the whole script) before CI ever saw it; guarded. Both suites extended with salvage tests — **49/49 pass**.

Verdict chain: #1877 (probe) → #1909 (round-trip) → #1912 (resolve + advisory) → this (salvage). base-nvidia proves the clean-db path; this closes the corrupt-at-rest path, which is also exactly bonito-rawhide's stage-2 shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_