### PR TITLE
fix(ci): surface why a sweep dispatch failed, and keep sweeping past it

### DIFF
--- a/scripts/rerun-startup-failures.py
+++ b/scripts/rerun-startup-failures.py
@@ -106,10 +106,27 @@ def needs_redispatch(runs, job_count):
     return not has_newer_run(runs, run)
 
 
+class GhError(RuntimeError):
+    """A gh invocation that failed, carrying what gh actually said."""
+
+
 def _gh(args):
-    return subprocess.run(
-        ["gh", *args], check=True, capture_output=True, text=True
-    ).stdout
+    """Run gh, and on failure raise with its stderr attached.
+
+    The first live sweep failed on a dispatch and the traceback carried only
+    `CalledProcessError: ... returned non-zero exit status 1` -- because
+    capture_output swallowed the one line that explains why. That is the same
+    defect as a capture step that tails past its own diagnostic: the helper
+    discarded the message it existed to surface.
+    """
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise GhError(
+            f"gh {' '.join(args)} exited {proc.returncode}\n"
+            f"  stdout: {proc.stdout.strip() or '(empty)'}\n"
+            f"  stderr: {proc.stderr.strip() or '(empty)'}"
+        )
+    return proc.stdout
 
 
 def runs_for(repo, workflow, limit=20):
@@ -152,7 +169,7 @@ def main(argv=None):
     )
     args = ap.parse_args(argv)
 
-    dispatched, deferred, skipped = [], [], []
+    dispatched, deferred, skipped, failed = [], [], [], []
     for workflow in WORKFLOWS:
         try:
             runs = runs_for(args.repo, workflow)
@@ -191,22 +208,36 @@ def main(argv=None):
             "still the newest run -- re-dispatching"
         )
         if not args.dry_run:
-            _gh([
-                "api",
-                "--method", "POST",
-                f"repos/{args.repo}/actions/workflows/{workflow}/dispatches",
-                "-f", f"ref={args.ref}",
-            ])
+            try:
+                _gh([
+                    "api",
+                    "--method", "POST",
+                    f"repos/{args.repo}/actions/workflows/{workflow}/dispatches",
+                    "-f", f"ref={args.ref}",
+                ])
+            except GhError as exc:
+                # One failed dispatch must not abandon the rest. The first
+                # live sweep aborted on its first POST and left every other
+                # lost variant unrecovered -- the same "keep going" rule the
+                # listing above already follows, which this did not.
+                print(f"::error::{workflow}: dispatch failed -- {exc}")
+                failed.append(workflow)
+                continue
         dispatched.append(workflow)
 
     print(
         f"\nre-dispatched {len(dispatched)}; deferred {len(deferred)}; "
-        f"unreadable {len(skipped)}"
+        f"unreadable {len(skipped)}; dispatch-failed {len(failed)}"
     )
     if dispatched:
         print("  dispatched: " + ", ".join(dispatched))
     if deferred:
         print("  deferred to the next sweep: " + ", ".join(deferred))
+    if failed:
+        print("  dispatch FAILED: " + ", ".join(failed))
+        # Non-zero so a sweep that recovered nothing cannot read as green,
+        # but only AFTER every workflow has had its turn.
+        return 1
     return 0
 
 

--- a/tests/test_rerun_startup_failures.py
+++ b/tests/test_rerun_startup_failures.py
@@ -199,6 +199,70 @@ def test_dry_run_dispatches_nothing(monkeypatch) -> None:
     assert posts == []
 
 
+# --- failure handling -------------------------------------------------------
+
+
+def test_gh_failures_carry_what_gh_said(monkeypatch) -> None:
+    """The first live sweep's traceback said only "exited 1".
+
+    capture_output swallowed the one line explaining why, which is the same
+    defect as a capture step that tails past its own diagnostic.
+    """
+    import subprocess as _sp
+
+    class Proc:
+        returncode = 1
+        stdout = ""
+        stderr = "HTTP 403: Resource not accessible by integration"
+
+    monkeypatch.setattr(_sp, "run", lambda *a, **k: Proc())
+    with pytest.raises(sweeper.GhError) as excinfo:
+        sweeper._gh(["api", "whatever"])
+    assert "Resource not accessible" in str(excinfo.value)
+    assert "exited 1" in str(excinfo.value)
+
+
+def test_one_failed_dispatch_does_not_abandon_the_rest(capsys, monkeypatch) -> None:
+    """The first live sweep aborted on its first POST.
+
+    Every other lost variant went unrecovered -- the listing loop already
+    kept going past one unreadable workflow, and the dispatch loop did not.
+    """
+    import json as _json
+
+    posts = []
+
+    def gh(args):
+        joined = " ".join(args)
+        if "--method" in args:
+            posts.append(joined)
+            if "build-albacore" in joined:
+                raise sweeper.GhError("gh ... exited 1\n  stderr: HTTP 403")
+            return ""
+        if "/runs?per_page" in joined:
+            return _json.dumps(
+                [{"id": 999, "event": "schedule", "conclusion": "failure",
+                  "created_at": "2026-08-21T02:17:57Z"}]
+            )
+        if "/jobs?per_page" in joined:
+            return "0\n"
+        return ""
+
+    monkeypatch.setattr(sweeper, "_gh", gh)
+    rc = sweeper.main(["--repo", "tuna-os/tunaOS"])
+    out = capsys.readouterr().out
+
+    # albacore is alphabetically first and fails. The sweep must carry on --
+    # and the failure must not consume a cap slot, because it put nothing in
+    # flight. So three POSTs are attempted and two succeed.
+    assert len(posts) == 3, f"gave up after the first failure: {posts}"
+    assert "re-dispatched 2" in out, "a failed dispatch ate a cap slot"
+    assert "dispatch-failed 1" in out
+    assert "dispatch FAILED: build-albacore.yml" in out
+    assert "HTTP 403" in out, "the reason must reach the log"
+    assert rc == 1, "a sweep that failed a dispatch must not read as green"
+
+
 # --- scope ------------------------------------------------------------------
 
 


### PR DESCRIPTION
Follow-up to #1935/#1936, from the sweeper's first live run (32455261767).

## The decision was right; the reporting was not

The sweep identified the lost night correctly:

```
build-albacore.yml: run 32439251806 failed with ZERO jobs and is still the newest run -- re-dispatching
```

That's the 2026-08-21 startup failure, exactly as designed. Then the POST failed and the run died with:

```
subprocess.CalledProcessError: Command '['gh', 'api', '--method', 'POST', ...]' returned non-zero exit status 1
```

…which says nothing about **why**. `capture_output=True` swallowed gh's stderr and `_gh` never printed it. The helper discarded the one message it existed to carry — the same defect this repo fixed in `installer-smoke.yml` three days ago, where `tail -30` hid the log the capture step was added to produce.

## Two fixes, both independent of the underlying cause

**1. `_gh` raises `GhError` with gh's exit code, stdout and stderr attached.** The next sweep names its own cause instead of costing a third run to discover it.

**2. A failed dispatch no longer aborts the sweep.** The listing loop already had this rule —

> one unreadable workflow must not stop the sweep: the whole point is recovering the OTHER twelve

— and the dispatch loop didn't, so the first POST failure abandoned every remaining lost variant. It now reports the failure with its reason, records it, and carries on.

A failed dispatch deliberately **does not consume a cap slot**: the cap bounds how many builds are in flight, and a dispatch that failed put none there. So a sweep where the first of three fails attempts all three and lands two. The run still exits non-zero if any dispatch failed — but only after every workflow has had its turn, because a sweep that recovered nothing must not read as green.

## Verification

18 tests; both new ones mutation-checked:

| mutation | caught by |
|---|---|
| re-hide stderr | `test_gh_failures_carry_what_gh_said` |
| re-raise instead of continuing | `test_one_failed_dispatch_does_not_abandon_the_rest` |

The stub asserts the reason (`HTTP 403`) reaches the log, three POSTs are attempted, two succeed, and the exit code is 1. 33 tests pass across the sweeper, schedule registry and smoke suites.

## What this does not fix

**The dispatch failure itself — because it isn't known yet.** Most likely `GITHUB_TOKEN` lacking permission to trigger `workflow_dispatch`, but I'm not going to guess and ship a permissions change on a hunch. The next 3-hourly sweep will print the actual gh error, and the fix follows from that.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_