### PR TITLE
fix(ci): a ternary in reusable-build-image.yml was failing every nightly

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -1239,8 +1239,23 @@ jobs:
     # iso-e2e-gpu.sh passes through. kde/xfce stay on hosted runners (per-
     # variant evidence: marlin passed 08-17), gnome is verifiable without a
     # render node. Everything else keeps the hosted runner — sparse by design.
+    # NOT a ternary: GitHub Actions expressions have no `? :`, and one here
+    # failed to PARSE, which fails the whole file, which fails every caller.
+    # That is what startup-failed all 13 variant nightlies on 2026-08-21 with
+    # zero jobs and zero duration, and what made every sweeper re-dispatch
+    # return HTTP 422 (run 32482857699):
+    #   reusable-build-image.yml (Line: 1242): Unexpected symbol: '?'
+    # The `cond && a || b` form on line 105 of this same file is the idiom.
+    # b2d29bdb introduced the same ternary into installer-smoke.yml too; that
+    # copy was fixed in #1919 and this one was not.
+    #
+    # And `'gpu'` alone was never a runner: RunsOn groups are addressed as
+    # runs-on=<run_id>/runner=<group>, as installer-smoke.yml does. A bare
+    # label would queue forever with no runner ever claiming it -- trading a
+    # parse error for a silent hang is not a fix, so both halves are repaired.
     runs-on: >-
-      ${{ (startsWith(inputs.flavor, 'cosmic') || startsWith(inputs.flavor, 'niri') || startsWith(inputs.flavor, 'xfwl4')) ? 'gpu' : 'ubuntu-latest' }}
+      ${{ (startsWith(inputs.flavor, 'cosmic') || startsWith(inputs.flavor, 'niri') || startsWith(inputs.flavor, 'xfwl4'))
+          && format('runs-on={0}/runner=gpu', github.run_id) || 'ubuntu-latest' }}
     timeout-minutes: 60
     permissions:
       contents: read

--- a/tests/test_workflow_expressions_parse.py
+++ b/tests/test_workflow_expressions_parse.py
@@ -1,0 +1,80 @@
+"""No workflow may use a C-style ternary in a GitHub Actions expression.
+
+GitHub Actions expressions have no `? :`. One reached main in b2d29bdb and
+cost a whole night of images: the expression failed to PARSE, which fails the
+entire workflow file, which fails every caller. All 13 variant nightlies
+startup-failed on 2026-08-21 with zero jobs and zero duration, and every
+re-dispatch the startup-failure sweeper attempted came back HTTP 422:
+
+    reusable-build-image.yml (Line: 1242, Col: 14): Unexpected symbol: '?'.
+    ... (startsWith(inputs.flavor,'cosmic') || ...) ? 'gpu' : 'ubuntu-latest'
+
+The same commit put the same ternary in installer-smoke.yml. That copy was
+found and fixed (#1919); this one was not, and sat broken for a day. Fixing
+one site of a copy-pasted defect is the recurring shape here, so this checks
+every workflow rather than the two known ones.
+
+The correct idiom is `cond && a || b`, which reusable-build-image.yml already
+used on line 105 while line 1242 did not.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+
+# `${{ ... ? ... : ... }}`. Deliberately scoped to expression bodies: a bare
+# '?' is legal in ordinary YAML strings, shell, and regexes.
+EXPRESSION = re.compile(r"\$\{\{(.*?)\}\}", re.DOTALL)
+
+
+def ternaries(text: str):
+    for match in EXPRESSION.finditer(text):
+        body = match.group(1)
+        # A '?' inside a quoted literal is data, not an operator.
+        stripped = re.sub(r"'[^']*'|\"[^\"]*\"", "", body)
+        if "?" in stripped:
+            yield body.strip()
+
+
+@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
+def test_no_workflow_uses_a_ternary_expression(path) -> None:
+    found = list(ternaries(path.read_text()))
+    assert not found, (
+        f"{path.name} uses `? :` in a GitHub Actions expression, which does "
+        f"not parse and fails the whole file: {found}\n"
+        "Use `cond && a || b` instead."
+    )
+
+
+@pytest.mark.parametrize("path", WORKFLOWS, ids=lambda p: p.name)
+def test_every_workflow_is_valid_yaml(path) -> None:
+    """A parse failure here is the cheap half of what CI would find late."""
+    yaml.safe_load(path.read_text())
+
+
+def test_the_detector_catches_the_expression_that_actually_broke_main() -> None:
+    """Verbatim from reusable-build-image.yml line 1242 as it stood."""
+    broken = (
+        "runs-on: >-\n"
+        "  ${{ (startsWith(inputs.flavor, 'cosmic') || "
+        "startsWith(inputs.flavor, 'niri')) ? 'gpu' : 'ubuntu-latest' }}\n"
+    )
+    assert list(ternaries(broken))
+
+
+def test_the_detector_does_not_flag_the_correct_idiom() -> None:
+    ok = "runs-on: ${{ contains(matrix.platform, 'amd64') && 'a' || 'b' }}\n"
+    assert not list(ternaries(ok))
+
+
+def test_a_question_mark_inside_a_string_literal_is_not_a_ternary() -> None:
+    """Otherwise the check would fire on legitimate text and get disabled."""
+    ok = "run: echo ${{ format('does it? yes', github.sha) }}\n"
+    assert not list(ternaries(ok))


### PR DESCRIPTION
## Every nightly has been failing to start, and this is why

GitHub Actions expressions have no `? :`. One reached main in `b2d29bdb`:

```yaml
runs-on: >-
  ${{ (startsWith(inputs.flavor, 'cosmic') || ...) ? 'gpu' : 'ubuntu-latest' }}
```

It does not parse. **A parse failure fails the whole file**, and this file is called by every per-variant nightly — so every one of them failed to start.

## This corrects my own diagnosis in #1933

I attributed the 13 zero-job startup failures on 2026-08-21 to a deleted `gh-readonly-queue` ref, because that's what the runs were attributed to and they produced no other evidence. **That was wrong.**

The real evidence came from the sweeper shipped in #1935/#1936. Run 32482857699 correctly identified all 13 and got HTTP 422 on every dispatch, quoting the parser directly:

```
reusable-build-image.yml (Line: 1242, Col: 14): Unexpected symbol: '?'
```

So the sweeper worked exactly as designed on its first real outing. It could not repair the fleet — but it produced the error message that named what actually broke it, which nothing else had managed in a full day of red.

## Two defects, both repaired

Fixing one alone would trade a parse error for a silent hang:

1. **The ternary** → replaced with the `cond && a || b` idiom that *this same file* already uses on line 105.
2. **`'gpu'` was never a runner.** RunsOn groups are addressed as `runs-on=<run_id>/runner=<group>`, the form `installer-smoke.yml` uses. A bare label queues forever with nothing claiming it.

## The recurring shape

`b2d29bdb` put the identical ternary in `installer-smoke.yml` too. That copy was caught and fixed in #1919; this one was not, and sat broken for a day taking the nightlies with it.

That's the third one-place-only fix this week, so the new test scans **every** workflow rather than the two known files, and also asserts each is valid YAML.

## Verification

123 tests, mutation-checked:

| mutation | result |
|---|---|
| reintroduce the exact broken expression | fails `test_no_workflow_uses_a_ternary_expression[reusable-build-image.yml]`, and nothing else |

The detector ignores `?` inside string literals — otherwise it would fire on legitimate text and end up disabled — and does not flag the correct idiom. 146 pass across the workflow, schedule-registry and sweeper suites.

**Not yet proven:** that a nightly now starts. The next scheduled slot is yellowfin at 00:20Z; a dispatch after this merges would confirm it sooner.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_