### PR TITLE
fix(niri): append the installer autostart to the config niri actually reads

### DIFF
--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -615,6 +615,26 @@ jobs:
             $SSH 'pgrep -xl "[c]osmic-comp|[n]iri|[x]fwl4|[k]win_wayland" 2>/dev/null || echo "(no compositor matched)"; ps -eo pid,comm,args | grep -iE "[I]nstaller" || echo "(no installer process)"' 2>/dev/null || true
 
             echo
+            echo "=== does the session command's compositor exist at all? ==="
+            # Run 32450214451's xfce leg: greetd's config is correctly shaped
+            # (user and command present in both [initial_session] and
+            # [default_session]) and `dbus-run-session startxfce4 --wayland
+            # xfwl4` still exited immediately, twice, after which greetd
+            # looped -- "greeter exited without creating a session". greetd
+            # does not capture the session's stderr, so the journal says only
+            # that it exited, never why.
+            #
+            # The cheapest discriminator is whether the binaries the config
+            # names are installed at all. tideforge-xfwl4-el10 is red today
+            # for want of libxfce4ui-devel, a build-chain product with no
+            # publisher (tunaos-packages#459), so "the compositor is simply
+            # not in the image" is a live hypothesis rather than a wild one --
+            # and one line of output settles it either way.
+            $SSH 'for b in startxfce4 xfwl4 labwc niri cosmic-comp kwin_wayland gnome-shell; do \
+                    printf "%-16s %s\n" "$b" "$(command -v "$b" 2>/dev/null || echo MISSING)"; \
+                  done' 2>/dev/null || true
+
+            echo
             echo "=== XDG_RUNTIME_DIR as the sandboxed frontend sees it ==="
             # Run 67 put the wizard ON SCREEN (evidence screenshot) with the
             # app's runtime dir present and EMPTY, and no stamp in either

--- a/live-iso/common/src/desktop-niri.sh
+++ b/live-iso/common/src/desktop-niri.sh
@@ -84,19 +84,52 @@ systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target 
 # user unit: spawn-at-startup is niri's own idiom and is demonstrably working
 # in this exact image, whereas a user unit would rest on an assumption about
 # how far niri-session takes graphical-session.target.
-NIRI_CONFIG=/usr/share/niri/config.kdl
-if [[ -f "${NIRI_CONFIG}" ]]; then
-	tee -a "${NIRI_CONFIG}" <<'NIRIEOF'
+# niri reads exactly ONE config -- the first of these that exists:
+#
+#   $XDG_CONFIG_HOME/niri/config.kdl   (liveuser's ~/.config/niri/config.kdl)
+#   /etc/niri/config.kdl
+#   /usr/share/niri/config.kdl
+#
+# This appended only to the LAST one, and run 32450214451 proved that never
+# takes effect. niri came up fine (pid 2083, socket wayland-1) and said so
+# itself:
+#
+#   niri_config: loaded config from "/var/home/liveuser/.config/niri/config.kdl"
+#
+# The niri package ships a skel copy, useradd --create-home installs it into
+# liveuser's home at customize-live.sh:81 -- fifteen lines before this script
+# is sourced -- and from then on the system default is dead weight. The
+# flatpak was installed and correct; `flatpak ps` was simply empty, because
+# nothing ever launched it. Exactly the read-path failure this repo keeps
+# hitting: the fix landed somewhere the target never looks.
+#
+# So append to every candidate that exists rather than guessing which wins.
+# niri reads one, so this cannot double-spawn, and it does not have to model
+# a precedence order that may change.
+_niri_home="$(getent passwd liveuser | cut -d: -f6)"
+NIRI_CONFIGS=(
+	"${_niri_home:-/var/home/liveuser}/.config/niri/config.kdl"
+	/etc/niri/config.kdl
+	/usr/share/niri/config.kdl
+)
+_niri_appended=0
+for _niri_cfg in "${NIRI_CONFIGS[@]}"; do
+	[[ -f "${_niri_cfg}" ]] || continue
+	tee -a "${_niri_cfg}" <<'NIRIEOF'
 
 // ── live ISO only ────────────────────────────────────────────────────────────
 // Appended by live-iso/common/src/desktop-niri.sh. Installed systems never see
 // this line: it is written into the live squash, not into the deployed image.
 spawn-at-startup "flatpak" "run" "org.tunaos.InstallerNiri"
 NIRIEOF
-else
+	echo "desktop-niri: installer autostart appended to ${_niri_cfg}"
+	_niri_appended=$((_niri_appended + 1))
+done
+
+if [[ "${_niri_appended}" -eq 0 ]]; then
 	# Fatal on purpose. A live niri ISO with no installer launcher is the exact
 	# defect this block exists to close, and it is invisible from outside — the
 	# ISO builds, the VM boots, the desktop comes up, and nothing runs.
-	echo "desktop-niri: ${NIRI_CONFIG} missing; cannot arrange installer autostart" >&2
+	echo "desktop-niri: no niri config.kdl found in any of ${NIRI_CONFIGS[*]}; cannot arrange installer autostart" >&2
 	exit 1
 fi


### PR DESCRIPTION
## First, the headline from run 32450214451

**The stamp fix works.** That run is the first in which the smoke gate functioned at all, and the results are a step change:

| | ISO build | assert | walkthrough |
|---|---|---|---|
| gnome | ✅ | ✅ **1s** | ❌ |
| kde | ✅ | ✅ **1s** | ❌ |
| cosmic | ✅ | ✅ **1s** | ❌ |
| niri | ✅ | ❌ | – |
| xfce | ✅ | ❌ | – |

- **All 5 ISOs built on `build-amd64` with no GPU** — #1937's routing change proven.
- **gnome, kde and cosmic pass the assert in ~1 second**, finding the stamp instantly at `.flatpak/<app>/xdg-run/`. No flavor had ever passed that step in runs 63–68.
- Three flavors now fail at the *walkthrough* — a stage nothing had previously reached.

And a working gate promptly found a real defect it could never previously see.

## The niri fix

niri came up fine — pid 2083, socket `wayland-1` — and the installer never started: no process, no debug log, no stamp anywhere under `/run/user`. The flatpak was installed and correct; `flatpak ps` was simply empty. niri said why itself:

```
niri_config: loaded config from "/var/home/liveuser/.config/niri/config.kdl"
```

niri reads exactly **one** config, the first that exists:

```
$XDG_CONFIG_HOME/niri/config.kdl    ← this one, and it exists
/etc/niri/config.kdl
/usr/share/niri/config.kdl          ← the only one this script appended to
```

The niri package ships a skel copy; `useradd --create-home` installs it into liveuser's home at `customize-live.sh:81` — *fifteen lines before this script is sourced*. From that point the system default is dead weight, and `spawn-at-startup` went into a file nothing would ever load.

Exactly the read-path failure this repo keeps paying for: a fix landing somewhere the target never looks, invisible because the ISO builds, the VM boots and the desktop comes up.

Now appends to every candidate that exists rather than guessing which wins. niri reads one, so it cannot double-spawn, and it needn't model a precedence order that may change. Still fatal when none exists.

## xfce: collecting what settles it, not guessing

**xfce fails differently and is not fixed here.** Its greetd config is correctly shaped — I checked, having first suspected a missing `user` key and been **wrong**:

```toml
[initial_session]
user = "liveuser"
command = "dbus-run-session startxfce4 --wayland xfwl4"
```

That command still exits immediately, twice, after which greetd loops with `greeter exited without creating a session`. greetd doesn't capture the session's stderr, so the journal says only *that* it exited, never why.

The live hypothesis: **`xfwl4` isn't in the image at all.** `tideforge-xfwl4-el10` is red for want of `libxfce4ui-devel` — a build-chain product with no publisher (tunaos-packages#459, and the publisher is tunaos-packages#463). One line of output settles it, so the capture now reports whether each compositor binary the greetd configs name actually exists.

## Verification

- `bash -n` and `shellcheck -S error` clean on `desktop-niri.sh`; capture step passes `bash -n`; yaml parses
- 38 tests pass across the smoke, desktop-verify and green-criteria suites

**Not yet proven:** the niri fix is reasoned from the image's own journal line, not from a green run. The next dispatch is the test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_