### PR TITLE
EXPERIMENT: gate the Rawhide rpmdb probe on IS_FEDORA to measure its real scope (#1823)

### DIFF
--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -759,6 +759,40 @@ install_rawhide_tolerant() {
 # transaction that follows is the real verdict either way, and a probe that
 # can kill a green pinned-Fedora build would cost more than it measures.
 rawhide_rpmdb_probe() {
+	# EXPERIMENT for tunaOS#1823. The comment above says this is "a no-op off
+	# Rawhide". It was not. detect_fedora_ver (above) maps an UNEXPANDED
+	# %fedora to "rawhide", and %fedora is undefined on every non-Fedora dnf
+	# image -- so "this is not a Fedora at all" was being read as "this is
+	# Rawhide", and the Rawhide-only copy-up ran on CentOS, RHEL and Alma too.
+	#
+	# Measured on skipjack (quay.io/centos-bootc/centos-bootc:stream10,
+	# IS_CENTOS=true, IS_FEDORA=false), run 32534198668:
+	#
+	#   ++ rpm -E %fedora
+	#   ++ ver=%fedora
+	#   ++ [[ %fedora == \%\f\e\d\o\r\a ]]
+	#   ++ echo rawhide
+	#   + [[ rawhide == \r\a\w\h\i\d\e ]]
+	#
+	# detect_fedora_ver's fallback is sound where it was designed to be used:
+	# 10-base-packages.sh only reaches it inside an `elif [[ $IS_FEDORA == true
+	# ]]` branch, where an unexpanded macro really can only mean an odd
+	# prerelease. This function consumed it with no such guard.
+	#
+	# Whether that misfire is inert or load-bearing on EL10 is exactly what
+	# this branch measures, and it is NOT obvious: #1912 and #1916 fixed real
+	# EL10 corruption with this same round-trip and salvage, and if EL10 cells
+	# have been reaching that code THROUGH the misdetection, gating it here
+	# reverts those fixes. The nvidia surface is unaffected either way --
+	# overlay/overrides/nvidia/10-kernel-swap.sh carries its own deliberately
+	# fatal copy, and describes itself as this probe "graduating on a stable
+	# base", which reads as though the two were always meant to be separate.
+	#
+	# Read the result before merging. If EL10 desktop cells behave identically
+	# with this gate in place, the misfire was inert and the scope can simply
+	# be made honest. If they change, this line must NOT land as-is and EL10
+	# needs its own named entry point instead.
+	[[ "${IS_FEDORA:-false}" == true ]] || return 0
 	[[ "$(detect_fedora_ver)" == "rawhide" ]] || return 0
 	# tunaOS#1823, PROVEN FIX ported from the nvidia overlay (run
 	# 32339591457, 2026-08-20): the sqlite corruption class is rpm writing

--- a/tests/bats/test_rawhide_rpmdb_probe.bats
+++ b/tests/bats/test_rawhide_rpmdb_probe.bats
@@ -53,8 +53,14 @@ STUB
   export OS_RELEASE
 }
 
+# IS_FEDORA defaults to true here because every case below models a FEDORA
+# image (Rawhide or pinned). It used to be unset, which meant these tests
+# reached the probe the same way CentOS did in production — through
+# detect_fedora_ver mapping an unexpanded %fedora to "rawhide" — rather than
+# by being a Fedora at all. See tunaOS#1823; the non-Fedora case is now
+# asserted explicitly below instead of being the accidental default.
 run_probe() {
-  PATH="${BIN}:$PATH" run bash -c "
+  PATH="${BIN}:$PATH" IS_FEDORA="${IS_FEDORA:-true}" run bash -c "
     set -euo pipefail
     ${FN_DETECT}
     ${FN_PROBE}
@@ -67,6 +73,33 @@ run_probe() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"TUNAOS_RPMDB_PROBE=rebuilt"* ]]
   [ "$(wc -l < "$REBUILD_LOG")" -eq 1 ]
+}
+
+@test "off Fedora entirely, the probe is a no-op — CentOS is not Rawhide" {
+  # The regression this guard exists for. On CentOS/RHEL/Alma `rpm -E %fedora`
+  # prints the macro back unexpanded, detect_fedora_ver reports "rawhide", and
+  # before the IS_FEDORA guard the Rawhide-only copy-up ran on a CentOS image
+  # and then aborted the build on a lossy salvage (skipjack,
+  # centos-bootc:stream10, run 32534198668).
+  printf 'PRETTY_NAME="CentOS Stream 10"\n' > "$OS_RELEASE"
+  IS_FEDORA=false RPM_E_OUT='%fedora' run_probe
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"TUNAOS_RPMDB_PROBE"* ]]
+  [ "$(wc -l < "$REBUILD_LOG")" -eq 0 ]
+}
+
+@test "detect_fedora_ver still reports rawhide there — the guard is what stops it" {
+  # Pins the MECHANISM, not just the outcome: detect_fedora_ver is deliberately
+  # left alone, because 10-base-packages.sh depends on that fallback inside an
+  # `elif [[ $IS_FEDORA == true ]]` branch. If a later change "fixes" the
+  # helper instead, this test says so.
+  PATH="${BIN}:$PATH" run bash -c "
+    set -euo pipefail
+    ${FN_DETECT}
+    RPM_E_OUT='%fedora' detect_fedora_ver
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == "rawhide" ]]
 }
 
 @test "off rawhide, the probe is a no-op — pinned Fedora never pays for it" {

--- a/tests/test_rawhide_probe_scope.py
+++ b/tests/test_rawhide_probe_scope.py
@@ -1,0 +1,104 @@
+"""The Rawhide rpmdb probe must not run on images that are not Fedora.
+
+`rawhide_rpmdb_probe` describes itself as "a no-op off Rawhide". It was not.
+`detect_fedora_ver` maps an UNEXPANDED `%fedora` to "rawhide", and `%fedora`
+is undefined on every non-Fedora dnf image, so "this is not a Fedora at all"
+was read as "this is Rawhide". Measured on skipjack
+(quay.io/centos-bootc/centos-bootc:stream10, IS_CENTOS=true, IS_FEDORA=false)
+in run 32534198668, where the Rawhide-only copy-up ran and then aborted the
+build on a lossy salvage.
+
+The fallback itself is fine where it was designed to be used:
+`10-base-packages.sh` only reaches it inside an `elif [[ $IS_FEDORA == true ]]`
+branch. What was missing is that this function consumed it with no such guard.
+
+This is an EXPERIMENT for tunaOS#1823 -- see the comment in lib.sh. These
+tests pin the shape of the change, not its outcome.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB = ROOT / "build_scripts" / "lib.sh"
+
+
+def probe_body() -> str:
+    text = LIB.read_text(encoding="utf-8")
+    start = text.index("rawhide_rpmdb_probe() {")
+    return text[start:text.index("\n}\n", start)]
+
+
+def run_probe(env: dict[str, str], fedora_macro: str) -> int:
+    """Run the two guard lines with a stubbed `rpm`, returning the exit code.
+
+    0 means the function returned early (probe skipped).
+    """
+    lib = LIB.read_text(encoding="utf-8")
+    detect = re.search(r"^detect_fedora_ver\(\) \{.*?^\}", lib, re.S | re.M).group(0)
+    guards = "\n".join(
+        ln for ln in probe_body().splitlines()
+        if ln.strip().startswith("[[") and "return 0" in ln
+    )
+    script = f"""
+    rpm() {{ [[ "$1" == "-E" && "$2" == "%fedora" ]] && {{ echo '{fedora_macro}'; return 0; }}; return 1; }}
+    {detect}
+    probe() {{
+    {guards}
+        echo RAN
+    }}
+    probe
+    """
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True,
+                       env={"PATH": "/usr/bin:/bin", **env})
+    return 0 if "RAN" not in r.stdout else 1
+
+
+def test_the_is_fedora_guard_is_present():
+    assert '[[ "${IS_FEDORA:-false}" == true ]] || return 0' in probe_body()
+
+
+def test_it_guards_before_consulting_detect_fedora_ver():
+    """detect_fedora_ver is the thing that misreports; checking it first and
+    IS_FEDORA second would leave the misfire in place for anything that
+    short-circuits on the first guard."""
+    # CODE only. The comment explaining this change names detect_fedora_ver
+    # repeatedly and sits above the guards, so scanning prose would compare
+    # the explanation instead of the logic.
+    code = "\n".join(
+        ln for ln in probe_body().splitlines() if not ln.strip().startswith("#")
+    )
+    assert code.index("IS_FEDORA") < code.index("detect_fedora_ver")
+
+
+def test_centos_skips_the_probe():
+    """The measured case: %fedora unexpanded, IS_FEDORA false."""
+    assert run_probe({"IS_FEDORA": "false"}, "%fedora") == 0
+
+
+def test_centos_skips_even_though_detect_still_says_rawhide():
+    """Pins the actual mechanism rather than the outcome: detect_fedora_ver is
+    deliberately left alone, because 10-base-packages.sh relies on its
+    fallback inside an IS_FEDORA branch."""
+    lib = LIB.read_text(encoding="utf-8")
+    detect = re.search(r"^detect_fedora_ver\(\) \{.*?^\}", lib, re.S | re.M).group(0)
+    r = subprocess.run(
+        ["bash", "-c", f"rpm() {{ echo '%fedora'; }}\n{detect}\ndetect_fedora_ver"],
+        capture_output=True, text=True, env={"PATH": "/usr/bin:/bin"})
+    assert r.stdout.strip() == "rawhide"
+
+
+def test_a_real_rawhide_image_still_runs_the_probe():
+    """The whole point of the probe must survive the gate."""
+    assert run_probe({"IS_FEDORA": "true"}, "%fedora") == 1
+
+
+def test_a_pinned_fedora_release_still_skips():
+    """Numeric %fedora is not Rawhide, so the second guard still applies."""
+    assert run_probe({"IS_FEDORA": "true"}, "44") == 0
+
+
+def test_the_experiment_is_labelled_with_its_issue():
+    assert "tunaOS#1823" in probe_body()


### PR DESCRIPTION
**This is an experiment. Read the `build` job before merging it.** It is opened for review because the result is the deliverable, not because the diff is obviously correct.

## The claim being tested

`rawhide_rpmdb_probe`'s own comment says it is *"a no-op off Rawhide"*. It is not, and never has been.

`detect_fedora_ver` maps an **unexpanded** `%fedora` to `"rawhide"`, and `%fedora` is undefined on every non-Fedora dnf image. So "this is not a Fedora at all" is read as "this is Rawhide", and the Rawhide-only copy-up runs on CentOS, RHEL and Alma too. From skipjack (`centos-bootc:stream10`, `IS_CENTOS=true`, `IS_FEDORA=false`), [run 32534198668](https://github.com/tuna-os/tunaOS/actions/runs/32534198668):

```
+ rawhide_rpmdb_probe
++ detect_fedora_ver
+++ rpm -E %fedora
++ ver=%fedora
++ [[ %fedora == \%\f\e\d\o\r\a ]]
++ echo rawhide
+ [[ rawhide == \r\a\w\h\i\d\e ]]
```

`detect_fedora_ver` is deliberately **left alone**. Its fallback is sound where it was designed to be used — `10-base-packages.sh` only reaches it inside an `elif [[ $IS_FEDORA == true ]]` branch, where an unexpanded macro really can only mean an odd prerelease. What was missing is that this function consumed it with no such guard.

## Why this is an experiment and not a fix

The obvious gate may be wrong, and the evidence on #1823 is the reason. #1912 and #1916 fixed real EL10 corruption using this same round-trip and salvage. **If EL10 cells have been reaching that code through this misdetection, gating it here reverts those fixes.** I have not tested which reading holds — that is what this branch is for.

The nvidia surface is unaffected either way: `overlay/overrides/nvidia/10-kernel-swap.sh` carries its own deliberately-fatal copy and describes itself as this probe *"graduating per its own protocol on a stable base"*, which reads as though the two were always meant to be separate.

## How to read the result

This PR's `build` job runs **skipjack / gnome — an EL10 desktop cell**, so the experiment costs nothing extra.

| outcome | meaning | next step |
|---|---|---|
| build behaves as it does on `main` | the misfire was inert on EL10 | the scope can simply be made honest; this can land |
| build newly **passes** | the probe was *causing* #1823 on EL10 | major finding — the guard is the fix |
| build newly **fails**, or fails differently | the misfire is load-bearing | **do not merge as-is** — EL10 needs its own named entry point calling the same body |

Note that skipjack/gnome is currently red on `main` for #1823 (`rpmdb data loss`, lossy salvage), so "unchanged" here means *the same* failure, not a green build.

## The test harness was itself encoding the bug

This is the sharpest evidence in the whole issue, and it was not something I went looking for — four bats tests failed on this change.

`tests/bats/test_rawhide_rpmdb_probe.bats` **never set `IS_FEDORA`**. Every case named "on rawhide" was reaching the probe exactly the way CentOS did in production — through the misdetection — rather than by modelling a Fedora image at all. A real Rawhide image has `IS_FEDORA=true`; the harness only ever set a Rawhide `os-release`.

Fixed by defaulting `IS_FEDORA=true` in the harness (every case in it models a Fedora image), plus two new cases:

- a CentOS image skips the probe — the regression this guard exists for;
- `detect_fedora_ver` **still** reports `"rawhide"` there, pinning the *mechanism* rather than the outcome. That one fails if someone later "fixes" the helper instead of the caller, which would break the Rawhide RPM Fusion path in `10-base-packages.sh`.

## Verification

- **69 bats assertions** pass across the probe, rawhide-tolerance and build-scripts suites; **0 failures**.
- `shellcheck --exclude=SC1091` clean — the gate's exact invocation, so info-level findings count.
- 7 pytest cases, mutation-checked rather than written green: removing the guard, ordering it *after* `detect_fedora_ver`, and "fixing" `detect_fedora_ver` instead each fail.

## Related

Separate from, and not fixed by, this PR: the error message at `build_scripts/lib.sh` points readers at #1893 (an ISO assembly hang) for a remedy while naming #1823 in its title. Flagged on #1823 with the evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_