### PR TITLE
feat(ci): recover nightlies that never started (#1933)

### DIFF
--- a/.github/workflows/rerun-startup-failures.yml
+++ b/.github/workflows/rerun-startup-failures.yml
@@ -1,0 +1,62 @@
+name: Re-run startup failures
+
+# A startup failure is a run GitHub refused to begin: zero jobs, zero
+# duration, conclusion "failure". On 2026-08-21 all 13 variant nightlies died
+# this way within nine minutes of each other, every one attributed to a
+# gh-readonly-queue/* ref that had been deleted when the PR it belonged to
+# merged the evening before. A whole night of images, lost silently
+# (tuna-os/tunaOS#1933).
+#
+# rerun-infra-failures.yml cannot recover these, for two independent reasons:
+#
+#   1. It classifies by reading each failed job's log and bails early when
+#      there are none -- exactly the shape of a run that produced no jobs.
+#   2. It is driven by `workflow_run: [completed]`, and GitHub does not emit
+#      that event for a run that never started. Verified against its own run
+#      history: nothing fired for any of the 13.
+#
+# The second is fatal, and it is why this is a POLLED sweep rather than
+# another workflow_run listener.
+#
+# Every three hours, not daily: the nightly stagger spreads the 13 variants
+# across the whole clock (00:20 yellowfin ... 23:20 flounder-sid), so a daily
+# sweep would leave a late-slot failure sitting for most of a day.
+on:
+  schedule:
+    - cron: "0 */3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Report what would be dispatched without dispatching it"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rerun-startup-failures
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Sweep for nightlies that never started
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Re-dispatch nightlies that produced no jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/rerun-startup-failures.py \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.event.repository.default_branch || 'main' }}" \
+            ${{ inputs.dry-run && '--dry-run' || '' }} \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/scripts/rerun-startup-failures.py
+++ b/scripts/rerun-startup-failures.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Re-dispatch variant nightlies that never started (tuna-os/tunaOS#1933).
+
+A startup failure is a run GitHub refused to begin: zero jobs, zero
+duration, conclusion "failure". On 2026-08-21 all 13 variant nightlies
+died this way at once, attributed to a `gh-readonly-queue/*` ref that had
+been deleted when the PR it belonged to merged the evening before. A whole
+night of images, lost silently.
+
+`rerun-infra-failures.yml` cannot recover these, for two independent
+reasons, and the second is the fatal one:
+
+  1. It classifies by reading each failed job's log, and bails early when
+     there are no failed jobs -- which is exactly the shape of a run that
+     never produced any.
+  2. It is driven by `workflow_run: [completed]`, and GitHub does not emit
+     that event for a run that never started. Verified against its own run
+     history: nothing fired for any of the 13.
+
+So recovery here has to be POLLED rather than evented, which is what this
+script is. It is deliberately narrow: a run with jobs is a real failure and
+must stay red and visible.
+
+Idempotency is structural rather than stateful. A workflow is re-dispatched
+only when the startup-failed scheduled run is still the newest run of that
+workflow; the dispatch itself then becomes the newest run, so the next
+sweep skips it. That also means a human who already re-ran it by hand is
+never duplicated.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+# Only the per-variant nightlies. Deliberately not every scheduled workflow:
+# re-dispatching an arbitrary workflow because it failed to start is a much
+# broader claim than this evidence supports.
+WORKFLOWS = [
+    "build-albacore.yml",
+    "build-bonito-rawhide.yml",
+    "build-bonito.yml",
+    "build-flounder-sid.yml",
+    "build-flounder.yml",
+    "build-grouper.yml",
+    "build-guppy.yml",
+    "build-gurnard.yml",
+    "build-hummingbird.yml",
+    "build-marlin.yml",
+    "build-sailfin.yml",
+    "build-skipjack.yml",
+    "build-yellowfin.yml",
+]
+
+
+def latest_scheduled(runs):
+    """The newest `schedule` run, or None. `runs` is newest-first."""
+    for run in runs:
+        if run.get("event") == "schedule":
+            return run
+    return None
+
+
+def is_startup_failure(run, job_count):
+    """A run that failed without producing a single job.
+
+    Job count is the discriminator, not duration: a run can fail fast for
+    real reasons, but a real failure always leaves a job behind.
+    """
+    return run.get("conclusion") == "failure" and job_count == 0
+
+
+def has_newer_run(runs, run):
+    """Anything newer means this startup failure has already been answered.
+
+    Either by a previous sweep's dispatch or by a human re-running it. This
+    is what keeps the sweep idempotent without storing state.
+    """
+    return any(other["created_at"] > run["created_at"] for other in runs)
+
+
+def needs_redispatch(runs, job_count):
+    """Decide for one workflow, given its runs (newest-first) and the job
+    count of its newest scheduled run."""
+    run = latest_scheduled(runs)
+    if run is None:
+        return False
+    if not is_startup_failure(run, job_count):
+        return False
+    return not has_newer_run(runs, run)
+
+
+def _gh(args):
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def runs_for(repo, workflow, limit=20):
+    out = _gh([
+        "api",
+        f"repos/{repo}/actions/workflows/{workflow}/runs?per_page={limit}",
+        "--jq",
+        "[.workflow_runs[] | {id, event, conclusion, created_at}]",
+    ])
+    return json.loads(out)
+
+
+def job_count(repo, run_id):
+    out = _gh([
+        "api",
+        f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=1",
+        "--jq",
+        ".total_count",
+    ])
+    return int(out.strip())
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--ref", default="main")
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be dispatched without dispatching it",
+    )
+    args = ap.parse_args(argv)
+
+    dispatched, skipped = [], []
+    for workflow in WORKFLOWS:
+        try:
+            runs = runs_for(args.repo, workflow)
+        except subprocess.CalledProcessError as exc:
+            # One unreadable workflow must not stop the sweep: the whole
+            # point is recovering the OTHER twelve.
+            print(f"  {workflow}: could not list runs ({exc}); skipping")
+            skipped.append(workflow)
+            continue
+
+        run = latest_scheduled(runs)
+        if run is None:
+            print(f"  {workflow}: no scheduled run in the window")
+            continue
+
+        count = job_count(args.repo, run["id"])
+        if not needs_redispatch(runs, count):
+            print(
+                f"  {workflow}: run {run['id']} "
+                f"conclusion={run['conclusion']} jobs={count} -- no action"
+            )
+            continue
+
+        print(
+            f"  {workflow}: run {run['id']} failed with ZERO jobs and is "
+            "still the newest run -- re-dispatching"
+        )
+        if not args.dry_run:
+            _gh([
+                "api",
+                "--method", "POST",
+                f"repos/{args.repo}/actions/workflows/{workflow}/dispatches",
+                "-f", f"ref={args.ref}",
+            ])
+        dispatched.append(workflow)
+
+    print(f"\nre-dispatched {len(dispatched)}; unreadable {len(skipped)}")
+    if dispatched:
+        print("  " + ", ".join(dispatched))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_rerun_startup_failures.py
+++ b/tests/test_rerun_startup_failures.py
@@ -1,0 +1,140 @@
+"""The sweeper must recover lost nights and nothing else (tunaOS#1933).
+
+Two failure modes matter and they pull in opposite directions. Re-dispatching
+too little loses a whole night of images across 13 variants, silently, which
+is what happened on 2026-08-21. Re-dispatching too much papers over real
+build failures and burns runner minutes hiding them.
+
+So the discriminator is pinned here: a run with ZERO jobs never started and
+is recoverable; a run with any job at all is a real failure and must stay
+red. Plus the idempotency property, which is structural rather than stored --
+a dispatch becomes the newest run, so the next sweep sees it and stops.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "rerun-startup-failures.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "rerun-startup-failures.yml"
+
+_spec = importlib.util.spec_from_file_location("rerun_startup", SCRIPT)
+sweeper = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sweeper)
+
+
+def run(rid, event="schedule", conclusion="failure", created="2026-08-21T02:17:57Z"):
+    return {"id": rid, "event": event, "conclusion": conclusion, "created_at": created}
+
+
+# --- the discriminator ------------------------------------------------------
+
+
+def test_zero_jobs_and_failed_is_a_startup_failure() -> None:
+    """Run 32439363459's exact shape: build-yellowfin, 0 jobs, 0 seconds."""
+    assert sweeper.is_startup_failure(run(32439363459), 0)
+
+
+def test_a_failure_with_jobs_is_a_real_failure() -> None:
+    """The property that stops this papering over broken builds."""
+    assert not sweeper.is_startup_failure(run(1), 30)
+
+
+def test_a_successful_run_with_no_jobs_is_not_recovered() -> None:
+    assert not sweeper.is_startup_failure(run(1, conclusion="success"), 0)
+
+
+# --- picking the run to judge -----------------------------------------------
+
+
+def test_latest_scheduled_ignores_dispatches_and_pushes() -> None:
+    runs = [
+        run(3, event="workflow_dispatch", created="2026-08-21T05:00:00Z"),
+        run(2, event="push", created="2026-08-21T04:00:00Z"),
+        run(1, event="schedule", created="2026-08-21T02:00:00Z"),
+    ]
+    assert sweeper.latest_scheduled(runs)["id"] == 1
+
+
+def test_latest_scheduled_is_none_when_never_scheduled() -> None:
+    assert sweeper.latest_scheduled([run(1, event="workflow_dispatch")]) is None
+
+
+# --- the end-to-end decision ------------------------------------------------
+
+
+def test_a_lost_night_is_redispatched() -> None:
+    runs = [run(32439363459)]
+    assert sweeper.needs_redispatch(runs, 0)
+
+
+def test_a_real_failure_is_left_red() -> None:
+    assert not sweeper.needs_redispatch([run(1)], 42)
+
+
+def test_a_green_nightly_is_left_alone() -> None:
+    assert not sweeper.needs_redispatch([run(1, conclusion="success")], 30)
+
+
+def test_the_sweep_is_idempotent() -> None:
+    """A dispatch becomes the newest run, so the next sweep must stop.
+
+    Without this the sweeper re-dispatches the same lost night on every
+    tick, which is the runaway the single-retry rule exists to prevent.
+    """
+    failed = run(1, created="2026-08-21T02:17:57Z")
+    assert sweeper.needs_redispatch([failed], 0)
+
+    after_dispatch = [
+        run(2, event="workflow_dispatch", conclusion=None,
+            created="2026-08-21T07:00:00Z"),
+        failed,
+    ]
+    assert not sweeper.needs_redispatch(after_dispatch, 0)
+
+
+def test_a_human_rerun_is_not_duplicated() -> None:
+    runs = [
+        run(2, event="workflow_dispatch", conclusion="success",
+            created="2026-08-21T06:00:00Z"),
+        run(1, created="2026-08-21T02:17:57Z"),
+    ]
+    assert not sweeper.needs_redispatch(runs, 0)
+
+
+# --- scope ------------------------------------------------------------------
+
+
+def test_every_variant_nightly_is_swept() -> None:
+    """A variant with a cron but no sweeper entry is a silent hole."""
+    scheduled = set()
+    for path in (ROOT / ".github" / "workflows").glob("build-*.yml"):
+        if path.stem[len("build-"):] in {"variant", "flavor", "toolchain"}:
+            continue
+        doc = yaml.safe_load(path.read_text())
+        triggers = doc.get("on", doc.get(True)) or {}
+        if not isinstance(triggers, dict) or not triggers.get("schedule"):
+            continue
+        crons = [s["cron"].strip() for s in triggers["schedule"]]
+        # Daily nightlies only; the weekly Arch base rebuild is out of scope.
+        if any(c.endswith("* * *") for c in crons):
+            scheduled.add(path.name)
+    assert scheduled == set(sweeper.WORKFLOWS)
+
+
+def test_the_sweeper_runs_often_enough_to_catch_every_slot() -> None:
+    """The stagger spreads nightlies across the whole clock, so a daily sweep
+    would leave a late-slot startup failure sitting for most of a day."""
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    triggers = doc.get("on", doc.get(True))
+    crons = [s["cron"].strip() for s in triggers["schedule"]]
+    assert crons, "the sweep must be scheduled; nothing else notices"
+    hours = [c.split()[1] for c in crons]
+    assert all(h == "*" or h.startswith("*/") for h in hours), (
+        f"expected a sub-daily sweep (hour field '*' or '*/N'), got {crons}"
+    )


### PR DESCRIPTION
Closes #1933.

## The lost night

On 2026-08-21 all **13** variant nightlies failed within nine minutes of each other with **zero jobs and zero duration** — runs GitHub refused to begin, every one attributed to a `gh-readonly-queue/*` ref deleted when the PR it belonged to merged the evening before. The same 0-second shape appears historically on other transient refs (runs 307–311 on `gh-readonly-queue/*` and `renovate/*`), so this recurs whenever a scheduled run resolves against a ref that no longer exists — and this repo merges through the queue constantly.

## Why the obvious fix is not the fix

`rerun-infra-failures.yml` looks like the natural place to patch. It is not, for two independent reasons:

1. It classifies by reading each failed job's log and **bails early when there are none** — exactly the shape of a run that produced no jobs.
2. It is driven by `workflow_run: [completed]`, and **GitHub does not emit that event for a run that never started.**

I verified point 2 before writing anything: that workflow's most recent run was `2026-08-20T15:53Z`, and nothing fired for any of the 13 failures at 02:14–02:23 on 08-21. **Patching its classifier alone would have been inert.** So recovery here is polled rather than evented.

## Design

**The discriminator is the job count, not the duration.** A run can fail fast for real reasons, but a real failure always leaves a job behind. A run with any job at all stays red and visible — a sweeper that papers over broken builds is worse than no sweeper.

**Idempotency is structural, not stored.** A workflow is re-dispatched only while the startup-failed run is still the newest run of that workflow; the dispatch then becomes the newest run, so the next sweep skips it. That also means a human who already re-ran it by hand is never duplicated. No state file, no retry counter.

**Every three hours, not daily.** #1932's stagger spreads the 13 variants across the whole clock (00:20 yellowfin … 23:20 flounder-sid), so a daily sweep would leave a late-slot failure sitting for most of a day.

The decision logic lives in `scripts/rerun-startup-failures.py` rather than inline bash, so it is testable without network.

## Verification

12 tests, and **each was mutation-checked** — every mutation fails the intended assertion and nothing else:

| mutation | caught by |
|---|---|
| ignore the job count | `test_a_failure_with_jobs_is_a_real_failure`, `test_a_real_failure_is_left_red` |
| drop the idempotency guard | `test_the_sweep_is_idempotent`, `test_a_human_rerun_is_not_duplicated` |
| drop a variant from the sweep list | `test_every_variant_nightly_is_swept` |
| make the sweep daily | `test_the_sweeper_runs_often_enough_to_catch_every_slot` |

An end-to-end run against a stubbed transport picks out exactly the one lost workflow, leaves the healthy twelve alone, and attempts **zero** POSTs under `--dry-run`. Coverage is pinned against the crons themselves, so adding a variant nightly without a sweeper entry fails here rather than silently going unswept.

`gh` is not available in my environment, so the network path is exercised only through that stub — the first real sweep is the live proof, and `workflow_dispatch` with `dry-run: true` is available to check it without dispatching anything.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_