### PR TITLE
fix: dconf-race contract ordering; loud rpmdb data-loss; live ISOs on RunsOn

### DIFF
--- a/.github/workflows/live-iso-bootc.yml
+++ b/.github/workflows/live-iso-bootc.yml
@@ -31,7 +31,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    # The stock GitHub runner's container storage corrupts the rpmdb sqlite
+    # across layer commits (#1823: every stage-2 script's guard found the db
+    # malformed again; the lossy rebuilds eventually drop system-release and
+    # dnf dies on literal epel-$releasever metalinks — runs 32392181047 /
+    # 32394645068, deterministic). installer-smoke escaped the same class of
+    # runner breakage by moving to RunsOn with the Kubic podman (#1919-#1923);
+    # build here the same way.
+    runs-on: runs-on=${{ github.run_id }}/runner=build-amd64
     permissions:
       contents: read
       packages: read
@@ -45,13 +52,32 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Maximize build space
-        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6 # main as of 2026-02-11
-
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y just podman jq rclone golang-go git systemd-boot-efi mtools squashfs-tools xorriso dosfstools gdisk e2fsprogs btrfs-progs
+
+      # Same wedge and same fix as installer-smoke.yml: the runner image's
+      # podman 5.8.4 cannot run/commit containers (tunaOS#1893) and its conmon
+      # lacks journald (handled by the k8s-file log drivers in the scripts) —
+      # install the Kubic podman and drop any image-baked shadow binary.
+      - name: setup working podman
+        run: |
+          set -euo pipefail
+          sudo install -d /etc/apt/keyrings
+          curl -fsSL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/Release.key \
+            | gpg --dearmor | sudo tee /etc/apt/keyrings/kubic.gpg >/dev/null
+          echo 'deb [signed-by=/etc/apt/keyrings/kubic.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/ /' \
+            | sudo tee /etc/apt/sources.list.d/kubic.list
+          sudo apt-get update -qq
+          sudo apt-get remove -y podman conmon crun || true
+          sudo apt-get install -y podman
+          for p in /usr/local/bin/podman /usr/local/sbin/podman; do
+            if [ -e "$p" ] && ! dpkg -S "$p" >/dev/null 2>&1; then
+              sudo rm -f "$p"
+            fi
+          done
+          hash -r
 
       - name: Setup rootless podman (subuid/subgid for runner)
         run: |

--- a/build_scripts/desktop/configure-desktop-runtime.sh
+++ b/build_scripts/desktop/configure-desktop-runtime.sh
@@ -261,7 +261,14 @@ gnome | kde | niri | cosmic | xfce | pantheon)
 	cat >/usr/lib/systemd/system/tunaos-desktop-contract.service <<EOF
 [Unit]
 Description=Verify TunaOS ${desktop} desktop experience
-After=display-manager.service
+# dconf-update.service compiles /etc/dconf/db/*.d keyfiles at boot. On bases
+# where the compiled db is baked at build this is a no-op; on guppy:gnome the
+# baked db was absent and the contract raced the compile at first boot,
+# failing on "missing compiled dconf database" while dconf-update would have
+# fixed it moments later (boot-gate run 32323551841). Order after it so the
+# check judges the settled state — a genuinely broken dconf still fails.
+After=display-manager.service dconf-update.service
+Wants=dconf-update.service
 Wants=display-manager.service
 
 [Service]

--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -899,7 +899,14 @@ if [[ "${_TD_DESKTOP}" == gnome || "${_TD_DESKTOP}" == kde || "${_TD_DESKTOP}" =
 	cat >/usr/lib/systemd/system/tunaos-desktop-contract.service <<EOF
 [Unit]
 Description=Verify TunaOS ${_TD_DESKTOP} desktop experience
-After=display-manager.service
+# dconf-update.service compiles /etc/dconf/db/*.d keyfiles at boot. On bases
+# where the compiled db is baked at build this is a no-op; on guppy:gnome the
+# baked db was absent and the contract raced the compile at first boot,
+# failing on "missing compiled dconf database" while dconf-update would have
+# fixed it moments later (boot-gate run 32323551841). Order after it so the
+# check judges the settled state — a genuinely broken dconf still fails.
+After=display-manager.service dconf-update.service
+Wants=dconf-update.service
 Requires=display-manager.service
 
 [Service]

--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -802,6 +802,17 @@ rawhide_rpmdb_probe() {
 			echo "::warning title=rpmdb probe (tunaOS#1823)::rpm --rebuilddb failed and left no rebuilt db to salvage; proceeding — the stage-2 transaction is the real verdict"
 		fi
 	fi
+	# A rebuild from an already-malformed db is LOSSY: it keeps whatever the
+	# failing SELECT managed to read. On the stock ubuntu-latest storage the
+	# corruption recurs after every layer commit, each salvage compounds the
+	# loss, and by install-desktop the db has dropped system-release — after
+	# which dnf cannot resolve $releasever and every later stage dies on
+	# 'metalink?repo=epel-$releasever' 404s that look like a repo outage
+	# (runs 32392181047 / 32394645068). Name the data loss here instead.
+	if ! rpm -q --whatprovides 'system-release(releasever)' >/dev/null 2>&1; then
+		echo "::error title=rpmdb data loss (tunaOS#1823)::the rebuilt rpmdb no longer provides system-release(releasever) — the salvage was lossy and dnf's \$releasever detection is gone. This build cannot produce a valid image; fix the runner's container storage (see #1893) instead of chasing the downstream epel-\$releasever 404s."
+		return 1
+	fi
 	return 0
 }
 


### PR DESCRIPTION
Three image-green fixes from today's boot-gate and Live-ISOs evidence, one commit each.

## 1. Order the desktop-contract unit after dconf-update.service

guppy:gnome was the single red cell in boot-gate run [32323551841](https://github.com/tuna-os/tunaOS/actions/runs/32323551841) (29/30 green):

```
verify-desktop-experience[694]: missing compiled dconf database:
keyfiles in /etc/dconf/db/distro.d but /etc/dconf/db/distro is missing or empty
```

The `distro.d` keyfiles come from a base package. The build compiles dconf DBs before its build-time verify (which is why the image published), but on the Gentoo base the compiled DB is absent at first boot, and `dconf-update.service` — enabled by `40-services.sh` for exactly this — has no ordering relationship with the contract unit. The contract ran at 15.19s and lost the race. Add `After=`/`Wants=dconf-update.service` to both unit writers: no-op where the DB is baked, deterministic where it isn't, and a genuinely broken dconf still fails.

## 2. Fail loudly when the rpmdb salvage was lossy

The Live-ISOs check fails deterministically on stock runners ([32392181047](https://github.com/tuna-os/tunaOS/actions/runs/32392181047), [32394645068](https://github.com/tuna-os/tunaOS/actions/runs/32394645068)): the #1823 corruption recurs after **every layer commit**, each stage's rebuild-from-malformed keeps only what the failing SELECT could read, and by `install-desktop` the accumulated loss has dropped `system-release` — after which dnf can't resolve `$releasever` and everything dies on literal `epel-$releasever` metalink 404s that read as a repo outage. The probe now asserts the db still provides `system-release(releasever)` and fails the build with a named error instead.

## 3. Build live ISOs on RunsOn with the Kubic podman

Same runner escape installer-smoke made in #1919–#1923 for the same class of stock-runner container-storage breakage (#1893). The scripts' k8s-file log drivers (#1927) cover those runners' conmon journald gap.

## Verification

`bash -n` + `shellcheck` clean on all touched scripts; all 46 `test_build_scripts.bats` tests pass; workflow YAML parses, actionlint reports only the pre-existing SC2034 in the untouched boot-screenshot block. End-to-end proof: the next guppy nightly boot gate (fix 1) and the next Live-ISOs dispatch (fixes 2–3).

Refs #1823, #1893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC