### PR TITLE
test(installer-smoke): make the debug log reachable, and probe the sandbox env

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -534,9 +534,32 @@ jobs:
             # Bracket the first letter so the pattern never matches its own
             # argv, the same defence the frontend check above already uses.
             $SSH 'pgrep -xl "[c]osmic-comp|[n]iri|[x]fwl4|[k]win_wayland" 2>/dev/null || echo "(no compositor matched)"; ps -eo pid,comm,args | grep -iE "[I]nstaller" || echo "(no installer process)"' 2>/dev/null || true
+
+            echo
+            echo "=== XDG_RUNTIME_DIR as the sandboxed frontend sees it ==="
+            # Run 67 put the wizard ON SCREEN (evidence screenshot) with the
+            # app's runtime dir present and EMPTY, and no stamp in either
+            # location the assert reads. So the window mapped and the stamp
+            # still was not written. readiness.stamp_path() returns None when
+            # XDG_RUNTIME_DIR is unset, and write_stamp swallows failures by
+            # design, so an unset variable INSIDE the sandbox produces exactly
+            # this shape and leaves no other trace. The host-side directory
+            # existing does not prove the variable is set in the sandbox --
+            # flatpak creates it either way. Read it from the process itself.
+            $SSH 'for p in $(pgrep -x bootc-installer 2>/dev/null); do \
+                    echo "-- pid $p"; \
+                    { sudo cat /proc/$p/environ 2>/dev/null || cat /proc/$p/environ 2>/dev/null; } | tr "\0" "\n" | grep -E "^(XDG_RUNTIME_DIR|FLATPAK_ID|HOME|XDG_CACHE_HOME)=" || echo "(could not read environ)"; \
+                  done; \
+                  echo "-- stamp anywhere under /run/user --"; \
+                  find /run/user -name "tuna-installer-ready" 2>/dev/null || true' 2>/dev/null || true
           } > "$out" 2>&1
           echo "--- captured $(wc -l < "$out") lines ---"
-          tail -30 "$out"
+          # NOT tail: the installer's own debug log is the FIRST section of
+          # five, so `tail -30` showed the last two and structurally could
+          # never show the one this capture was added for (run 67). The whole
+          # file is ~170 lines -- small enough to print, and the point is to
+          # be readable without downloading an artifact.
+          cat "$out"
 
       - name: Screenshot desktop evidence
         if: always()
@@ -570,11 +593,14 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: installer-smoke-${{ matrix.variant }}-${{ matrix.flavor }}
+          # *.log rather than serial.log alone: the capture step writes
+          # installer-stderr-<flavor>.log, which matched no pattern here, so
+          # run 67's capture reached neither the console nor the artifact.
           path: |
             smoke-out/*.png
             smoke-out/*.json
             smoke-out/*.tap
-            smoke-out/serial.log
+            smoke-out/*.log
           if-no-files-found: warn
 
   # Publishes the walkthrough-*.png frames captured above to docs, the same


### PR DESCRIPTION
## The headline: the installer works

Run 67's evidence screenshot shows the wizard **on screen** — "Welcome to Yellowfin", Install / Power Off, GNOME shell and dock all drawn. Runs 63–67 have been read as "the installer starts but puts nothing on the screen". That is not what is happening. The installer renders, the window maps, the UI is correct.

What is missing is only the **readiness stamp**. This is a gate defect, not a UI regression.

The runtime dirs the assert already dumps confirm it:

```
·/·r·un/user/1000/app/org.bootcinstaller.Installer/:
total 0                      <- exists, writable, EMPTY
```

…and no `tuna-installer-ready` in either location the assert reads. The window was mapped from ~03:38:50, three minutes before polling began at 03:40:54, so this is not a timing race either.

Worth noting run 67 *did* clear a real bug: per bootc-installer#24's own table, run 66 had the installer never start at all (`ModuleNotFoundError`). Release `v2026.08.21-8404a083` was cut from #24's merge commit at 01:02Z and this ISO built at 02:57, so it contains the fix — pid 2985 is alive and logging. We moved from "never ran" to "runs, renders, doesn't stamp".

## Why I am not fixing the stamp in this PR

Three causes remain, and they need different fixes:

1. `readiness.arm()` never reached
2. the GTK `map` signal never firing
3. `XDG_RUNTIME_DIR` unset **inside** the sandbox

The log that tells them apart was unreadable — because the capture I added in #1931 was visible nowhere:

| gap | effect |
|---|---|
| `tail -30 "$out"` | showed the last two of five sections; the installer's debug log is the **first**, so the tail could structurally never show it |
| upload patterns are `*.png`, `*.json`, `*.tap`, `serial.log` | the capture is `installer-stderr-<flavor>.log` — matched nothing, so it never reached the artifact either |

I confirmed the second by downloading run 67's artifact: it contains only `installer-gnome.png` and `serial.log`.

## Changes

- **print the whole capture** instead of tailing it (~170 lines — small enough to read without downloading an artifact)
- **upload `*.log`** rather than `serial.log` alone
- **probe the one cause that leaves no other trace.** `stamp_path()` returns `None` when `XDG_RUNTIME_DIR` is unset, and `write_stamp` swallows failures by design, so an unset variable inside the sandbox produces exactly run 67's shape — mapped window, empty runtime dir, no stamp, nothing logged. The host-side directory existing does *not* prove the variable is set in the sandbox; flatpak creates it either way. So read it from the process itself via `/proc/<pid>/environ`, and search all of `/run/user` for a stamp that landed somewhere unexpected.

## Verification

- yaml parses; the capture step passes `bash -n`
- the upload path list parses to exactly four patterns — an earlier draft of mine put a `#` comment *inside* the `path: |` block scalar, where it would have been a literal path rather than a comment; moved above the key
- 28 desktop/green-criteria/schedule tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_