### PR TITLE
chore(iso): bump tacklebox pin to f3dd168 (k8s-file log driver)

### DIFF
--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -48,7 +48,10 @@ downloads:
   # runs, and the boot dies in emergency on `overlayfs: failed to resolve
   # '/run/rootfsbase'`. Proven both ways by named runs: broken at
   # tacklebox 30629145076, booting to login at 30630284339.
-  tacklebox: "dca2b63c1c647dca46d2866eb8dcb8864e4ab0b0"
+  tacklebox: "f3dd168bf15b235b554e497e7192a64a6563c4a4"
+  # f3dd168 carries the k8s-file log-driver fix for all podman runs
+  # (tunaOS#1893): the runner images lack journald for the container,
+  # and the customize/initramfs/commit steps otherwise die in conmon.
 
   # Zirconium's mkosi.extra payload, fetched as a source tarball by
   # build_scripts/install-zirconium.sh (niri stages only). Pinned to a commit


### PR DESCRIPTION
tunaOS#1893: the GitHub/RunsOn runner images lack a usable systemd-journald for the container, and the customize/initramfs/commit steps die in conmon with `[conmon:e]: Include journald in compilation path`. tacklebox f3dd168 adds `--log-driver=k8s-file` to every podman run, resolving the journald gap. The tunaos ISO build pulls tacklebox from this pin, so it needs the fix before installer-smoke/LUKS can re-verify.