### PR TITLE
Free UID 1000 on the Ubuntu bases so gurnard and grouper can build an ISO

### DIFF
--- a/build_scripts/01-workarounds.sh
+++ b/build_scripts/01-workarounds.sh
@@ -90,6 +90,67 @@ if [[ "$IS_CENTOS" = true ]] && ! [[ "$IS_ALMALINUX" = true ]]; then
 		/etc/yum.repos.d/compose.repo
 	cat /etc/yum.repos.d/compose.repo
 fi
+# ── Ubuntu: free UID 1000 for a real user ───────────────────────────────────
+#
+# docker.io/library/ubuntu ships a packaged cloud account at UID 1000.
+# Measured on the pinned gurnard base
+# (ubuntu:noble@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea),
+# by extracting /etc/passwd from its single layer:
+#
+#   ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
+#
+# Two things follow, and the second is what made this visible.
+#
+# 1. The first REAL user an installed gurnard/grouper creates lands at 1001,
+#    while a passwordless phantom account holds the UID every desktop
+#    session, flatpak permission and $XDG_RUNTIME_DIR path assumes. Nothing
+#    in tunaOS references this account -- it is dead weight from the cloud
+#    image lineage.
+#
+# 2. The live ISO cannot be built at all. tacklebox's CustomizeLive prepends
+#    its embedded src/live/baseline.sh, which creates the live user with an
+#    unconditional `--uid 1000`:
+#
+#      >>> [customize] (1/2) baseline.sh
+#      useradd: UID 1000 is not unique
+#      Error: live customize for gurnard-pantheon: ... exit status 4
+#
+#    (gurnard run 32484024591, both linux-amd64 and linux-arm64.) tunaOS
+#    hit exactly this bug in its OWN live-iso/common/src/customize-live.sh
+#    and fixed it there by asking for 1000 only when it is free -- but that
+#    script runs as (2/2) and never gets the chance.
+#
+# Removing the account fixes the shipped image on its own merits and frees
+# the UID as a consequence. Deliberately narrow: only an account that is
+# still the stock one -- name `ubuntu`, UID exactly 1000 -- is removed, so a
+# base image that stops shipping it, renumbers it, or an operator who has
+# repurposed the name is left alone rather than silently altered.
+if [[ "${IS_UBUNTU:-false}" = true ]]; then
+	if [[ "$(id -u ubuntu 2>/dev/null || echo -)" == "1000" ]]; then
+		echo "removing the stock cloud account 'ubuntu' (UID 1000)"
+		# --remove deletes /home/ubuntu. bootc images make /home a symlink to
+		# a var/home that is empty in the container layer, so that half can
+		# legitimately fail; the account removal is what has to succeed.
+		userdel --remove ubuntu 2>/dev/null || userdel ubuntu
+		getent group ubuntu >/dev/null && groupdel ubuntu 2>/dev/null || true
+		# cloud-init's sudoers drop-in names the account just deleted, which
+		# leaves a rule for a user that no longer exists. Removed only when
+		# it actually mentions `ubuntu`: on a base that repurposed the file
+		# for something else, deleting it would revoke unrelated sudo.
+		if grep -q '\bubuntu\b' /etc/sudoers.d/90-cloud-init-users 2>/dev/null; then
+			rm -f /etc/sudoers.d/90-cloud-init-users
+		fi
+	fi
+	# Not fatal, but named where it can be seen. If UID 1000 is still taken
+	# the live ISO build WILL fail later in tacklebox's baseline.sh with
+	# "useradd: UID 1000 is not unique" -- a message that arrives an hour
+	# downstream, in another repo's code, with no mention of this image.
+	if getent passwd 1000 >/dev/null; then
+		echo "WARNING: UID 1000 is still taken; the live ISO build will fail:"
+		getent passwd 1000
+	fi
+fi
+
 echo "Build variant info:"
 echo "is_fedora: $IS_FEDORA"
 echo "is_rhel: $IS_RHEL"

--- a/tests/test_ubuntu_uid_1000_is_free.py
+++ b/tests/test_ubuntu_uid_1000_is_free.py
@@ -1,0 +1,99 @@
+"""The Ubuntu bases must not ship a packaged account on UID 1000.
+
+Measured, not assumed: extracting /etc/passwd from the single layer of the
+pinned gurnard base
+(docker.io/library/ubuntu:noble@sha256:561618e2…) yields
+
+    ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
+
+Two consequences, and the second is what surfaced it.
+
+  THE IMAGE   the first real user an installed gurnard/grouper creates lands
+              at 1001 while a passwordless phantom holds the UID every
+              desktop session, flatpak permission and $XDG_RUNTIME_DIR path
+              assumes.
+
+  THE ISO     tacklebox's CustomizeLive prepends its embedded
+              src/live/baseline.sh, which creates the live user with an
+              unconditional `--uid 1000`. gurnard run 32484024591 died there
+              on BOTH arches:
+
+                  >>> [customize] (1/2) baseline.sh
+                  useradd: UID 1000 is not unique
+                  ... exit status 4
+
+              tunaOS hit the identical bug in its own
+              live-iso/common/src/customize-live.sh and fixed it by asking
+              for 1000 only when free — but that script is (2/2) and never
+              runs. So the two guards are not redundant: they sit on
+              opposite sides of a failure that aborts the build between
+              them, and a test that only knew about one would go green
+              while every Ubuntu ISO stayed red.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKAROUNDS = ROOT / "build_scripts" / "01-workarounds.sh"
+CUSTOMIZE_LIVE = ROOT / "live-iso" / "common" / "src" / "customize-live.sh"
+BUILD_CONFIG = ROOT / ".github" / "build-config.yml"
+
+
+def test_the_stock_ubuntu_account_is_removed_on_ubuntu_bases():
+    text = WORKAROUNDS.read_text()
+    assert "userdel" in text, "nothing removes the stock cloud account"
+    block = text[text.index("IS_UBUNTU"):]
+    assert "ubuntu" in block
+
+
+def test_the_removal_is_gated_on_the_ubuntu_base():
+    """A userdel that ran everywhere would delete whatever an unrelated base
+    happens to call `ubuntu`."""
+    text = WORKAROUNDS.read_text()
+    guard = text.index('if [[ "${IS_UBUNTU:-false}" = true ]]; then')
+    assert guard < text.index("userdel")
+
+
+def test_the_removal_is_narrow_enough_to_be_safe():
+    """Only the STOCK account goes. A base that renumbers it, drops it, or an
+    operator who repurposed the name must be left alone rather than silently
+    altered — so the UID is checked, not just the name."""
+    text = WORKAROUNDS.read_text()
+    guard = text[text.index('if [[ "${IS_UBUNTU:-false}" = true ]]; then'):
+                 text.index("userdel")]
+    assert re.search(r"id -u ubuntu\b", guard), "the account is not identified by name"
+    assert re.search(r'==\s*"?1000"?', guard), "the removal does not pin UID 1000"
+
+
+def test_the_account_removal_itself_must_succeed():
+    """`userdel --remove` can legitimately fail on its home-directory half:
+    bootc images symlink /home to a var/home that is empty in the container
+    layer. Falling back to a plain userdel keeps the failure that matters
+    fatal, where a blanket `|| true` would let the UID stay taken and the
+    ISO keep failing with the build reported green."""
+    text = WORKAROUNDS.read_text()
+    assert "userdel --remove ubuntu 2>/dev/null || userdel ubuntu" in text
+    fallback = text.index("|| userdel ubuntu")
+    line_end = text.index("\n", fallback)
+    assert "|| true" not in text[fallback:line_end]
+
+
+def test_customize_live_still_asks_for_1000_only_when_free():
+    """The other side of the same failure. This guard predates the fix above
+    and must survive it: the two are not redundant (see the module
+    docstring)."""
+    text = CUSTOMIZE_LIVE.read_text()
+    assert "getent passwd 1000 >/dev/null || _uid_args=(--uid 1000)" in text
+
+
+def test_the_ubuntu_bases_this_applies_to_are_still_ubuntu():
+    """If gurnard or grouper is ever rebased off Ubuntu the workaround stops
+    applying, and this test says so instead of leaving dead code guarded by
+    a flag nothing sets."""
+    config = BUILD_CONFIG.read_text()
+    for variant in ("gurnard", "grouper"):
+        start = config.index(f"- id: {variant}\n")
+        window = config[start:start + 600]
+        assert "docker.io/library/ubuntu" in window, variant


### PR DESCRIPTION
Found while verifying gurnard run [32484024591](https://github.com/tuna-os/tunaOS/actions/runs/32484024591) — the dispatched build that proved #1946. Both flavors went **green through Promote**; the run is still red because the ISO job failed on both arches, and this is why.

## The measurement

`docker.io/library/ubuntu` ships a packaged cloud account on UID 1000. Extracted from the single layer of the pinned gurnard base (`ubuntu:noble@sha256:561618e2…`):

```
ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
```

## Two consequences

**The image.** The first real user an installed gurnard or grouper creates lands at **1001**, while a passwordless phantom holds the UID every desktop session, flatpak permission and `$XDG_RUNTIME_DIR` path assumes. Nothing in tunaOS references the account — it is dead weight from the cloud-image lineage.

**The ISO.** tacklebox's `CustomizeLive` prepends its embedded `src/live/baseline.sh`, which creates the live user with an unconditional `--uid 1000`:

```
>>> [customize] (1/2) baseline.sh
useradd: UID 1000 is not unique
Error: live customize for gurnard-pantheon: … exit status 4
```

Both `iso:pantheon (linux-amd64)` and `(linux-arm64)`, identically.

tunaOS hit the **identical bug** in its own `live-iso/common/src/customize-live.sh` and fixed it there by asking for 1000 only when it is free — the comment even names grouper and exit 4. But that script runs as **(2/2)** and never gets the chance: the build aborts in (1/2).

So the two guards are not redundant. They sit on opposite sides of a failure that aborts the build between them, which is why the test covers both — a test that knew only about `customize-live.sh` would stay green while every Ubuntu ISO stayed red.

## The change

Remove the stock account in `build_scripts/01-workarounds.sh`, on the Ubuntu path only.

Removing it is right on the image's own merits and frees the UID as a consequence. That ordering matters: the alternative framing was a workaround for a downstream tool, and this is a defect in what we ship.

Deliberately narrow — only an account that is **still the stock one** (name `ubuntu`, UID exactly 1000) is touched, so a base that renumbers it, drops it, or an operator who repurposed the name is left alone rather than silently altered:

- the cloud-init sudoers drop-in goes only if it actually names `ubuntu`;
- `userdel --remove` may fail on its home-directory half — bootc images symlink `/home` to a `var/home` that is empty in the container layer — so it falls back to a plain `userdel`. The account removal is what has to succeed; a blanket `|| true` there would leave the UID taken and the ISO still failing with the build reported green. There is a test for exactly that.

## What is deliberately not fixed

The unconditional `--uid 1000` in tacklebox's baseline stays. It is a pinned external component, and after this it is **latent rather than blocking** — it will bite again on the next base that ships a packaged user at 1000. The build now warns, at the point of cause, that the ISO will fail an hour downstream in another repo's code:

```
WARNING: UID 1000 is still taken; the live ISO build will fail:
```

## Also confirmed in that run, no action needed

`Attest SBOM` failed on both flavors, and it is a real Sigstore outage, not ours — `rekor.sigstore.dev` returning `502 Bad Gateway`, retried 6 times across the 10-minute budget, then `SIGSTORE_OUTAGE: giving up`. Promote succeeded anyway on both flavors, which is #1560's decoupling behaving exactly as designed.

## Verification

- 6 new tests, all mutation-checked: dropping the UID pin, swapping the `userdel` fallback for `|| true`, and removing the `IS_UBUNTU` guard each fail the test that exists for it (1, 1 and 3 failures respectively).
- `bash -n` and `shellcheck -S warning` clean on the changed script.
- pytest collection clean (694 tests). The full local suite did not finish inside the time I gave it in this environment — CI is the authority on it.
- The end-to-end proof needs a dispatched gurnard build, since the ISO job only runs there; I'll pick that up once this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_