### PR TITLE
test(installer-smoke): read the stamp's window class, which nothing looked at

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -454,6 +454,47 @@ jobs:
               exit 1 ;;
           esac
 
+          # The stamp's `window` field was designed and never read.
+          #
+          # readiness.py states plainly why it carries the window class:
+          # do_activate does not always present the wizard. Depending on the
+          # machine it presents BootcRamWindow, BootcCpuWindow or
+          # BootcUnsupportedWindow instead -- real windows, correctly mapped,
+          # that are not the installer. Its own words: "A CI VM sized just
+          # under the RAM threshold would show the not-enough-RAM screen and
+          # pass every check we currently run."
+          #
+          # That was true until now. app_id proves WHICH frontend stamped;
+          # signal proves a surface reached the screen; neither can tell the
+          # wizard from the sorry-your-VM-is-too-small screen. So the field
+          # existed, the frontends all wrote it, and nothing looked.
+          #
+          # A denylist rather than an allowlist, because the wizard class is
+          # per-frontend -- BootcWindow on gnome, ApplicationWindow on niri --
+          # and an allowlist would have to be updated every time a fork
+          # renames a class, failing green cells when it was not.
+          STAMP_WINDOW=$(echo "$STAMP" | sed -n 's/^window=//p' | head -1)
+          case "${STAMP_WINDOW}" in
+            BootcRamWindow|BootcCpuWindow|BootcUnsupportedWindow)
+              echo "::error::${FLAVOR}: the frontend presented ${STAMP_WINDOW}, not the installer."
+              echo "  The window mapped and the stamp is genuine -- this is the"
+              echo "  wrong window, which means the VM does not meet the"
+              echo "  installer's own requirements:"
+              echo "    BootcRamWindow         not enough RAM"
+              echo "    BootcCpuWindow         not enough CPU"
+              echo "    BootcUnsupportedWindow not booted UEFI"
+              echo "  Fix the harness sizing in scripts/iso-e2e.sh, or set"
+              echo "  IGNORE_RAM / IGNORE_CPU in the live autostart if the"
+              echo "  threshold is deliberately not met in CI."
+              exit 1 ;;
+            "")
+              echo "::warning::${FLAVOR}: stamp carries no window class; cannot"\
+                   "tell the wizard from the RAM/CPU/UEFI screens"
+              ;;
+            *)
+              echo "${FLAVOR}: window class ${STAMP_WINDOW}" ;;
+          esac
+
       # Capturing frames proves nothing on its own, so this also asserts the
       # installer RENDERS (non-blank), ADVANCES (frames differ), and WHICH
       # spec'd screens it reached (OCR vs tests/installer-screens.yaml) — the

--- a/tests/test_readiness_stamp_lookup.py
+++ b/tests/test_readiness_stamp_lookup.py
@@ -86,3 +86,79 @@ def test_the_failure_branch_locates_a_misplaced_stamp() -> None:
 def test_the_failure_branch_lists_the_sandbox_dir() -> None:
     body = WORKFLOW.read_text()
     assert "/run/user/*/.flatpak/*/xdg-run/" in body
+
+
+# --- the window class (the designed-but-unread field) -----------------------
+
+
+def assert_step() -> str:
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    for job in doc["jobs"].values():
+        for step in (job.get("steps") or []):
+            if "Assert live desktop" in str(step.get("name", "")):
+                return step["run"]
+    raise AssertionError("assert step not found")
+
+
+def test_the_window_class_is_actually_read() -> None:
+    """readiness.py carries it precisely so this check can exist.
+
+    Its own words: "A CI VM sized just under the RAM threshold would show the
+    not-enough-RAM screen and pass every check we currently run." app_id
+    proves which frontend stamped and signal proves a surface reached the
+    screen; neither tells the wizard from the too-small-VM screen.
+    """
+    assert re.search(r"STAMP_WINDOW=\$\(", code_of(assert_step())), (
+        "the stamp's window field is written by every frontend and read by "
+        "nothing; a RAM/CPU/UEFI window would pass the gate"
+    )
+
+
+def code_of(run: str) -> str:
+    """Executable lines only. Comments and echo text name these classes for
+    documentation, and matching those made the first version of these tests
+    pass against a gate that had stopped checking anything."""
+    out = []
+    for line in run.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#") or stripped.startswith("echo "):
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def case_patterns(run: str) -> set[str]:
+    """The patterns of every `case` arm, e.g. {"BootcRamWindow", ...}."""
+    patterns = set()
+    for line in code_of(run).splitlines():
+        m = re.match(r"\s*([A-Za-z0-9_|\"*-]+)\)\s*$", line)
+        if m:
+            patterns.update(p.strip('"') for p in m.group(1).split("|"))
+    return patterns
+
+
+@pytest.mark.parametrize(
+    "klass", ["BootcRamWindow", "BootcCpuWindow", "BootcUnsupportedWindow"]
+)
+def test_the_non_wizard_windows_are_rejected(klass) -> None:
+    """Must appear as a `case` PATTERN, not merely somewhere in the text."""
+    assert klass in case_patterns(assert_step()), (
+        f"{klass} is not matched by any case arm, so a VM that presents it "
+        "passes the gate"
+    )
+
+
+def test_the_check_is_a_denylist_not_an_allowlist() -> None:
+    """The wizard class differs per frontend -- BootcWindow on gnome,
+    ApplicationWindow on niri -- so an allowlist would fail green cells
+    every time a fork renamed a class."""
+    # Comments may name the per-frontend classes -- that is documentation.
+    # What must not happen is a `case` PATTERN matching one.
+    code = code_of(assert_step())
+    assert "ApplicationWindow" not in code, (
+        "the gate matches on a per-frontend wizard class, which makes it an "
+        "allowlist that will fail cells when a fork renames one"
+    )
+    assert "BootcWindow" not in code, (
+        "same, for gnome's wizard class"
+    )


### PR DESCRIPTION
## The field that was designed and never read

`readiness.py` carries the window class for one stated reason, and until now nothing acted on it. Its own words:

> `do_activate` does not always present the installer. Depending on the machine it may present `BootcRamWindow`, `BootcCpuWindow` or `BootcUnsupportedWindow` instead — real windows, correctly mapped, that are not the wizard. **A CI VM sized just under the RAM threshold would show the not-enough-RAM screen and pass every check we currently run.**

That was literally true. The gate checked `app_id` (which frontend stamped) and `signal` (a surface reached the screen); neither can tell the wizard from the sorry-your-VM-is-too-small screen. Every frontend wrote the field; the gate never looked.

**A denylist, not an allowlist.** The wizard class is per-frontend — `BootcWindow` on gnome, `ApplicationWindow` on niri — so an allowlist would fail green cells whenever a fork renamed a class. The three not-the-wizard classes are a closed set that `readiness.py` itself enumerates.

## niri and xfce, verified end to end

Checked while preparing the five-flavor run. **Both are correctly wired and need no change:**

| | niri | xfce |
|---|---|---|
| **autostart** | appends `spawn-at-startup` to the shipped `/usr/share/niri/config.kdl`; fatal if absent | `/etc/xdg/autostart` with no `OnlyShowIn` — correct, since `systemd-xdg-autostart-condition` would silently skip it |
| **readiness ships** | `readiness.go` compiled into the binary | flatpak does `cp -r tuna_installer_xfce`, so `readiness.py` ships automatically |
| **signal** | `frame-swapped` ✓ | `gtk-map` ✓ |
| **app_id** | matches the workflow mapping ✓ | matches ✓ |

The xfce point is worth noting: because its flatpak copies the whole package directory rather than an explicit file list, it **cannot** hit the omission that cost bootc-installer #24 — where `meson.build` listed files by hand and `readiness.py` was never added.

## Verification

4 new tests, mutation-checked — **and the first version of two of them was wrong.**

Deleting the `STAMP_WINDOW` read, and removing `BootcRamWindow` from the denylist, both *passed*. The assertions were substring-matching text that also appears in comments and `echo` output, so they'd have gone on passing against a gate that had stopped checking anything. They now parse `case` patterns from executable lines only:

| mutation | caught by |
|---|---|
| delete the `STAMP_WINDOW` read | `test_the_window_class_is_actually_read` |
| drop `BootcRamWindow` from the denylist | `test_the_non_wizard_windows_are_rejected[BootcRamWindow]` |
| turn it into an allowlist | `test_the_check_is_a_denylist_not_an_allowlist` |

61 tests pass across the smoke, desktop-verify, green-criteria, schedule-registry and sweeper suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_