### PR TITLE
test(installer-smoke): capture the installer's own debug log

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -472,6 +472,28 @@ jobs:
           SSH="sshpass -p live ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null liveuser@127.0.0.1"
           out="smoke-out/installer-stderr-${FLAVOR}.log"
           {
+            # The installer's OWN log, which is where its Python logging
+            # actually goes. main.py configures basicConfig with both a
+            # StreamHandler and a FileHandler at
+            #   $XDG_CACHE_HOME/bootc-installer/installer-debug.log
+            # and inside the Flatpak sandbox XDG_CACHE_HOME is the app's
+            # private ~/.var/app/<app-id>/cache. The journal therefore sees
+            # almost nothing from it: smoke run 32435080411 captured 133
+            # lines and exactly ONE came from the installer (an libEGL
+            # warning), which is why "running but never reported a window"
+            # has stayed undiagnosable across runs 63-66.
+            #
+            # This file answers it directly. It records "do_activate called",
+            # which of BootcWindow / BootcRamWindow / BootcCpuWindow /
+            # BootcUnsupportedWindow was constructed, "Main window created",
+            # and any traceback from the do_activate except-branch. If the
+            # window was built and armed but never mapped, the log ends after
+            # "Main window created" with no exception — which distinguishes a
+            # renderer that cannot present from an app that never got that
+            # far. Collect what settles it rather than guessing at a fix.
+            echo "=== installer's own debug log ==="
+            $SSH 'cat ~/.var/app/org.bootcinstaller.Installer/cache/bootc-installer/installer-debug.log 2>/dev/null || cat ~/.cache/bootc-installer/installer-debug.log 2>/dev/null || echo "(no installer-debug.log found)"' 2>/dev/null || true
+            echo
             echo "=== user journal (installer + portal + flatpak) ==="
             $SSH 'journalctl --user -b --no-pager 2>/dev/null | grep -iE "installer|flatpak|portal|wgpu|EGL|MESA|wayland|vulkan" | tail -120' 2>/dev/null || true
             echo


### PR DESCRIPTION
## What

Adds one diagnostic to the smoke harness's capture step: the installer's own debug log.

## Why

`gnome: org.bootcinstaller.Installer is running but never reported a window` has now failed four consecutive runs (63, 64, 65, 66) and remains undiagnosed — not because the evidence doesn't exist, but because the harness has never collected it.

`main.py` configures logging with **two** handlers:

```python
_log_file = os.path.join(_cache_dir, "installer-debug.log")
logging.basicConfig(
    handlers=[logging.StreamHandler(sys.stderr),
              logging.FileHandler(_log_file, mode="w")],
)
```

and inside the Flatpak sandbox `XDG_CACHE_HOME` is the app's private `~/.var/app/org.bootcinstaller.Installer/cache`. So the journal sees almost nothing: run 32435080411 captured 133 diagnostic lines, of which **exactly one** came from the installer (a libEGL warning). Everything the app says about its own startup went to a file nobody reads.

## What the log will settle

`do_activate` logs at every branch:

| log ends at | meaning | fix direction |
|---|---|---|
| `Main window created`, no exception | window built and armed, `map` never fired | renderer cannot present (GSK/EGL) |
| `Not enough RAM` / `Not enough CPU` / `Not UEFI` | a non-wizard window was presented | CI VM sizing, not a UI bug |
| traceback from the except-branch | `do_activate` died | whatever the traceback says |
| nothing at all | never reached `do_activate` | startup/sandbox |

These need opposite fixes, which is why guessing at one now would be premature. The libEGL warning makes the first row most likely, but "most likely" is not what a four-run-old mystery deserves.

This is the same principle the greetd diagnostic block in this file already states: *"Rather than change autologin on a guess, collect what settles it."*

## Scope

Additive: one `echo` + one SSH `cat` with a non-sandboxed fallback path, inside the existing `if: always()` capture step. No behavior change to any gate. YAML parses; diff is 22 lines.

## Context

Prior fixes in this chain, all confirmed: #1929 (build on RunsOn, boot where KVM exists), #1930 (bundle the fork's release), bootc-installer#22 (port the stamp from `main` to `dev`), bootc-installer#24 (install `readiness.py` — it had never been in a packaged build). Run 66 proves #24 worked: the installer process is alive again where run 65 had none.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_