### PR TITLE
fix(ci): cap the startup-failure sweep so recovery is not a thundering herd

### DIFF
--- a/scripts/rerun-startup-failures.py
+++ b/scripts/rerun-startup-failures.py
@@ -26,6 +26,16 @@ only when the startup-failed scheduled run is still the newest run of that
 workflow; the dispatch itself then becomes the newest run, so the next
 sweep skips it. That also means a human who already re-ran it by hand is
 never duplicated.
+
+And the sweep is CAPPED, because the failure it recovers from is a mass one.
+The 2026-08-21 event lost all 13 at once, so an uncapped sweep would dispatch
+13 full variant builds simultaneously into a 20-concurrent-job ceiling --
+recreating exactly the thundering herd the nightly stagger (#1932) exists to
+prevent, and starving them all into the same slow failure it was meant to
+cure. Recovering two per sweep drains a total loss over the following day
+while never putting more than two extra variants in flight, and in the common
+case -- one variant lost -- recovery is still immediate. What the cap defers
+is reported, never silently dropped.
 """
 from __future__ import annotations
 
@@ -38,6 +48,10 @@ import sys
 # Only the per-variant nightlies. Deliberately not every scheduled workflow:
 # re-dispatching an arbitrary workflow because it failed to start is a much
 # broader claim than this evidence supports.
+# See the module docstring: an uncapped sweep answers a 13-variant loss with
+# 13 simultaneous builds, which the job ceiling cannot absorb.
+DEFAULT_MAX_DISPATCH = 2
+
 WORKFLOWS = [
     "build-albacore.yml",
     "build-bonito-rawhide.yml",
@@ -127,9 +141,18 @@ def main(argv=None):
         action="store_true",
         help="report what would be dispatched without dispatching it",
     )
+    ap.add_argument(
+        "--max-dispatch",
+        type=int,
+        default=DEFAULT_MAX_DISPATCH,
+        help=(
+            "most workflows to re-dispatch in one sweep; the rest are "
+            "reported and picked up by the next sweep"
+        ),
+    )
     args = ap.parse_args(argv)
 
-    dispatched, skipped = [], []
+    dispatched, deferred, skipped = [], [], []
     for workflow in WORKFLOWS:
         try:
             runs = runs_for(args.repo, workflow)
@@ -153,6 +176,16 @@ def main(argv=None):
             )
             continue
 
+        if len(dispatched) >= args.max_dispatch:
+            # Deferred, not dropped: say so, so a capped sweep never reads as
+            # a clean one.
+            print(
+                f"  {workflow}: run {run['id']} failed with ZERO jobs -- "
+                f"DEFERRED, {args.max_dispatch} already dispatched this sweep"
+            )
+            deferred.append(workflow)
+            continue
+
         print(
             f"  {workflow}: run {run['id']} failed with ZERO jobs and is "
             "still the newest run -- re-dispatching"
@@ -166,9 +199,14 @@ def main(argv=None):
             ])
         dispatched.append(workflow)
 
-    print(f"\nre-dispatched {len(dispatched)}; unreadable {len(skipped)}")
+    print(
+        f"\nre-dispatched {len(dispatched)}; deferred {len(deferred)}; "
+        f"unreadable {len(skipped)}"
+    )
     if dispatched:
-        print("  " + ", ".join(dispatched))
+        print("  dispatched: " + ", ".join(dispatched))
+    if deferred:
+        print("  deferred to the next sweep: " + ", ".join(deferred))
     return 0
 
 

--- a/tests/test_rerun_startup_failures.py
+++ b/tests/test_rerun_startup_failures.py
@@ -107,6 +107,98 @@ def test_a_human_rerun_is_not_duplicated() -> None:
     assert not sweeper.needs_redispatch(runs, 0)
 
 
+# --- the cap ----------------------------------------------------------------
+
+
+def _all_lost_transport(posts):
+    """Every workflow showing the 2026-08-21 shape: failed, zero jobs."""
+    import json as _json
+
+    def gh(args):
+        joined = " ".join(args)
+        if "--method" in args:
+            posts.append(joined)
+            return ""
+        if "/runs?per_page" in joined:
+            return _json.dumps(
+                [{
+                    "id": 999,
+                    "event": "schedule",
+                    "conclusion": "failure",
+                    "created_at": "2026-08-21T02:17:57Z",
+                }]
+            )
+        if "/jobs?per_page" in joined:
+            return "0\n"
+        return ""
+
+    return gh
+
+
+def test_a_total_loss_does_not_become_a_thundering_herd(monkeypatch) -> None:
+    """The regression this cap exists for.
+
+    Every variant's full build alone exceeds the 20-concurrent-job ceiling,
+    which is why the nightlies are staggered at all (#1932). An uncapped
+    sweep answers a 13-variant loss with 13 simultaneous builds and starves
+    them into the same slow failure it was meant to cure.
+    """
+    posts = []
+    monkeypatch.setattr(sweeper, "_gh", _all_lost_transport(posts))
+    sweeper.main(["--repo", "tuna-os/tunaOS"])
+    assert len(posts) == sweeper.DEFAULT_MAX_DISPATCH
+
+
+def test_the_cap_defers_rather_than_drops(capsys, monkeypatch) -> None:
+    """A capped sweep must not read as a clean one."""
+    posts = []
+    monkeypatch.setattr(sweeper, "_gh", _all_lost_transport(posts))
+    sweeper.main(["--repo", "tuna-os/tunaOS"])
+    out = capsys.readouterr().out
+    assert "deferred 11" in out
+    assert "deferred to the next sweep:" in out
+    for name in sweeper.WORKFLOWS:
+        assert name in out, f"{name} vanished from the report"
+
+
+def test_the_common_case_is_still_immediate(monkeypatch) -> None:
+    """One variant lost must recover on the very next sweep, not be rationed."""
+    import json as _json
+
+    posts = []
+
+    def gh(args):
+        joined = " ".join(args)
+        if "--method" in args:
+            posts.append(joined)
+            return ""
+        if "/runs?per_page" in joined:
+            lost = "build-yellowfin" in joined
+            return _json.dumps(
+                [{
+                    "id": 999 if lost else 1,
+                    "event": "schedule",
+                    "conclusion": "failure" if lost else "success",
+                    "created_at": "2026-08-21T02:17:57Z",
+                }]
+            )
+        if "/jobs?per_page" in joined:
+            return "0\n" if "999" in joined else "30\n"
+        return ""
+
+    monkeypatch.setattr(sweeper, "_gh", gh)
+    sweeper.main(["--repo", "tuna-os/tunaOS"])
+    assert len(posts) == 1
+    assert "build-yellowfin.yml" in posts[0]
+
+
+def test_dry_run_dispatches_nothing(monkeypatch) -> None:
+    posts = []
+    monkeypatch.setattr(sweeper, "_gh", _all_lost_transport(posts))
+    sweeper.main(["--repo", "tuna-os/tunaOS", "--dry-run"])
+    assert posts == []
+
+
 # --- scope ------------------------------------------------------------------
 
 


### PR DESCRIPTION
Follow-up to #1935, which I shipped with a defect.

## The defect

#1935's sweep was uncapped — wrong for exactly the failure it was written to recover from. The 2026-08-21 event lost **all 13** variant nightlies at once, so the first sweep would have answered it by dispatching **13 full variant builds simultaneously** into a 20-concurrent-job ceiling. That recreates the thundering herd #1932 removed hours earlier, and starves all 13 into the same slow failure the stagger exists to cure.

One fix undoing the other.

## Caught before it fired

The cron is `0 */3 * * *`, so the live run would have been **06:00Z**. With the stagger now in effect, only gurnard (04:20) would have had a newer scheduled run by then — the other twelve would all still show yesterday's startup failure as their newest run, and all twelve would have gone out together.

## The fix

Cap at **two per sweep**:

- a total loss drains over the following day while never putting more than two extra variants in flight
- the common case — one variant lost — still recovers on the very next sweep, unrationed
- the naturally scheduled nightly is still there underneath, so the cap **delays** recovery rather than preventing it

What the cap defers is reported by name, never silently dropped. A capped sweep that read as a clean one would be the same class of defect as the `tail -30` that hid the installer debug log in #1934.

## Verification

4 new tests, each mutation-checked:

| mutation | caught by |
|---|---|
| remove the cap | `test_a_total_loss_does_not_become_a_thundering_herd` |
| raise the cap to 13 | `test_the_cap_defers_rather_than_drops` |

Against a stubbed transport: a total-loss scenario produces exactly **2** POSTs and names all 11 deferred workflows; a single-loss scenario produces exactly **1**, for the right workflow; `--dry-run` produces **0**. 21 tests pass across the sweeper and the schedule registry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_