### PR TITLE
Fetch and deploy the installer flatpak for the ISO's own architecture

### DIFF
--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -484,13 +484,36 @@ if [[ -n "${INSTALLER_APP}" ]]; then
 		# missing stamp. Fallback: tuna-os/tuna-installer, which mirrors
 		# the same app ID as a release asset.
 		INSTALLER_FLATPAK_FILE="/tmp/bootc-installer.flatpak"
+		# A flatpak bundle carries refs for ONE architecture, so the asset has
+		# to match the host. The release was x86_64-only and the name carried
+		# no arch, so an aarch64 ISO downloaded it, imported
+		# app/org.bootcinstaller.Installer/x86_64/master, and then:
+		#
+		#   error: Nothing matches org.bootcinstaller.Installer in remote
+		#          installer-local
+		#
+		# (gurnard run 32495176056, iso:pantheon linux-arm64.) x86_64 keeps
+		# the bare name — every existing consumer fetches that exact URL, and
+		# renaming it would break them for no gain. See
+		# tuna-os/bootc-installer#25.
+		_installer_asset="org.bootcinstaller.Installer.flatpak"
+		if [[ "$(uname -m)" != "x86_64" ]]; then
+			_installer_asset="org.bootcinstaller.Installer-$(uname -m).flatpak"
+		fi
 		if ! curl --retry 3 --fail --location --max-time 300 \
-			"https://github.com/tuna-os/bootc-installer/releases/latest/download/org.bootcinstaller.Installer.flatpak" \
+			"https://github.com/tuna-os/bootc-installer/releases/latest/download/${_installer_asset}" \
 			-o "${INSTALLER_FLATPAK_FILE}" 2>/dev/null; then
 			echo "tuna-os/bootc-installer unavailable, falling back to tuna-os/tuna-installer..."
-			curl --retry 3 --fail --location --max-time 300 \
-				"https://github.com/tuna-os/tuna-installer/releases/latest/download/org.bootcinstaller.Installer.flatpak" \
-				-o "${INSTALLER_FLATPAK_FILE}"
+			if ! curl --retry 3 --fail --location --max-time 300 \
+				"https://github.com/tuna-os/tuna-installer/releases/latest/download/${_installer_asset}" \
+				-o "${INSTALLER_FLATPAK_FILE}"; then
+				# Name the arch. Without this the next failure reads as
+				# "Nothing matches ... in remote installer-local" three
+				# commands later, which looks like a corrupt download rather
+				# than an asset that was never published.
+				echo "ERROR: no ${_installer_asset} published for $(uname -m)" >&2
+				exit 1
+			fi
 		fi
 		INSTALLER_LOCAL_REPO="/tmp/installer-local-repo"
 		ostree init --repo="${INSTALLER_LOCAL_REPO}" --mode=archive-z2
@@ -508,7 +531,10 @@ if [[ -n "${INSTALLER_APP}" ]]; then
 		# the deployment directory but omits the 'active' symlink inside the
 		# branch directory, leaving the app unreachable to flatpak run/list.
 		# Reproduce the symlink a normal installation would create.
-		_app_arch_dir="/var/lib/flatpak/app/${INSTALLER_APP}/x86_64"
+		# $(uname -m), not a hardcoded x86_64: flatpak deploys under the
+		# host arch, so on aarch64 this globbed a directory that does not
+		# exist and the repair below silently did nothing.
+		_app_arch_dir="/var/lib/flatpak/app/${INSTALLER_APP}/$(uname -m)"
 		for _branch_dir in "${_app_arch_dir}"/*/; do
 			_branch_dir="${_branch_dir%/}"
 			[[ -d "${_branch_dir}" ]] || continue

--- a/tests/test_installer_asset_is_arch_aware.py
+++ b/tests/test_installer_asset_is_arch_aware.py
@@ -1,0 +1,95 @@
+"""The live ISO must fetch and deploy the installer for its OWN architecture.
+
+A flatpak bundle carries refs for one architecture. The published release
+asset was x86_64-only and its name carried no arch, so an aarch64 ISO
+downloaded it, imported `app/org.bootcinstaller.Installer/x86_64/master`, and
+then found nothing matching the host:
+
+    error: Nothing matches org.bootcinstaller.Installer in remote installer-local
+
+Measured on gurnard run 32495176056, `iso:pantheon (linux-arm64)`. The arm64
+ISO could therefore never carry the installer — and nothing downstream of it,
+including the installer smoke gate and the walkthrough, was ever exercisable
+on that arch.
+
+Reading that block turned up a SECOND hardcoded arch a few lines down: the
+active-symlink repair globbed `/var/lib/flatpak/app/<app>/x86_64`, which on
+aarch64 is a directory that does not exist, so the repair silently did
+nothing. Both are pinned here, because one being fixed without the other
+leaves the ISO booting to an installer that flatpak cannot launch.
+
+The x86_64 asset name stays bare on purpose: every existing consumer fetches
+`releases/latest/download/org.bootcinstaller.Installer.flatpak`, and renaming
+it would break them all to no benefit. Paired change: tuna-os/bootc-installer#25.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "live-iso" / "common" / "src" / "customize-live.sh"
+
+
+def script() -> str:
+    return SCRIPT.read_text(encoding="utf-8")
+
+
+def test_the_asset_name_is_chosen_from_the_host_arch():
+    text = script()
+    assert '_installer_asset="org.bootcinstaller.Installer.flatpak"' in text
+    assert '_installer_asset="org.bootcinstaller.Installer-$(uname -m).flatpak"' in text
+
+
+def test_x86_64_keeps_the_bare_asset_name():
+    """Downstreams fetch that exact URL; the arch suffix is for everyone else."""
+    text = script()
+    guard = re.search(r'if \[\[ "\$\(uname -m\)" != "x86_64" \]\]; then', text)
+    assert guard, "the suffix is not gated on being a non-x86_64 host"
+    bare = text.index('_installer_asset="org.bootcinstaller.Installer.flatpak"')
+    assert bare < guard.start(), "x86_64 must be the default, not the exception"
+
+
+def test_both_download_urls_use_the_resolved_asset():
+    """The fallback mirror has to agree with the primary — fetching a bare
+    name there would reintroduce the bug for anyone who hits the fallback."""
+    text = script()
+    urls = re.findall(r"releases/latest/download/([^\"]+)", text)
+    assert urls, "no release download URLs found"
+    assert all(u == "${_installer_asset}" for u in urls), urls
+
+
+def test_a_missing_arch_asset_fails_by_name():
+    """Otherwise the next failure reads as 'Nothing matches ... in remote
+    installer-local' three commands later, which looks like a corrupt
+    download rather than an asset that was never published."""
+    text = script()
+    assert 'echo "ERROR: no ${_installer_asset} published for $(uname -m)"' in text
+
+
+def test_the_deploy_path_is_not_hardcoded_to_x86_64():
+    """The second bug in the same block: flatpak deploys under the host arch,
+    so a hardcoded x86_64 made the active-symlink repair a silent no-op on
+    aarch64."""
+    text = script()
+    assert '_app_arch_dir="/var/lib/flatpak/app/${INSTALLER_APP}/$(uname -m)"' in text
+    assert "/var/lib/flatpak/app/${INSTALLER_APP}/x86_64" not in text
+
+
+def test_no_arch_is_hardcoded_anywhere_in_the_installer_block():
+    """A sweep rather than a spot check — either hardcoding alone is enough to
+    break the arm64 ISO."""
+    text = script()
+    start = text.index("INSTALLER_FLATPAK_FILE=")
+    end = text.index('rm -rf "${INSTALLER_LOCAL_REPO}"', start)
+    # CODE only. The comments in this block quote the incident, including
+    # `app/org.bootcinstaller.Installer/x86_64/master` — scanning them would
+    # make the test fail on its own explanation.
+    code = "\n".join(
+        line for line in text[start:end].splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    # The one legitimate literal is the guard that keeps x86_64 on the bare
+    # asset name; everything else must derive the arch at runtime.
+    code = code.replace('!= "x86_64"', "")
+    assert "x86_64" not in code, "a literal x86_64 remains in the installer block"


### PR DESCRIPTION
The tunaOS half of tuna-os/bootc-installer#25. Paired with tuna-os/bootc-installer#26, which publishes the aarch64 bundle.

## The measurement

gurnard run [32495176056](https://github.com/tuna-os/tunaOS/actions/runs/32495176056), `iso:pantheon (linux-arm64)`:

```
+ flatpak build-import-bundle /tmp/installer-local-repo /tmp/bootc-installer.flatpak
Importing app/org.bootcinstaller.Installer/x86_64/master   ← on an aarch64 host
+ flatpak install --system --noninteractive installer-local org.bootcinstaller.Installer
error: Nothing matches org.bootcinstaller.Installer in remote installer-local
+ exit 1
```

A flatpak bundle carries refs for one architecture. The release asset is x86_64-only and its name carries no arch, so the arm64 ISO fetched a bundle it could not use. The same run's amd64 leg went the whole distance on the same commit — build → boot gate → sign → walkthrough → R2 upload — so this is the one thing standing between tunaOS and a green arm64 ISO.

That also means nothing downstream of the arm64 ISO has ever been exercisable: not the installer smoke gate, not the walkthrough.

## The change

Pick the asset from `$(uname -m)`, and keep x86_64 on the bare name:

| host | asset |
|---|---|
| x86_64 | `org.bootcinstaller.Installer.flatpak` |
| everything else | `org.bootcinstaller.Installer-$(uname -m).flatpak` |

Every existing consumer fetches that exact x86_64 URL, so the suffix is for the other arches only. The **fallback mirror uses the same resolved name** — fetching a bare name there would reintroduce the bug for anyone who reaches the fallback, and there's a test that both URLs agree.

When no asset exists for the arch it now fails naming the arch:

```
ERROR: no org.bootcinstaller.Installer-aarch64.flatpak published for aarch64
```

Without that, the next failure is `Nothing matches … in remote installer-local` three commands later, which reads as a corrupt download rather than an asset that was never published. That misreading is exactly why this took a whole ISO run to find.

## A second hardcoded arch in the same block

Reading that code turned up another one a few lines down:

```bash
_app_arch_dir="/var/lib/flatpak/app/${INSTALLER_APP}/x86_64"
```

flatpak deploys under the host arch, so on aarch64 that globbed a directory that does not exist and the active-symlink repair silently did nothing. Fixing only the download would have left the arm64 ISO booting to an installer flatpak cannot launch.

Both move to `$(uname -m)`, and `test_no_arch_is_hardcoded_anywhere_in_the_installer_block` sweeps the whole block for any literal that remains — a sweep rather than a spot check, because either hardcoding alone breaks the ISO. It strips comment lines first: the comments quote the incident, `x86_64/master` included, and scanning them would make the test fail on its own explanation.

## Ordering

This side is inert until #26 lands — no aarch64 asset exists yet. Until then arm64 fails with a message naming what is missing instead of one that looks like corruption, which is strictly better than today. x86_64 behaviour is byte-identical.

## Verification

- `bash -n` and `shellcheck --exclude=SC1091` clean (the repo's bats gate uses that exact invocation, so info-level findings count).
- 6 new tests, mutation-checked: reverting the download to the bare name fails `test_both_download_urls_use_the_resolved_asset`; re-hardcoding the deploy path fails `test_the_deploy_path_is_not_hardcoded_to_x86_64`.
- 77 assertions green across `test_customize_live.bats`, `test_live_installer_launch.bats` and `test_build_scripts.bats`, 0 failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_