### PR TITLE
fix(live-iso): bundle the stamp-capable installer flatpak from the tuna-os fork

### DIFF
--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -469,19 +469,25 @@ if [[ -n "${INSTALLER_APP}" ]]; then
 	export DBUS_SESSION_BUS_ADDRESS="unix:path=${SESSION_BUS_SOCK}"
 	if [[ "${INSTALLER_APP}" == "org.bootcinstaller.Installer" ]]; then
 		# gnome: mirrors projectbluefin/dakota-iso's install-flatpaks.sh —
-		# download the upstream release bundle and import it into a
-		# throwaway local ostree repo. `flatpak install --bundle` in a
-		# container build only creates the installer-origin: remote ref, not
-		# the deploy/ ref that `flatpak run`/`flatpak list` need; installing
-		# from a local file:// remote goes through the full deploy pipeline.
-		# Primary source: projectbluefin/bootc-installer (upstream). Fallback:
-		# tuna-os/tuna-installer, which mirrors the same app ID as a release
-		# asset.
+		# download a release bundle and import it into a throwaway local
+		# ostree repo. `flatpak install --bundle` in a container build only
+		# creates the installer-origin: remote ref, not the deploy/ ref
+		# that `flatpak run`/`flatpak list` need; installing from a local
+		# file:// remote goes through the full deploy pipeline.
+		#
+		# Primary source: the tuna-os/bootc-installer fork's release. It
+		# MUST be the fork, not upstream projectbluefin: installer-smoke's
+		# readiness assert requires the tuna-installer-ready stamp the fork
+		# writes on window map (bootc-installer#7/#8), and the upstream
+		# release predates it — smoke run 32408962415's gnome leg had the
+		# session and installer process fully up yet failed on exactly the
+		# missing stamp. Fallback: tuna-os/tuna-installer, which mirrors
+		# the same app ID as a release asset.
 		INSTALLER_FLATPAK_FILE="/tmp/bootc-installer.flatpak"
 		if ! curl --retry 3 --fail --location --max-time 300 \
-			"https://github.com/projectbluefin/bootc-installer/releases/latest/download/org.bootcinstaller.Installer.flatpak" \
+			"https://github.com/tuna-os/bootc-installer/releases/latest/download/org.bootcinstaller.Installer.flatpak" \
 			-o "${INSTALLER_FLATPAK_FILE}" 2>/dev/null; then
-			echo "projectbluefin/bootc-installer unavailable, falling back to tuna-os/tuna-installer..."
+			echo "tuna-os/bootc-installer unavailable, falling back to tuna-os/tuna-installer..."
 			curl --retry 3 --fail --location --max-time 300 \
 				"https://github.com/tuna-os/tuna-installer/releases/latest/download/org.bootcinstaller.Installer.flatpak" \
 				-o "${INSTALLER_FLATPAK_FILE}"


### PR DESCRIPTION
## What

`customize-live.sh` now downloads the gnome installer flatpak (`org.bootcinstaller.Installer.flatpak`) from **tuna-os/bootc-installer's latest release** instead of upstream projectbluefin's, keeping the tuna-os/tuna-installer mirror as the fallback.

## Why

Smoke run 32408962415 (run 63) was the first whose boot phase executed at all — #1929's KVM split works: both ISOs built on RunsOn, transferred, and booted on ubuntu-latest in ~3 minutes. Its gnome leg then failed on exactly one missing piece:

- `gnome: compositor running: gnome-shell` ✔
- `installer frontend: org.bootcinstaller.Installer` running ✔
- readiness stamp: **never written** — `/run/user/1000/app/org.bootcinstaller.Installer/` empty after 3 minutes → assert timeout

The assert's own caveat applied: "If this frontend's stamp is new, confirm the ISO's flatpak postdates it." The `tuna-installer-ready` stamp feature was added in the **tuna-os fork** (bootc-installer#7/#8, Aug 8), while the live ISO downloaded upstream projectbluefin's latest release, which predates it. The fork publishes the same asset name from its head (currently v2026.08.15-5a4b051c, stamp included), so the installer can finally *prove* the window mapped.

## What this PR deliberately does not touch

The same run's **xfce** leg failed differently — `no compositor process running` — and the harness itself printed why: `-vga virtio headless (no render node/virgl) — niri/xfwl4 will not render here`. Per iso-e2e.sh's GPU-selection notes, xfwl4 is a Smithay compositor with no software fallback: it cannot start on GPU-less hosted runners at all. That leg needs the GPU-runner matrix (same bucket as cosmic/niri/kde), which is blocked on AWS quota — tracked separately. GNOME is the one desktop verifiable on a CPU-only runner, and this PR unblocks exactly that proof.

## Validation

`bash -n` + `shellcheck -S error` pass. Asset verified present: `https://github.com/tuna-os/bootc-installer/releases/latest/download/org.bootcinstaller.Installer.flatpak` (93.5 MB, sha256 d2007425…).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_