### PR TITLE
fix(rpmdb): run the #1823 copy-up guard in every dnf stage

### DIFF
--- a/build_scripts/01-workarounds.sh
+++ b/build_scripts/01-workarounds.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 printf "::group:: === 00-workarounds ===\n"
 
 source /run/context/build_scripts/lib.sh
+
+rpmdb_stage2_guard
 # This is a bucket list. We want to not have anything in this file at all.
 if [[ "$IS_RHEL" = true || "$IS_CENTOS" = true ]]; then rm -f /usr/lib/bootc/install/20-rhel.toml; fi
 # Remove amd-legacy.conf from upstream: TunaOS kernel is not compiled with si_support/cik_support

--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -6,6 +6,8 @@ printf "::group:: === 10 Base Packages ===\n"
 
 source /run/context/build_scripts/lib.sh
 
+rpmdb_stage2_guard
+
 # Source RHSM credentials from the BuildKit secret if it's mounted.
 # /run/secrets/rhsm is provided by the `--mount=type=secret,id=rhsm`
 # directive in the Containerfile (only when RHSM_* env was set when

--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -12,6 +12,8 @@ export MAJOR_VERSION_NUMBER
 
 source /run/context/build_scripts/lib.sh
 
+rpmdb_stage2_guard
+
 # Make sure an SSH server EXISTS on every variant, whatever it is packaged as.
 #
 # tunaOS#951. openssh-server was installed in exactly one place in this file —

--- a/build_scripts/99-cleanup.sh
+++ b/build_scripts/99-cleanup.sh
@@ -4,6 +4,8 @@ set -xeuo pipefail
 printf "::group:: ===Image Cleanup===\n"
 source /run/context/build_scripts/lib.sh
 
+rpmdb_stage2_guard
+
 # Image cleanup
 # Specifically called by build.sh
 

--- a/build_scripts/desktop/gnome-extensions.sh
+++ b/build_scripts/desktop/gnome-extensions.sh
@@ -14,6 +14,8 @@ set -xeuo pipefail
 
 source /run/context/build_scripts/lib.sh
 
+rpmdb_stage2_guard
+
 # ── apt (Ubuntu/Debian) path ──────────────────────────────────────────
 if [[ "$PKG_MGR" == "apt" ]]; then
 	# Ubuntu ships pre-built extensions; just compile schemas

--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -19,6 +19,16 @@ _TD_CTX="/run/context"
 # lib.sh first: manifest resolution below needs IS_DEBIAN / PKG_MGR.
 source "${_TD_CTX}/build_scripts/lib.sh"
 
+# tunaOS#1823: the stage-2 desktop dnf writes inherit an rpmdb in a LOWER
+# overlay layer; rpm mmaps it and overlayfs copy-up under an mmap'd write
+# corrupts it ("database disk image is malformed"). 20-packages.sh guards
+# its own stage, but every desktop stage's install-desktop.sh dnf writes
+# hit the same shape on the freshly imported base. Same probe as
+# 20-packages.sh — no-op off the dnf path (debian/arch/opensuse/gentoo).
+if [[ "${PKG_MGR:-}" == dnf ]]; then
+	rawhide_rpmdb_probe
+fi
+
 # Per-distro manifest overrides: <desktop>-debian.yaml / <desktop>-arch.yaml
 # beat the generic <desktop>.yaml when they exist — package names, session
 # files, and display managers differ across distros (kde-debian.yaml

--- a/build_scripts/desktop/kcm-ublue.sh
+++ b/build_scripts/desktop/kcm-ublue.sh
@@ -12,6 +12,8 @@ set -xeuo pipefail
 
 source /run/context/build_scripts/lib.sh
 
+rpmdb_stage2_guard
+
 # kcm_ublue and its build tooling come from dnf/COPR. On RPM-less distros
 # (openSUSE/Gentoo/Arch) skip it rather than fail with "dnf: command not found".
 if ! command -v dnf &>/dev/null; then

--- a/build_scripts/desktop/niri.sh
+++ b/build_scripts/desktop/niri.sh
@@ -4,6 +4,8 @@ set -xeuo pipefail
 
 source /run/context/build_scripts/lib.sh
 
+rpmdb_stage2_guard
+
 case "${1:-}" in
 "base")
 	# ── apt (Ubuntu/Debian) Niri path ──────────────────────────────────

--- a/build_scripts/desktop/xfce.sh
+++ b/build_scripts/desktop/xfce.sh
@@ -4,6 +4,8 @@ set -xeuo pipefail
 
 source /run/context/build_scripts/lib.sh
 
+rpmdb_stage2_guard
+
 case "${1:-}" in
 "base")
 	# ── dnf (RPM) XFCE path ──────────────────────────────────────────

--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -805,6 +805,16 @@ rawhide_rpmdb_probe() {
 	return 0
 }
 
+# Stage-2 rpmdb guard: every RUN layer that does dnf inherits the rpmdb in a
+# LOWER overlay layer and can corrupt it under an mmap'd write (#1823).
+# install-desktop.sh calls the probe directly; the other desktop scripts that
+# run dnf (gnome-extensions, kcm-ublue, niri, xfce) call this wrapper, which
+# no-ops off the dnf path.
+rpmdb_stage2_guard() {
+	[[ "${PKG_MGR:-}" == dnf ]] || return 0
+	rawhide_rpmdb_probe
+}
+
 # systemctl enable wrapper that tolerates the unit-not-present case.
 # Build scripts run in a multi-stage container build where some units may
 # only exist on certain variants (e.g. tailscaled on EL10 but not on EL9).


### PR DESCRIPTION
The rpmdb copy-up probe existed only in 20-packages.sh and the nvidia kernel-swap; every other stage-2 RUN that does dnf inherits the rpmdb in a LOWER overlay layer and corrupts it under an mmap-write (#1823, database disk image is malformed). This is what the installer-smoke Build dev ISO step hit for yellowfin gnome/xfce.

Add rpmdb_stage2_guard() (no-op off dnf) to lib.sh and call it after the lib.sh source in every dnf-running build script: install-desktop.sh, gnome-extensions.sh, kcm-ublue.sh, niri.sh, xfce.sh, 01-workarounds.sh, 10-base-packages.sh, 40-services.sh, 99-cleanup.sh.

Verification: bash -n + shellcheck clean. A yellowfin installer-smoke dispatch is queued to prove the ISO build no longer corrupts the rpmdb.