### PR TITLE
fix(walkthrough): leave the shell overview before driving any key

### DIFF
--- a/scripts/installer-walkthrough.py
+++ b/scripts/installer-walkthrough.py
@@ -296,7 +296,47 @@ def load_spec(path):
 # ── Capture ──────────────────────────────────────────────────────────────
 time.sleep(5)  # let the installer settle on its first screen
 frames = []
-p = shot(0, "initial screen")
+
+# Leave the shell overview before driving a single key.
+#
+# Run 32450214451's gnome leg reached this point with a mapped, correctly
+# stamped installer window and still produced 9 frames, 2 visual states and
+# zero page advances. The frames say why: the session was sitting in GNOME's
+# ACTIVITIES OVERVIEW, with the installer rendered as a window thumbnail
+# behind the "Type to search" entry. Every key went to the shell, not the
+# app — the widen-the-focus-sweep loop then walked focus onto the
+# thumbnail's CLOSE button and the dash icon, which is worse than useless:
+# one more Return would have closed the installer.
+#
+# Escape is the right key and the only safe one here. In GNOME it closes the
+# overview and does nothing when the overview is already down, so it costs a
+# single keystroke on the four flavors that never had this problem. Super
+# would TOGGLE — opening the overview on any session that was fine.
+#
+# Whether it was needed is itself a finding, so it is measured rather than
+# assumed: capture before, press, capture after, and compare. A frontend
+# that boots behind its own compositor's shell is a real defect in the live
+# session, and quietly dismissing it would hide exactly the inconsistency
+# this workflow exists to catch.
+overlay_dismissed = False
+_pre = shot(0, "initial screen")
+if _pre:
+    _probe = _pre[:-4] + "-preesc.png"
+    shutil.copyfile(_pre, _probe)
+    send_keys("esc")
+    time.sleep(2)
+    _post = shot(0, "initial screen (after leaving any shell overview)")
+    if _post and changed_pixels(_probe, _post) > DIFF_PIXELS:
+        overlay_dismissed = True
+        note("a shell overlay was covering the installer at session start; "
+             "'esc' dismissed it")
+    try:
+        os.remove(_probe)
+    except OSError:
+        pass
+    p = _post or _pre
+else:
+    p = _pre
 if p:
     frames.append(p)
 
@@ -405,6 +445,17 @@ for i in range(1, steps + 1):
 
 print(f"\n# walkthrough verification ({flavor}) — {len(frames)} frames, "
       f"strict={strict}\n", flush=True)
+
+# Reported, not enforced -- for now. The wizard behind it has never been
+# exercised on gnome, so failing here would replace one unknown with
+# another. It is a genuine live-session defect and belongs in the record
+# while that sequencing plays out; see tuna-os/tunaOS#1941.
+tap(not overlay_dismissed,
+    f"{flavor}: installer is frontmost at session start",
+    "a shell overlay (GNOME Activities overview or equivalent) was covering "
+    "the installer and had to be dismissed with 'esc' before the walkthrough "
+    "could drive it -- a user booting this ISO sees the same thing",
+    enforced=False)
 
 tap(len(frames) >= 2, f"{flavor}: captured at least 2 frames",
     f"got {len(frames)}")
@@ -567,6 +618,11 @@ summary = {
     "screens": reached,
     "strict": strict,
     "failures": _fails,
+    # The assertions themselves, not just how many failed. A bare count says
+    # "5 failed" and leaves every consumer -- the scoreboard, a reviewer, a
+    # test -- to re-parse stdout to learn WHICH, and whether each was
+    # enforced or advisory.
+    "tap": _tap,
 }
 with open(os.path.join(outdir, f"walkthrough-{flavor}.json"), "w") as f:
     json.dump(summary, f, indent=2)

--- a/tests/test_installer_walkthrough.py
+++ b/tests/test_installer_walkthrough.py
@@ -73,6 +73,10 @@ class FakeQEMUMonitor:
     def __init__(self, sock_path, outdir):
         self.sock_path = sock_path
         self.outdir = outdir
+        # Recorded so tests can assert the ORDER keys are sent, not just that
+        # the run finished. The overview-dismissal fix is entirely about
+        # sending 'esc' BEFORE anything else.
+        self.commands = []
         self._srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._srv.bind(sock_path)
         self._srv.listen(8)
@@ -97,6 +101,7 @@ class FakeQEMUMonitor:
                         break
                     data += chunk
                 cmd = data.decode("utf-8", "replace").strip()
+                self.commands.append(cmd)
                 if cmd.startswith("screendump "):
                     ppm = cmd.split(None, 1)[1]
                     with open(ppm, "w") as f:
@@ -150,6 +155,7 @@ def run_walkthrough(tess, magick_ae=5000, magick_stddev=0.5, steps="2",
         summary_path = outdir / f"walkthrough-{flavor}.json"
         if summary_path.exists():
             summary = json.loads(summary_path.read_text())
+        run_walkthrough.last_commands = list(mon.commands)
         return proc, summary
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
@@ -253,3 +259,74 @@ class TestTapContract:
         assert proc.returncode == 0, proc.stdout + proc.stderr
         assert "# Results:" in proc.stdout
         assert "screens reached: welcome" in proc.stdout
+
+
+class TestLeavesTheShellOverview:
+    """Run 32450214451's gnome leg: a mapped, correctly stamped installer
+    window, 9 frames, 2 visual states, zero page advances.
+
+    The frames showed why -- the session sat in GNOME's Activities overview
+    with the installer as a thumbnail behind the "Type to search" entry, so
+    every key went to the shell. The focus-widening loop then walked onto the
+    thumbnail's CLOSE button, which is worse than useless: one more Return
+    would have closed the installer.
+    """
+
+    def test_escape_is_sent_before_any_advance_key(self):
+        """Escape must come first, or the overview eats the whole run."""
+        run_walkthrough({"0": "Welcome", "1": "Welcome"}, steps="2")
+        keys = [c.split(None, 1)[1] for c in run_walkthrough.last_commands
+                if c.startswith("sendkey ")]
+        assert keys, "no keys were sent at all"
+        assert keys[0] == "esc", (
+            f"first key sent was {keys[0]!r}, not 'esc' -- an overview would "
+            f"swallow it and every key after it (full order: {keys})"
+        )
+
+    def test_escape_precedes_the_first_activation(self):
+        run_walkthrough({"0": "Welcome"}, steps="2")
+        keys = [c.split(None, 1)[1] for c in run_walkthrough.last_commands
+                if c.startswith("sendkey ")]
+        assert "ret" in keys, f"no activation key was sent: {keys}"
+        assert keys.index("esc") < keys.index("ret")
+
+    def test_a_dismissed_overlay_is_reported(self):
+        """High pixel-diff stub => the screen changed when esc was pressed."""
+        proc, summary = run_walkthrough(
+            {"0": "Welcome", "1": "Disk", "2": "Disk"},
+            magick_ae=5000, steps="2")
+        assert "shell overlay was covering the installer" in proc.stdout, (
+            f"the dismissal was not reported:\n{proc.stdout}"
+        )
+        entry = _find_tap(summary, "frontmost at session start")
+        assert entry is not None, "no frontmost assertion in the summary"
+        assert entry["ok"] is False
+
+    def test_no_overlay_is_reported_when_escape_changes_nothing(self):
+        """magick_ae=0 => esc changed no pixels => nothing was covering it."""
+        proc, summary = run_walkthrough(
+            {"0": "Welcome", "1": "Welcome", "2": "Welcome"},
+            magick_ae=0, steps="2")
+        assert "shell overlay was covering the installer" not in proc.stdout
+        entry = _find_tap(summary, "frontmost at session start")
+        assert entry is not None
+        assert entry["ok"] is True
+
+    def test_the_overlay_finding_does_not_fail_the_run_on_its_own(self):
+        """Reported, not enforced -- the wizard behind it has never been
+        exercised on gnome, so failing here would swap one unknown for
+        another. It must still be in the record."""
+        _, summary = run_walkthrough(
+            {"0": "Welcome", "1": "Disk", "2": "Disk"},
+            magick_ae=5000, steps="2")
+        entry = _find_tap(summary, "frontmost at session start")
+        assert entry["enforced"] is False
+
+
+def _find_tap(summary, needle):
+    if not summary:
+        return None
+    for entry in summary.get("tap", []):
+        if needle in entry.get("desc", ""):
+            return entry
+    return None


### PR DESCRIPTION
Implements #1941's own third diagnostic, and settles the mechanism it left open.

## It is the Activities overview

#1941 declined to claim this, correctly on the evidence it cited. But four tells are visible in **frame 00, before a single key is sent**:

1. a **`Type to search` entry** centred at the top — the overview's search box; a normal desktop has no such widget
2. the **dash** along the bottom, drawn only in the overview
3. **black panels flanking the installer** at x≈180–1100 and x≈1190+ of a 1280px frame — the workspace's other window thumbnails
4. a top bar carrying **only the clock and status icons** — no window title, no app menu

On #1941's "not scaled or tiled" objection: it is. The installer sits at x≈307–970 of 1280, inset vertically, between those two black panels. That's the overview's window carousel — it just doesn't *look* scaled because the installer's own window is small and centred to begin with.

Frame 03's large circular `×` is the overview's **thumbnail close button**; the `bootc Installer` tooltip is the dash item under the pointer. Both are overview chrome, consistent with the overview being up throughout rather than something opening at step 3.

So: **the session comes up in the overview, the installer maps behind it, every key goes to the shell.** That also explains the detail #1941 flagged as odd — the "Install Yellowfin" row never shows a focus ring in any of the nine frames. It never had focus, because the app never did.

## It was also dangerous

The widen-the-focus-sweep loop had walked focus onto the thumbnail's **close** control by frame 03. One more activation would have closed the installer, and the run would have reported "the installer stopped running" as though the app had crashed.

## The change

Send `esc` once, before frame 0 — #1941's option 3, with per-retry narrowed to once.

Escape is the only safe key here: in GNOME it closes the overview and is a no-op when the overview is already down, so it costs one keystroke on the flavors that never had this problem. `Super` would **toggle**, opening the overview on a session that was fine.

Whether it was needed is **measured, not assumed** — capture before, press, capture after, compare:

```
# a shell overlay was covering the installer at session start; 'esc' dismissed it
not ok - gnome: installer is frontmost at session start
```

Reported but **not enforced**, deliberately: nothing behind the overview has ever been exercised on gnome, so failing here would swap one unknown for another.

Also adds the TAP entries to `walkthrough-<flavor>.json`, which carried only a failure *count* — every consumer had to re-parse stdout to learn which assertion failed or whether it was advisory.

## What this does not fix

The product side. A user booting this ISO sees the same overview with the installer behind it, while kde/cosmic/xfce present theirs directly — the cross-flavor inconsistency the ISO axis exists to remove. That stays open on #1941.

## Verification

5 new tests. The two that matter most assert **order**, not presence:

| test | pins |
|---|---|
| `test_escape_is_sent_before_any_advance_key` | `esc` is the *first* key sent |
| `test_escape_precedes_the_first_activation` | `esc` comes before `ret` |
| `test_a_dismissed_overlay_is_reported` | changed screen → reported, not-ok |
| `test_no_overlay_is_reported_when_escape_changes_nothing` | unchanged → silent, ok |
| `test_the_overlay_finding_does_not_fail_the_run_on_its_own` | non-enforced either way |

Both reporting branches are driven through the pixel-diff stub. The fake QEMU monitor now records commands so ordering is assertable at all. **12/12 walkthrough tests pass.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_