### PR TITLE
fix(installer-smoke): set up the working podman before the GHCR login

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -112,11 +112,6 @@ jobs:
             systemd-boot-efi xorriso mtools squashfs-tools dosfstools gdisk
           sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
 
-      - name: Log in to GHCR
-        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       # The RunsOn ubuntu24 image ships podman 5.8.4 (same wedge as the GitHub
       # runner); install the Kubic podman and drop the image shadow so the ISO
       # build's podman run/commit work (tunaOS#1893). The bumped tacklebox pin
@@ -139,6 +134,11 @@ jobs:
           done
           hash -r
           echo ">>> podman: $(podman --version)"
+
+      - name: Log in to GHCR
+        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build dev ISO
         env:


### PR DESCRIPTION
The dispatch showed all cells dying at "Log in to GHCR" — `podman login` ran with the image broken podman 5.8.4 before the Kubic setup step. Reorder: install the working podman first, then log in, then build the ISO.