### PR TITLE
fix(installer-smoke): root podman for the GHCR login

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -136,7 +136,9 @@ jobs:
           echo ">>> podman: $(podman --version)"
 
       - name: Log in to GHCR
-        run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
+        # sudo (root) podman: the runner rootless re-exec is broken
+        # ("cannot re-exec process"); the ISO build also runs as root.
+        run: echo "${{ env.GITHUB_TOKEN }}" | sudo -n podman login ghcr.io -u ${{ github.actor }} --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The GHCR login ran rootless podman, which dies with "cannot re-exec process" on the RunsOn runner (same rootless-re-exec issue as the fixture builds). sudo -n it, matching the root ISO build.