### PR TITLE
fix(installer-smoke): read the stamp where flatpak puts it, and stop asking for unused GPU

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -64,13 +64,13 @@ jobs:
             v="${FILTER_VARIANT:-yellowfin}"
             f="${FILTER_FLAVORS:-gnome,kde,cosmic,niri,xfce}"
             M=$(jq -cn --arg v "$v" --arg f "$f" \
-              '{include: ($f | split(",") | map({variant: $v, flavor: ., runner: (if (. | test("^(cosmic|niri|xfwl4|kde)")) then "gpu" else "build-amd64" end)}))}')
+              '{include: ($f | split(",") | map({variant: $v, flavor: ., runner: "build-amd64"}))}')
           else
             M=$(echo "$json" | jq -c \
               '{include: [ .variants[] | . as $variant | .id as $v | .flavors[]
                  | select(.build_iso == true)
                  | select((.platforms // $variant.platforms // []) | index("linux/amd64"))
-                 | {variant: $v, flavor: .id, runner: (if (.id | test("^(cosmic|niri|xfwl4|kde)")) then "gpu" else "build-amd64" end)} ]}')
+                 | {variant: $v, flavor: .id, runner: "build-amd64"} ]}')
           fi
           echo "matrix=$M" >> "$GITHUB_OUTPUT"
           echo "$M" | jq .
@@ -79,10 +79,25 @@ jobs:
     name: build ${{ matrix.variant }}:${{ matrix.flavor }}
     needs: generate-matrix
     # RunsOn for all cells: the ISO build (tacklebox + podman) cannot work on
-    # the GitHub runner's podman 5.8.4 (tunaOS#1893). The `gpu` group (g4dn
-    # spot) also supplies the DRM render node the compositor-rendering checks
-    # need for cosmic/niri/xfwl4/kde (kwin_wayland); gnome/xfce run on the
-    # `build-amd64` CPU group (the readiness-stamp path needs no GPU).
+    # the GitHub runner's podman 5.8.4 (tunaOS#1893).
+    #
+    # build-amd64 for every flavor, including cosmic/niri/xfwl4/kde. Those
+    # four were routed to the `gpu` group (g4dn spot) for the DRM render node
+    # the compositor checks need -- but #1929 split this workflow in two, and
+    # the render node is needed by the half that no longer runs here. THIS job
+    # checks out, sets up podman, builds an ISO and uploads it; it touches no
+    # DRM device and invokes no compositor. The boot-and-assert half is the
+    # `smoke` job below, which runs on ubuntu-latest for every flavor and
+    # drives scripts/iso-e2e.sh -- not iso-e2e-gpu.sh.
+    #
+    # So the gpu routing survived the split as a no-op that still provisions
+    # a g4dn per cell. Removing it makes cosmic/niri/kde testable without any
+    # GPU capacity at all, which matters because the g4dn quota is a real
+    # constraint (the on-demand increase was declined 2026-08-21, and this
+    # group is spot anyway -- a different quota, L-3819A6DF).
+    #
+    # The boot Gate in reusable-build-image.yml is unaffected: it genuinely
+    # runs iso-e2e-gpu.sh and still asks for `gpu`.
     runs-on: runs-on=${{ github.run_id }}/runner=${{ matrix.runner }}
     timeout-minutes: 75
     strategy:

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -362,14 +362,33 @@ jobs:
           # GPU, no OCR, just a file read over SSH. Contract and field list:
           # docs/INSTALLER-FRONTENDS.md.
           #
-          # Inside the Flatpak sandbox $XDG_RUNTIME_DIR is the app's own
-          # runtime dir, which the host sees at /run/user/<uid>/app/<app-id>/;
-          # an unsandboxed run writes to /run/user/<uid>/ directly. Look in
-          # both rather than assuming which one this ISO produced.
+          # Inside the Flatpak sandbox $XDG_RUNTIME_DIR reads as
+          # /run/user/<uid>, but that is a BIND MOUNT and the host path
+          # differs. Current flatpak backs it with
+          #   /run/user/<uid>/.flatpak/<app-id>/xdg-run/
+          # and that is where run 32445454947 actually found the stamp:
+          #   /run/user/1000/.flatpak/org.bootcinstaller.Installer/xdg-run/
+          #     tuna-installer-ready
+          # while the app's own log said it had written
+          # "/run/user/1000/tuna-installer-ready" -- the in-sandbox view of
+          # the same file.
+          #
+          # This check previously read only /run/user/<uid>/app/<app-id>/ and
+          # /run/user/<uid>/. Neither is where the file lands, so runs 63-68
+          # were ALL false negatives: the installer mapped its window (run 67's
+          # evidence screenshot shows the wizard), wrote a correct stamp naming
+          # BootcWindow, and the gate reported "running but never reported a
+          # window". The app/<app-id>/ directory does still exist -- flatpak
+          # creates it -- which is why an empty-directory listing looked like
+          # confirmation that nothing had been written.
+          #
+          # All three paths are read, newest layout first: an unsandboxed run
+          # still writes to /run/user/<uid>/ directly, and app/<app-id>/ costs
+          # nothing to keep for older flatpak.
           echo "expecting readiness stamp from: ${APP}"
           STAMP=""
           for _ in $(seq 1 18); do
-            STAMP=$($SSH "cat /run/user/*/app/${APP}/tuna-installer-ready /run/user/*/tuna-installer-ready 2>/dev/null | head -20" 2>/dev/null || true)
+            STAMP=$($SSH "cat /run/user/*/.flatpak/${APP}/xdg-run/tuna-installer-ready /run/user/*/app/${APP}/tuna-installer-ready /run/user/*/tuna-installer-ready 2>/dev/null | head -20" 2>/dev/null || true)
             [ -n "$STAMP" ] && break
             sleep 10
           done
@@ -381,7 +400,11 @@ jobs:
             echo "  that starts, stays up, and puts nothing on the screen."
             echo "  If this frontend's stamp is new, confirm the ISO's flatpak"
             echo "  postdates it before treating this as a UI regression."
-            echo "--- runtime dirs:"; $SSH 'ls -la /run/user/*/ /run/user/*/app/*/ 2>/dev/null | head -40' 2>/dev/null || true
+            echo "--- runtime dirs:"; $SSH 'ls -la /run/user/*/ /run/user/*/app/*/ /run/user/*/.flatpak/*/xdg-run/ 2>/dev/null | head -60' 2>/dev/null || true
+            # A stamp that exists but sits somewhere none of the three reads
+            # cover is the exact defect this block just had, so name it
+            # rather than making the next reader deduce it again.
+            echo "--- stamp anywhere under /run/user:"; $SSH 'find /run/user -name tuna-installer-ready 2>/dev/null || echo "(none)"' 2>/dev/null || true
             exit 1
           fi
 

--- a/tests/test_installer_smoke_needs_no_gpu.py
+++ b/tests/test_installer_smoke_needs_no_gpu.py
@@ -1,0 +1,74 @@
+"""The smoke ISO build must not ask for GPU capacity it never uses.
+
+#1929 split this workflow in two: `build-iso` builds and uploads the ISO,
+`smoke` downloads it, boots it and asserts. The DRM render node the
+compositor checks need belongs to the second half -- which runs on
+ubuntu-latest and drives scripts/iso-e2e.sh, not iso-e2e-gpu.sh.
+
+The `gpu` routing for cosmic/niri/xfwl4/kde survived that split as a no-op
+that still provisions a g4dn spot instance per cell. That is not free: g4dn
+capacity is quota-limited (the on-demand increase was declined on
+2026-08-21), so a no-op GPU request is the difference between those four
+flavors being testable and not.
+
+These tests pin both halves of the claim -- that the build asks for no GPU,
+and that it is entitled to ask for none.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "installer-smoke.yml"
+
+
+def jobs():
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    return doc["jobs"]
+
+
+def test_no_cell_is_routed_to_the_gpu_group() -> None:
+    """The regression: four flavors provisioning a g4dn to run podman."""
+    body = WORKFLOW.read_text()
+    assert '"gpu"' not in body, (
+        "the smoke ISO build routes a cell to the gpu group; it builds an "
+        "image and uploads it, and touches no DRM device"
+    )
+
+
+def test_the_build_job_touches_no_drm_device() -> None:
+    """What entitles the build to run without a render node."""
+    build = jobs()["build-iso"]
+    steps = yaml.dump(build["steps"])
+    for token in ("/dev/dri", "renderD", "iso-e2e-gpu"):
+        assert token not in steps, f"build-iso references {token}"
+
+
+def test_the_boot_half_runs_where_the_render_node_question_lives() -> None:
+    """The split is the whole argument, so pin it.
+
+    If `smoke` ever moves back onto RunsOn, the reasoning above stops
+    holding and this file should be revisited rather than quietly passing.
+    """
+    assert jobs()["smoke"]["runs-on"] == "ubuntu-latest"
+
+
+def test_the_boot_half_uses_the_non_gpu_harness() -> None:
+    steps = yaml.dump(jobs()["smoke"]["steps"])
+    assert "iso-e2e.sh" in steps
+    assert "iso-e2e-gpu.sh" not in steps
+
+
+def test_every_flavor_builds_on_the_same_runner() -> None:
+    """A per-flavor runner split is what drifted last time."""
+    body = WORKFLOW.read_text()
+    runners = {
+        line.split('runner: ')[1].split('}')[0].strip().strip('"').strip("'")
+        for line in body.splitlines()
+        if "runner: " in line and "matrix.runner" not in line
+    }
+    assert runners == {"build-amd64"}, f"mixed build runners: {runners}"

--- a/tests/test_readiness_stamp_lookup.py
+++ b/tests/test_readiness_stamp_lookup.py
@@ -1,0 +1,88 @@
+"""The gate must read the stamp where flatpak actually puts it.
+
+Runs 63-68 of installer-smoke all failed with "running but never reported a
+window". Every one was a false negative. Run 32445454947 settled it: the
+installer's own log records
+
+    readiness stamp written: /run/user/1000/tuna-installer-ready (BootcWindow)
+
+-- a correct stamp, naming the wizard -- and a `find` across /run/user
+located the file at
+
+    /run/user/1000/.flatpak/org.bootcinstaller.Installer/xdg-run/
+      tuna-installer-ready
+
+Inside the sandbox $XDG_RUNTIME_DIR reads as /run/user/<uid>, but it is a
+bind mount and the host path differs. The gate read only
+/run/user/<uid>/app/<app-id>/ and /run/user/<uid>/, so it never saw the file.
+
+What made this durable rather than obvious: flatpak still CREATES
+app/<app-id>/, so listing it showed an empty directory, which reads as
+confirmation that nothing was written rather than as a wrong path.
+
+These tests pin all three read locations, because dropping the new one
+silently restores a gate that fails on working installers.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "installer-smoke.yml"
+
+# The layout current flatpak actually uses, measured in run 32445454947.
+SANDBOX_HOST_PATH = "/run/user/*/.flatpak/${APP}/xdg-run/tuna-installer-ready"
+# Older flatpak layout; kept because it costs nothing.
+LEGACY_APP_PATH = "/run/user/*/app/${APP}/tuna-installer-ready"
+# An unsandboxed frontend writes here directly.
+UNSANDBOXED_PATH = "/run/user/*/tuna-installer-ready"
+
+
+def stamp_read_line() -> str:
+    for line in WORKFLOW.read_text().splitlines():
+        if "STAMP=$(" in line and "tuna-installer-ready" in line:
+            return line
+    raise AssertionError("no stamp-reading line found in installer-smoke.yml")
+
+
+def test_the_sandbox_host_path_is_read() -> None:
+    """The regression: this is the only path the file is actually at."""
+    assert SANDBOX_HOST_PATH in stamp_read_line(), (
+        "the gate does not read /run/user/*/.flatpak/<app>/xdg-run/, which is "
+        "where flatpak backs $XDG_RUNTIME_DIR -- runs 63-68 failed on working "
+        "installers for exactly this reason"
+    )
+
+
+def test_the_legacy_and_unsandboxed_paths_are_still_read() -> None:
+    line = stamp_read_line()
+    assert LEGACY_APP_PATH in line
+    assert UNSANDBOXED_PATH in line
+
+
+def test_the_sandbox_path_is_read_first() -> None:
+    """Newest layout first, so the common case does not depend on fallbacks."""
+    line = stamp_read_line()
+    assert line.index(SANDBOX_HOST_PATH) < line.index(LEGACY_APP_PATH)
+
+
+def test_the_failure_branch_locates_a_misplaced_stamp() -> None:
+    """A stamp outside all three reads is precisely the defect just fixed.
+
+    Without this, the next path change reproduces the same multi-run hunt.
+    """
+    body = WORKFLOW.read_text()
+    assert re.search(r"find /run/user -name tuna-installer-ready", body), (
+        "the failure branch must search for the stamp, not just list the "
+        "directories it already assumes are right"
+    )
+
+
+def test_the_failure_branch_lists_the_sandbox_dir() -> None:
+    body = WORKFLOW.read_text()
+    assert "/run/user/*/.flatpak/*/xdg-run/" in body


### PR DESCRIPTION
Two `installer-smoke.yml` fixes from the same investigation. The second one is the headline.

---

# 1. The gate has been failing on a working installer

**Runs 63–68 all failed with "running but never reported a window". Every one was a false negative.**

Run `32445454947`'s debug log — readable for the first time now that the capture isn't tail-truncated (#1934):

```
readiness stamp written: /run/user/1000/tuna-installer-ready (BootcWindow)
```

A correct stamp, naming the wizard, written at **04:46:06** — two minutes *before* the assert began polling at 04:48:10. And the new `/proc/<pid>/environ` probe located the file on the host:

```
·/·r·un/user/1000/.flatpak/org.bootcinstaller.Installer/xdg-run/tuna-installer-ready
```

Inside the sandbox `$XDG_RUNTIME_DIR` reads as `/run/user/<uid>`, but it's a bind mount and the host path differs — current flatpak backs it with `.flatpak/<app-id>/xdg-run/`. The gate read only `/run/user/<uid>/app/<app-id>/` and `/run/user/<uid>/`, so it never looked at the file it was waiting for.

**What made this durable rather than obvious:** flatpak still *creates* `app/<app-id>/`. Run 67's diagnostic listed it as present and empty, which reads as "nothing was written" rather than "wrong path" — and that reading sent three rounds of investigation at the installer instead of at the gate.

The fix reads all three paths, newest layout first. The failure branch now also runs `find /run/user -name tuna-installer-ready` and lists the `.flatpak` dir, so a stamp outside all three names itself instead of costing another multi-run hunt — that absence is exactly what this block just spent six runs on.

# 2. The build asks for GPU capacity it never uses

AWS declined the g4dn quota increase on 2026-08-21, which prompted a look at what actually needs g4dn. For this workflow: nothing.

#1929 split the workflow in two:

| job | what it does | runs on |
|---|---|---|
| `build-iso` | checkout, podman setup, build ISO, upload | RunsOn — **`gpu`** for cosmic/niri/xfwl4/kde |
| `smoke` | download, boot under OVMF, assert | **`ubuntu-latest`, every flavor** |

The render node belongs to the *second* half — which already runs on `ubuntu-latest` and drives `iso-e2e.sh`, not `iso-e2e-gpu.sh`. The gpu routing survived the split as a no-op that still provisions a g4dn per cell, to run podman. Verified: `build-iso` references no `/dev/dri`, no `renderD`, no `iso-e2e-gpu.sh`.

Routing every build to `build-amd64` makes cosmic, niri and kde smoke-testable with **no GPU capacity at all**.

Two corrections to the comment this replaces:

- **The declined request was the wrong quota.** It was `L-DB2E81BA` (On-Demand G and VT). The `gpu` group is `spot: capacity-optimized`, so it draws on `L-3819A6DF`. Approving it would not have unblocked these cells.
- **The boot Gate in `reusable-build-image.yml` is deliberately untouched** — a genuine `iso-e2e-gpu.sh` consumer, and the only remaining real claim on `gpu`.

---

## Verification

10 tests across two new files, each mutation-checked:

| mutation | caught by |
|---|---|
| revert to the two old stamp paths | `test_the_sandbox_host_path_is_read`, `test_the_sandbox_path_is_read_first` |
| drop the `find` diagnostic | `test_the_failure_branch_locates_a_misplaced_stamp` |
| restore gpu routing | `test_no_cell_is_routed_to_the_gpu_group`, `test_every_flavor_builds_on_the_same_runner` |
| move the boot half back onto RunsOn | `test_the_boot_half_runs_where_the_render_node_question_lives` |

38 tests pass across the smoke, desktop-verify, green-criteria and schedule-registry suites.

**Not yet proven:** that the gate goes green. The stamp path is confirmed from run 68's `find` output, but no run has yet passed with the fix in place — I'll dispatch one once this merges.