### PR TITLE
Unbreak the BATS shellcheck gate that #1950 turned red on main

### DIFF
--- a/build_scripts/01-workarounds.sh
+++ b/build_scripts/01-workarounds.sh
@@ -132,7 +132,12 @@ if [[ "${IS_UBUNTU:-false}" = true ]]; then
 		# a var/home that is empty in the container layer, so that half can
 		# legitimately fail; the account removal is what has to succeed.
 		userdel --remove ubuntu 2>/dev/null || userdel ubuntu
-		getent group ubuntu >/dev/null && groupdel ubuntu 2>/dev/null || true
+		# An if-block, not `A && B || C`: shellcheck's SC2015 is an INFO
+		# finding, and tests/bats/test_build_scripts.bats runs shellcheck
+		# with only SC1091 excluded, so info findings fail the gate.
+		if getent group ubuntu >/dev/null; then
+			groupdel ubuntu 2>/dev/null || true
+		fi
 		# cloud-init's sudoers drop-in names the account just deleted, which
 		# leaves a rule for a user that no longer exists. Removed only when
 		# it actually mentions `ubuntu`: on a base that repurposed the file


### PR DESCRIPTION
Follow-up to #1950, which is merged and turned `Run BATS tests` red on main. My defect, found and fixed.

## What broke

```
not ok 277 build_scripts/01-workarounds.sh: passes shellcheck
```

```
getent group ubuntu >/dev/null && groupdel ubuntu 2>/dev/null || true
                               ^-- SC2015 (info): Note that A && B || C is not if-then-else.
```

`tests/bats/test_build_scripts.bats` runs `shellcheck --exclude=SC1091` — **info findings fail it**. Replaced with a plain `if` block; `shellcheck --exclude=SC1091` now exits 0 and the file's BATS run is 46/46.

## How I let it through

Two checks, same shape, both narrower than the gate:

1. I ran `shellcheck -S warning`, which suppresses info findings. The repo's gate does not suppress them.
2. I then ran `bats tests/bats/test_build_scripts.bats` and read only the **tail** of the output. The failing assertion is test 73 in that file; the tail showed tests 22–46 of a later section, all `ok`, and I read that as "46/46 passed".

Either check on its own would have caught it. I did both and still missed it, because each was a narrower thing than the gate and I treated the result as the gate's answer. The comment now sitting next to the `if` says so, so the next person to write `A && B || C` in this file learns it from the file rather than from CI.

## Verification

- `shellcheck --exclude=SC1091 build_scripts/01-workarounds.sh` → exit 0, no output.
- `bats tests/bats/test_build_scripts.bats` → `1..46`, 46 ok, 0 not ok.
- `pytest tests/test_ubuntu_uid_1000_is_free.py` → 6 passed; the removal's behaviour is unchanged, only the shape of the group-delete guard.

Rebased onto current main (`40da6438`), so this is a fresh branch on top of the merged #1950 rather than a reopening of it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_