### PR TITLE
fix(nightly): apply the documented stagger — 13 variants shared one cron

### DIFF
--- a/.github/workflows/build-albacore.yml
+++ b/.github/workflows/build-albacore.yml
@@ -1,7 +1,7 @@
 name: Build Albacore
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 2 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-bonito-rawhide.yml
+++ b/.github/workflows/build-bonito-rawhide.yml
@@ -1,7 +1,7 @@
 name: Build Bonito-rawhide
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 15 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-bonito.yml
+++ b/.github/workflows/build-bonito.yml
@@ -1,7 +1,7 @@
 name: Build Bonito
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 11 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-flounder-sid.yml
+++ b/.github/workflows/build-flounder-sid.yml
@@ -1,7 +1,7 @@
 name: Build Flounder-sid
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 23 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-flounder.yml
+++ b/.github/workflows/build-flounder.yml
@@ -1,7 +1,7 @@
 name: Build Flounder
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 21 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-grouper.yml
+++ b/.github/workflows/build-grouper.yml
@@ -1,7 +1,7 @@
 name: Build Grouper
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 17 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-guppy.yml
+++ b/.github/workflows/build-guppy.yml
@@ -1,7 +1,7 @@
 name: Build Guppy
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 6 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-gurnard.yml
+++ b/.github/workflows/build-gurnard.yml
@@ -1,7 +1,7 @@
 name: Build Gurnard
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 4 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-hummingbird.yml
+++ b/.github/workflows/build-hummingbird.yml
@@ -1,7 +1,7 @@
 name: Build Hummingbird
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 22 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-marlin.yml
+++ b/.github/workflows/build-marlin.yml
@@ -1,7 +1,7 @@
 name: Build Marlin
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 13 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-sailfin.yml
+++ b/.github/workflows/build-sailfin.yml
@@ -1,7 +1,7 @@
 name: Build Sailfin
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 19 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-skipjack.yml
+++ b/.github/workflows/build-skipjack.yml
@@ -1,7 +1,7 @@
 name: Build Skipjack
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 9 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -8,10 +8,11 @@ name: Unified Build
 # Biggest variants overnight; only the two smallest inside the 04:00–09:00
 # proving window (daily-verify 04:00, verify-asahi 05:40, matrix-status &
 # catalog-facts 06:00, desktop-contract-sweep 08:00).
-#   00:20 yellowfin(20fl)  02:20 albacore(20)   04:20 gurnard(2)
-#   06:20 flounder-sid(5)  09:20 skipjack(18)   11:20 bonito(15)
-#   13:20 bonito-rawhide(14) 15:20 marlin(9)    17:20 grouper(7)
-#   19:20 sailfin(7)       21:20 flounder(6)    23:20 guppy(4)
+#   00:20 yellowfin(20fl)  02:20 albacore(20)       04:20 gurnard(2)
+#   06:20 guppy(4)         09:20 skipjack(18)       11:20 bonito(16)
+#   13:20 marlin(16)       15:20 bonito-rawhide(14) 17:20 grouper(7)
+#   19:20 sailfin(7)       21:20 flounder(7)        22:20 hummingbird(5)
+#   23:20 flounder-sid(7)
 # If you add a variant or move a cron, keep this table true.
 on:
   workflow_call:

--- a/.github/workflows/build-yellowfin.yml
+++ b/.github/workflows/build-yellowfin.yml
@@ -1,7 +1,7 @@
 name: Build Yellowfin
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "20 0 * * *"
   workflow_dispatch:
     inputs:
       flavor:

--- a/tests/test_nightly_schedule_registry.py
+++ b/tests/test_nightly_schedule_registry.py
@@ -1,0 +1,135 @@
+"""The nightly crons must match the registry table, and each other never.
+
+`build-variant.yml` opens with a schedule registry and the instruction "If you
+add a variant or move a cron, keep this table true." Nothing enforced it, and
+it stopped being true: every one of the 13 per-variant nightlies sat on the
+same `0 1 * * *` cron while the table described a ~2h stagger, and
+hummingbird was missing from the table altogether.
+
+That is not a documentation nit. The org has a 20-concurrent-job ceiling, so
+13 simultaneous crons queue against each other: scheduled yellowfin runs took
+1h32m-8h45m and failed 14 nights running, while the same build dispatched
+by hand off-peak finished green in 1h02m. The stagger is the fix that was
+written down and then lost.
+
+These tests pin the three things that can rot independently: the crons
+against the table, the table against the real flavor counts, and the slots
+against each other.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github/workflows"
+VARIANT_WORKFLOW = WORKFLOWS / "build-variant.yml"
+BUILD_CONFIG = ROOT / ".github/build-config.yml"
+
+# The proving workflows this window is reserved for: daily-verify 04:00,
+# verify-asahi 05:40, matrix-status & catalog-facts 06:00,
+# desktop-contract-sweep 08:00.
+PROVING_WINDOW = (4, 9)
+MAX_IN_PROVING_WINDOW = 2
+
+# `20 13 * * *` -> ("13", "20"); anything else is not a daily slot.
+_DAILY_CRON = re.compile(r"^(\d{1,2}) (\d{1,2}) \* \* \*$")
+# `#   00:20 yellowfin(20fl)  02:20 albacore(20)` -> repeated (HH, MM, name, n)
+_TABLE_ENTRY = re.compile(r"(\d{2}):(\d{2}) ([a-z0-9-]+)\((\d+)(?:fl)?\)")
+
+
+def registry_table() -> dict[str, tuple[int, int, int]]:
+    """variant -> (hour, minute, documented flavor count), from the comment."""
+    entries: dict[str, tuple[int, int, int]] = {}
+    for line in VARIANT_WORKFLOW.read_text().splitlines():
+        # The table lives in the header comment block, above the `on:` key.
+        if line.rstrip() == "on:":
+            break
+        if not line.startswith("#"):
+            continue
+        for hh, mm, name, count in _TABLE_ENTRY.findall(line):
+            entries[name] = (int(hh), int(mm), int(count))
+    return entries
+
+
+def scheduled_crons() -> dict[str, tuple[int, int]]:
+    """variant -> (hour, minute), from each build-<variant>.yml."""
+    slots: dict[str, tuple[int, int]] = {}
+    for path in sorted(WORKFLOWS.glob("build-*.yml")):
+        variant = path.stem[len("build-") :]
+        if variant in {"variant", "flavor", "toolchain"}:
+            continue  # reusable plumbing, not a variant nightly
+        doc = yaml.safe_load(path.read_text())
+        # PyYAML parses the bare `on:` key as the boolean True.
+        triggers = doc.get("on", doc.get(True)) or {}
+        schedule = triggers.get("schedule") if isinstance(triggers, dict) else None
+        if not schedule:
+            continue
+        match = _DAILY_CRON.match(schedule[0]["cron"].strip())
+        if not match:
+            continue  # e.g. the weekly archlinuxarm base rebuild
+        minute, hour = match.groups()
+        slots[variant] = (int(hour), int(minute))
+    return slots
+
+
+def flavor_counts() -> dict[str, int]:
+    config = yaml.safe_load(BUILD_CONFIG.read_text())
+    return {v["id"]: len(v.get("flavors", [])) for v in config["variants"]}
+
+
+def test_every_nightly_appears_in_the_registry() -> None:
+    """hummingbird was scheduled but undocumented, so nothing balanced it."""
+    assert set(scheduled_crons()) == set(registry_table())
+
+
+def test_the_registry_matches_the_actual_crons() -> None:
+    table = registry_table()
+    for variant, (hour, minute) in scheduled_crons().items():
+        assert (hour, minute) == table[variant][:2], (
+            f"{variant} runs at {hour:02d}:{minute:02d} but the registry in "
+            f"build-variant.yml says {table[variant][0]:02d}:{table[variant][1]:02d}"
+        )
+
+
+def test_the_registry_flavor_counts_are_real() -> None:
+    """The counts are what the stagger is balanced on, so they must not rot."""
+    counts = flavor_counts()
+    for variant, (_, _, documented) in registry_table().items():
+        assert documented == counts[variant], (
+            f"registry says {variant} has {documented} flavors; "
+            f"build-config.yml declares {counts[variant]}"
+        )
+
+
+def test_no_two_variants_share_a_slot() -> None:
+    """The regression itself: 13 nightlies on one cron, starving each other."""
+    slots = scheduled_crons()
+    seen: dict[tuple[int, int], str] = {}
+    for variant, slot in sorted(slots.items()):
+        assert slot not in seen, (
+            f"{variant} and {seen[slot]} both fire at "
+            f"{slot[0]:02d}:{slot[1]:02d}; the 20-job ceiling makes them queue"
+        )
+        seen[slot] = variant
+
+
+def test_the_proving_window_carries_only_the_smallest_builds() -> None:
+    """04:00-09:00 belongs to the verification workflows, not the fleet."""
+    counts = flavor_counts()
+    low, high = PROVING_WINDOW
+    inside = [v for v, (h, _) in scheduled_crons().items() if low <= h < high]
+    assert len(inside) <= MAX_IN_PROVING_WINDOW, (
+        f"{sorted(inside)} all fire inside the {low:02d}:00-{high:02d}:00 "
+        "proving window"
+    )
+    smallest = sorted(counts, key=lambda v: (counts[v], v))[: len(inside)]
+    assert sorted(inside) == sorted(smallest), (
+        f"the proving window carries {sorted(inside)}; the smallest builds "
+        f"are {sorted(smallest)}"
+    )


### PR DESCRIPTION
## What

`build-variant.yml` opens with a nightly schedule registry and the instruction *"If you add a variant or move a cron, keep this table true."* It was not true:

- all **13** per-variant nightlies sat on the same cron, `0 1 * * *`, while the table described a ~2h stagger
- **hummingbird was missing from the table entirely**, so nothing balanced it against anything
- four documented flavor counts had drifted from `build-config.yml`

## Why it matters

The org has a 20-concurrent-job ceiling and one variant's full build alone exceeds it, so 13 simultaneous crons queue against each other. The cost shows up in yellowfin's own run history:

| | duration | outcome |
|---|---|---|
| scheduled runs 322–335 | 1h32m – 8h45m | **failed 14 nights running** |
| run 334, dispatched by hand off-peak | 1h02m | green |

The stagger isn't an optimization — it's the fix that was written down and then lost.

## The schedule now applied

```
00:20 yellowfin(20)  02:20 albacore(20)       04:20 gurnard(2)
06:20 guppy(4)       09:20 skipjack(18)       11:20 bonito(16)
13:20 marlin(16)     15:20 bonito-rawhide(14) 17:20 grouper(7)
19:20 sailfin(7)     21:20 flounder(7)        22:20 hummingbird(5)
23:20 flounder-sid(7)
```

`gurnard(2)` and `guppy(4)` are the two smallest builds and the only two inside the 04:00–09:00 proving window, per the rule the registry already states. Counts corrected against `build-config.yml`: bonito 15→16, marlin 9→16, flounder 6→7, flounder-sid 5→7.

## Enforcement

A comment asking to be kept true is not a mechanism, which is why it drifted. `tests/test_nightly_schedule_registry.py` pins the three things that rot independently:

1. the crons against the table
2. the table's flavor counts against `build-config.yml`
3. the slots against each other

## Verification

- 5 new tests pass, and each was **mutation-checked** — collide two variants onto one slot, drop hummingbird from the table, move skipjack into the proving window — with the intended assertion failing in every case
- 99 schedule-adjacent tests pass (`test_generate_workflows`, `test_matrix_status`, `test_green_master_plan`, `test_build_ceiling_clears_the_slowest_variant`, others)
- all 14 build workflow files parse

## Not in this PR

Two findings surfaced while diagnosing this and are left for separate work:

- **Startup failures are unrecoverable.** The 2026-08-21 nightly lost all 13 variants to 0-job startup failures (runs attributed to a deleted `gh-readonly-queue/*` ref). `rerun-infra-failures.yml` cannot recover these: it bails on zero failed jobs, and — verified against its run history — the `workflow_run: completed` event does not fire for a run that never started, so patching that classifier would be inert. Needs a scheduled sweeper instead.
- **The rpmdb copy-up guard is still unverified by a nightly.** Run 335's nvidia leg ran at 06:05 on 08-20, but the round-2 fix landed 06:25 and the round-4 salvage 12:10. The only nightly since was one of the startup failures, so rounds 2 and 4 have never actually been exercised on a schedule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_