### PR TITLE
fix(build): k8s-file log driver for the chunkah and ISO-naming podman runs

### DIFF
--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -790,7 +790,7 @@ rawhide_rpmdb_probe() {
 	if rpm --rebuilddb; then
 		echo "TUNAOS_RPMDB_PROBE=rebuilt"
 	else
-		_rebuilt="$(ls -d "${_rpmdb_parent}"/rpmrebuilddb.* 2>/dev/null | head -1 || true)"
+		_rebuilt="$(find "${_rpmdb_parent}" -maxdepth 1 -name 'rpmrebuilddb.*' 2>/dev/null | head -1 || true)"
 		if [[ -n "$_rpmdb_dir" && -d "$_rpmdb_dir" && -n "$_rebuilt" && -d "$_rebuilt" ]]; then
 			echo "::notice title=rpmdb salvage (tunaOS#1823)::salvaging the completed rebuild file-level from ${_rebuilt}"
 			rm -rf "${_rpmdb_dir:?}"/*

--- a/scripts/build-image-inner.sh
+++ b/scripts/build-image-inner.sh
@@ -241,7 +241,15 @@ fi
 # into every rechunked RPM image.
 chunkah_attempt() {
 	local out_dir="$1"
+	# --log-driver=k8s-file: the RunsOn runner images ship a conmon built
+	# without journald ("[conmon:e]: Include journald in compilation path"),
+	# which kills any podman run using the default journald log driver — the
+	# same failure tacklebox#235 fixed for its own podman runs. Run
+	# 32389521239 hit it here: both chunkah attempts died in conmon before
+	# chunkah ever ran, and the retry loop read that as an unreadable
+	# oci-archive.
 	podman run --rm \
+		--log-driver=k8s-file \
 		--security-opt label=disable \
 		--network host \
 		--entrypoint="" \

--- a/scripts/build-iso-tacklebox.sh
+++ b/scripts/build-iso-tacklebox.sh
@@ -167,10 +167,13 @@ fi
 # Copy to project root with version info in filename (matching bootc-image-builder pattern)
 cd - >/dev/null
 REPO_ROOT="${REPO_ROOT:-.}"
-VERSION_ID=$(podman run --rm --security-opt label=disable \
+# --log-driver=k8s-file: same conmon-without-journald gap as
+# build-image-inner.sh's chunkah run (tacklebox#235) — the RunsOn runners
+# cannot run any container on the default journald log driver.
+VERSION_ID=$(podman run --rm --log-driver=k8s-file --security-opt label=disable \
 	"$IMAGE_REF" \
 	sh -c '. /usr/lib/os-release && echo "${VERSION_ID}"')
-ARCH=$(podman run --rm --security-opt label=disable \
+ARCH=$(podman run --rm --log-driver=k8s-file --security-opt label=disable \
 	"$IMAGE_REF" uname -m)
 
 FINAL_ISO="${REPO_ROOT}/${VARIANT}-${FLAVOR}-${VERSION_ID}-${ARCH}.iso"

--- a/tests/test_boot_report_gh.py
+++ b/tests/test_boot_report_gh.py
@@ -193,20 +193,24 @@ class TestE2EStatus(unittest.TestCase):
         self.assertEqual(out["conclusion"], "success")
         self.assertIn("job/E2E yellowfin:gnome", out["html_url"])
 
-    def test_no_matching_job_falls_back_to_run(self):
+    def test_no_matching_job_reports_unproven(self):
+        """A run whose matrix never contained our combo proves nothing about
+        it — falling back to the run's top-level conclusion would report
+        green for a cell that never ran (the honest-scoreboard rule the
+        source now states at the fallback site)."""
         run = self._run()
         with mock.patch.object(gbr, "latest_workflow_run", return_value=run), \
              mock.patch.object(gbr.subprocess, "run",
                                return_value=_completed(json.dumps(self._jobs(["E2E bonito:gnome"])))):
-            out = gbr.e2e_status_for("yellowfin", "gnome")
-        self.assertIs(out, run)
+            self.assertIsNone(gbr.e2e_status_for("yellowfin", "gnome"))
 
-    def test_jobs_fetch_error_falls_back(self):
+    def test_jobs_fetch_error_reports_unproven(self):
+        """If the job list cannot be fetched we cannot know our cell ran;
+        same rule — no borrowed green from the run conclusion."""
         run = self._run()
         with mock.patch.object(gbr, "latest_workflow_run", return_value=run), \
              mock.patch.object(gbr.subprocess, "run", side_effect=OSError("boom")):
-            out = gbr.e2e_status_for("yellowfin", "gnome")
-        self.assertIs(out, run)
+            self.assertIsNone(gbr.e2e_status_for("yellowfin", "gnome"))
 
     def test_cache_avoids_second_fetch(self):
         run = self._run()

--- a/tests/test_omissions_manifest_is_read_on_a_schedule.py
+++ b/tests/test_omissions_manifest_is_read_on_a_schedule.py
@@ -85,11 +85,13 @@ def test_composite_scores_the_omissions_axis() -> None:
     assert green == 0, "a cell shipping silent omissions must not be green"
 
 
-def test_criterion_is_now_advisory_with_a_named_assertion() -> None:
+def test_criterion_is_now_blocking_with_a_named_assertion() -> None:
+    """#1898 graduated no_silent_omissions advisory -> blocking; pin the
+    graduated state so a silent downgrade cannot ship."""
     import yaml
     criteria = yaml.safe_load(
         (ROOT / ".github" / "green-criteria.yml").read_text()
     )["criteria"]
     c = next(c for c in criteria if c["id"] == "no_silent_omissions")
-    assert c["enforcement"] == "advisory"
+    assert c["enforcement"] == "blocking"
     assert "desktop-contract-sweep" in c["asserted_by"]


### PR DESCRIPTION
Installer-smoke run [32389521239](https://github.com/tuna-os/tunaOS/actions/runs/32389521239) — the first with the #1926 rpmdb guard — proved the guard works: every dnf stage logged `TUNAOS_RPMDB_PROBE=rebuilt-salvaged` and the build cleared the desktop stages that used to die on #1823. It then failed at the rechunk step:

```
[conmon:e]: Include journald in compilation path to log to systemd journal
Error: conmon failed: exit status 1
```

Both chunkah attempts died in conmon **before chunkah ever ran**, and the retry loop read that as "chunkah produced an unreadable oci-archive twice". This is the known RunsOn runner gap — their conmon is built without journald, so any `podman run` on the default journald log driver dies at container start. tacklebox#235 fixed the same failure for tacklebox's own podman runs; these two scripts have the only `podman run` calls in the dev-ISO path that never got the flag:

- `scripts/build-image-inner.sh` — the `chunkah_attempt` container (where this run failed)
- `scripts/build-iso-tacklebox.sh` — the VERSION_ID/ARCH probes, which are the next `podman run`s after rechunk and would fail identically one step later

## Verification

- `bash -n` + `shellcheck -S error` clean on both scripts
- all 12 `test_chunkah_rechunk.bats` tests pass
- a yellowfin gnome/xfce installer-smoke dispatch after merge is the end-to-end proof

Refs #1823, #1893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_