### PR TITLE
docs(xfce): the stack is upstream — stop calling it a personal fork

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -106,7 +106,7 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
+        # tunaOS xfce-wayland stack comes from repo.tunaos.org, which only
         # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
         platforms:
           - linux/amd64
@@ -208,7 +208,7 @@ variants:
         build_image: true
         build_iso: false
         build_qcow2: false
-        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
+        # tunaOS xfce-wayland stack comes from repo.tunaos.org, which only
         # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
         platforms:
           - linux/amd64
@@ -284,7 +284,7 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
+        # tunaOS xfce-wayland stack comes from repo.tunaos.org, which only
         # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
         platforms:
           - linux/amd64
@@ -386,7 +386,7 @@ variants:
         build_image: true
         build_iso: false
         build_qcow2: false
-        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
+        # tunaOS xfce-wayland stack comes from repo.tunaos.org, which only
         # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
         platforms:
           - linux/amd64
@@ -463,7 +463,7 @@ variants:
         build_image: true
         build_iso: true
         build_qcow2: false
-        # hanthor/xfce-wayland stack comes from repo.tunaos.org, which only
+        # tunaOS xfce-wayland stack comes from repo.tunaos.org, which only
         # publishes EL10 x86_64 packages — no aarch64 until the repo grows one.
         platforms:
           - linux/amd64

--- a/build_scripts/desktop/xfce.sh
+++ b/build_scripts/desktop/xfce.sh
@@ -13,7 +13,7 @@ case "${1:-}" in
 		if [[ $IS_FEDORA == true ]]; then
 			# repo.tunaos.org currently ships EL10/x86_64 only, so bonito
 			# gets stock Fedora XFCE 4.20 (X11). Switch to the
-			# hanthor/xfce-wayland stack once a Fedora chroot is published.
+			# tunaOS xfce-wayland stack once a Fedora chroot is published.
 			# NOTE: do NOT install the tuna-os.repo file here — its
 			# $releasever baseurl 404s on Fedora with
 			# skip_if_unavailable=False, breaking every later transaction.
@@ -35,11 +35,21 @@ case "${1:-}" in
 				xfce4-dict \
 				catfish
 		else
-			# EL10 (AlmaLinux/CentOS Stream): the hanthor/xfce-wayland port —
+			# EL10 (AlmaLinux/CentOS Stream): the tunaOS xfce-wayland port —
 			# xfwl4 (Rust/Smithay compositor) plus Wayland-adapted
 			# panel/session/xfdesktop/settings/thunar. Packaged from
 			# tuna-os/tunaos-packages (formerly github-copr) src/xfce-wayland,
 			# served by repo.tunaos.org
+			#
+			# "port" here means the PACKAGING is ours; every SOURCE is
+			# upstream. Verified 2026-08-21 across all 35 specs in
+			# tunaos-packages src/xfce-wayland: archive.xfce.org and
+			# gitlab.xfce.org for the XFCE components,
+			# gitlab.freedesktop.org for wlr-protocols, and the real
+			# upstreams for gtk-layer-shell (wmww) and gtkgreet
+			# (~kennylevinsen). No fork is involved anywhere in the stack.
+			# This paragraph exists because the previous wording named a
+			# personal namespace and was read as naming the source.
 			# (EL10 x86_64 only — build-config restricts xfce* platforms).
 			# NOTE: the stack is not published yet — the EL10 xfce flavors
 			# are commented out in build-config until tunaos-packages#65

--- a/manifests/desktops/xfce.yaml
+++ b/manifests/desktops/xfce.yaml
@@ -18,7 +18,7 @@ packages:
       - xfce4-wayland
 
   el10:
-    # Wayland-only XFCE — the hanthor/xfce-wayland port (xfwl4 Rust/Smithay
+    # Wayland-only XFCE — the tunaOS xfce-wayland port (xfwl4 Rust/Smithay
     # compositor + Wayland-adapted panel/session/settings/xfdesktop/thunar).
     # No X11 (xfce-desktop group + gdm dropped). Greeter is greetd on a VT,
     # Wayland-native, so the whole session is X11-free.


### PR DESCRIPTION
## There is no fork to move off

Eight comments across `build-config.yml`, `build_scripts/desktop/xfce.sh` and `manifests/desktops/xfce.yaml` described the EL10 XFCE stack as the **"hanthor/xfce-wayland" port**. Read plainly, that names a personal namespace as the *source* of the code — and it was read exactly that way today, prompting "we should not be using hanthor xfce code at all."

It isn't true, and hasn't been. I checked all 35 specs in `tunaos-packages src/xfce-wayland`. Every `Source0` is upstream:

| origin | packages |
|---|---|
| `archive.xfce.org` | exo, garcon, libxfce4util, libxfce4windowing, mousepad, ristretto, xfce4-dev-tools, notifyd, taskmanager, terminal, panel plugins |
| `gitlab.xfce.org` | libxfce4ui, thunar, tumbler, xfconf, xfdesktop, xfce4-panel, -session, -settings, -appfinder, -power-manager, **and xfwl4 itself** |
| `gitlab.freedesktop.org` | wlr-protocols |
| upstream projects | gtk-layer-shell (wmww), gtkgreet (~kennylevinsen) |

The tideforge recipe `packages/xfwl4/package.yaml` is upstream too — `gitlab.xfce.org/xfce/xfwl4` at a pinned commit, with the cargo vendor tree and `xfce-wayland-protocols` carried as explicit source closure rather than network fetches.

**So xfwl4 is already on the official source, in both places it is defined.**

## What changed

The comments now say what is actually ours — the *packaging* — in one place, instead of implying the opposite in eight. A short paragraph records what was verified and when, so the next reader doesn't re-derive it. The confusion cost real time today.

No behaviour change: comments plus one manifest description string.

## Verification

- both manifests parse as YAML
- `xfce.sh` passes `bash -n` **and** every line of the rewritten block is a comment

That second check earned its place. A draft of this had a continuation line lose its `#`. `bash -n` accepted it happily — `src/xfce-wayland: ...` is a syntactically valid command — and it would have failed at runtime with "command not found" inside the EL10 install path. Syntax checking cannot catch that class; grepping the block for non-comment lines can.

29 desktop / experience / green-criteria tests pass.

## The real duplication, noted not fixed here

`xfwl4` is defined **twice** — `packages/xfwl4` (tideforge) and `src/xfce-wayland/xfwl4` (build-chain) — both on upstream. That is the same trap `adw-gtk3-theme` set earlier: one package, two build systems. Worth collapsing, but it is a factory decision rather than a comment fix, so it is not in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_