### PR TITLE
Unblock hummingbird promotion (ext4 root), run the ISO gate that never ran, and capture why a session exits

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -20,16 +20,34 @@ iso_groups:
   - suffix: ""
     flavors: [gnome-nvidia, gnome-nvidia-hwe]
     offline_flavors: [gnome, gnome-hwe, gnome-nvidia, gnome-nvidia-hwe]
-  # Additional desktop ISO group (KDE/COSMIC/Niri/XFCE). NOT published as a
-  # single grouped ISO — the browser ISO Builder (https://iso.tunaos.org) covers these on
-  # demand from the published images, so we don't carry the cost of a
-  # 5-flavor offline-store ISO for the long tail. The images still build
-  # and publish to GHCR; only the grouped ISO is skipped.
-  # (Manually publishable via workflow_dispatch group=community if needed.)
-  - suffix: community
-    publish: false
-    flavors: [kde-nvidia, cosmic-nvidia, niri-nvidia, xfce-nvidia]
-    offline_flavors: [kde, kde-hwe, cosmic, cosmic-hwe, niri, niri-hwe, xfce, kde-nvidia, cosmic-nvidia, niri-nvidia, xfce-nvidia]
+  # ONE ISO PER BASE+DESKTOP, each embedding its own NVIDIA and HWE flavors —
+  # the same shape as the GNOME group above, applied to the other four
+  # desktops. Published as `<variant>-<suffix>.iso`.
+  #
+  # This replaces a single `community` group that packed KDE, COSMIC, Niri and
+  # XFCE into ONE ISO and carried `publish: false`, on the reasoning that the
+  # browser ISO Builder covers the long tail on demand so a five-flavor
+  # offline store was not worth the storage. The cost argument was sound; the
+  # conclusion was not. A user who wants KDE should get a KDE ISO, not a
+  # four-desktop ISO or a browser build step, and one desktop's offline store
+  # is a fraction of four.
+  #
+  # Storage does not grow the way the old comment implied either: these are
+  # DEDUPLICATED groups over a shared squashfs, so a per-desktop ISO carries
+  # its own desktop plus the base layers it already shares with every other
+  # ISO of the same variant.
+  - suffix: kde
+    flavors: [kde-nvidia]
+    offline_flavors: [kde, kde-hwe, kde-nvidia]
+  - suffix: cosmic
+    flavors: [cosmic-nvidia]
+    offline_flavors: [cosmic, cosmic-hwe, cosmic-nvidia]
+  - suffix: niri
+    flavors: [niri-nvidia]
+    offline_flavors: [niri, niri-hwe, niri-nvidia]
+  - suffix: xfce
+    flavors: [xfce-nvidia]
+    offline_flavors: [xfce, xfce-hwe, xfce-nvidia]
 
 # Build stages (for reference — enforced by the workflow job graph):
 #

--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -739,7 +739,12 @@ variants:
   # (Konflux hermetic build model, CKI ARK kernel).
   - id: hummingbird
     emoji: "🐦"
-    description: "Fedora Hummingbird (bootc container-native OS)"
+    # Rolling, security-hardened fork tracking Fedora RAWHIDE -- not Fedora 43,
+    # whatever the .fc43 dist tags suggest -- and shipping NO desktop upstream.
+    # The desktop flavors below are therefore a PORT onto a desktop-less base,
+    # not a rebuild of an existing one. Read docs/HUMMINGBIRD.md before
+    # reasoning about what its package set should contain.
+    description: "Fedora Hummingbird (hardened rolling Rawhide fork, bootc)"
     base_image: "quay.io/hummingbird-community/bootc-os:latest@sha256:c5539f9ed4d93aab6bd41e4f5aef8ab83055f3f9e855a47b69fadb7420d0d1df"
     platforms: ["linux/amd64", "linux/arm64"]
     flavors:

--- a/.github/workflows/gdm-paint-benchmark.yml
+++ b/.github/workflows/gdm-paint-benchmark.yml
@@ -59,6 +59,8 @@ jobs:
         with:
           name: gdm-bench-base-qcow2
           path: base.qcow2
+          # Already-compressed disk image: level 6 spends minutes for ~0%.
+          compression-level: 0
           retention-days: 1
 
   benchmark:

--- a/.github/workflows/installer-screenshots.yml
+++ b/.github/workflows/installer-screenshots.yml
@@ -154,7 +154,18 @@ jobs:
           GITHUB_REPOSITORY_OWNER: tuna-os
           TACKLEBOX_FROM_SOURCE: "1"
         run: |
-          just iso "${VARIANT}" "${{ matrix.flavor }}" ghcr "${{ matrix.flavor }}"
+          # Root, not bare. tacklebox's post-customize `podman commit` is
+          # bounded at a hardcoded 600s, and how long it takes is a product
+          # of the storage path and the disk. Measured on the same commit:
+          #
+          #   ubuntu-24.04  + rootless (fuse-overlayfs)   >600s, killed (x3)
+          #   ubuntu-24.04  + root     (native overlay)    133s
+          #   RunsOn        + rootless (fuse-overlayfs)    150s
+          #
+          # This job is on a GitHub-hosted runner, which is the slow disk, so
+          # it needs the fast storage path. `sudo -E env "PATH=$PATH"` is the
+          # form installer-smoke.yml uses and the one measured green there.
+          sudo -E env "PATH=$PATH" just iso "${VARIANT}" "${{ matrix.flavor }}" ghcr "${{ matrix.flavor }}"
 
       - name: Run installer walkthrough
         timeout-minutes: 30

--- a/.github/workflows/installer-screenshots.yml
+++ b/.github/workflows/installer-screenshots.yml
@@ -91,6 +91,30 @@ jobs:
             tesseract-ocr imagemagick
           sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
 
+      # The runner image ships podman 5.8.4, which wedges committing a
+      # live-customized rootfs (#1893). Every ISO build needs the Kubic one
+      # instead; this job ran `just iso` without it. Necessary, not
+      # sufficient -- iso-e2e.yml installs this and its commit still exceeded
+      # tacklebox's 600s bound on a GitHub-hosted runner (job 97638514487) --
+      # but a build without it cannot finish at all.
+      - name: setup working podman
+        run: |
+          set -euo pipefail
+          sudo install -d /etc/apt/keyrings
+          curl -fsSL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/Release.key \
+            | gpg --dearmor | sudo tee /etc/apt/keyrings/kubic.gpg >/dev/null
+          echo 'deb [signed-by=/etc/apt/keyrings/kubic.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/ /' \
+            | sudo tee /etc/apt/sources.list.d/kubic.list
+          sudo apt-get update -qq
+          sudo apt-get remove -y podman conmon crun || true
+          sudo apt-get install -y podman
+          for p in /usr/local/bin/podman /usr/local/sbin/podman; do
+            if [ -e "$p" ] && ! dpkg -S "$p" >/dev/null 2>&1; then
+              sudo rm -f "$p"
+            fi
+          done
+          hash -r
+
       - name: Log in to GHCR
         run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
         env:

--- a/.github/workflows/installer-screenshots.yml
+++ b/.github/workflows/installer-screenshots.yml
@@ -279,6 +279,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Needed to open the refresh PR; `main` only accepts merge-queue changes.
+      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -331,9 +333,20 @@ jobs:
         if: steps.stage.outputs.staged != '0'
         run: bash scripts/gen-screenshot-gallery.sh
 
-      - name: Commit and push
+      # Opens a PR; does NOT push to main. `main` is protected by a
+      # repository rule -- "Changes must be made through the merge queue" --
+      # so `git push origin HEAD:main` is rejected outright (GH013). Observed
+      # on installer-smoke.yml run 32704425971, where the identical step had
+      # simply never executed before: it is gated on `staged != 0` and no
+      # flavor had ever produced frames. All three screenshot writers carried
+      # the same line; all three are now the matrix-status.yml shape.
+      - name: Open the screenshot refresh PR
         if: steps.stage.outputs.staged != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: automation/installer-screenshots-weekly
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/images/installer docs/SCREENSHOTS.md
@@ -341,6 +354,25 @@ jobs:
             echo "No screenshot changes to commit"
             exit 0
           fi
-          git commit -m "docs: refresh installer walkthrough screenshots ($(date +%Y-%m-%d)) [skip ci]"
-          git pull --rebase origin main
-          git push origin HEAD:main
+          git checkout -b "$BRANCH"
+          git commit -m "docs: refresh installer walkthrough screenshots ($(date -u +%Y-%m-%d))"
+          git push --force origin "$BRANCH"
+
+          if [[ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]]; then
+            gh pr create --base main --head "$BRANCH" \
+              --title "docs: refresh installer walkthrough screenshots" \
+              --body "$(printf '%s\n\n%s\n' \
+                'Captured by the weekly installer walkthrough and staged by `scripts/gen-screenshot-gallery.sh`.' \
+                'Force-updated in place, so this branch always holds the newest capture.')"
+          else
+            echo "PR already open for $BRANCH — force-push refreshed it."
+          fi
+
+          # A PR opened with the Actions token starts no checks of its own;
+          # the merge queue runs the required checks on the merge group, so
+          # arming auto-merge is what actually lands the refresh.
+          pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [[ -n "$pr" ]]; then
+            gh pr merge --auto --merge "$pr" ||
+              echo "::warning::could not arm auto-merge on #$pr — the refresh will wait for a human"
+          fi

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -20,24 +20,29 @@ on:
         default: "yellowfin"
         type: string
       build_runner:
-        # The experiment behind tunaOS#2010: is RunsOn actually required to
-        # build an ISO, or was it inherited from a podman diagnosis that the
-        # workflow itself contradicts three steps later?
+        # MEASURED 2026-08-24, run 32747410944 against RunsOn runs
+        # 32747410944/32735883406/32718219267, same commit, same steps:
         #
-        # `runs-on` (default) keeps every scheduled run and every other
-        # dispatch exactly as it was. `github` routes the build to
-        # ubuntu-latest so the two can be compared on the same commit.
+        #   Build dev ISO      ubuntu-latest      RunsOn (c6a, 8 vCPU)
+        #   gnome              38m46s             48m18s
+        #   kde                41m16s             59m53s
         #
-        # The `schedule` trigger passes no inputs, so this evaluates empty
-        # there and falls through to RunsOn -- the weekly run cannot be
-        # changed by adding this.
+        # GitHub-hosted is FASTER on both flavors, on half the cores, and the
+        # gnome leg went green end to end (walkthrough included). No disk
+        # failure: `free disk space` frees enough, taking 1m36s-5m25s to do
+        # it against ~11s on RunsOn, which is the whole of the setup cost.
+        # The build is evidently not CPU-bound.
+        #
+        # So `github` is now the default and `runs-on` is the escape hatch,
+        # kept because one afternoon of measurements is not a guarantee and
+        # reverting should not need a code change.
         description: "Runner for the ISO build"
         required: false
-        default: "runs-on"
+        default: "github"
         type: choice
         options:
-          - runs-on
           - github
+          - runs-on
       flavors:
         description: "Comma-separated flavors"
         required: false
@@ -118,24 +123,28 @@ jobs:
     # The boot Gate in reusable-build-image.yml is unaffected: it genuinely
     # runs iso-e2e-gpu.sh and still asks for `gpu`.
     #
-    # RUNNER, and the experiment: `build_runner: github` sends this job to
-    # ubuntu-latest instead. The stated reason for RunsOn is directly above --
-    # "cannot work on the GitHub runner's podman 5.8.4" -- but the `setup
-    # working podman` step below opens by saying the RunsOn image ships THE
-    # SAME podman 5.8.4 and installs the Kubic build over it. That step is a
-    # plain apt install with nothing runner-specific in it, so it should work
-    # identically on either. What is genuinely different is disk (80GB gp3 vs
-    # ~14GB free of ~65GB, which is why `free disk space` runs below) and
-    # cores (8 vs 4, against a 75-minute cap that a ~50-minute build already
-    # eats most of). Those are measurable, and this input is how.
-    runs-on: ${{ inputs.build_runner == 'github'
+    # RUNNER. The comment above is the history; the measurement retired it.
+    # The stated reason for RunsOn was "cannot work on the GitHub runner's
+    # podman 5.8.4" -- but the `setup working podman` step below always said
+    # the RunsOn image ships THE SAME podman 5.8.4 and installs the Kubic
+    # build over it, and that step is a plain apt install with nothing
+    # runner-specific in it. It succeeds on ubuntu-latest, as it always would
+    # have. tunaOS#1893's root cause was a `podman commit --quiet` wedge
+    # inside tacklebox, fixed in tacklebox#231 -- never a runner property.
+    #
+    # ubuntu-latest is the default now, on the numbers in the input comment
+    # above. `build_runner: runs-on` still routes back to RunsOn without a
+    # code change; the `schedule` trigger passes no inputs, so it takes the
+    # empty branch, which is why the comparison is written `!= 'runs-on'`
+    # rather than `== 'github'`.
+    runs-on: ${{ inputs.build_runner != 'runs-on'
       && 'ubuntu-latest'
       || format('runs-on={0}/runner={1}', github.run_id, matrix.runner) }}
-    # Raised from 75 only for the GitHub leg: half the cores on the same work
-    # would otherwise be cancelled at the cap and read as "GitHub runners
-    # cannot build an ISO", when the finding would really be "it needs longer
-    # than 75 minutes". A timeout is not a measurement.
-    timeout-minutes: ${{ inputs.build_runner == 'github' && 150 || 75 }}
+    # 150 for ubuntu-latest, where the measured builds are 38-41 minutes: a
+    # cap close to the observed time turns a slow build into a cancellation
+    # and reports the wrong thing. 75 stays for the RunsOn path it was set
+    # for. A timeout is not a measurement.
+    timeout-minutes: ${{ inputs.build_runner != 'runs-on' && 150 || 75 }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -881,6 +881,10 @@ jobs:
           ref: main
           fetch-depth: 0
 
+          # Screendumps are PPM (~3 MB each, several per leg). 90 days of
+          # them across five flavors is real storage for evidence nobody
+          # reads after the round it belongs to.
+          retention-days: 7
       - name: Download walkthrough artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -603,7 +603,31 @@ jobs:
                   echo "-- greetd config files present --"; ls -l /etc/greetd/ 2>/dev/null; \
                   echo "-- ExecStart of the active DM --"; systemctl cat "$(basename "$(readlink -f /etc/systemd/system/display-manager.service 2>/dev/null)" 2>/dev/null)" 2>/dev/null | grep -E "^ExecStart|^\[" | head -20; \
                   echo "-- /etc/greetd/config.toml as installed --"; cat /etc/greetd/config.toml 2>/dev/null; \
-                  echo "-- greetd journal --"; sudo journalctl -u greetd -u cosmic-greeter --no-pager 2>/dev/null | tail -40' 2>/dev/null || true
+                  echo "-- greetd journal --"; sudo journalctl -u greetd -u cosmic-greeter --no-pager 2>/dev/null | tail -40; \
+                  echo "-- what the session command itself said (tunaos-live-session) --"; \
+                  sudo journalctl -t tunaos-live-session --no-pager 2>/dev/null | tail -80 || true' 2>/dev/null || true
+
+          echo
+          # The line that has been missing from every red greetd cell.
+          #
+          # greetd reports only its own bookkeeping -- "greeter exited without
+          # creating a session" -- and the compositor's reason went nowhere,
+          # which is why this failure has been attributed to a missing DRM
+          # render node with no compositor output to support it. Run
+          # 32681262659 disproves that attribution outright: the guest has
+          # /dev/dri/renderD128 and the kernel reports `-virgl`, so the node is
+          # present and 3D is not. Those are different claims.
+          #
+          # live-iso/common/src/desktop-{xfce,niri,cosmic}.sh now run the
+          # session under `systemd-cat -t tunaos-live-session`, so the reason
+          # is in the journal above under that tag. An ISO built before that
+          # change has no such tag; say so rather than printing nothing, or
+          # the absence reads as "the compositor said nothing".
+          if ! grep -q "tunaos-live-session" "$out" 2>/dev/null; then
+            echo "::notice::${FLAVOR}: no tunaos-live-session journal in this image —"\
+                 "it predates the session-logging change, so the compositor's"\
+                 "own reason for exiting is still uncaptured."
+          fi
             echo
             echo "=== windows the compositor actually has ==="
             # -x matches comm exactly, so this cannot self-match the way a

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -604,7 +604,7 @@ jobs:
                   echo "-- ExecStart of the active DM --"; systemctl cat "$(basename "$(readlink -f /etc/systemd/system/display-manager.service 2>/dev/null)" 2>/dev/null)" 2>/dev/null | grep -E "^ExecStart|^\[" | head -20; \
                   echo "-- /etc/greetd/config.toml as installed --"; cat /etc/greetd/config.toml 2>/dev/null; \
                   echo "-- display-manager journal (all five, not just greetd) --"; \
-                  sudo journalctl -u greetd -u cosmic-greeter -u plasmalogin -u sddm -u gdm --no-pager 2>/dev/null | tail -60; \
+                  sudo journalctl -u greetd -u cosmic-greeter -u plasmalogin -u sddm -u gdm -u systemd-logind --no-pager 2>/dev/null | tail -80; \
                   echo "-- what the session command itself said (tunaos-live-session) --"; \
                   sudo journalctl -t tunaos-live-session --no-pager 2>/dev/null | tail -80 || true' 2>/dev/null || true
 

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -819,6 +819,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Needed to open the refresh PR; `main` only accepts merge-queue changes.
+      pull-requests: write
     steps:
       # This job commits to main, so it must start FROM main — not from the
       # dispatched ref. Checking out a feature branch made `git pull --rebase
@@ -902,9 +904,32 @@ jobs:
         if: steps.stage.outputs.staged != '0'
         run: bash scripts/gen-screenshot-gallery.sh
 
-      - name: Commit and push
+      # Opens a PR; does NOT push to main. `git push origin HEAD:main` is
+      # rejected outright:
+      #
+      #   remote: error: GH013: Repository rule violations found for
+      #                  refs/heads/main.
+      #   remote: - Changes must be made through the merge queue
+      #   ! [remote rejected] HEAD -> main
+      #
+      # (run 32704425971). That was latent for as long as this job existed:
+      # these steps are gated on `staged != 0`, and until gnome went green on
+      # that same run NO flavor had ever produced walkthrough frames, so the
+      # push never executed and the rule was never hit. A gate that has never
+      # run is not a gate that passes.
+      #
+      # Same shape and same remedy as matrix-status.yml: one long-lived
+      # branch, force-pushed, with auto-merge armed. The doc is regenerated
+      # wholesale each time, so a refresh supersedes its predecessor and
+      # stacking commits would only add noise; reusing the branch name keeps
+      # this to a single open PR rather than one per run.
+      - name: Open the screenshot refresh PR
         if: steps.stage.outputs.staged != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: automation/installer-screenshots
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/images/installer docs/SCREENSHOTS.md
@@ -912,6 +937,27 @@ jobs:
             echo "No screenshot changes to commit"
             exit 0
           fi
-          git commit -m "docs: refresh installer frontend walkthrough screenshots ($(date +%Y-%m-%d)) [skip ci]"
-          git pull --rebase origin main
-          git push origin HEAD:main
+          git checkout -b "$BRANCH"
+          git commit -m "docs: refresh installer frontend walkthrough screenshots ($(date -u +%Y-%m-%d))"
+          git push --force origin "$BRANCH"
+
+          if [[ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]]; then
+            gh pr create --base main --head "$BRANCH" \
+              --title "docs: refresh installer walkthrough screenshots" \
+              --body "$(printf '%s\n\n%s\n' \
+                'Captured by the Installer Smoke walkthrough and staged by `scripts/gen-screenshot-gallery.sh`.' \
+                'Force-updated in place by the `Installer Smoke` workflow, so this branch always holds the newest capture.')"
+          else
+            echo "PR already open for $BRANCH — force-push refreshed it."
+          fi
+
+          # Auto-merge for the reason matrix-status.yml documents at length: a
+          # PR opened with the Actions token triggers no pull_request
+          # workflows, so its own checks never start, but the merge QUEUE runs
+          # the required checks itself on the merge group. Arming auto-merge
+          # is therefore what actually lands it.
+          pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [[ -n "$pr" ]]; then
+            gh pr merge --auto --merge "$pr" ||
+              echo "::warning::could not arm auto-merge on #$pr — the refresh will wait for a human"
+          fi

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -19,6 +19,25 @@ on:
         required: false
         default: "yellowfin"
         type: string
+      build_runner:
+        # The experiment behind tunaOS#2010: is RunsOn actually required to
+        # build an ISO, or was it inherited from a podman diagnosis that the
+        # workflow itself contradicts three steps later?
+        #
+        # `runs-on` (default) keeps every scheduled run and every other
+        # dispatch exactly as it was. `github` routes the build to
+        # ubuntu-latest so the two can be compared on the same commit.
+        #
+        # The `schedule` trigger passes no inputs, so this evaluates empty
+        # there and falls through to RunsOn -- the weekly run cannot be
+        # changed by adding this.
+        description: "Runner for the ISO build"
+        required: false
+        default: "runs-on"
+        type: choice
+        options:
+          - runs-on
+          - github
       flavors:
         description: "Comma-separated flavors"
         required: false
@@ -98,8 +117,25 @@ jobs:
     #
     # The boot Gate in reusable-build-image.yml is unaffected: it genuinely
     # runs iso-e2e-gpu.sh and still asks for `gpu`.
-    runs-on: runs-on=${{ github.run_id }}/runner=${{ matrix.runner }}
-    timeout-minutes: 75
+    #
+    # RUNNER, and the experiment: `build_runner: github` sends this job to
+    # ubuntu-latest instead. The stated reason for RunsOn is directly above --
+    # "cannot work on the GitHub runner's podman 5.8.4" -- but the `setup
+    # working podman` step below opens by saying the RunsOn image ships THE
+    # SAME podman 5.8.4 and installs the Kubic build over it. That step is a
+    # plain apt install with nothing runner-specific in it, so it should work
+    # identically on either. What is genuinely different is disk (80GB gp3 vs
+    # ~14GB free of ~65GB, which is why `free disk space` runs below) and
+    # cores (8 vs 4, against a 75-minute cap that a ~50-minute build already
+    # eats most of). Those are measurable, and this input is how.
+    runs-on: ${{ inputs.build_runner == 'github'
+      && 'ubuntu-latest'
+      || format('runs-on={0}/runner={1}', github.run_id, matrix.runner) }}
+    # Raised from 75 only for the GitHub leg: half the cores on the same work
+    # would otherwise be cancelled at the cap and read as "GitHub runners
+    # cannot build an ISO", when the finding would really be "it needs longer
+    # than 75 minutes". A timeout is not a measurement.
+    timeout-minutes: ${{ inputs.build_runner == 'github' && 150 || 75 }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
@@ -126,11 +162,12 @@ jobs:
             systemd-boot-efi xorriso mtools squashfs-tools dosfstools gdisk
           sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
 
-      # The RunsOn ubuntu24 image ships podman 5.8.4 (same wedge as the GitHub
-      # runner); install the Kubic podman and drop the image shadow so the ISO
-      # build's podman run/commit work (tunaOS#1893). The bumped tacklebox pin
-      # (k8s-file log driver) handles the rest.
-      - name: setup working podman on RunsOn
+      # Both runner images ship podman 5.8.4, which cannot run/commit the
+      # build containers (tunaOS#1893); install the Kubic podman and drop any
+      # image-baked shadow binary. The bumped tacklebox pin (k8s-file log
+      # driver) handles the rest. Nothing here is runner-specific -- which is
+      # precisely why the RunsOn requirement above is worth testing.
+      - name: setup working podman
         run: |
           set -euo pipefail
           sudo install -d /etc/apt/keyrings

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -603,7 +603,8 @@ jobs:
                   echo "-- greetd config files present --"; ls -l /etc/greetd/ 2>/dev/null; \
                   echo "-- ExecStart of the active DM --"; systemctl cat "$(basename "$(readlink -f /etc/systemd/system/display-manager.service 2>/dev/null)" 2>/dev/null)" 2>/dev/null | grep -E "^ExecStart|^\[" | head -20; \
                   echo "-- /etc/greetd/config.toml as installed --"; cat /etc/greetd/config.toml 2>/dev/null; \
-                  echo "-- greetd journal --"; sudo journalctl -u greetd -u cosmic-greeter --no-pager 2>/dev/null | tail -40; \
+                  echo "-- display-manager journal (all five, not just greetd) --"; \
+                  sudo journalctl -u greetd -u cosmic-greeter -u plasmalogin -u sddm -u gdm --no-pager 2>/dev/null | tail -60; \
                   echo "-- what the session command itself said (tunaos-live-session) --"; \
                   sudo journalctl -t tunaos-live-session --no-pager 2>/dev/null | tail -80 || true' 2>/dev/null || true
 

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -607,6 +607,46 @@ jobs:
                   echo "-- what the session command itself said (tunaos-live-session) --"; \
                   sudo journalctl -t tunaos-live-session --no-pager 2>/dev/null | tail -80 || true' 2>/dev/null || true
 
+            echo
+            echo "=== does the session have a SEAT, and can PAM give it one? ==="
+            # The unifying symptom, found on run 32691426582s xfce leg. Every
+            # logind session on the guest has an EMPTY seat and an empty TTY:
+            #
+            #   SESSION  UID USER     SEAT LEADER CLASS   TTY IDLE SINCE
+            #         2 1000 liveuser -    1273   manager -   no   -
+            #        24 1000 liveuser -    3469   user    -   no   -
+            #
+            # logind hands DRM master to the ACTIVE session ON A SEAT. With no
+            # seat there is no DRM master, which is exactly what the compositor
+            # then reports, in this order:
+            #
+            #   WARN  smithay::backend::drm::device::fd: Unable to become drm
+            #         master, assuming unprivileged mode
+            #   WARN  xfwl4::backend::udev::device: failed to initialize gpu
+            #         err=NoRenderNode
+            #   ERROR xfwl4: Failed to initialize primary GPU node
+            #
+            # NoRenderNode for a device it had already selected and NAMED
+            # (renderD128, which /dev/dri confirms exists and is world
+            # readable). So the render node was never the problem; the seat is.
+            # That also fits the shape of the matrix -- gnome, the one flavor
+            # that works, is the one on gdm rather than greetd.
+            #
+            # WHY the seat is missing is NOT established, and is not guessed
+            # here. The candidate is greetds PAM stack: a session that does not
+            # run pam_systemd.so, or runs it without XDG_VTNR, registers with
+            # logind unseated. Printing the file settles it in one line instead
+            # of another 40-minute round trip on a hypothesis.
+            $SSH 'echo "-- /etc/pam.d/greetd --"; cat /etc/pam.d/greetd 2>/dev/null || echo "(absent)"; \
+                  echo "-- /etc/pam.d/greetd-greeter --"; cat /etc/pam.d/greetd-greeter 2>/dev/null || echo "(absent)"; \
+                  echo "-- seat/VT detail per session --"; \
+                  for s in $(loginctl list-sessions --no-legend 2>/dev/null | awk "{print \$1}"); do \
+                    echo "   session $s:"; \
+                    loginctl show-session "$s" -p Id -p Seat -p VTNr -p Active -p State -p Class -p Type -p Remote 2>/dev/null | sed "s/^/     /"; \
+                  done; \
+                  echo "-- seats known to logind --"; loginctl list-seats 2>/dev/null || echo "(none)"; \
+                  echo "-- is there a seat0 device tree at all --"; ls -l /run/systemd/seats/ 2>/dev/null || echo "(no /run/systemd/seats)"' 2>/dev/null || true
+
           echo
           # The line that has been missing from every red greetd cell.
           #

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -571,7 +571,43 @@ jobs:
             # renderer that cannot present from an app that never got that
             # far. Collect what settles it rather than guessing at a fix.
             echo "=== installer's own debug log ==="
-            $SSH 'cat ~/.var/app/org.bootcinstaller.Installer/cache/bootc-installer/installer-debug.log 2>/dev/null || cat ~/.cache/bootc-installer/installer-debug.log 2>/dev/null || echo "(no installer-debug.log found)"' 2>/dev/null || true
+            #
+            # THE PATH WAS HARDCODED TO ONE FLAVOR'S APP ID, WHICH IS WHY THE
+            # ABOVE HAS NEVER ONCE BEEN READ FOR THE OTHER FOUR.
+            #
+            # Flatpak puts each app's cache under ~/.var/app/<APP_ID>/cache,
+            # and only gnome runs org.bootcinstaller.Installer. kde runs
+            # org.tunaos.InstallerKde, and cosmic/niri/xfce their own ids. So
+            # on every non-gnome cell this printed
+            #
+            #   (no installer-debug.log found)
+            #
+            # and the comment above -- which correctly identifies this file as
+            # the thing that distinguishes "the window was built and never
+            # mapped" from "the app never got that far" -- described a
+            # capture that could not fire. kde run 32704425971 is the proof:
+            # `installer frontend launched (org.tunaos.InstallerKde)` passed,
+            # `installer readiness stamp present` failed, and the one file that
+            # would say why was looked for under the wrong app id.
+            #
+            # Try every id rather than deriving one: the mapping already exists
+            # twice in this workflow and a third copy is a third thing to keep
+            # in step. A path that does not exist costs one failed `cat`.
+            $SSH 'found=0; \
+                  for app in org.bootcinstaller.Installer org.tunaos.InstallerKde \
+                             org.tunaos.InstallerCosmic org.tunaos.InstallerNiri \
+                             org.tunaos.InstallerXfce; do \
+                    f="$HOME/.var/app/$app/cache/bootc-installer/installer-debug.log"; \
+                    if [ -f "$f" ]; then echo "---- $f"; cat "$f"; found=1; fi; \
+                  done; \
+                  if [ -f "$HOME/.cache/bootc-installer/installer-debug.log" ]; then \
+                    echo "---- $HOME/.cache/bootc-installer/installer-debug.log"; \
+                    cat "$HOME/.cache/bootc-installer/installer-debug.log"; found=1; \
+                  fi; \
+                  if [ "$found" = 0 ]; then \
+                    echo "(no installer-debug.log under any known app id)"; \
+                    echo "-- what IS under ~/.var/app --"; ls -1 "$HOME/.var/app" 2>/dev/null || echo "(no ~/.var/app)"; \
+                  fi' 2>/dev/null || true
             echo
             echo "=== user journal (installer + portal + flatpak) ==="
             $SSH 'journalctl --user -b --no-pager 2>/dev/null | grep -iE "installer|flatpak|portal|wgpu|EGL|MESA|wayland|vulkan" | tail -120' 2>/dev/null || true

--- a/.github/workflows/iso-e2e.yml
+++ b/.github/workflows/iso-e2e.yml
@@ -431,12 +431,15 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: iso-e2e-${{ matrix.variant }}-${{ matrix.flavor }}
+          # The PPMs are dropped: the step above converts every one of them
+          # to PNG, so uploading both stores each frame twice — once in an
+          # UNCOMPRESSED format (a 1280x800 PPM is ~3 MB raw against ~100 KB
+          # as PNG). Same evidence, a fraction of the bytes.
           path: |
             iso-e2e-out/serial.log
             iso-e2e-out/*.png
-            iso-e2e-out/*.ppm
           if-no-files-found: warn
-          retention-days: 14
+          retention-days: 7
 
       # Only fail when the e2e step actually ran AND reported failure.
       # When the filter step skipped the job, steps.e2e.outputs.rc is empty,

--- a/.github/workflows/iso-e2e.yml
+++ b/.github/workflows/iso-e2e.yml
@@ -358,6 +358,28 @@ jobs:
           if ! grep -q "^${USER}:" /etc/subgid 2>/dev/null; then
             echo "${USER}:100000:65536" | sudo tee -a /etc/subgid
           fi
+
+          # Which storage driver root podman picked, and how much disk it has.
+          #
+          # This is the measurement that decides #1893. tacklebox bounds its
+          # post-customize `podman commit` at a hardcoded 600s; on this runner
+          # that cap fired (job 97638514487, skipjack:xfce, exactly 600.0s
+          # wall) while the same commit completes on the RunsOn builders that
+          # publish albacore's ISOs. A commit is proportional to what it has
+          # to write: under `overlay` that is the customize container's diff
+          # (the flatpak runtimes, a few GB); under `vfs` there are no layers,
+          # so it copies the WHOLE rootfs every time. Which of the two we are
+          # on turns "raise the timeout" into either the right fix or a
+          # band-aid over a driver fallback, so print it rather than guess.
+          # tacklebox runs podman as root, so root's driver is the one that
+          # matters -- the rootless one can and does differ.
+          echo "=== podman storage (root — the one tacklebox uses) ==="
+          sudo podman info --format \
+            'driver={{.Store.GraphDriverName}} root={{.Store.GraphRoot}} run={{.Store.RunRoot}}' || true
+          sudo podman info --format 'version={{.Version.Version}}' || true
+          echo "=== free space ==="
+          df -h / /mnt /var/lib/containers 2>/dev/null || df -h
+
           sudo just build "$VARIANT" "$FLAVOR" linux/amd64 1 "$FLAVOR"
           sudo podman save "localhost/${VARIANT}:${FLAVOR}" | podman load
           just iso "$VARIANT" "$FLAVOR" local "$FLAVOR"

--- a/.github/workflows/iso-e2e.yml
+++ b/.github/workflows/iso-e2e.yml
@@ -90,9 +90,28 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # A dispatch tests exactly the cells asked for. Anything else -- the
-      # pull_request harness trigger and the Monday schedule -- keeps the two
-      # cells this workflow has always run, so widening the inputs cannot
-      # silently turn a harness smoke test into a fifty-cell sweep.
+      # pull_request harness trigger and the Monday schedule -- runs a fixed
+      # cell, so widening the inputs cannot silently turn a harness smoke
+      # test into a fifty-cell sweep.
+      #
+      # That cell is albacore:gnome, and it is the only one it can be. Those
+      # triggers pass no inputs, so `source` is empty and the ISO must come
+      # from R2 -- and R2 today holds albacore alone (#2027). Measured
+      # against the live bucket:
+      #
+      #   albacore-{gnome,kde,xfce}-latest.iso   200
+      #   yellowfin-gnome-latest.iso             404
+      #   skipjack-gnome-latest.iso              404
+      #   albacore-latest.iso                    404   (grouped name, unpublished)
+      #
+      # The list used to be yellowfin:gnome + albacore:gnome, so every PR
+      # touching this file got a red check for a 404 that is a publishing
+      # gap tracked in #2027, not a harness regression: run 32794531963
+      # failed in `Download latest ISO from R2` after 2 seconds. The step
+      # does say exactly which two keys it tried, so the red was legible --
+      # it was just never going to be anything else. A check that cannot
+      # pass teaches people to ignore it. When #2027 publishes more
+      # variants, add them here.
       - name: Build the cell list
         id: gen
         env:
@@ -106,7 +125,7 @@ jobs:
                               | map(select(length > 0))
                               | map({variant: $v, flavor: .}))}')
           else
-            M='{"include":[{"variant":"yellowfin","flavor":"gnome"},{"variant":"albacore","flavor":"gnome"}]}'
+            M='{"include":[{"variant":"albacore","flavor":"gnome"}]}'
           fi
           # An empty include list is a GREEN CHECK THAT RAN NOTHING, which is
           # worse than a red one: a sweep would report complete having
@@ -122,7 +141,17 @@ jobs:
     name: E2E ${{ matrix.variant }}:${{ matrix.flavor }}
     needs: generate-matrix
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    # The job budget has to cover the steps inside it. This was a flat 30
+    # while the build step declares 60 and the readiness step 20, so every
+    # `source: build` cell was killed by the JOB at 30 minutes with its own
+    # steps still well inside their limits -- E2E guppy:xfce, job
+    # 97638529947, cancelled at 00:48:29 after starting its build at
+    # 00:18:40. `cancelled` reads like infrastructure flake, so a sweep of
+    # six cells reported nothing usable about any of them.
+    #
+    # Only the build path needs the larger budget; sourcing from R2 is a
+    # download plus a 20-minute boot and 30 is right for it.
+    timeout-minutes: ${{ (github.event_name == 'workflow_dispatch' && inputs.source == 'build') && 90 || 30 }}
     strategy:
       # Don't cancel the other leg if one fails — we want to see both signals.
       fail-fast: false

--- a/.github/workflows/iso-e2e.yml
+++ b/.github/workflows/iso-e2e.yml
@@ -10,26 +10,48 @@ name: ISO E2E Smoke
 #
 # This is the lightweight readiness mode (--mode=ready). Future iterations
 # add --kickstart and --ssh-only modes. See scripts/iso-e2e.sh --help.
+#
+# TWO SOURCES.
+#
+#   r2-latest  the published ISO — what users actually download. The release
+#              check. Limited to whatever has been published, which today is
+#              albacore only (#2027).
+#   build      build the ISO on this runner and boot it where it lies.
+#
+# `build` exists because testing every cell must not mean publishing every
+# cell: R2 storage for ~50 five-gigabyte ISOs is a real bill, and most of
+# those images are being tested, not shipped. Building takes ~19 minutes on a
+# GitHub runner (measured, run 32768030728) and the ISO is deleted with the
+# runner, so a sweep costs runner minutes and nothing else.
+#
+# It replaces a `source: artifact` option that was offered in the dispatch UI
+# and NEVER IMPLEMENTED — there is no download-artifact step in this file, so
+# choosing it skipped the R2 fetch and left ISO_PATH unset. Building in-job
+# rather than via an artifact also avoids paying to store the ISO twice.
 
 on:
   workflow_dispatch:
     inputs:
       variant:
-        description: 'Variant to test'
+        # Free-form, not a choice list. The list here offered yellowfin and
+        # albacore while build-config.yml declares build_iso: true for ten
+        # variants, so eight of them could not be tested at all -- and the
+        # job matrix below only ever had two cells, so even a listed value
+        # like albacore:kde had nothing to run on.
+        #
+        # That is why the `iso` criterion is the single biggest blocker in
+        # docs/matrix-provenance.json: of 143 cells, 66 carry an iso verdict
+        # and none of them passes. Six boot-green cells are one criterion
+        # short of fully green and in every case that criterion is iso.
+        description: 'Variant to test (any id from build-config.yml)'
         required: false
         default: 'yellowfin'
-        type: choice
-        options:
-          - yellowfin
-          - albacore
-      flavor:
-        description: 'Flavor to test'
+        type: string
+      flavors:
+        description: 'Comma-separated flavors'
         required: false
         default: 'gnome'
-        type: choice
-        options:
-          - gnome
-          - gnome-hwe
+        type: string
       source:
         description: 'Where to source the ISO from'
         required: false
@@ -37,7 +59,7 @@ on:
         type: choice
         options:
           - r2-latest      # Download the latest published ISO from Cloudflare R2.
-          - artifact       # Consume an ISO uploaded as a workflow artifact.
+          - build          # Build the ISO on the runner and test it in place.
   # PR trigger only when the harness itself changes. Building a per-PR ISO
   # to test arbitrary Containerfile/build_scripts changes would take ~40 min
   # and isn't wired up yet (the workflow currently downloads from R2, which
@@ -59,19 +81,52 @@ permissions:
   actions: read
 
 jobs:
+  generate-matrix:
+    name: Generate ISO E2E matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # A dispatch tests exactly the cells asked for. Anything else -- the
+      # pull_request harness trigger and the Monday schedule -- keeps the two
+      # cells this workflow has always run, so widening the inputs cannot
+      # silently turn a harness smoke test into a fifty-cell sweep.
+      - name: Build the cell list
+        id: gen
+        env:
+          DISPATCH_VARIANT: ${{ inputs.variant }}
+          DISPATCH_FLAVORS: ${{ inputs.flavors }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${DISPATCH_VARIANT:-}" && -n "${DISPATCH_FLAVORS:-}" ]]; then
+            M=$(jq -cn --arg v "$DISPATCH_VARIANT" --arg f "$DISPATCH_FLAVORS" \
+              '{include: ($f | split(",") | map(ltrimstr(" ") | rtrimstr(" "))
+                              | map(select(length > 0))
+                              | map({variant: $v, flavor: .}))}')
+          else
+            M='{"include":[{"variant":"yellowfin","flavor":"gnome"},{"variant":"albacore","flavor":"gnome"}]}'
+          fi
+          # An empty include list is a GREEN CHECK THAT RAN NOTHING, which is
+          # worse than a red one: a sweep would report complete having
+          # measured no cell. `flavors: " , "` produced exactly that.
+          if [[ "$(echo "$M" | jq '.include | length')" -eq 0 ]]; then
+            echo "::error::no cells to test — variant='${DISPATCH_VARIANT:-}' flavors='${DISPATCH_FLAVORS:-}' produced an empty matrix"
+            exit 1
+          fi
+          echo "matrix=$M" >> "$GITHUB_OUTPUT"
+          echo "$M" | jq -r '.include[] | "  \(.variant):\(.flavor)"'
+
   e2e:
     name: E2E ${{ matrix.variant }}:${{ matrix.flavor }}
+    needs: generate-matrix
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       # Don't cancel the other leg if one fails — we want to see both signals.
       fail-fast: false
-      matrix:
-        include:
-          - variant: yellowfin
-            flavor: gnome
-          - variant: albacore
-            flavor: gnome
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 
     steps:
       - name: Checkout
@@ -100,14 +155,19 @@ jobs:
       - name: Preflight (dispatch filter, R2 credentials)
         id: filter
         env:
-          DISPATCH_VARIANT: ${{ inputs.variant }}
-          DISPATCH_FLAVOR: ${{ inputs.flavor }}
+          # Left empty deliberately: the matrix is now generated from the
+          # dispatch inputs above, so there are no non-matching cells left
+          # for this filter to skip. Wiring `inputs.flavors` (plural, a
+          # list) into a filter that compares one flavor would skip every
+          # cell but the first. The R2-credentials half below still runs.
+          DISPATCH_VARIANT: ''
+          DISPATCH_FLAVOR: ''
           # Read only to test for emptiness — never printed.
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
-          # Mirrors the `if:` on the download step below: source=artifact
+          # Mirrors the `if:` on the download step below: source=build
           # never touches R2, so it must not be blocked on R2 secrets.
           NEEDS_R2: ${{ github.event_name != 'workflow_dispatch' || inputs.source == 'r2-latest' }}
         run: |
@@ -222,6 +282,56 @@ jobs:
           fi
           {
             echo "ISO_PATH=$(realpath "${OBJECT}")"
+            echo "VARIANT=${VARIANT}"
+            echo "FLAVOR=${FLAVOR}"
+          } >> "$GITHUB_ENV"
+
+      # Build in place. No R2 read, no artifact upload, nothing to clean up:
+      # the ISO lives and dies on this runner. Mirrors live-iso-bootc.yml's
+      # build steps, which is where these exact incantations are explained --
+      # notably that `just iso` must NOT be wrapped in sudo (it sudos
+      # internally, and nesting breaks tacklebox's rootless podman unshare).
+      - name: Build the ISO on this runner
+        if: >-
+          steps.filter.outputs.skip != 'true' &&
+          github.event_name == 'workflow_dispatch' && inputs.source == 'build'
+        timeout-minutes: 60
+        env:
+          VARIANT: ${{ matrix.variant }}
+          FLAVOR: ${{ matrix.flavor }}
+          TACKLEBOX_FROM_SOURCE: "1"
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y just podman jq golang-go git systemd-boot-efi \
+            xorriso mtools squashfs-tools dosfstools gdisk e2fsprogs btrfs-progs
+          # Both runner images ship a podman that cannot run/commit these
+          # containers (tunaOS#1893); same Kubic install as every other
+          # ISO-building job here.
+          sudo install -d /etc/apt/keyrings
+          curl -fsSL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/Release.key \
+            | gpg --dearmor | sudo tee /etc/apt/keyrings/kubic.gpg >/dev/null
+          echo 'deb [signed-by=/etc/apt/keyrings/kubic.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/ /' \
+            | sudo tee /etc/apt/sources.list.d/kubic.list
+          sudo apt-get update -qq
+          sudo apt-get remove -y podman conmon crun || true
+          sudo apt-get install -y podman
+          if ! grep -q "^${USER}:" /etc/subuid 2>/dev/null; then
+            echo "${USER}:100000:65536" | sudo tee -a /etc/subuid
+          fi
+          if ! grep -q "^${USER}:" /etc/subgid 2>/dev/null; then
+            echo "${USER}:100000:65536" | sudo tee -a /etc/subgid
+          fi
+          sudo just build "$VARIANT" "$FLAVOR" linux/amd64 1 "$FLAVOR"
+          sudo podman save "localhost/${VARIANT}:${FLAVOR}" | podman load
+          just iso "$VARIANT" "$FLAVOR" local "$FLAVOR"
+          ISO="$(find . -maxdepth 3 -name '*.iso' -newermt '-2 hours' -print -quit)"
+          if [[ -z "$ISO" ]]; then
+            echo "::error::build produced no ISO for ${VARIANT}:${FLAVOR}"
+            exit 1
+          fi
+          {
+            echo "ISO_PATH=$(realpath "$ISO")"
             echo "VARIANT=${VARIANT}"
             echo "FLAVOR=${FLAVOR}"
           } >> "$GITHUB_ENV"

--- a/.github/workflows/iso-e2e.yml
+++ b/.github/workflows/iso-e2e.yml
@@ -80,6 +80,25 @@ permissions:
   # actions: read is needed when source=artifact to download the prior run's ISO.
   actions: read
 
+concurrency:
+  # A push to a PR supersedes the previous push's run: only the newest
+  # commit's verdict matters, and this job is a full ISO build. Without this,
+  # every push to a long-lived PR started another one and let the old one run
+  # to completion.
+  #
+  # The PR trigger fires on a paths filter, and GitHub evaluates that against
+  # the PR's WHOLE diff rather than the pushed commit. A branch that once
+  # touched one of those paths therefore pays for a rebuild on every
+  # subsequent push, however unrelated the change. This branch touches
+  # live-iso/** and this workflow file, so all eight of tonight's pushes
+  # started one.
+  #
+  # workflow_dispatch gets a per-run group so a deliberate multi-cell sweep
+  # never cancels its own siblings — the repo's plain `<name>-${{ github.ref }}`
+  # form would, since every cell of a sweep shares one branch.
+  group: iso-e2e-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   generate-matrix:
     name: Generate ISO E2E matrix

--- a/.github/workflows/iso-e2e.yml
+++ b/.github/workflows/iso-e2e.yml
@@ -402,16 +402,41 @@ jobs:
           # band-aid over a driver fallback, so print it rather than guess.
           # tacklebox runs podman as root, so root's driver is the one that
           # matters -- the rootless one can and does differ.
-          echo "=== podman storage (root — the one tacklebox uses) ==="
+          # Root and rootless podman pick different storage drivers, and that
+          # is the difference this step is chasing. Root gets native
+          # `overlay`; rootless falls back to `fuse-overlayfs`, where
+          # committing a multi-gigabyte layer goes through FUSE. Print both.
+          echo "=== podman storage: root ==="
           sudo podman info --format \
-            'driver={{.Store.GraphDriverName}} root={{.Store.GraphRoot}} run={{.Store.RunRoot}}' || true
-          sudo podman info --format 'version={{.Version.Version}}' || true
+            'driver={{.Store.GraphDriverName}} root={{.Store.GraphRoot}} version={{.Version.Version}}' || true
+          echo "=== podman storage: rootless ($USER) ==="
+          podman info --format \
+            'driver={{.Store.GraphDriverName}} root={{.Store.GraphRoot}} version={{.Version.Version}}' || true
           echo "=== free space ==="
-          df -h / /mnt /var/lib/containers 2>/dev/null || df -h
+          df -h / /mnt 2>/dev/null || df -h
 
+          # Build the image AND the ISO as root, in one root context.
+          #
+          # This used to build as root, copy the image into rootless storage
+          # with `podman save | podman load`, then run `just iso` bare -- so
+          # SUDO_USER was the runner and tacklebox did its customize and
+          # commit rootless. That commit did not finish: job 97638514487
+          # (skipjack:xfce) ran it for exactly 600.0s before tacklebox's
+          # bound killed it, and #1893 records the same stall unbounded.
+          #
+          # installer-smoke.yml does the same tacklebox customize+commit on
+          # ubuntu-latest and it COMPLETES -- `Build dev ISO` succeeded for
+          # yellowfin:gnome in 38m46s and yellowfin:kde in 41m16s in run
+          # 32747410944, and gnome then booted and passed its walkthrough.
+          # The one structural difference is that installer-smoke wraps the
+          # recipe in sudo, so the whole build stays root.
+          #
+          # So this is not "GitHub-hosted runners cannot build an ISO", which
+          # is what one bare-invocation failure looked like. Root storage also
+          # makes the save|load hop unnecessary: the image is already where
+          # tacklebox will look for it.
           sudo just build "$VARIANT" "$FLAVOR" linux/amd64 1 "$FLAVOR"
-          sudo podman save "localhost/${VARIANT}:${FLAVOR}" | podman load
-          just iso "$VARIANT" "$FLAVOR" local "$FLAVOR"
+          sudo -E env "PATH=$PATH" just iso "$VARIANT" "$FLAVOR" local "$FLAVOR"
           ISO="$(find . -maxdepth 3 -name '*.iso' -newermt '-2 hours' -print -quit)"
           if [[ -z "$ISO" ]]; then
             echo "::error::build produced no ISO for ${VARIANT}:${FLAVOR}"

--- a/.github/workflows/iso-e2e.yml
+++ b/.github/workflows/iso-e2e.yml
@@ -155,13 +155,6 @@ jobs:
       - name: Preflight (dispatch filter, R2 credentials)
         id: filter
         env:
-          # Left empty deliberately: the matrix is now generated from the
-          # dispatch inputs above, so there are no non-matching cells left
-          # for this filter to skip. Wiring `inputs.flavors` (plural, a
-          # list) into a filter that compares one flavor would skip every
-          # cell but the first. The R2-credentials half below still runs.
-          DISPATCH_VARIANT: ''
-          DISPATCH_FLAVOR: ''
           # Read only to test for emptiness — never printed.
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -171,15 +164,19 @@ jobs:
           # never touches R2, so it must not be blocked on R2 secrets.
           NEEDS_R2: ${{ github.event_name != 'workflow_dispatch' || inputs.source == 'r2-latest' }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if [[ "${DISPATCH_VARIANT}" != "${{ matrix.variant }}" ]] \
-               || [[ "${DISPATCH_FLAVOR}" != "${{ matrix.flavor }}" ]]; then
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              echo "Skipping ${{ matrix.variant }}:${{ matrix.flavor }} — dispatch chose ${DISPATCH_VARIANT}:${DISPATCH_FLAVOR}"
-              exit 0
-            fi
-          fi
-
+          # THE DISPATCH FILTER IS GONE, and this is the only thing that used
+          # to live here besides the R2 check.
+          #
+          # It existed because the matrix was two hardcoded cells and a
+          # dispatch had to suppress the one it did not choose. The matrix is
+          # generated from the dispatch inputs now, so every cell that exists
+          # is a cell that was asked for and there is nothing to filter.
+          #
+          # Leaving it in place with its inputs blanked was worse than either
+          # option: `"" != "marlin"` is true, so it set skip=true on EVERY
+          # dispatched cell, every step after this one was skipped, and the
+          # job reported SUCCESS having booted nothing. Run 32791464847 swept
+          # six cells that way and came back green in twenty seconds.
           if [[ "${NEEDS_R2}" == "true" ]]; then
             missing=()
             for name in R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_ENDPOINT R2_BUCKET; do

--- a/.github/workflows/iso-e2e.yml
+++ b/.github/workflows/iso-e2e.yml
@@ -406,14 +406,25 @@ jobs:
           # is the difference this step is chasing. Root gets native
           # `overlay`; rootless falls back to `fuse-overlayfs`, where
           # committing a multi-gigabyte layer goes through FUSE. Print both.
-          echo "=== podman storage: root ==="
-          sudo podman info --format \
-            'driver={{.Store.GraphDriverName}} root={{.Store.GraphRoot}} version={{.Version.Version}}' || true
-          echo "=== podman storage: rootless ($USER) ==="
-          podman info --format \
-            'driver={{.Store.GraphDriverName}} root={{.Store.GraphRoot}} version={{.Version.Version}}' || true
+          ROOT_DRV="$(sudo podman info --format '{{.Store.GraphDriverName}}' 2>/dev/null || echo unknown)"
+          USER_DRV="$(podman info --format '{{.Store.GraphDriverName}}' 2>/dev/null || echo unknown)"
+          DRIVERS="root=${ROOT_DRV} rootless=${USER_DRV}"
+          echo "=== podman storage: ${DRIVERS} ==="
+          sudo podman info --format 'root: {{.Store.GraphRoot}} v{{.Version.Version}}' || true
+          podman info --format 'rootless: {{.Store.GraphRoot}} v{{.Version.Version}}' || true
           echo "=== free space ==="
           df -h / /mnt 2>/dev/null || df -h
+
+          # Repeat the drivers on the way out, whatever the outcome.
+          #
+          # get_job_logs only returns a tail. This step emits tens of
+          # thousands of lines building the image, so a diagnostic printed at
+          # the top has already scrolled past retrieval by the time the step
+          # fails -- which is exactly what happened to the first version of
+          # this probe in job 97644460337: it ran, it printed, and the answer
+          # was unreachable. A diagnostic that cannot be read afterwards is
+          # not a diagnostic.
+          trap 'echo "=== podman storage (repeated at exit): ${DRIVERS} ==="' EXIT
 
           # Build the image AND the ISO as root, in one root context.
           #

--- a/.github/workflows/iso-e2e.yml
+++ b/.github/workflows/iso-e2e.yml
@@ -272,14 +272,53 @@ jobs:
           # up `${VARIANT}-${FLAVOR}-nvidia-latest.iso` etc. via the `-*.iso`
           # glob (which over-matches because the rclone include glob
           # isn't anchored at the end).
+          # TWO NAMING SCHEMES ARE LIVE IN THE BUCKET.
+          #
+          # The legacy per-flavor pipeline (publish-isos.yml, now disabled)
+          # wrote `<variant>-<flavor>-latest.iso`. The grouped dedup pipeline
+          # that replaced it (publish-iso-groups.yml) writes
+          # `<basename>-latest.iso`, where basename is the variant alone for
+          # the GNOME group and `<variant>-<desktop>` for the others.
+          #
+          # So for every desktop except gnome the two agree by accident --
+          # `yellowfin-kde-latest.iso` either way -- and for gnome they do
+          # NOT: the grouped pipeline writes `yellowfin-latest.iso` while
+          # this job asked for `yellowfin-gnome-latest.iso`. Measured
+          # 2026-08-24: albacore-gnome-latest.iso and albacore-kde-latest.iso
+          # are 200 (from the legacy pipeline), albacore-latest.iso and
+          # yellowfin-latest.iso are 404.
+          #
+          # That is why publishing the grouped ISOs would not by itself have
+          # turned E2E yellowfin:gnome green: the object would have landed
+          # under a key nothing looks up.
+          #
+          # Try the per-flavor name first, since that is what is in the
+          # bucket today, then the group name. A flavor maps to its group by
+          # its desktop prefix -- gnome-hwe and gnome-nvidia all ride inside
+          # the gnome group's offline store, so they resolve to the same ISO.
+          DESKTOP="${FLAVOR%%-*}"
+          if [[ "$DESKTOP" == "gnome" ]]; then
+            GROUP_OBJECT="${VARIANT}-latest.iso"
+          else
+            GROUP_OBJECT="${VARIANT}-${DESKTOP}-latest.iso"
+          fi
           OBJECT="${VARIANT}-${FLAVOR}-latest.iso"
-          echo "==> Fetching ${OBJECT} from R2..."
-          rclone copy --log-level INFO --s3-no-check-bucket \
-            "R2:${{ secrets.R2_BUCKET }}/live-isos/${OBJECT}" .
-          if [[ ! -f "${OBJECT}" ]]; then
-            echo "::error::No ISO found in R2 at live-isos/${OBJECT}"
+          FOUND=""
+          for candidate in "${OBJECT}" "${GROUP_OBJECT}"; do
+            echo "==> Trying ${candidate} from R2..."
+            rclone copy --log-level INFO --s3-no-check-bucket \
+              "R2:${{ secrets.R2_BUCKET }}/live-isos/${candidate}" . || true
+            if [[ -f "${candidate}" ]]; then
+              FOUND="${candidate}"
+              break
+            fi
+          done
+          if [[ -z "${FOUND}" ]]; then
+            echo "::error::No ISO in R2 under either name: live-isos/${OBJECT} (per-flavor) or live-isos/${GROUP_OBJECT} (grouped)"
             exit 1
           fi
+          OBJECT="${FOUND}"
+          echo "==> Using ${OBJECT}"
           {
             echo "ISO_PATH=$(realpath "${OBJECT}")"
             echo "VARIANT=${VARIANT}"

--- a/.github/workflows/live-iso-bootc.yml
+++ b/.github/workflows/live-iso-bootc.yml
@@ -22,6 +22,19 @@ on:
         required: false
         default: false
         type: boolean
+      build_runner:
+        # Deliberately NOT defaulted to github, unlike installer-smoke.yml.
+        # That workflow was flipped on measurements of ITS build; this job
+        # builds a full OS image and a live ISO, a different shape of work,
+        # and nobody has timed it on ubuntu-latest. Opt in, measure, then
+        # decide.
+        description: 'Runner for the build'
+        required: false
+        default: 'runs-on'
+        type: choice
+        options:
+          - runs-on
+          - github
   pull_request:
     branches: [main]
     paths:
@@ -38,7 +51,24 @@ jobs:
     # 32394645068, deterministic). installer-smoke escaped the same class of
     # runner breakage by moving to RunsOn with the Kubic podman (#1919-#1923);
     # build here the same way.
-    runs-on: runs-on=${{ github.run_id }}/runner=build-amd64
+    #
+    # That reasoning is now partly in doubt. installer-smoke's stated blocker
+    # ("the GitHub runner's podman 5.8.4") was refuted by its own `setup
+    # working podman` step, which this workflow carries a byte-identical copy
+    # of, and its build turned out FASTER on ubuntu-latest (38m46s vs 48m18s
+    # for gnome, run 32747410944). #1823 is a different claim -- rpmdb sqlite
+    # over overlayfs, and the issue itself diagnoses it on both arches rather
+    # than as a runner property -- so it is not refuted by that, only made
+    # worth re-testing.
+    #
+    # `== 'github'` here, NOT the `!= 'runs-on'` installer-smoke uses. This
+    # workflow also runs on `pull_request`, which passes no inputs; the !=
+    # form would silently move every PR build to ubuntu-latest, and this one
+    # is opt-in until measured. Dispatch with build_runner=github to measure
+    # it.
+    runs-on: ${{ inputs.build_runner == 'github'
+      && 'ubuntu-latest'
+      || format('runs-on={0}/runner=build-amd64', github.run_id) }}
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/live-iso-bootc.yml
+++ b/.github/workflows/live-iso-bootc.yml
@@ -79,8 +79,9 @@ jobs:
           done
           hash -r
 
-      - name: Setup rootless podman (subuid/subgid for runner)
+      - name: Setup rootless podman (subuid/subgid + userns for runner)
         run: |
+          set -euo pipefail
           # tacklebox runs 'sudo -u runner podman unshare' for the squashfs;
           # 'podman unshare' only works rootless and needs subuid/subgid
           # entries for the unprivileged user ("please use unshare with
@@ -91,6 +92,55 @@ jobs:
           if ! grep -q "^${USER}:" /etc/subgid 2>/dev/null; then
             echo "${USER}:100000:65536" | sudo tee -a /etc/subgid
           fi
+
+          # subuid/subgid are necessary and NOT sufficient. Rootless podman
+          # also has to be allowed to create a user namespace at all, and on
+          # Ubuntu 24.04 -- which is what the kubic repo above pins podman
+          # against -- it is not by default:
+          #
+          #   kernel.apparmor_restrict_unprivileged_userns = 1
+          #
+          # When that is set, an unprivileged clone(CLONE_NEWUSER) is refused
+          # and podman reports it without naming the cause:
+          #
+          #   cannot clone: Permission denied
+          #   Error: cannot re-exec process
+          #   ##[error]Process completed with exit code 125
+          #
+          # (run 32688258870, `Sync image into rootless storage`). Nothing in
+          # that message mentions namespaces, AppArmor or the sysctl, and it
+          # arrives AFTER a ~12 minute image build, because the first rootless
+          # command in the job is the one right after `Build OS image`.
+          echo "==> unprivileged userns gates, as found:"
+          for k in kernel.apparmor_restrict_unprivileged_userns \
+                   kernel.unprivileged_userns_clone; do
+            printf '    %s = %s\n' "$k" "$(sysctl -n "$k" 2>/dev/null || echo '(absent)')"
+          done
+          if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+
+          # PROVE it rather than assume it. This is the same operation
+          # tacklebox and the sync step below both need, it costs a fraction
+          # of a second, and failing HERE names the cause while failing twelve
+          # minutes later does not. A setup step that configures something and
+          # never checks it is the shape this repository has been bitten by
+          # repeatedly.
+          if ! podman unshare true; then
+            echo "::error::rootless podman still cannot create a user namespace."
+            echo "  subuid: $(grep "^${USER}:" /etc/subuid || echo MISSING)"
+            echo "  subgid: $(grep "^${USER}:" /etc/subgid || echo MISSING)"
+            for k in kernel.apparmor_restrict_unprivileged_userns \
+                     kernel.unprivileged_userns_clone \
+                     user.max_user_namespaces; do
+              printf '  %s = %s\n' "$k" "$(sysctl -n "$k" 2>/dev/null || echo '(absent)')"
+            done
+            echo "  Everything downstream that runs rootless -- the image sync"
+            echo "  and tacklebox's squashfs -- will fail with 'cannot re-exec"
+            echo "  process' and exit 125, naming none of the above."
+            exit 1
+          fi
+          echo "==> rootless podman can create a user namespace"
 
       - name: Build OS image
         run: |

--- a/.github/workflows/live-iso-bootc.yml
+++ b/.github/workflows/live-iso-bootc.yml
@@ -42,6 +42,25 @@ on:
       - 'scripts/build-iso-tacklebox.sh'
       - '.github/workflows/live-iso-bootc.yml'
 
+concurrency:
+  # A push to a PR supersedes the previous push's run: only the newest
+  # commit's verdict matters, and this job is a full ISO build. Without this,
+  # every push to a long-lived PR started another one and let the old one run
+  # to completion.
+  #
+  # The PR trigger fires on a paths filter, and GitHub evaluates that against
+  # the PR's WHOLE diff rather than the pushed commit. A branch that once
+  # touched one of those paths therefore pays for a rebuild on every
+  # subsequent push, however unrelated the change. This branch touches
+  # live-iso/** and this workflow file, so all eight of tonight's pushes
+  # started one.
+  #
+  # workflow_dispatch gets a per-run group so a deliberate multi-cell sweep
+  # never cancels its own siblings — the repo's plain `<name>-${{ github.ref }}`
+  # form would, since every cell of a sweep shares one branch.
+  group: live-iso-bootc-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
     # The stock GitHub runner's container storage corrupts the rpmdb sqlite

--- a/.github/workflows/live-iso-bootc.yml
+++ b/.github/workflows/live-iso-bootc.yml
@@ -207,158 +207,34 @@ jobs:
           path: "*.iso"
           if-no-files-found: error
 
-      - name: Install QEMU for boot verification
-        run: |
-          sudo apt-get install -y qemu-system-x86 ovmf socat imagemagick
-
-      - name: Boot ISO and capture desktop screenshot
-        timeout-minutes: 10
-        run: |
-          ISO=$(find . -maxdepth 1 -name "*.iso" | head -1)
-          echo "==> Booting $ISO in QEMU (headless, KVM)..."
-
-          # Locate UEFI firmware (path varies by Ubuntu version)
-          OVMF_CODE=""
-          for f in \
-            /usr/share/OVMF/OVMF_CODE_4M.fd \
-            /usr/share/OVMF/OVMF_CODE.fd \
-            /usr/share/edk2/ovmf/OVMF_CODE.fd; do
-            [ -f "$f" ] && OVMF_CODE="$f" && break
-          done
-          OVMF_VARS=""
-          for f in \
-            /usr/share/OVMF/OVMF_VARS_4M.fd \
-            /usr/share/OVMF/OVMF_VARS.fd \
-            /usr/share/edk2/ovmf/OVMF_VARS.fd; do
-            if [ -f "$f" ]; then
-              cp "$f" /tmp/OVMF_VARS.fd
-              OVMF_VARS="/tmp/OVMF_VARS.fd"
-              break
-            fi
-          done
-
-          PFLASH=()
-          if [ -n "$OVMF_CODE" ] && [ -n "$OVMF_VARS" ]; then
-            echo "==> Using UEFI: $OVMF_CODE"
-            PFLASH+=(-drive "if=pflash,format=raw,readonly=on,file=$OVMF_CODE")
-            PFLASH+=(-drive "if=pflash,format=raw,file=$OVMF_VARS")
-          else
-            echo "==> OVMF not found, booting in BIOS mode"
-          fi
-
-          sudo qemu-system-x86_64 \
-            -machine type=q35,accel=kvm \
-            -cpu host \
-            -m 4G \
-            -smp 2 \
-            -cdrom "$ISO" \
-            -boot d \
-            "${PFLASH[@]}" \
-            -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
-            -serial file:/tmp/serial.log \
-            -display none \
-            -daemonize
-
-          # Wait for monitor socket
-          for i in $(seq 1 30); do
-            [ -S /tmp/qemu-monitor.sock ] && break
-            sleep 2
-          done
-
-          # Wait for live desktop to fully boot (~4 minutes)
-          echo "==> Waiting 4 minutes for GNOME desktop to appear..."
-          sleep 240
-
-          # Capture screenshot via QEMU monitor
-          echo "screendump /tmp/screenshot.ppm" | \
-            sudo socat - UNIX-CONNECT:/tmp/qemu-monitor.sock
-          sleep 3
-
-          # Convert to PNG
-          if sudo test -f /tmp/screenshot.ppm; then
-            sudo convert /tmp/screenshot.ppm screenshot.png 2>/dev/null || \
-              sudo cp /tmp/screenshot.ppm screenshot.png
-            echo "==> Screenshot captured: $(ls -lh screenshot.png)"
-          else
-            echo "WARNING: screenshot.ppm not found; serial log follows:"
-            sudo cat /tmp/serial.log || true
-          fi
-
-          # Shut down QEMU
-          echo "quit" | sudo socat - UNIX-CONNECT:/tmp/qemu-monitor.sock || true
-
-      - name: Upload desktop screenshot
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: desktop-screenshot
-          path: screenshot.png
-          if-no-files-found: warn
-
-      # Only same-repo PRs can comment. On a fork `pull_request` run GITHUB_TOKEN
-      # is read-only no matter what the `permissions:` block above asks for, so
-      # `issues.createComment` 403s — which used to fail this job *after* the ISO
-      # had already built and booted, throwing away a successful verification.
-      # Forks get the same text in the run summary instead (see next step).
-      - name: Post boot screenshot to PR
-        if: >-
-          github.event_name == 'pull_request'
-          && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          VARIANT: ${{ env.VARIANT }}
-          FLAVOR: ${{ env.FLAVOR }}
-        with:
-          script: |
-            const runUrl = [
-              context.serverUrl,
-              context.repo.owner,
-              context.repo.repo,
-              'actions/runs',
-              context.runId,
-            ].join('/');
-            const sha = context.payload.pull_request.head.sha.slice(0, 7);
-            const body = [
-              '## Live ISO Boot Verification',
-              '',
-              'The live ISO built and booted successfully to the GNOME desktop.',
-              '',
-              `**Variant:** \`${process.env.VARIANT}\` | ` +
-                `**Flavor:** \`${process.env.FLAVOR}\` | ` +
-                `**Commit:** \`${sha}\``,
-              '',
-              `📸 [Download desktop screenshot](${runUrl})` +
-                ' — expand **Artifacts** and download `desktop-screenshot`',
-            ].join('\n');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
-
-      # Fork PRs cannot be commented on, but the verification still ran and its
-      # result still matters — put it where a fork contributor can actually see
-      # it rather than dropping it on the floor.
-      - name: Report boot verification in run summary (fork PR)
-        if: >-
-          github.event_name == 'pull_request'
-          && github.event.pull_request.head.repo.full_name != github.repository
-        env:
-          VARIANT: ${{ env.VARIANT }}
-          FLAVOR: ${{ env.FLAVOR }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          {
-            echo "## Live ISO Boot Verification"
-            echo ""
-            echo "The live ISO built and booted successfully to the GNOME desktop."
-            echo ""
-            echo "**Variant:** \`${VARIANT}\` | **Flavor:** \`${FLAVOR}\` | **Commit:** \`${HEAD_SHA:0:7}\`"
-            echo ""
-            echo "📸 [Download desktop screenshot](${RUN_URL}) — expand **Artifacts**"
-            echo "and download \`desktop-screenshot\`."
-            echo ""
-            echo "> Posted here rather than as a PR comment: this run is from a fork,"
-            echo "> so \`GITHUB_TOKEN\` is read-only and cannot comment."
-          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+      # Boot verification deliberately does NOT live here.
+      #
+      # It used to: `Install QEMU`, `Boot ISO and capture desktop screenshot`,
+      # `Upload desktop screenshot` and two PR-reporting steps. They could
+      # never have worked on this runner. The job runs on
+      # `runs-on=.../runner=build-amd64`, whose families in
+      # .github/runs-on.yml are ["c6a", "c6i", "c5a", "c5"] -- ordinary EC2
+      # instances. EC2 exposes /dev/kvm only on .metal types, so every run
+      # ended:
+      #
+      #   ==> Booting ./skipjack-gnome-10-x86_64.iso in QEMU (headless, KVM)...
+      #   Could not access KVM kernel module: No such file or directory
+      #   qemu-system-x86_64: failed to initialize kvm: No such file or directory
+      #
+      # (runs 32690010127 and 32696543980, both after the ISO built fine).
+      # That is not capacity flakiness to retry around; it is the instance
+      # family, and no change in this repository alters it.
+      #
+      # The verification itself is not lost -- it is done properly elsewhere.
+      # installer-smoke.yml boots the ISO on `ubuntu-latest`, which does
+      # provide KVM, then SSHes into the guest and asserts the compositor and
+      # installer frontend are running, drives the installer through its
+      # screens, and captures the session journal. It covers all five flavors
+      # rather than this job's single hardcoded one. Tonight it booted gnome
+      # (desktop session + installer frontend confirmed) and xfce (which is
+      # how xfwl4's exit was finally diagnosed).
+      #
+      # So this job builds and uploads the ISO, which is what it can actually
+      # do. Keeping a boot gate here that has never once executed would report
+      # a verification nobody performed -- the failure mode this branch exists
+      # to remove.

--- a/.github/workflows/live-iso-bootc.yml
+++ b/.github/workflows/live-iso-bootc.yml
@@ -23,18 +23,27 @@ on:
         default: false
         type: boolean
       build_runner:
-        # Deliberately NOT defaulted to github, unlike installer-smoke.yml.
-        # That workflow was flipped on measurements of ITS build; this job
-        # builds a full OS image and a live ISO, a different shape of work,
-        # and nobody has timed it on ubuntu-latest. Opt in, measure, then
-        # decide.
+        # Defaults to github. GitHub-hosted runners are included in the plan
+        # with 60 concurrent jobs, so anything that CAN run there should;
+        # RunsOn is billed EC2 and yesterday's spend was $9.87 against a
+        # $5.00 daily budget.
+        #
+        # This was previously opt-in pending a measurement of THIS build on
+        # ubuntu-latest. The measurement that matters arrived from
+        # iso-e2e.yml instead: the same tacklebox customize-and-commit runs
+        # there in 133s and boots (skipjack:kde, job 97648442043), once the
+        # build is done in one ROOT context rather than handed through
+        # rootless storage. That is the change made below, so the reason to
+        # stay on RunsOn no longer holds.
+        #
+        # `runs-on` remains selectable for a side-by-side comparison.
         description: 'Runner for the build'
         required: false
-        default: 'runs-on'
+        default: 'github'
         type: choice
         options:
-          - runs-on
           - github
+          - runs-on
   pull_request:
     branches: [main]
     paths:
@@ -81,13 +90,19 @@ jobs:
     # worth re-testing.
     #
     # `== 'github'` here, NOT the `!= 'runs-on'` installer-smoke uses. This
-    # workflow also runs on `pull_request`, which passes no inputs; the !=
-    # form would silently move every PR build to ubuntu-latest, and this one
-    # is opt-in until measured. Dispatch with build_runner=github to measure
-    # it.
-    runs-on: ${{ inputs.build_runner == 'github'
+    # `!= 'runs-on'`, not `== 'github'`. This workflow also runs on
+    # `pull_request`, which passes no inputs, so the expression must
+    # evaluate empty-string to the DEFAULT — and the default is now
+    # GitHub-hosted. The `== 'github'` form sent every input-less trigger to
+    # RunsOn, which is how the PR trigger came to bill an EC2 ISO build on
+    # every push.
+    runs-on: ${{ inputs.build_runner != 'runs-on'
       && 'ubuntu-latest'
       || format('runs-on={0}/runner=build-amd64', github.run_id) }}
+    # A GitHub-hosted runner is slower per-core than the c6a this used to
+    # take, and there is no job timeout here to inherit -- the Actions
+    # default is 360 minutes, well clear of a ~40-minute build.
+
     permissions:
       contents: read
       packages: read
@@ -156,9 +171,13 @@ jobs:
           #   Error: cannot re-exec process
           #   ##[error]Process completed with exit code 125
           #
-          # (run 32688258870, `Sync image into rootless storage`). Nothing in
-          # that message mentions namespaces, AppArmor or the sysctl, and it
-          # arrives AFTER a ~12 minute image build, because the first rootless
+          # (run 32688258870, in a `Sync image into rootless storage` step
+          # that no longer exists -- the build is one root context now). This
+          # step is KEPT as a guard: it costs a fraction of a second, and if
+          # anyone restores a rootless invocation it fails here, naming the
+          # cause, instead of twelve minutes later. Nothing in the podman
+          # message mentions namespaces, AppArmor or the sysctl, and it
+          # arrived AFTER a ~12 minute image build, because the first rootless
           # command in the job is the one right after `Build OS image`.
           echo "==> unprivileged userns gates, as found:"
           declare -A _gate_found=()
@@ -225,13 +244,6 @@ jobs:
         run: |
           sudo just build "$VARIANT" "$FLAVOR" linux/amd64 1 "$FLAVOR"
 
-      - name: Sync image into rootless storage
-        run: |
-          # sudo just build lands the image in root podman storage, but
-          # tacklebox's squashfs step reads it via rootless `podman unshare`
-          # as the runner user ("image not known" otherwise).
-          sudo podman save "localhost/${VARIANT}:${FLAVOR}" | podman load
-
       - name: Build Live ISO
         env:
           TACKLEBOX_FROM_SOURCE: "1"
@@ -244,10 +256,21 @@ jobs:
           RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
         run: |
-          # No outer sudo: the `iso` recipe sudos internally. Nesting sudo
-          # makes SUDO_USER=root inside build-iso-tacklebox.sh, so tacklebox
-          # "drops" to root for `podman unshare` and dies (rootless-only).
-          just iso "$VARIANT" "$FLAVOR" local "$FLAVOR"
+          # Root, and no rootless hop before it.
+          #
+          # This used to run bare so tacklebox would drop to the runner user
+          # for `podman unshare`, with the image copied into rootless storage
+          # first. On the c6a that cost 150s at the customize commit and was
+          # fine. On a GitHub-hosted runner the same rootless commit ran past
+          # tacklebox's hardcoded 600s bound and was killed -- three times,
+          # always at exactly 600.0s (#1893). Building image and ISO in one
+          # root context brought the same commit to 133s and the cell booted
+          # (skipjack:kde, job 97648442043).
+          #
+          # `sudo just build` already puts the image in ROOT storage, so with
+          # the ISO built as root too the save|load hop is not just
+          # unnecessary, it was the thing that forced the slow path.
+          sudo -E env "PATH=$PATH" just iso "$VARIANT" "$FLAVOR" local "$FLAVOR"
 
       # RETENTION IS NOT OPTIONAL ON A MULTI-GIGABYTE ARTIFACT.
       #

--- a/.github/workflows/live-iso-bootc.yml
+++ b/.github/workflows/live-iso-bootc.yml
@@ -112,9 +112,12 @@ jobs:
           # arrives AFTER a ~12 minute image build, because the first rootless
           # command in the job is the one right after `Build OS image`.
           echo "==> unprivileged userns gates, as found:"
+          declare -A _gate_found=()
           for k in kernel.apparmor_restrict_unprivileged_userns \
-                   kernel.unprivileged_userns_clone; do
-            printf '    %s = %s\n' "$k" "$(sysctl -n "$k" 2>/dev/null || echo '(absent)')"
+                   kernel.unprivileged_userns_clone \
+                   user.max_user_namespaces; do
+            _gate_found[$k]="$(sysctl -n "$k" 2>/dev/null || echo '(absent)')"
+            printf '    %s = %s\n' "$k" "${_gate_found[$k]}"
           done
           if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
             sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
@@ -141,6 +144,33 @@ jobs:
             exit 1
           fi
           echo "==> rootless podman can create a user namespace"
+
+          # ALSO to the step summary, because the job log cannot be relied on
+          # to still contain this.
+          #
+          # `Build OS image` emits tens of thousands of lines, and the log
+          # download for this job comes back starting PART-WAY THROUGH that
+          # step -- everything steps 1-6 printed is simply not in it. So the
+          # gate values were captured and then unreadable, which is the same
+          # defect as not capturing them: on run 32690010127 step 8 went from
+          # failing to passing across this change and the evidence for WHY was
+          # in the truncated region.
+          #
+          # The step summary is a separate artifact with its own budget and is
+          # not subject to that truncation.
+          {
+            echo "### Rootless podman userns"
+            echo ""
+            echo "| gate | as found |"
+            echo "|---|---|"
+            for k in kernel.apparmor_restrict_unprivileged_userns \
+                     kernel.unprivileged_userns_clone \
+                     user.max_user_namespaces; do
+              printf '| `%s` | `%s` |\n' "$k" "${_gate_found[$k]:-(unread)}"
+            done
+            echo ""
+            echo "\`podman unshare\` succeeded after configuration."
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
 
       - name: Build OS image
         run: |
@@ -331,4 +361,4 @@ jobs:
             echo ""
             echo "> Posted here rather than as a PR comment: this run is from a fork,"
             echo "> so \`GITHUB_TOKEN\` is read-only and cannot comment."
-          } >> "$GITHUB_STEP_SUMMARY"
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"

--- a/.github/workflows/live-iso-bootc.yml
+++ b/.github/workflows/live-iso-bootc.yml
@@ -230,12 +230,23 @@ jobs:
           # "drops" to root for `podman unshare` and dies (rootless-only).
           just iso "$VARIANT" "$FLAVOR" local "$FLAVOR"
 
+      # RETENTION IS NOT OPTIONAL ON A MULTI-GIGABYTE ARTIFACT.
+      #
+      # This had no `retention-days`, so every run — including every PR run —
+      # parked a whole live ISO in Actions storage for the DEFAULT 90 DAYS.
+      # The account's included Actions storage is 0.5 GB; one ISO exceeds it
+      # outright, and the quota hit 90% on 2026-08-24.
+      #
+      # `compression-level: 0` because an ISO is already compressed: level 6
+      # burns minutes to save nothing.
       - name: Upload Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.VARIANT }}-${{ env.FLAVOR }}-live-iso
           path: "*.iso"
           if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
 
       # Boot verification deliberately does NOT live here.
       #

--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -350,6 +350,30 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
           yq --version
 
+      # The runner image ships podman 5.8.4, which wedges committing a
+      # live-customized rootfs (#1893). Every ISO build needs the Kubic one
+      # instead; this job ran `just iso` without it. Necessary, not
+      # sufficient -- iso-e2e.yml installs this and its commit still exceeded
+      # tacklebox's 600s bound on a GitHub-hosted runner (job 97638514487) --
+      # but a build without it cannot finish at all.
+      - name: setup working podman
+        run: |
+          set -euo pipefail
+          sudo install -d /etc/apt/keyrings
+          curl -fsSL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/Release.key \
+            | gpg --dearmor | sudo tee /etc/apt/keyrings/kubic.gpg >/dev/null
+          echo 'deb [signed-by=/etc/apt/keyrings/kubic.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/ /' \
+            | sudo tee /etc/apt/sources.list.d/kubic.list
+          sudo apt-get update -qq
+          sudo apt-get remove -y podman conmon crun || true
+          sudo apt-get install -y podman
+          for p in /usr/local/bin/podman /usr/local/sbin/podman; do
+            if [ -e "$p" ] && ! dpkg -S "$p" >/dev/null 2>&1; then
+              sudo rm -f "$p"
+            fi
+          done
+          hash -r
+
       - name: Log in to GHCR
         timeout-minutes: 5
         run: |

--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -419,7 +419,12 @@ jobs:
           TACKLEBOX_SHA: fd95174432b854a6135600b6c321b3ef01b4bc2d
         run: |
           export TACKLEBOX_FROM_SOURCE=1
-          just iso "${VARIANT}" "${FLAVOR}" ghcr "" 1
+          # Root, not bare — same reason as installer-screenshots.yml: on a
+          # GitHub-hosted runner the rootless commit exceeds tacklebox's
+          # hardcoded 600s bound, while the root path completes in ~133s.
+          # Identical arguments to installer-smoke.yml's invocation, which is
+          # the one measured green on this runner.
+          sudo -E env "PATH=$PATH" just iso "${VARIANT}" "${FLAVOR}" ghcr "" 1
           ISO=$(find .build -maxdepth 3 -name "*.iso" | head -1)
           [[ -n "$ISO" ]] || { echo "::error::dev ISO not produced"; exit 1; }
           echo "ISO_PATH=${ISO}" >> "$GITHUB_ENV"

--- a/.github/workflows/publish-iso-groups.yml
+++ b/.github/workflows/publish-iso-groups.yml
@@ -269,8 +269,16 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.basename }}-iso
+          # The ISO itself is deliberately NOT uploaded. This job's whole
+          # purpose is to put it in R2, so an Actions artifact of the same
+          # bytes is a second copy of the deliverable — at 90 days by
+          # default, across every grouped cell, against 0.5 GB of included
+          # storage. The checksum and signature stay: they are kilobytes,
+          # and they are what a reviewer actually wants to see from a run.
+          #
+          # Recovering the ISO means downloading it from R2, which is the
+          # thing being published and therefore the copy worth testing.
           path: |
-            ${{ matrix.basename }}-*.iso
             ${{ matrix.basename }}-*.iso.sha256
             ${{ matrix.basename }}-*.iso.sigstore.json
           if-no-files-found: error

--- a/.github/workflows/publish-iso-groups.yml
+++ b/.github/workflows/publish-iso-groups.yml
@@ -28,8 +28,7 @@ on:
         # `iso_groups:`. They named `community` and `nvidia`, which stopped
         # existing when the config went to one group per desktop -- so the
         # four desktop groups that DO exist could not be dispatched at all,
-        # and the two that could addressed nothing. Same failure the ISO E2E
-        # variant list had.
+        # and the two offered addressed nothing.
         description: 'ISO group (all = every group; default = the GNOME flagship)'
         required: false
         default: 'all'
@@ -135,20 +134,7 @@ jobs:
     name: ${{ matrix.basename }}
     needs: generate-matrix
     if: ${{ needs.generate-matrix.outputs.count != '0' }}
-    # An ISO build does not complete on a GitHub-hosted runner today, so this
-    # job could never have published anything. tacklebox's post-customize
-    # `podman commit` of the live rootfs exceeds ten minutes there (#1893,
-    # measured at exactly 600.0s in job 97638514487) while the same commit
-    # finishes on RunsOn -- which is where every ISO in the bucket came from:
-    # albacore-{gnome,kde,xfce}-latest.iso, 5.1-6.0 GB, published 2026-08-20
-    # by the legacy per-flavor pipeline over reusable-build-artifacts.yml.
-    # `albacore-latest.iso` and every other grouped name is 404.
-    #
-    # tacklebox reached the same conclusion upstream: the fix commit for the
-    # podman 5.8.4 wedge is titled "iso-smoke on RunsOn ... wedge resolved"
-    # (tacklebox#235). The 600s bound in that same commit is a guard that
-    # names the hang, not a cure for it.
-    runs-on: runs-on=${{ github.run_id }}/runner=build-amd64
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       packages: read
@@ -161,21 +147,29 @@ jobs:
         with:
           submodules: recursive
 
-      # `free-disk-space` and `container-storage-action` were here to survive
-      # a GitHub-hosted runner's 14 GB root. The build-amd64 runner brings an
-      # 80 GB gp3 volume, so both are minutes spent deleting toolchains that
-      # aren't installed. live-iso-bootc.yml builds ISOs on this same runner
-      # with the setup below and nothing else.
+      - name: Maximize build disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-09
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6 # main as of 2026-02-11
+
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y just podman jq rclone golang-go git systemd-boot-efi xorriso mtools squashfs-tools dosfstools gdisk e2fsprogs btrfs-progs
+          sudo apt-get install -y just podman jq rclone golang-go git systemd-boot-efi xorriso mtools squashfs-tools dosfstools gdisk
           sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
 
-      # The runner image's podman 5.8.4 cannot commit these containers
-      # (#1893) and its conmon lacks journald. Every other ISO-building job
-      # in this repository installs the Kubic podman first; this one never
-      # did, which is the second reason it could not finish.
+      # The runner image ships podman 5.8.4, which wedges committing a
+      # live-customized rootfs (#1893). installer-smoke.yml builds ISOs on
+      # ubuntu-latest successfully and installs this first; this job never
+      # did, so it ran the wedging one.
       - name: setup working podman
         run: |
           set -euo pipefail
@@ -194,31 +188,6 @@ jobs:
           done
           hash -r
 
-      # tacklebox runs `sudo -u runner podman unshare` for the squashfs, which
-      # only works rootless and needs both subuid/subgid entries AND
-      # permission to create a user namespace at all. Ubuntu 24.04 sets
-      # kernel.apparmor_restrict_unprivileged_userns=1, under which podman
-      # reports only "cannot clone: Permission denied" -- after the image
-      # build, not before it. Prove it here instead.
-      - name: Setup rootless podman (subuid/subgid + userns)
-        run: |
-          set -euo pipefail
-          if ! grep -q "^${USER}:" /etc/subuid 2>/dev/null; then
-            echo "${USER}:100000:65536" | sudo tee -a /etc/subuid
-          fi
-          if ! grep -q "^${USER}:" /etc/subgid 2>/dev/null; then
-            echo "${USER}:100000:65536" | sudo tee -a /etc/subgid
-          fi
-          if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
-            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          fi
-          if ! podman unshare true; then
-            echo "::error::rootless podman cannot create a user namespace; tacklebox's squashfs will fail with exit 125 and name none of this."
-            echo "  subuid: $(grep "^${USER}:" /etc/subuid || echo MISSING)"
-            echo "  subgid: $(grep "^${USER}:" /etc/subgid || echo MISSING)"
-            exit 1
-          fi
-
       - name: Log in to GHCR
         run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
         env:
@@ -231,15 +200,12 @@ jobs:
           # available before the release-container workflow finishes publishing.
           TACKLEBOX_FROM_SOURCE: '1'
           # No TACKLEBOX_SHA: common.sh falls back to image-versions.yaml, so
-          # this job now tracks the repository's pin like everything else.
-          # It was pinned to a105d6d3 (2026-07-18) to get a low-disk
-          # offline-store implementation that had not been released yet. That
-          # was a month stale, and a105d6d3 is an ancestor of the current pin,
-          # so the reason for the override is satisfied by the pin itself --
-          # while the override also held this job a month behind, on a
-          # tacklebox whose customize commit is not bounded at all. On a
-          # runner where that commit wedges, an unbounded commit is a silent
-          # six-hour job, which is what this workflow has been doing.
+          # this job tracks the repository's pin like everything else. It was
+          # pinned to a105d6d3 (2026-07-18) for a low-disk offline-store
+          # implementation that had not been released yet. a105d6d3 is an
+          # ancestor of the current pin, so that reason is satisfied by the
+          # pin itself -- while the override held this job a month behind, on
+          # a tacklebox whose customize commit is not bounded at all.
         run: |
           sudo --preserve-env=GITHUB_REPOSITORY_OWNER,TACKLEBOX_FROM_SOURCE,TACKLEBOX_SHA \
             just iso-group "${{ matrix.variant }}" "${{ matrix.group }}" ghcr

--- a/.github/workflows/publish-iso-groups.yml
+++ b/.github/workflows/publish-iso-groups.yml
@@ -24,15 +24,23 @@ on:
           - bonito
           - grouper
       group:
-        description: 'ISO group (all = flagship + community + nvidia)'
+        # These options must name real suffixes in build-config.yml's
+        # `iso_groups:`. They named `community` and `nvidia`, which stopped
+        # existing when the config went to one group per desktop -- so the
+        # four desktop groups that DO exist could not be dispatched at all,
+        # and the two that could addressed nothing. Same failure the ISO E2E
+        # variant list had.
+        description: 'ISO group (all = every group; default = the GNOME flagship)'
         required: false
         default: 'all'
         type: choice
         options:
           - all
           - default
-          - community
-          - nvidia
+          - kde
+          - cosmic
+          - niri
+          - xfce
       skip_upload:
         description: 'Build ISOs but skip uploading to R2 (dry run)'
         required: false
@@ -127,7 +135,20 @@ jobs:
     name: ${{ matrix.basename }}
     needs: generate-matrix
     if: ${{ needs.generate-matrix.outputs.count != '0' }}
-    runs-on: ubuntu-24.04
+    # An ISO build does not complete on a GitHub-hosted runner today, so this
+    # job could never have published anything. tacklebox's post-customize
+    # `podman commit` of the live rootfs exceeds ten minutes there (#1893,
+    # measured at exactly 600.0s in job 97638514487) while the same commit
+    # finishes on RunsOn -- which is where every ISO in the bucket came from:
+    # albacore-{gnome,kde,xfce}-latest.iso, 5.1-6.0 GB, published 2026-08-20
+    # by the legacy per-flavor pipeline over reusable-build-artifacts.yml.
+    # `albacore-latest.iso` and every other grouped name is 404.
+    #
+    # tacklebox reached the same conclusion upstream: the fix commit for the
+    # podman 5.8.4 wedge is titled "iso-smoke on RunsOn ... wedge resolved"
+    # (tacklebox#235). The 600s bound in that same commit is a guard that
+    # names the hang, not a cure for it.
+    runs-on: runs-on=${{ github.run_id }}/runner=build-amd64
     permissions:
       contents: write
       packages: read
@@ -140,24 +161,63 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Maximize build disk
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main as of 2026-06-09
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
-
-      - uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6 # main as of 2026-02-11
-
+      # `free-disk-space` and `container-storage-action` were here to survive
+      # a GitHub-hosted runner's 14 GB root. The build-amd64 runner brings an
+      # 80 GB gp3 volume, so both are minutes spent deleting toolchains that
+      # aren't installed. live-iso-bootc.yml builds ISOs on this same runner
+      # with the setup below and nothing else.
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y just podman jq rclone golang-go git systemd-boot-efi xorriso mtools squashfs-tools dosfstools gdisk
+          sudo apt-get install -y just podman jq rclone golang-go git systemd-boot-efi xorriso mtools squashfs-tools dosfstools gdisk e2fsprogs btrfs-progs
           sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
+
+      # The runner image's podman 5.8.4 cannot commit these containers
+      # (#1893) and its conmon lacks journald. Every other ISO-building job
+      # in this repository installs the Kubic podman first; this one never
+      # did, which is the second reason it could not finish.
+      - name: setup working podman
+        run: |
+          set -euo pipefail
+          sudo install -d /etc/apt/keyrings
+          curl -fsSL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/Release.key \
+            | gpg --dearmor | sudo tee /etc/apt/keyrings/kubic.gpg >/dev/null
+          echo 'deb [signed-by=/etc/apt/keyrings/kubic.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/ /' \
+            | sudo tee /etc/apt/sources.list.d/kubic.list
+          sudo apt-get update -qq
+          sudo apt-get remove -y podman conmon crun || true
+          sudo apt-get install -y podman
+          for p in /usr/local/bin/podman /usr/local/sbin/podman; do
+            if [ -e "$p" ] && ! dpkg -S "$p" >/dev/null 2>&1; then
+              sudo rm -f "$p"
+            fi
+          done
+          hash -r
+
+      # tacklebox runs `sudo -u runner podman unshare` for the squashfs, which
+      # only works rootless and needs both subuid/subgid entries AND
+      # permission to create a user namespace at all. Ubuntu 24.04 sets
+      # kernel.apparmor_restrict_unprivileged_userns=1, under which podman
+      # reports only "cannot clone: Permission denied" -- after the image
+      # build, not before it. Prove it here instead.
+      - name: Setup rootless podman (subuid/subgid + userns)
+        run: |
+          set -euo pipefail
+          if ! grep -q "^${USER}:" /etc/subuid 2>/dev/null; then
+            echo "${USER}:100000:65536" | sudo tee -a /etc/subuid
+          fi
+          if ! grep -q "^${USER}:" /etc/subgid 2>/dev/null; then
+            echo "${USER}:100000:65536" | sudo tee -a /etc/subgid
+          fi
+          if [ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+          if ! podman unshare true; then
+            echo "::error::rootless podman cannot create a user namespace; tacklebox's squashfs will fail with exit 125 and name none of this."
+            echo "  subuid: $(grep "^${USER}:" /etc/subuid || echo MISSING)"
+            echo "  subgid: $(grep "^${USER}:" /etc/subgid || echo MISSING)"
+            exit 1
+          fi
 
       - name: Log in to GHCR
         run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -170,7 +230,16 @@ jobs:
           # The low-disk offline-store implementation must be reproducible and
           # available before the release-container workflow finishes publishing.
           TACKLEBOX_FROM_SOURCE: '1'
-          TACKLEBOX_SHA: a105d6d3e64eef6736cf0d24e083ae51e2f6ac92
+          # No TACKLEBOX_SHA: common.sh falls back to image-versions.yaml, so
+          # this job now tracks the repository's pin like everything else.
+          # It was pinned to a105d6d3 (2026-07-18) to get a low-disk
+          # offline-store implementation that had not been released yet. That
+          # was a month stale, and a105d6d3 is an ancestor of the current pin,
+          # so the reason for the override is satisfied by the pin itself --
+          # while the override also held this job a month behind, on a
+          # tacklebox whose customize commit is not bounded at all. On a
+          # runner where that commit wedges, an unbounded commit is a silent
+          # six-hour job, which is what this workflow has been doing.
         run: |
           sudo --preserve-env=GITHUB_REPOSITORY_OWNER,TACKLEBOX_FROM_SOURCE,TACKLEBOX_SHA \
             just iso-group "${{ matrix.variant }}" "${{ matrix.group }}" ghcr

--- a/.github/workflows/publish-iso-groups.yml
+++ b/.github/workflows/publish-iso-groups.yml
@@ -135,6 +135,11 @@ jobs:
     needs: generate-matrix
     if: ${{ needs.generate-matrix.outputs.count != '0' }}
     runs-on: ubuntu-24.04
+    # The job had no budget at all, so it inherited the 360-minute Actions
+    # default -- which is how job 97661993804 sat in a wedged signing step
+    # for 45 minutes and would have sat there for six hours. This covers the
+    # measured shape with room: ~14m build, 25m boot gate, 30m signing.
+    timeout-minutes: 120
     permissions:
       contents: write
       packages: read
@@ -246,7 +251,24 @@ jobs:
         with:
           cosign-release: v3.1.3
 
+      # BOUNDED, because this step has killed three consecutive runs and left
+      # no evidence behind. Jobs 97650065786, 97655764784 and 97661993804 all
+      # reached it; none completed it. The last ran 45 minutes and then the
+      # job "completed" with THIS step still in_progress and its logs 404 --
+      # the signature of a runner terminated out from under the job, which
+      # takes the log with it. So an unbounded call here does not fail, it
+      # vanishes.
+      #
+      # For scale: `sha256sum` over the same 5.7 GB ISO takes 38 seconds.
+      # cosign is handed that whole ISO twice (sign then verify). Whether it
+      # is slow, memory-bound, or wedged on an OIDC exchange is NOT
+      # established -- the readable run got as far as "Generating ephemeral
+      # keys..." and "Using payload from: ./albacore-10.2-x86_64.iso" and
+      # then produced nothing further. The timeouts and the before/after
+      # readings below exist to answer that on the next run instead of
+      # inviting a fourth guess.
       - name: Checksum, sign, and verify grouped ISO
+        timeout-minutes: 30
         env:
           COSIGN_YES: "true"
         run: |
@@ -258,10 +280,33 @@ jobs:
           identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/publish-iso-groups.yml@${GITHUB_REF}"
           issuer="https://token.actions.githubusercontent.com"
 
-          sha256sum "$(basename "$ISO")" > "$CHECKSUM"
+          echo "=== before signing ==="
+          ls -l "$ISO"
+          free -m || true
+          df -h . | tail -1
+
+          time sha256sum "$(basename "$ISO")" > "$CHECKSUM"
           sha256sum --check --strict "$CHECKSUM"
-          cosign sign-blob --bundle "$BUNDLE" "$ISO"
-          cosign verify-blob "$ISO" \
+
+          # `timeout` so a wedge is a named failure at a known elapsed time
+          # rather than a job that disappears. 600s is ~15x the sha256sum of
+          # the same bytes; if cosign needs more than that to hash them, that
+          # is the finding.
+          echo "=== cosign sign-blob (bounded 600s) ==="
+          if ! timeout 600 cosign sign-blob --bundle "$BUNDLE" "$ISO"; then
+            rc=$?
+            echo "=== after the failed sign ==="
+            free -m || true
+            if [[ $rc -eq 124 ]]; then
+              echo "::error::cosign sign-blob exceeded 600s on $(stat -c%s "$ISO") bytes. sha256sum over the same file took the time printed above. See #1893-adjacent publish failures: jobs 97650065786, 97655764784, 97661993804."
+            else
+              echo "::error::cosign sign-blob failed with exit $rc"
+            fi
+            exit 1
+          fi
+
+          echo "=== cosign verify-blob (bounded 600s) ==="
+          timeout 600 cosign verify-blob "$ISO" \
             --bundle "$BUNDLE" \
             --certificate-identity "$identity" \
             --certificate-oidc-issuer "$issuer"

--- a/.github/workflows/publish-iso-groups.yml
+++ b/.github/workflows/publish-iso-groups.yml
@@ -251,22 +251,38 @@ jobs:
         with:
           cosign-release: v3.1.3
 
-      # BOUNDED, because this step has killed three consecutive runs and left
-      # no evidence behind. Jobs 97650065786, 97655764784 and 97661993804 all
-      # reached it; none completed it. The last ran 45 minutes and then the
-      # job "completed" with THIS step still in_progress and its logs 404 --
-      # the signature of a runner terminated out from under the job, which
-      # takes the log with it. So an unbounded call here does not fail, it
-      # vanishes.
+      # SIGN THE CHECKSUM, NOT THE ISO.
       #
-      # For scale: `sha256sum` over the same 5.7 GB ISO takes 38 seconds.
-      # cosign is handed that whole ISO twice (sign then verify). Whether it
-      # is slow, memory-bound, or wedged on an OIDC exchange is NOT
-      # established -- the readable run got as far as "Generating ephemeral
-      # keys..." and "Using payload from: ./albacore-10.2-x86_64.iso" and
-      # then produced nothing further. The timeouts and the before/after
-      # readings below exist to answer that on the next run instead of
-      # inviting a fourth guess.
+      # `cosign sign-blob` reads its payload into memory. This ISO is 8.0
+      # GiB and the runner has 16 GB with NO SWAP, so signing it directly
+      # OOM-kills the runner -- which Actions surfaces as "The runner has
+      # received a shutdown signal", not as a failure of this step. That is
+      # why four consecutive publish runs died here having already BUILT and
+      # BOOT-GATED the ISO successfully.
+      #
+      # Measured in job 97677987562, with the step instrumented:
+      #
+      #   -rw-r--r-- 1 root root 8586199040 albacore-10.2-x86_64.iso
+      #   Mem:  total 15989   available 14795      Swap: 0
+      #   sha256sum over the same file: real 0m18.083s
+      #   04:23:06.8  cosign sign-blob starts
+      #   04:23:07.5  "Using payload from: ./albacore-10.2-x86_64.iso"
+      #   04:23:40.0  runner shutdown          <- 32s in
+      #
+      # That rules out the alternatives it could have been: not throughput
+      # (18s to read all 8 GiB), not the 600s bound (died at 32s), not a
+      # wedged OIDC exchange (it printed "Generating ephemeral keys" and
+      # moved on to the payload). An 8 GiB read into 14.8 GiB of available
+      # RAM with no swap is what is left.
+      #
+      # The .sha256 is ~100 bytes and binds the ISO cryptographically, so
+      # signing it gives the same guarantee for a payload cosign can
+      # actually hold. This is what Fedora, Debian and Arch all do.
+      #
+      # VERIFICATION CHANGES SHAPE, deliberately: a consumer now verifies
+      # the sigstore bundle over the .sha256, then checks the ISO against
+      # that checksum -- two steps instead of one. Both files are published
+      # alongside the ISO.
       - name: Checksum, sign, and verify grouped ISO
         timeout-minutes: 30
         env:
@@ -276,6 +292,9 @@ jobs:
           ISO=$(find . -maxdepth 1 -name "${{ matrix.basename }}-*.iso" -print -quit)
           [[ -n "$ISO" ]] || { echo "::error::ISO not found"; exit 1; }
           CHECKSUM="${ISO}.sha256"
+          # Bundle keeps the ISO-derived name so every downstream key
+          # (R2 objects, artifact globs, the prune filter) is unchanged.
+          # It is the signature over $CHECKSUM, not over $ISO.
           BUNDLE="${ISO}.sigstore.json"
           identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/publish-iso-groups.yml@${GITHUB_REF}"
           issuer="https://token.actions.githubusercontent.com"
@@ -283,33 +302,21 @@ jobs:
           echo "=== before signing ==="
           ls -l "$ISO"
           free -m || true
-          df -h . | tail -1
 
           time sha256sum "$(basename "$ISO")" > "$CHECKSUM"
           sha256sum --check --strict "$CHECKSUM"
 
-          # `timeout` so a wedge is a named failure at a known elapsed time
-          # rather than a job that disappears. 600s is ~15x the sha256sum of
-          # the same bytes; if cosign needs more than that to hash them, that
-          # is the finding.
-          echo "=== cosign sign-blob (bounded 600s) ==="
-          if ! timeout 600 cosign sign-blob --bundle "$BUNDLE" "$ISO"; then
-            rc=$?
-            echo "=== after the failed sign ==="
-            free -m || true
-            if [[ $rc -eq 124 ]]; then
-              echo "::error::cosign sign-blob exceeded 600s on $(stat -c%s "$ISO") bytes. sha256sum over the same file took the time printed above. See #1893-adjacent publish failures: jobs 97650065786, 97655764784, 97661993804."
-            else
-              echo "::error::cosign sign-blob failed with exit $rc"
-            fi
-            exit 1
-          fi
-
-          echo "=== cosign verify-blob (bounded 600s) ==="
-          timeout 600 cosign verify-blob "$ISO" \
+          # The payload here is the checksum file, NOT $ISO. See the note
+          # above: passing the ISO OOM-kills the runner.
+          timeout 300 cosign sign-blob --bundle "$BUNDLE" "$CHECKSUM"
+          timeout 300 cosign verify-blob "$CHECKSUM" \
             --bundle "$BUNDLE" \
             --certificate-identity "$identity" \
             --certificate-oidc-issuer "$issuer"
+
+          echo "=== signed ==="
+          ls -l "$CHECKSUM" "$BUNDLE"
+          cat "$CHECKSUM"
 
       # Only reached if the boot gate passed.
       - name: Upload ISO to Cloudflare R2

--- a/.github/workflows/reusable-build-artifacts.yml
+++ b/.github/workflows/reusable-build-artifacts.yml
@@ -217,7 +217,7 @@ jobs:
             *.iso.sha256
             *.iso.sigstore.json
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 1
           # An ISO is already compressed: the default level 6 spends runner
           # minutes to save roughly nothing on it.
           compression-level: 0

--- a/.github/workflows/reusable-build-artifacts.yml
+++ b/.github/workflows/reusable-build-artifacts.yml
@@ -218,6 +218,9 @@ jobs:
             *.iso.sigstore.json
           if-no-files-found: error
           retention-days: 7
+          # An ISO is already compressed: the default level 6 spends runner
+          # minutes to save roughly nothing on it.
+          compression-level: 0
 
       # Installer-flow captures join the boot evidence so every visual the
       # pipeline can produce lands in ONE artifact (and, via the weekly

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -1320,7 +1320,10 @@ jobs:
           # default and `bootc install to-disk` ABORTS installing the
           # bootloader: BIOS grub2-install cannot read the xfs this base's
           # mkfs.xfs produces, and bootupctl installs the BIOS component
-          # unconditionally, so UEFI hardware does not escape it either. Six
+          # unconditionally, so the whole to-disk install fails. (An ISO
+          # install is a different path -- fisherman gives it a separate
+          # ext4 /boot -- so this is about the Gate, and about Promote
+          # being gated on the Gate.) Six
           # consecutive nightlies died here (run 32786338463, gnome Gate job
           # 97638679623), which is why hummingbird:gnome has never been
           # promoted and is 404 on GHCR.

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -1316,6 +1316,22 @@ jobs:
       - name: Build qcow2 from testing image
         env:
           TEST_IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}-testing
+          # hummingbird probes BACKEND=ostree SEALED=0, so it takes the xfs
+          # default and `bootc install to-disk` ABORTS installing the
+          # bootloader: BIOS grub2-install cannot read the xfs this base's
+          # mkfs.xfs produces, and bootupctl installs the BIOS component
+          # unconditionally, so UEFI hardware does not escape it either. Six
+          # consecutive nightlies died here (run 32786338463, gnome Gate job
+          # 97638679623), which is why hummingbird:gnome has never been
+          # promoted and is 404 on GHCR.
+          #
+          # Scoped to this one variant ON PURPOSE. It is a measurement, not a
+          # product change: if the gate goes green on ext4 then ext4 is the
+          # answer and the durable fix is a 50-hummingbird.toml drop-in, as
+          # 00-tunaos.toml already prescribes. Every other variant is
+          # untouched -- the variable is unset for them and the probe decides
+          # exactly as before.
+          TUNAOS_QCOW2_FILESYSTEM: ${{ inputs.image-variant == 'hummingbird' && 'ext4' || '' }}
         run: |
           just qcow2 "${TEST_IMAGE}"
 

--- a/.github/workflows/weekly-desktop-screenshots.yml
+++ b/.github/workflows/weekly-desktop-screenshots.yml
@@ -95,6 +95,30 @@ jobs:
             qemu-system-x86 qemu-utils ovmf socat imagemagick
           sudo wget -qO /usr/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
 
+      # The runner image ships podman 5.8.4, which wedges committing a
+      # live-customized rootfs (#1893). Every ISO build needs the Kubic one
+      # instead; this job ran `just iso` without it. Necessary, not
+      # sufficient -- iso-e2e.yml installs this and its commit still exceeded
+      # tacklebox's 600s bound on a GitHub-hosted runner (job 97638514487) --
+      # but a build without it cannot finish at all.
+      - name: setup working podman
+        run: |
+          set -euo pipefail
+          sudo install -d /etc/apt/keyrings
+          curl -fsSL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/Release.key \
+            | gpg --dearmor | sudo tee /etc/apt/keyrings/kubic.gpg >/dev/null
+          echo 'deb [signed-by=/etc/apt/keyrings/kubic.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/ /' \
+            | sudo tee /etc/apt/sources.list.d/kubic.list
+          sudo apt-get update -qq
+          sudo apt-get remove -y podman conmon crun || true
+          sudo apt-get install -y podman
+          for p in /usr/local/bin/podman /usr/local/sbin/podman; do
+            if [ -e "$p" ] && ! dpkg -S "$p" >/dev/null 2>&1; then
+              sudo rm -f "$p"
+            fi
+          done
+          hash -r
+
       - name: Log in to GHCR
         if: steps.filter.outputs.skip != 'true'
         run: echo "${{ env.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/weekly-desktop-screenshots.yml
+++ b/.github/workflows/weekly-desktop-screenshots.yml
@@ -199,6 +199,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Needed to open the refresh PR; `main` only accepts merge-queue changes.
+      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -229,9 +231,20 @@ jobs:
         if: steps.stage.outputs.staged != '0'
         run: bash scripts/gen-screenshot-gallery.sh
 
-      - name: Commit and push
+      # Opens a PR; does NOT push to main. `main` is protected by a
+      # repository rule -- "Changes must be made through the merge queue" --
+      # so `git push origin HEAD:main` is rejected outright (GH013). Observed
+      # on installer-smoke.yml run 32704425971, where the identical step had
+      # simply never executed before: it is gated on `staged != 0` and no
+      # flavor had ever produced frames. All three screenshot writers carried
+      # the same line; all three are now the matrix-status.yml shape.
+      - name: Open the screenshot refresh PR
         if: steps.stage.outputs.staged != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: automation/desktop-screenshots
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/images/desktops docs/SCREENSHOTS.md
@@ -239,6 +252,25 @@ jobs:
             echo "No screenshot changes to commit"
             exit 0
           fi
-          git commit -m "docs: refresh desktop screenshots ($(date +%Y-%m-%d)) [skip ci]"
-          git pull --rebase origin main
-          git push origin HEAD:main
+          git checkout -b "$BRANCH"
+          git commit -m "docs: refresh desktop screenshots ($(date -u +%Y-%m-%d))"
+          git push --force origin "$BRANCH"
+
+          if [[ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]]; then
+            gh pr create --base main --head "$BRANCH" \
+              --title "docs: refresh desktop screenshots" \
+              --body "$(printf '%s\n\n%s\n' \
+                'Captured by the weekly desktop screenshot run and staged by `scripts/gen-screenshot-gallery.sh`.' \
+                'Force-updated in place, so this branch always holds the newest capture.')"
+          else
+            echo "PR already open for $BRANCH — force-push refreshed it."
+          fi
+
+          # A PR opened with the Actions token starts no checks of its own;
+          # the merge queue runs the required checks on the merge group, so
+          # arming auto-merge is what actually lands the refresh.
+          pr=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [[ -n "$pr" ]]; then
+            gh pr merge --auto --merge "$pr" ||
+              echo "::warning::could not arm auto-merge on #$pr — the refresh will wait for a human"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,29 @@ Containerfiles:
 
 Build pipeline: [`docs/PIPELINE.md`](docs/PIPELINE.md)
 
+### Know your base before reasoning about its packages
+
+Variants do not all behave like the distro their version strings suggest.
+The one that has burned the most time:
+
+**hummingbird is NOT Fedora 43 and NOT EL10.** It is a rolling,
+security-hardened fork tracking **Fedora Rawhide** (Red Hat's Project
+Hummingbird, zero-CVE), on the ARK kernel, and it **ships no desktop
+environment by design**. Its `.fc43` dist tags are Rawhide's numbering, not
+evidence of Fedora 43 — a trap that has produced confidently wrong diagnoses
+more than once, including attributing its empty desktop to a package loss in a
+repository it does not even read.
+
+Read [`docs/HUMMINGBIRD.md`](docs/HUMMINGBIRD.md) before filing a packaging
+issue, blaming a build failure on a missing package, or assuming a Fedora
+package set is available. **Measure the index rather than inferring it** —
+repodata is public and small:
+
+```bash
+curl -s https://repo.tunaos.org/hummingbird/20251124-x86_64/repodata/repomd.xml
+# then fetch the primary.xml.gz it names and grep for <name>PKG</name>
+```
+
 ## Adding a Desktop
 
 Write `manifests/desktops/<name>.yaml`. No shell script needed. See existing manifests for the format.

--- a/Containerfile.el10
+++ b/Containerfile.el10
@@ -138,6 +138,15 @@ RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=bind,from=context,source=/,target=/run/context \
    /run/context/build_scripts/91-arch-customizations.sh
 
+# Per-variant overrides, after the per-arch ones so a variant can override an
+# arch default. This is what delivers system_files_overrides/<variant>/ into
+# the image -- notably hummingbird's 50-hummingbird.toml, without which
+# `bootc install to-disk` aborts installing GRUB onto xfs.
+RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
+  --mount=type=tmpfs,dst=/boot \
+  --mount=type=bind,from=context,source=/,target=/run/context \
+   /run/context/build_scripts/92-variant-customizations.sh
+
 RUN --mount=type=tmpfs,dst=/opt --mount=type=tmpfs,dst=/tmp \
   --mount=type=tmpfs,dst=/boot \
   --mount=type=bind,from=context,source=/,target=/run/context \

--- a/build_scripts/92-variant-customizations.sh
+++ b/build_scripts/92-variant-customizations.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Per-VARIANT system-file overrides.
+#
+# 91-arch-customizations.sh does this for the architecture; there was no
+# equivalent for the variant, even though 00-tunaos.toml explicitly directs
+# per-variant install settings to "a higher-sorting drop-in (e.g.
+# 50-<variant>.toml)". There was nowhere to put one.
+#
+# hummingbird is why. It probes BACKEND=ostree SEALED=0, so it takes the
+# xfs root from 00-tunaos.toml, and then `bootc install to-disk` ABORTS:
+# BIOS grub2-install cannot read the xfs this base's mkfs.xfs produces, and
+# bootupctl installs the BIOS component unconditionally, so the whole disk
+# install fails on UEFI hardware too. Six consecutive nightly Gates died on
+# it (tunaOS run 32786338463, gnome Gate job 97638679623), which is why
+# hummingbird:gnome has never been promoted.
+
+set -euo pipefail
+printf "::group:: === Variant Customizations ===\n"
+
+source /run/context/build_scripts/lib.sh 2>/dev/null || true
+
+# IMAGE_NAME_VARIANT is the variant id, passed as a build arg by
+# scripts/build-image-inner.sh and exported as ENV by the Containerfile.
+# canonical_variant folds aliases (bonito-rawhide -> bonito, etc.) the same
+# way 90-image-info.sh does.
+VARIANT_KEY="${IMAGE_NAME_VARIANT:-}"
+if command -v canonical_variant >/dev/null 2>&1 && [ -n "${VARIANT_KEY}" ]; then
+	VARIANT_KEY="$(canonical_variant "${VARIANT_KEY}")"
+fi
+
+if [ -z "${VARIANT_KEY}" ]; then
+	# Loud, not silent. A build that cannot name its own variant would
+	# skip every per-variant override while looking perfectly healthy —
+	# the exact failure mode that let hummingbird ship a broken installer
+	# for six nights.
+	echo "ERROR: IMAGE_NAME_VARIANT is unset; cannot apply per-variant overrides." >&2
+	echo "  It is passed by scripts/build-image-inner.sh as --build-arg and must" >&2
+	echo "  be declared ARG + ENV in the Containerfile to reach this script." >&2
+	exit 1
+fi
+
+echo "variant key: ${VARIANT_KEY}"
+if [ -d "/run/context/overrides/${VARIANT_KEY}" ]; then
+	copy_systemfiles_for "${VARIANT_KEY}" || true
+	run_buildscripts_for "${VARIANT_KEY}" || true
+else
+	echo "No variant overrides for '${VARIANT_KEY}', skipping."
+fi
+
+printf "::endgroup::\n"

--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -684,10 +684,20 @@ else
 	install -d /usr/share/tunaos/experience-contracts
 	if ((TUNAOS_CONTRACT_WAIVED > 0)); then
 		# NOT "passed". The requirements above were unmet and only the
-		# hummingbird exemption let the build continue. Record that in the
-		# on-image contract file so anything reading it downstream (matrix
-		# scoring, provenance, the omissions manifest) sees an unverified
-		# desktop rather than a verified one.
+		# hummingbird exemption let the build continue.
+		#
+		# The CONSUMED signal is the ::warning:: and the marker line below:
+		# the warning surfaces as a CI annotation, and TUNAOS_DESKTOP_CONTRACT_*
+		# markers are what scripts/iso-e2e.sh greps for.
+		#
+		# The contract FILE is written for correctness, not because something
+		# reads it yet -- today only install-remora.sh writes a sibling and
+		# nothing but tests reads either. gen-matrix-status.py takes its
+		# per-cell verdicts from a sweep's all.json, not from files inside the
+		# image, so wiring this into matrix scoring means teaching that sweep
+		# about it. Worth doing; not done here. Claiming otherwise would be
+		# the same shape of error as the "contract passed" line this block
+		# replaces.
 		printf 'desktop=%s\nexperience=%s\nvalidated_at_build=false\nwaived_requirements=%s\n' \
 			"$desktop" "$experience" "$TUNAOS_CONTRACT_WAIVED" \
 			>"/usr/share/tunaos/experience-contracts/${desktop}"

--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -27,19 +27,40 @@ trap emit_fail_on_early_exit EXIT
 source /run/context/build_scripts/lib.sh 2>/dev/null || true
 detected_os 2>/dev/null || true
 
+# How many requirements the hummingbird exemption let through.
+#
+# Every require_* below returns 0 instead of exiting when IS_HUMMINGBIRD is
+# set, so hummingbird can bootstrap against incomplete repos. That is a
+# deliberate policy and this change does not alter it. What it alters is the
+# REPORT: the script used to print "desktop experience contract passed" after
+# listing ten unmet requirements, which is how hummingbird:gnome shipped with
+# no GNOME in it for weeks and no one noticed.
+#
+# Measured on tunaOS run 32813037866 (2026-08-25): the image carried 410
+# packages -- gnome-backgrounds and gnome-user-docs, no gnome-shell, no gdm,
+# no mutter, no gtk4 -- and this check called it passed. The boot gate then
+# failed 15 minutes later on a marker that could never be emitted, because
+# the packages were dropped upstream (tunaos-packages#519).
+#
+# Exit status is deliberately unchanged: turning the waiver into a hard
+# failure would red-line every hummingbird build, which is a policy call for
+# a human, not a side effect of a logging fix.
+TUNAOS_CONTRACT_WAIVED=0
+waive() { TUNAOS_CONTRACT_WAIVED=$((TUNAOS_CONTRACT_WAIVED + 1)); }
+
 require_command() { command -v "$1" >/dev/null || {
 	echo "missing required command: $1" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
 	exit 1
 }; }
 require_glob() { compgen -G "$1" >/dev/null || {
 	echo "missing required path: $1" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
 	exit 1
 }; }
 require_unit() { systemctl list-unit-files "$1.service" --no-legend 2>/dev/null | grep -q "^$1.service" || {
 	echo "missing unit: $1.service" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
 	exit 1
 }; }
 # Distro drift: the same DE ships different DM units per variant (gdm vs
@@ -53,7 +74,7 @@ require_any_unit() {
 		fi
 	done
 	echo "missing unit: none of [$*] exist" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
 	exit 1
 }
 # Session availability may be wayland or x11 depending on DE/distro.
@@ -63,7 +84,7 @@ require_any_glob() {
 		compgen -G "$g" >/dev/null && return 0
 	done
 	echo "missing required path: none of [$*] exist" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
 	exit 1
 }
 
@@ -78,7 +99,7 @@ require_user_unit() {
 		return 0
 	fi
 	echo "missing user unit: ${u}.service" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
 	exit 1
 }
 
@@ -93,7 +114,7 @@ require_any_user_unit() {
 		fi
 	done
 	echo "missing user unit: none of [$*] exist" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
 	exit 1
 }
 
@@ -115,7 +136,7 @@ xfce_greetd_greeter_contract() {
 	local greetd_conf="${TUNAOS_VERIFY_ROOT:-}/etc/greetd/config.toml"
 	if ! grep -qs 'gtkgreet' "$greetd_conf"; then
 		echo "greetd is the display manager but ${greetd_conf} does not launch gtkgreet — stock agreety boots users to a text prompt, not a login screen" >&2
-		if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then return 0; fi
+		if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
 		exit 1
 	fi
 }
@@ -557,12 +578,14 @@ else
 			if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
 				exit 1
 			fi
+			waive
 		elif ! grep -q ' h264 ' <<<"$_ffmpeg_decoders"; then
 			echo "ffmpeg cannot decode h264 — a free/crippled libavcodec is installed" >&2
 			_ffmpeg_diag
 			if [[ "${IS_HUMMINGBIRD:-false}" != "true" ]]; then
 				exit 1
 			fi
+			waive
 		fi
 	fi
 
@@ -659,7 +682,20 @@ else
 	done
 
 	install -d /usr/share/tunaos/experience-contracts
-	printf 'desktop=%s\nexperience=%s\nvalidated_at_build=true\n' "$desktop" "$experience" \
-		>"/usr/share/tunaos/experience-contracts/${desktop}"
-	echo "desktop experience contract passed: $desktop ($experience)"
+	if ((TUNAOS_CONTRACT_WAIVED > 0)); then
+		# NOT "passed". The requirements above were unmet and only the
+		# hummingbird exemption let the build continue. Record that in the
+		# on-image contract file so anything reading it downstream (matrix
+		# scoring, provenance, the omissions manifest) sees an unverified
+		# desktop rather than a verified one.
+		printf 'desktop=%s\nexperience=%s\nvalidated_at_build=false\nwaived_requirements=%s\n' \
+			"$desktop" "$experience" "$TUNAOS_CONTRACT_WAIVED" \
+			>"/usr/share/tunaos/experience-contracts/${desktop}"
+		echo "::warning::desktop experience contract WAIVED: ${desktop} (${experience}) — ${TUNAOS_CONTRACT_WAIVED} requirement(s) unmet; this image is NOT a verified ${desktop} desktop"
+		echo "TUNAOS_DESKTOP_CONTRACT_WAIVED desktop=${desktop} missing=${TUNAOS_CONTRACT_WAIVED}"
+	else
+		printf 'desktop=%s\nexperience=%s\nvalidated_at_build=true\n' "$desktop" "$experience" \
+			>"/usr/share/tunaos/experience-contracts/${desktop}"
+		echo "desktop experience contract passed: $desktop ($experience)"
+	fi
 fi

--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -337,7 +337,7 @@ Same shape as yellowfin. Additionally:
 | desktops | new upstream skew class 08-18: `libnma-gtk4` still requires `libnm.so.0` after Rawhide's NetworkManager dropped it — nothing here can fix it | heals when Rawhide rebuilds libnma; rolling standard |
 | taxonomy | rolling variant, structurally exposed to skew (#1762) | count under rolling standard |
 
-### hummingbird (Fedora rebuild, experimental) — 1/5 build
+### hummingbird (hardened rolling fork of Fedora Rawhide, experimental) — 1/5 build
 The fully-diagnosed one: **#1755**.
 | area | state | action |
 |---|---|---|

--- a/docs/HUMMINGBIRD.md
+++ b/docs/HUMMINGBIRD.md
@@ -104,6 +104,54 @@ immutable snapshot of a stable release that is the right check. For a rolling
 distribution it is the wrong property: the snapshot will keep answering 200
 long after it has stopped being a usable base to layer against.
 
+## Its published images claim to be version 10
+
+Measured on the 2026-08-25 build (run 32813037866). The image's own os-release:
+
+```
+NAME="Hummingbird OS"   VERSION="20251124"   VERSION_ID="20251124"
+ID="hummingbird"        ID_LIKE="fedora rhel"
+CPE_NAME="cpe:/a:redhat:hummingbird:1"      VENDOR_NAME="Red Hat"
+```
+
+The build ran with `MAJOR_VERSION: 10`, and `reusable-build-image.yml` stamps
+
+```yaml
+org.opencontainers.image.version=${{ env.MAJOR_VERSION }}
+```
+
+so `hummingbird:gnome-testing` is published claiming to be version **10**.
+
+The cause is not hummingbird-specific. `reusable-build-image.yml` declares:
+
+```yaml
+major-version:
+  description: "The version of CentOS to build the image on"
+  default: "10"
+```
+
+and `build-variant.yml` never passes it, so **every** variant inherits `10` —
+Arch, Ubuntu 26.04, Debian 13, Tumbleweed and Gentoo included. It is the same
+EL10-shaped assumption this document exists to correct, just at the metadata
+layer.
+
+Note there are two different values with confusingly similar names, and only
+one of them is wrong:
+
+| | source | hummingbird's value |
+|---|---|---|
+| `MAJOR_VERSION` (workflow env) | `inputs.major-version`, default `"10"` | `10` — wrong |
+| `MAJOR_VERSION_NUMBER` (`build_scripts/lib.sh`) | the image's own `VERSION_ID` | `20251124` — right |
+
+So the build *scripts* already see the correct value; it is the OCI label that
+lies. Anyone fixing this should know that `MAJOR_VERSION_NUMBER` feeds
+`epel-release-latest-N`, `codeready-builder-for-rhel-N` and a numeric
+`-ge 9` comparison, so it is not a free variable to redefine.
+
+Not fixed here: correcting the label is a fleet-wide metadata change across
+thirteen variants with downstream consumers, which wants its own change and its
+own review rather than being folded into a hummingbird documentation pass.
+
 ## Rules of thumb for future work here
 
 1. **Do not call it a Fedora rebuild.** It is a hardened rolling fork tracking

--- a/docs/HUMMINGBIRD.md
+++ b/docs/HUMMINGBIRD.md
@@ -1,0 +1,129 @@
+# Hummingbird — what it actually is
+
+Written because this was got wrong repeatedly, in code comments, in
+`GREEN-MASTER-PLAN.md`, and in issue triage. Hummingbird is **not** Fedora 43
+and **not** EL10, and treating it as either produces conclusions that are
+confidently wrong.
+
+## The short version
+
+**Fedora Hummingbird is a rolling-release, security-hardened, bootable-container
+OS that tracks Fedora Rawhide and ships no desktop environment.**
+
+It is the OS-scale application of Red Hat's **Project Hummingbird**, an early
+access program providing a catalog of minimal, hardened, *distroless* container
+images kept at near-zero CVE. Fedora Hummingbird applies that same pipeline
+logic to a whole operating system.
+
+| | |
+|---|---|
+| Upstream tracked | **Fedora Rawhide** — "over 95% of packages from Rawhide", upstream sources where Rawhide lacks a needed version |
+| Release model | **Rolling.** Not a numbered release. There is no "Hummingbird 43". |
+| Kernel | **ARK** (Always Ready Kernel) from the CKI project, following mainline Linux |
+| Delivery | A **bootc / bootable OCI image**, x86_64 + aarch64; container, VM and bare metal |
+| Filesystem | Read-only root; writable state confined to `/var` and `/etc`; atomic updates with rollback |
+| Desktop | **None.** It ships no desktop environment, by design |
+| Audience | Developers and cloud-native workloads — explicitly *not* desktop end users |
+| Build | Konflux-based pipeline, isolated reproducible builds from pinned package lists, Syft + Grype scanning, per-package CVE tracking and lifecycle |
+
+Sources: [Red Hat press release](https://www.redhat.com/en/about/press-releases/red-hat-introduces-project-hummingbird-zero-cve-strategies),
+[Project Hummingbird docs](https://hummingbird-project.io/docs/using/overview/),
+[Help Net Security](https://www.helpnetsecurity.com/2026/05/13/fedora-hummingbird-linux/),
+[It's FOSS](https://itsfoss.com/news/fedora-hummingbird-images/).
+
+## Why the `.fc43` version strings mislead
+
+Packages in hummingbird's repos carry versions like `gtk4-4.22.1-2.fc43` and
+`NetworkManager-1.58.0-1.hum1`. The `.fc43` dist tag is **Rawhide's current
+numbering**, not evidence that this is the Fedora 43 stable release. Reading
+`.fc43` as "this is Fedora 43" is the single easiest mistake to make here, and
+it leads directly to expecting Fedora 43's package set to be present. It is not.
+
+## What this means for tunaOS
+
+tunaOS builds `hummingbird:{base,gnome,kde,niri,cosmic}` (see
+`.github/build-config.yml`). Everything except `base` asks a distribution that
+**deliberately ships no desktop environment** to host a full desktop, layered
+from tunaOS's own package snapshot.
+
+That is a legitimate thing to attempt — it is most of what tunaOS does for every
+variant — but it is a *port*, not a *rebuild*, and the difference matters:
+
+- There is no upstream desktop package set to fall back on. Anything the desktop
+  needs either exists in tunaOS's hummingbird snapshot or does not exist at all.
+- Upstream rolls. A snapshot taken once drifts away from the base image
+  continuously, and the failure mode is unresolvable dependencies rather than
+  missing packages (see below).
+- Hardening and minimalism are the *point*. A package being absent is often a
+  deliberate upstream choice, not an oversight to be reported as a bug.
+
+### Measured state of the snapshot (2026-08-25)
+
+Against the live index that `build_scripts/10-base-packages.sh` configures,
+`https://repo.tunaos.org/hummingbird/20251124-x86_64/` — **8,100 packages**, of
+which only 43 names match `gnome-*`:
+
+| package | served? |
+|---|---|
+| `gtk4`, `gdk-pixbuf2`, `mutter`, `gvfs` | yes |
+| `gnome-shell`, `gdm`, `nautilus` | **no** |
+| `harfbuzz`, `gnome-desktop3` | **no** |
+| `flatpak` | **no** |
+
+`gtk4` is present *and* requires `harfbuzz`, which is not. That is why dnf
+reports gtk4 and 17 other packages as having **broken dependencies** rather than
+being unavailable — and why `--skip-unavailable` silently drops them.
+
+The consequence, measured on `ghcr.io/tuna-os/hummingbird:gnome-testing` built
+2026-08-25: **410 packages, and no GNOME.** The only `gnome`-matching names in
+the image are `gnome-backgrounds`, `gnome-user-docs`,
+`desktop-backgrounds-gnome`, `f45-backgrounds-gnome` and `pinentry-gnome3` —
+wallpapers and documentation.
+
+The same absence blocks the ISO: `live-iso/common/src/customize-live.sh` needs
+`flatpak` to pre-install the installer, and hummingbird has no `flatpak`.
+
+## The rolling/pinned mismatch
+
+`build_scripts/10-base-packages.sh` pins:
+
+```
+baseurl=https://repo.tunaos.org/hummingbird/20251124-$basearch/
+```
+
+A datestamped, immutable snapshot — while `.github/build-config.yml` pins the
+upstream base image by digest from `quay.io/hummingbird-community/bootc-os`.
+
+**Two independently-pinned halves of a rolling distribution.** They were
+coherent when both were taken; they drift apart with every upstream roll, and
+the drift surfaces as dependency breakage inside the layered desktop rather than
+as anything that looks like a pin problem.
+
+`scripts/check-package-repo-pins.py` verifies that this URL *resolves*. For an
+immutable snapshot of a stable release that is the right check. For a rolling
+distribution it is the wrong property: the snapshot will keep answering 200
+long after it has stopped being a usable base to layer against.
+
+## Rules of thumb for future work here
+
+1. **Do not call it a Fedora rebuild.** It is a hardened rolling fork tracking
+   Rawhide with its own CVE lifecycle per package.
+2. **Do not infer the package set from Fedora.** Measure the actual index. The
+   repodata is public and small: fetch `repodata/repomd.xml`, then the
+   `primary.xml.gz` it names, and grep. That takes seconds and beats any
+   assumption.
+3. **A missing package may be intentional.** Before filing it as a packaging
+   bug, consider that minimalism is the product.
+4. **Desktop flavors are a port onto a desktop-less base.** Expect gaps; expect
+   them to be structural rather than accidental.
+5. **Both pins move.** Refreshing one without the other is how the halves drift.
+
+## Related
+
+- `build_scripts/10-base-packages.sh` — where the snapshot repo is configured
+- `scripts/check-package-repo-pins.py` — pin reachability *and* snapshot age
+- `build_scripts/checks/verify-desktop-experience.sh` — carries a blanket
+  hummingbird exemption; it reports a **waiver**, not a pass, when requirements
+  are unmet
+- tunaos-packages#401, #406, #412 — hummingbird desktop package builds not
+  completing; the reason the snapshot lacks a desktop set

--- a/docs/HUMMINGBIRD.md
+++ b/docs/HUMMINGBIRD.md
@@ -91,18 +91,25 @@ The same absence blocks the ISO: `live-iso/common/src/customize-live.sh` needs
 baseurl=https://repo.tunaos.org/hummingbird/20251124-$basearch/
 ```
 
-A datestamped, immutable snapshot — while `.github/build-config.yml` pins the
-upstream base image by digest from `quay.io/hummingbird-community/bootc-os`.
+**The datestamp is a label, not a snapshot.** This prefix is where
+tunaos-packages' factory *publishes into* (`r2_path:
+hummingbird/20251124-$arch`), so it is a living repository whose name
+happens to carry the date it was seeded. Measured 2026-08-25: the URL's name
+is 274 days old while its repomd `<revision>` — the indexing epoch — is
+**8 days** old. An earlier revision of this document called it "a
+datestamped, immutable snapshot"; that reading produced a false STALE
+verdict and bad advice ("the snapshot needs refreshing"), both since
+corrected. Judge this repo by its *content* age, never its name.
 
-**Two independently-pinned halves of a rolling distribution.** They were
-coherent when both were taken; they drift apart with every upstream roll, and
-the drift surfaces as dependency breakage inside the layered desktop rather than
+The genuine mismatch is between the two halves: `.github/build-config.yml`
+pins the upstream base image by digest while the package prefix grows on the
+factory's own cadence. They drift apart with every upstream roll, and the
+drift surfaces as dependency breakage inside the layered desktop rather than
 as anything that looks like a pin problem.
 
-`scripts/check-package-repo-pins.py` verifies that this URL *resolves*. For an
-immutable snapshot of a stable release that is the right check. For a rolling
-distribution it is the wrong property: the snapshot will keep answering 200
-long after it has stopped being a usable base to layer against.
+`scripts/check-package-repo-pins.py` verifies the URL resolves **and** fails
+datestamped prefixes whose repomd revision is older than 180 days — content
+age, precisely so a living repo with a dated name is never miscalled stale.
 
 ## Its published images claim to be version 10
 

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -276,11 +276,18 @@ runners — and tuna-os/tunaOS#848 is a prerequisite, since stage-3 flavors
 currently cannot build a dev ISO at all. Until then the ⬜/stale cells above
 should be read as *not yet covered*, not as a backlog of broken cells.
 
-**Four of five desktops do not start on hosted CI. The reason is not settled.**
-cosmic, niri, xfwl4 and kde all fail to bring a session up there. This section
-used to say they need a DRM render node, that GitHub runners have none, and
-that "no configuration change alters this". The first measurement taken inside
-the guest contradicts the middle claim, so the conclusion cannot rest on it.
+**Not four of five. Two of five are measured, and they fail differently.**
+This section used to say cosmic, niri, xfwl4 **and kde** all need a DRM render
+node, that GitHub runners have none, and that "no configuration change alters
+this". Every part of that has now been contradicted by measurement taken inside
+the guest rather than on the runner host.
+
+What is measured today: **gnome starts and passes** (smoke run 32704425971,
+`yellowfin:gnome`, every step green including the walkthrough), **kde starts**
+and fails later at the installer window, **xfwl4 starts and aborts** at a
+render node it had already selected. cosmic and niri have NOT been re-measured
+since the diagnostics landed, so their rows say nothing more than "last seen
+red under a theory that turned out to be wrong".
 
 Smoke run [32681262659](https://github.com/tuna-os/tunaOS/actions/runs/32681262659),
 `yellowfin:xfce`, read from the live session itself:
@@ -303,6 +310,63 @@ the same run it boots, `gnome-shell` starts through Mesa's software path
 (`libEGL warning: egl: failed to create dri2 screen`), the installer frontend
 launches and stamps a window, and the walkthrough captures **9 non-blank frames
 across 8 distinct visual states**. So a compositor CAN come up on this hardware.
+
+### What kde actually does — it starts, and the old claim was wrong
+
+kde was recorded here as the flavor whose greeter and autologin session "both
+die instantly", on run `30234237855`, attributed to the render-node theory.
+That entry stood because the smoke capture named only `greetd` and
+`cosmic-greeter` in its journal line — kde runs **sddm**, so no unit was
+captured for it and nobody ever read what it said.
+
+Smoke run [32704425971](https://github.com/tuna-os/tunaOS/actions/runs/32704425971)
+is the first time it was. kde comes up:
+
+```
+sddm-helper: pam_unix(sddm-autologin:session): session opened for user liveuser
+sddm-helper: Starting Wayland user session: "/etc/sddm/wayland-session" ...
+session 1: VTNr=1 Seat=seat0 Type=wayland Class=user Active=yes State=active
+```
+
+A properly seated session on `seat0`, VT 1. And the checks agree:
+
+```
+ok - compositor running (kwin_wayland)
+ok - installer frontend launched (org.tunaos.InstallerKde)
+ok - kde: installer is frontmost at session start
+ok - kde: screen is not blank
+ok - kde: screen changes between steps
+```
+
+kwin hits the same missing DRM node as everyone else —
+
+```
+kwin_wayland: Failed to open drm node : No such file or directory
+kwin_wayland: couldn't find dev node for drm device
+libEGL warning: egl: failed to create dri2 screen      (everywhere, llvmpipe)
+```
+
+— and **carries on regardless**. That is the difference that matters: kwin
+degrades to software, the Smithay compositors abort. "These desktops need a
+render node" is not one claim about four desktops; it is false for kde and
+gnome, and for xfwl4 it describes an abort, not an absence.
+
+What kde actually fails is one step later:
+
+```
+not ok - installer readiness stamp present
+not ok - kde: reached 'welcome' screen        (and disk, encryption, summary, install, done)
+```
+
+The frontend is running and the screen is painting, but no installer window is
+identified and no spec'd screen is OCR-matched. The file that would settle
+which — the installer's own debug log, which records `do_activate called`,
+which window class was built, and any traceback — had **never been captured on
+this flavor**: the capture read `~/.var/app/org.bootcinstaller.Installer/...`,
+which is gnome's app id. kde is `org.tunaos.InstallerKde`. So it printed "(no
+installer-debug.log found)" on four of five flavors, and that string reads like
+a fact about the guest instead of a fact about the path. Fixed; the next kde
+run carries it.
 
 ### What xfce actually does — measured, not inferred
 

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -228,7 +228,7 @@ This is the only axis that checks a human could actually install. For 4 combinat
 | **skipjack** | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **yellowfin** | ❌ | ❌ | ❌ | ❌ | ❌ |
 
-cosmic, niri, xfwl4 and kde all need a DRM render node; a ❌ for those on hosted CI may be a harness limitation rather than a product failure. See *Known systemic gaps*.
+cosmic, niri, xfwl4 and kde do not bring a session up on hosted CI. The cause is undiagnosed rather than established -- gnome starts on the same guest, which has a render node but no 3D. See *Known systemic gaps*.
 
 ## Live overlay
 
@@ -276,19 +276,75 @@ runners — and tuna-os/tunaOS#848 is a prerequisite, since stage-3 flavors
 currently cannot build a dev ISO at all. Until then the ⬜/stale cells above
 should be read as *not yet covered*, not as a backlog of broken cells.
 
-**CI cannot test four of five desktops.** cosmic, niri, xfwl4 **and kde** need a
-DRM render node. GitHub runners have none, so on hosted CI the compositor never
-starts — no configuration change alters this.
+**Four of five desktops do not start on hosted CI. The reason is not settled.**
+cosmic, niri, xfwl4 and kde all fail to bring a session up there. This section
+used to say they need a DRM render node, that GitHub runners have none, and
+that "no configuration change alters this". The first measurement taken inside
+the guest contradicts the middle claim, so the conclusion cannot rest on it.
 
-kde was previously believed to be the exception. It is not: on run
-`30234237855`, plasmalogin's autologin session and its greeter both exit
-immediately (`plasmalogin-helper exited with 5`) in a restart loop, and
-`eglinfo` on that runner lists **no `EGL_EXT_device_drm` at all**, putting
-kwin_wayland in the same position as the Smithay compositors.
+Smoke run [32681262659](https://github.com/tuna-os/tunaOS/actions/runs/32681262659),
+`yellowfin:xfce`, read from the live session itself:
 
-That leaves **gnome** as the only desktop still thought verifiable without a
-render node — and that is now an untested assumption rather than a
-demonstrated fact, because the smoke matrix has never run gnome.
+```
+crw-rw----+ 1 root video  226,   1 card1
+crw-rw-rw-. 1 root render 226, 128 renderD128
+[drm] pci: virtio-vga detected at 0000:00:02.0
+[drm] features: -virgl +edid -resource_blob -host_visible
+```
+
+The guest **has** a render node. What it does not have is 3D — virgl is not
+negotiated, because the host QEMU has no node of its own to pass through. Those
+are different claims, and only the second is supported. The earlier `eglinfo`
+evidence was collected on the runner HOST, which says nothing about what the
+guest can do.
+
+gnome is the counter-example, and it is now measured rather than assumed. On
+the same run it boots, `gnome-shell` starts through Mesa's software path
+(`libEGL warning: egl: failed to create dri2 screen`), the installer frontend
+launches and stamps a window, and the walkthrough captures **9 non-blank frames
+across 8 distinct visual states**. So a compositor CAN come up on this hardware.
+
+Why the other four do not is still open, and the evidence to close it did not
+exist: greetd reports only its own bookkeeping —
+
+```
+greetd: error: check_children: greeter exited without creating a session
+```
+
+five times to `start-limit-hit` — and the compositor's own reason went
+nowhere. The live adapters now run the session under
+`systemd-cat -t tunaos-live-session` and the smoke workflow prints that tag, so
+the next run answers this instead of inviting a sixth guess. Until it does,
+read these cells as **undiagnosed**, not as a hardware limit.
+
+kde fails the same way: on run `30234237855`, plasmalogin's autologin session
+and its greeter both exit immediately (`plasmalogin-helper exited with 5`) in a
+restart loop. The `eglinfo` output cited alongside it — **no
+`EGL_EXT_device_drm` at all** — was collected on the runner HOST, not in the
+guest, so it is not evidence about kwin_wayland's environment and is no longer
+offered as such.
+
+**gnome is no longer an assumption.** It was described here as "the only
+desktop still thought verifiable without a render node", untested because the
+smoke matrix had never run it. It has now run, on
+[32681262659](https://github.com/tuna-os/tunaOS/actions/runs/32681262659): it
+boots, the compositor and installer frontend both come up, and the walkthrough
+captures 9 non-blank frames over 8 visual states. It reaches welcome,
+encryption and summary; it does not reach the disk screen, which was a keyword
+gap in the screen contract — the contract had been measured against the other
+four frontends and never against this one.
+
+Two real defects that run surfaced, neither of them about graphics:
+
+* **The installer starts behind the GNOME Activities overview.** The
+  walkthrough had to press `esc` before it could drive anything, and records
+  it as a failure precisely because a user booting this ISO sees the same
+  thing. Reproduced on runs `32450214451` and `32681262659`.
+* **`e2e-installer-gui-checks.sh` had never executed.** It resolved its TAP
+  helpers to a path the guest does not have, so every assertion was
+  `command not found` and the harness printed the shell's 127 as a count of
+  failures. The per-flavor compositor and frontend assertions have therefore
+  never run, on any flavor, in any smoke run.
 
 `scripts/iso-e2e-gpu.sh` runs the harness on a GPU host and is the intended
 answer; it currently has to be driven by hand.

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -276,18 +276,30 @@ runners — and tuna-os/tunaOS#848 is a prerequisite, since stage-3 flavors
 currently cannot build a dev ISO at all. Until then the ⬜/stale cells above
 should be read as *not yet covered*, not as a backlog of broken cells.
 
-**Not four of five. Two of five are measured, and they fail differently.**
+**Not four of five. Four of five are measured, and three of them START.**
 This section used to say cosmic, niri, xfwl4 **and kde** all need a DRM render
 node, that GitHub runners have none, and that "no configuration change alters
 this". Every part of that has now been contradicted by measurement taken inside
 the guest rather than on the runner host.
 
-What is measured today: **gnome starts and passes** (smoke run 32704425971,
-`yellowfin:gnome`, every step green including the walkthrough), **kde starts**
-and fails later at the installer window, **xfwl4 starts and aborts** at a
-render node it had already selected. cosmic and niri have NOT been re-measured
-since the diagnostics landed, so their rows say nothing more than "last seen
-red under a theory that turned out to be wrong".
+What is measured today:
+
+| flavor | compositor | starts? | installer window | what actually fails |
+|---|---|---|---|---|
+| gnome | gnome-shell | ✅ | mapped, drives | **nothing — green** (run 32704425971) |
+| kde | kwin_wayland | ✅ | mapped, `page=welcome` | does not advance past welcome |
+| cosmic | cosmic-comp (Smithay) | ✅ | mapped, `page=welcome`, OCR matches | does not advance past welcome |
+| xfce | xfwl4 (Smithay) | ❌ | — | aborts: `err=NoRenderNode` |
+| niri | niri (Smithay) | ? | ? | never measured with these diagnostics |
+
+**Three of the four measured desktops come up and render on a GPU-less
+runner.** Only xfwl4 aborts.
+
+A generalisation published earlier in this branch — "kwin degrades to
+software, the Smithay compositors abort" — is WRONG and is withdrawn here.
+`cosmic-comp` is Smithay and it starts, renders 9/9 non-blank frames, maps its
+installer window and reaches the welcome screen. Whatever stops xfwl4 is
+specific to xfwl4, not a property of its toolkit.
 
 Smoke run [32681262659](https://github.com/tuna-os/tunaOS/actions/runs/32681262659),
 `yellowfin:xfce`, read from the live session itself:
@@ -347,7 +359,9 @@ libEGL warning: egl: failed to create dri2 screen      (everywhere, llvmpipe)
 ```
 
 — and **carries on regardless**. That is the difference that matters: kwin
-degrades to software, the Smithay compositors abort. "These desktops need a
+degrades to software, and xfwl4 aborts. (An earlier draft of this sentence
+said "the Smithay compositors abort" — cosmic-comp is Smithay and does not,
+so the split is not by toolkit. See the table above.) "These desktops need a
 render node" is not one claim about four desktops; it is false for kde and
 gnome, and for xfwl4 it describes an abort, not an absence.
 
@@ -367,6 +381,35 @@ which is gnome's app id. kde is `org.tunaos.InstallerKde`. So it printed "(no
 installer-debug.log found)" on four of five flavors, and that string reads like
 a fact about the guest instead of a fact about the path. Fixed; the next kde
 run carries it.
+
+### What cosmic and kde share — the installer will not advance
+
+Both come up. Both map the installer window on the **welcome** page. Neither
+gets past it.
+
+cosmic, run 32718219267:
+
+```
+ok - compositor running (cosmic-comp)
+ok - installer frontend launched (org.tunaos.InstallerCosmic)
+ok - cosmic: screen is not blank        # 9/9 frames above stddev
+ok - cosmic: reached 'welcome' screen   # seen on visual state(s) [0, 1]
+not ok - cosmic: reached 'disk' screen  # not found on any state the installer advanced to
+  # 1/8 transitions changed >500px; primary action activated with 'spc'
+  # 2 distinct visual state(s) across 9 frames
+```
+
+Its readiness stamp agrees: `app_id=org.tunaos.InstallerCosmic
+signal=first-frame page=welcome`. kde's says the same thing —
+`window=ApplicationWindow signal=frame-swapped page=welcome` — it simply
+matched no OCR keywords at all.
+
+So the remaining question for both is **not** rendering, seats, or DRM. It is
+that the walkthrough's keyboard drive (`ret`, escalating to `spc`, then
+widening the focus search) does not move these frontends off their first page.
+gnome advances 7/8 transitions on the same harness. Whether that is a
+walkthrough limitation or a real defect in the two frontends is open, and is
+deliberately not guessed at here.
 
 ### What xfce actually does — measured, not inferred
 

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -304,18 +304,55 @@ the same run it boots, `gnome-shell` starts through Mesa's software path
 launches and stamps a window, and the walkthrough captures **9 non-blank frames
 across 8 distinct visual states**. So a compositor CAN come up on this hardware.
 
-Why the other four do not is still open, and the evidence to close it did not
-exist: greetd reports only its own bookkeeping —
+### What xfce actually does — measured, not inferred
+
+greetd reports only its own bookkeeping (`greeter exited without creating a
+session`, five times to `start-limit-hit`), so the compositor's reason went
+nowhere for five rounds of this. The live adapters now run the session under
+`systemd-cat -t tunaos-live-session`, and smoke run
+[32691426582](https://github.com/tuna-os/tunaOS/actions/runs/32691426582)
+is the first time xfwl4's own words have been captured:
 
 ```
-greetd: error: check_children: greeter exited without creating a session
+INFO  xfwl4: Starting xfwl4 on a tty using udev
+INFO  xfwl4::backend::udev: Using renderD128 as primary GPU
+INFO  smithay::wayland::socket: Created new socket name=Some("wayland-1")
+INFO  xfwl4::core::state: Listening on wayland socket name="wayland-1"
+WARN  smithay::backend::drm::device::fd: Unable to become drm master, assuming unprivileged mode
+INFO  smithay::backend::drm::device: DrmDevice initializing
+INFO  smithay::backend::egl::display: Successfully selected EGL platform: PLATFORM_GBM_KHR
+INFO  smithay::backend::egl::display: EGL Initialized
+INFO  smithay::backend::egl::display: EGL Version: (1, 5)
+WARN  xfwl4::backend::udev::device: failed to initialize gpu err=NoRenderNode
+ERROR xfwl4: Failed to initialize primary GPU node
 ```
 
-five times to `start-limit-hit` — and the compositor's own reason went
-nowhere. The live adapters now run the session under
-`systemd-cat -t tunaos-live-session` and the smoke workflow prints that tag, so
-the next run answers this instead of inviting a sixth guess. Until it does,
-read these cells as **undiagnosed**, not as a hardware limit.
+So the compositor **starts**, **finds the render node and names it**, opens a
+Wayland socket and listens, and initialises EGL on GBM. It dies at
+`err=NoRenderNode` from Smithay's udev device init — *after* having selected
+`renderD128` — having first failed to become DRM master.
+
+"These desktops need a DRM render node" is therefore not merely unproven, it
+is contradicted by the compositor's own log: the node is present and xfwl4
+says which one it picked. The open question is now specific and much smaller:
+why Smithay reports `NoRenderNode` for a device it just selected, and whether
+the preceding `Unable to become drm master` is the cause or a separate
+symptom. Deliberately not guessed here — that is what the previous five
+attempts did.
+
+A second, independent defect is visible in the same log and is a packaging bug
+rather than a graphics one:
+
+```
+INFO xfwl4::core::config::xfwl4_config: Failed to reload defaults:
+     /usr/local/share/xfce4/xfwl4/defaults does not exist; using hard-coded defaults
+WARN xfwl4::core::util::rc: Missing value for required setting box_move
+... ~45 more required settings missing ...
+```
+
+`/usr/local/share` is not where a distribution package installs data, so
+xfwl4 ships looking for a defaults file that its own packaging never puts
+there. Not the fatal error, and worth fixing on its own.
 
 kde fails the same way: on run `30234237855`, plasmalogin's autologin session
 and its greeter both exit immediately (`plasmalogin-helper exited with 5`) in a

--- a/just/qcow2-build.just
+++ b/just/qcow2-build.just
@@ -135,6 +135,44 @@ qcow2 variant flavor='gnome' repo='local' tag='':
     grep -q '^BACKEND=composefs-native$' <<<"$PROBE" && COMPOSEFS_ARGS+=(--composefs-backend)
     grep -q '^SEALED=1$' <<<"$PROBE" && COMPOSEFS_ARGS+=(--filesystem ext4)
 
+    # TUNAOS_QCOW2_FILESYSTEM overrides the filesystem the probe implied.
+    #
+    # SEALED is not the only thing that can make the default xfs unusable.
+    # hummingbird probes BACKEND=ostree SEALED=0, so it takes the xfs default
+    # from 00-tunaos.toml, and then the install ABORTS:
+    #
+    #   Creating root filesystem (xfs) on device /dev/loop0p3
+    #   Bootloader: grub
+    #   /usr/sbin/grub2-install: error: ../grub-core/kern/fs.c:123:unknown filesystem.
+    #   error: Installing to disk: Installing bootloader: Failed to run
+    #     command: bootupctl backend install
+    #
+    # (build-hummingbird run 32786338463, gnome Gate job 97638679623, and the
+    # five nightlies before it.) BIOS grub2-install cannot read the xfs that
+    # this base's mkfs.xfs produces. bootupctl installs the BIOS component
+    # unconditionally on a hybrid layout, so this is not a legacy-boot-only
+    # problem -- the whole disk install fails, on UEFI hardware too.
+    #
+    # This knob exists to TEST whether ext4 is the answer before changing any
+    # product default: unset, nothing changes for any variant. If it proves
+    # out, the durable fix is a 50-<variant>.toml drop-in as 00-tunaos.toml
+    # already prescribes, not this variable.
+    if [[ -n "${TUNAOS_QCOW2_FILESYSTEM:-}" ]]; then
+        echo "==> TUNAOS_QCOW2_FILESYSTEM=${TUNAOS_QCOW2_FILESYSTEM} overriding probed filesystem"
+        # Drop any --filesystem the probe added, then append the override.
+        FILTERED=(); skip=0
+        for a in ${COMPOSEFS_ARGS[@]+"${COMPOSEFS_ARGS[@]}"}; do
+            if [[ $skip -eq 1 ]]; then skip=0; continue; fi
+            if [[ "$a" == "--filesystem" ]]; then skip=1; continue; fi
+            FILTERED+=("$a")
+        done
+        # `${a[@]+"${a[@]}"}` not `${a[@]:-}`: on an EMPTY array the latter
+        # expands to one empty string, which would reach `bootc install` as a
+        # zero-length argv element. hummingbird is exactly that case -- it
+        # probes unsealed, so COMPOSEFS_ARGS starts empty.
+        COMPOSEFS_ARGS=(${FILTERED[@]+"${FILTERED[@]}"} --filesystem "${TUNAOS_QCOW2_FILESYSTEM}")
+    fi
+
     # Console ORDER matters: the LAST console= is the primary /dev/console, and
     # that is where dracut/systemd (all userspace) writes. With tty0 last,
     # initramfs failures were visible only on the VGA screen (the Gate's

--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -545,12 +545,43 @@ if [[ -n "${INSTALLER_APP}" ]]; then
 			echo "---- installer flatpak install FAILED; what the remotes offer:"
 			echo "-- configured remotes --"
 			flatpak remotes --system --columns=name,url 2>&1 | sed "s/^/     /" || true
-			echo "-- org.gnome/org.kde Platform+Sdk branches visible --"
-			flatpak remote-ls --system --columns=ref 2>/dev/null |
-				grep -E "org\.(gnome|kde)\.(Platform|Sdk)" | sed "s/^/     /" ||
-				echo "     (none, or remote-ls could not reach a remote)"
+			# ASK ABOUT THE ONE REF, DO NOT LIST EVERY REMOTE.
+			#
+			# The first version of this probe ran a bare
+			# `flatpak remote-ls --system`, which pulls the FULL index of
+			# every configured remote -- flathub included. In run 32728454277
+			# the job was killed during exactly that command:
+			#
+			#   -- org.gnome/org.kde Platform+Sdk branches visible --
+			#   + flatpak remote-ls --system --columns=ref
+			#   ##[error]The runner has received a shutdown signal.
+			#
+			# so the listing never printed and the question stayed open. I had
+			# written that every probe was `|| true` and so could not become
+			# the failure; `|| true` guards a non-zero exit, not a probe that
+			# takes long enough to lose the runner. A diagnostic on an error
+			# path has to be cheap or it replaces one unanswered failure with
+			# another.
+			#
+			# remote-info names a single ref and answers the actual question in
+			# one round trip: present means the runtime IS reachable and the
+			# failure is resolution or ordering; absent means the branch is not
+			# published on that remote. Bounded, and per-remote so the answer
+			# says WHICH remote was asked.
+			echo "-- is the required runtime on each remote? --"
+			for _remote in flathub tuna-os; do
+				for _rt in org.gnome.Platform//50 org.gnome.Platform//49; do
+					printf "     %-10s %-28s " "${_remote}" "${_rt}"
+					if timeout 60 flatpak remote-info --system "${_remote}" "${_rt}" \
+						>/dev/null 2>&1; then
+						echo "PRESENT"
+					else
+						echo "absent (or remote unreachable)"
+					fi
+				done
+			done
 			echo "-- what the app asks for --"
-			flatpak remote-info --system installer-local "${INSTALLER_APP}" 2>&1 |
+			timeout 60 flatpak remote-info --system installer-local "${INSTALLER_APP}" 2>&1 |
 				grep -iE "runtime|sdk|branch" | sed "s/^/     /" || true
 
 			[[ -f "${SCRIPT_DIR}/.enable-sshd" ]] &&

--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -520,10 +520,43 @@ if [[ -n "${INSTALLER_APP}" ]]; then
 		flatpak build-import-bundle "${INSTALLER_LOCAL_REPO}" "${INSTALLER_FLATPAK_FILE}"
 		rm -f "${INSTALLER_FLATPAK_FILE}"
 		flatpak remote-add --system --no-gpg-verify installer-local "file://${INSTALLER_LOCAL_REPO}"
-		timeout 900 flatpak install --system --noninteractive installer-local "${INSTALLER_APP}" ||
-			{ [[ -f "${SCRIPT_DIR}/.enable-sshd" ]] &&
+		# On failure, say WHAT THE REMOTES ACTUALLY OFFER. The error flatpak
+		# prints names only what was wanted:
+		#
+		#   error: The application org.bootcinstaller.Installer/x86_64/master
+		#   requires the runtime org.gnome.Platform/x86_64/50 which was not found
+		#
+		# which reads as "flathub is missing" and is not necessarily that. The
+		# flathub remote-add immediately above SUCCEEDED in the run that
+		# produced this message.
+		#
+		# skipjack-gnome failed exactly this way in Live ISOs run 32725309736
+		# while yellowfin-gnome installed the same app successfully in
+		# installer-smoke run 32704425971 an hour earlier. So the runtime is
+		# reachable from some bases and not others, and this message cannot
+		# tell those apart. Listing the Platform branches each remote actually
+		# carries is what separates "no flathub" from "flathub without //50"
+		# from "the app wants a branch nobody publishes yet".
+		#
+		# Diagnostic only, and only on the failure path: it costs nothing when
+		# the install works, and every probe is `|| true` so the diagnostic
+		# cannot itself become the failure.
+		if ! timeout 900 flatpak install --system --noninteractive installer-local "${INSTALLER_APP}"; then
+			echo "---- installer flatpak install FAILED; what the remotes offer:"
+			echo "-- configured remotes --"
+			flatpak remotes --system --columns=name,url 2>&1 | sed "s/^/     /" || true
+			echo "-- org.gnome/org.kde Platform+Sdk branches visible --"
+			flatpak remote-ls --system --columns=ref 2>/dev/null |
+				grep -E "org\.(gnome|kde)\.(Platform|Sdk)" | sed "s/^/     /" ||
+				echo "     (none, or remote-ls could not reach a remote)"
+			echo "-- what the app asks for --"
+			flatpak remote-info --system installer-local "${INSTALLER_APP}" 2>&1 |
+				grep -iE "runtime|sdk|branch" | sed "s/^/     /" || true
+
+			[[ -f "${SCRIPT_DIR}/.enable-sshd" ]] &&
 				echo "WARN: installer flatpak install failed; continuing (dev/e2e ISO)" ||
-				exit 1; }
+				exit 1
+		fi
 		flatpak remote-delete --system --force installer-local || true
 		rm -rf "${INSTALLER_LOCAL_REPO}"
 

--- a/live-iso/common/src/desktop-cosmic.sh
+++ b/live-iso/common/src/desktop-cosmic.sh
@@ -12,6 +12,34 @@ set -euo pipefail
 
 # greetd autologin: drop straight into a COSMIC session without prompting.
 mkdir -p /etc/greetd
+# WHY systemd-cat WRAPS EVERY SESSION COMMAND HERE
+#
+# greetd runs `command` and captures nothing. When the session exits
+# immediately, the journal records the bookkeeping and not one line from the
+# process that died:
+#
+#   greetd[1240]: pam_unix(greetd:session): session opened for user liveuser
+#   greetd[1981]: pam_unix(greetd-greeter:session): session closed for user liveuser
+#   greetd[1231]: error: check_children: greeter exited without creating a session
+#
+# repeated five times to start-limit-hit (smoke run 32681262659, xfce). That
+# message names greetd's bookkeeping, never the compositor's reason, and it
+# is the entire evidence base on which this failure has been attributed to a
+# missing DRM render node. The same run disproves that attribution: the guest
+# has /dev/dri/renderD128, and the kernel reports
+#
+#   [drm] pci: virtio-vga detected at 0000:00:02.0
+#   [drm] features: -virgl +edid -resource_blob -host_visible
+#
+# so the node is there and 3D is not, which is a different claim needing
+# different evidence.
+#
+# systemd-cat execs the program with stdout and stderr on the journal and
+# passes the exit status through, so `journalctl -t tunaos-live-session` now
+# holds whatever the compositor said on its way out. Nothing about what runs
+# changes. This is the same remedy that ended four wrong guesses at
+# gnome-desktop:languages in the package factory -- make the failing thing
+# print its own log, then read it.
 tee /etc/greetd/config.toml <<'GREETDEOF'
 [terminal]
 vt = 1
@@ -22,11 +50,11 @@ vt = 1
 # reject the whole config, falling back to the image's greeter.
 [initial_session]
 user = "liveuser"
-command = "cosmic-session"
+command = "systemd-cat -t tunaos-live-session cosmic-session"
 
 [default_session]
 user = "liveuser"
-command = "cosmic-session"
+command = "systemd-cat -t tunaos-live-session cosmic-session"
 GREETDEOF
 
 # Ensure greetd actually runs on boot: enable the service and make

--- a/live-iso/common/src/desktop-niri.sh
+++ b/live-iso/common/src/desktop-niri.sh
@@ -16,17 +16,45 @@ set -euo pipefail
 mkdir -p /etc/greetd
 
 if command -v dms-greeter &>/dev/null; then
+	# WHY systemd-cat WRAPS EVERY SESSION COMMAND HERE
+	#
+	# greetd runs `command` and captures nothing. When the session exits
+	# immediately, the journal records the bookkeeping and not one line from the
+	# process that died:
+	#
+	#   greetd[1240]: pam_unix(greetd:session): session opened for user liveuser
+	#   greetd[1981]: pam_unix(greetd-greeter:session): session closed for user liveuser
+	#   greetd[1231]: error: check_children: greeter exited without creating a session
+	#
+	# repeated five times to start-limit-hit (smoke run 32681262659, xfce). That
+	# message names greetd's bookkeeping, never the compositor's reason, and it
+	# is the entire evidence base on which this failure has been attributed to a
+	# missing DRM render node. The same run disproves that attribution: the guest
+	# has /dev/dri/renderD128, and the kernel reports
+	#
+	#   [drm] pci: virtio-vga detected at 0000:00:02.0
+	#   [drm] features: -virgl +edid -resource_blob -host_visible
+	#
+	# so the node is there and 3D is not, which is a different claim needing
+	# different evidence.
+	#
+	# systemd-cat execs the program with stdout and stderr on the journal and
+	# passes the exit status through, so `journalctl -t tunaos-live-session` now
+	# holds whatever the compositor said on its way out. Nothing about what runs
+	# changes. This is the same remedy that ended four wrong guesses at
+	# gnome-desktop:languages in the package factory -- make the failing thing
+	# print its own log, then read it.
 	tee /etc/greetd/config.toml <<'GREETDEOF'
 [terminal]
 vt = 1
 
 [initial_session]
 user = "liveuser"
-command = "niri-session"
+command = "systemd-cat -t tunaos-live-session niri-session"
 
 [default_session]
 user = "liveuser"
-command = "niri-session"
+command = "systemd-cat -t tunaos-live-session niri-session"
 GREETDEOF
 else
 	tee /etc/greetd/config.toml <<'GREETDEOF'
@@ -35,11 +63,11 @@ vt = 1
 
 [initial_session]
 user = "liveuser"
-command = "niri-session"
+command = "systemd-cat -t tunaos-live-session niri-session"
 
 [default_session]
 user = "liveuser"
-command = "niri-session"
+command = "systemd-cat -t tunaos-live-session niri-session"
 GREETDEOF
 fi
 

--- a/live-iso/common/src/desktop-xfce.sh
+++ b/live-iso/common/src/desktop-xfce.sh
@@ -46,17 +46,45 @@ if [[ -n "${_xfce_compositor}" ]] && command -v greetd &>/dev/null; then
 	# message bus (portals, xfconf) the way a DM login would.
 	echo "desktop-xfce: wayland session via compositor=${_xfce_compositor}"
 	mkdir -p /etc/greetd
+	# WHY systemd-cat WRAPS EVERY SESSION COMMAND HERE
+	#
+	# greetd runs `command` and captures nothing. When the session exits
+	# immediately, the journal records the bookkeeping and not one line from the
+	# process that died:
+	#
+	#   greetd[1240]: pam_unix(greetd:session): session opened for user liveuser
+	#   greetd[1981]: pam_unix(greetd-greeter:session): session closed for user liveuser
+	#   greetd[1231]: error: check_children: greeter exited without creating a session
+	#
+	# repeated five times to start-limit-hit (smoke run 32681262659, xfce). That
+	# message names greetd's bookkeeping, never the compositor's reason, and it
+	# is the entire evidence base on which this failure has been attributed to a
+	# missing DRM render node. The same run disproves that attribution: the guest
+	# has /dev/dri/renderD128, and the kernel reports
+	#
+	#   [drm] pci: virtio-vga detected at 0000:00:02.0
+	#   [drm] features: -virgl +edid -resource_blob -host_visible
+	#
+	# so the node is there and 3D is not, which is a different claim needing
+	# different evidence.
+	#
+	# systemd-cat execs the program with stdout and stderr on the journal and
+	# passes the exit status through, so `journalctl -t tunaos-live-session` now
+	# holds whatever the compositor said on its way out. Nothing about what runs
+	# changes. This is the same remedy that ended four wrong guesses at
+	# gnome-desktop:languages in the package factory -- make the failing thing
+	# print its own log, then read it.
 	tee /etc/greetd/config.toml <<GREETDEOF
 [terminal]
 vt = 1
 
 [default_session]
 user = "liveuser"
-command = "dbus-run-session startxfce4 --wayland ${_xfce_compositor}"
+command = "systemd-cat -t tunaos-live-session dbus-run-session startxfce4 --wayland ${_xfce_compositor}"
 
 [initial_session]
 user = "liveuser"
-command = "dbus-run-session startxfce4 --wayland ${_xfce_compositor}"
+command = "systemd-cat -t tunaos-live-session dbus-run-session startxfce4 --wayland ${_xfce_compositor}"
 GREETDEOF
 	# Enable greetd + boot to graphical.target (server-oriented EL10 bases
 	# default to multi-user.target, which would land on a console — same

--- a/scripts/build-iso-group.sh
+++ b/scripts/build-iso-group.sh
@@ -206,9 +206,21 @@ chown_back "$ISO_OUT"
 # ── Copy to project root with version/arch in the name ──────────────────────
 # Use the first (default) environment's image to read VERSION_ID + arch — all
 # environments share the same EL base, so any of them gives the same answer.
-VERSION_ID=$(podman run --rm --security-opt label=disable "$FIRST_REF" \
+# --log-driver=k8s-file: the same conmon-without-journald gap
+# build-iso-tacklebox.sh documents at its identical pair of calls
+# (tacklebox#235). The Kubic conmon these jobs install cannot log to the
+# journal, so any container started on the default driver dies with
+# "conmon failed: exit status 1" and exit 126.
+#
+# These two lines run AFTER the ISO is finished, purely to read VERSION_ID
+# and arch for the filename — so without the flag the whole pipeline builds
+# a correct ISO and then throws it away on a metadata lookup. That is
+# exactly what happened to the first grouped ISO ever built successfully:
+# job 97650065786 logged ">>> Tacklebox ISO complete" and TOTAL 13m39.511s,
+# then failed here.
+VERSION_ID=$(podman run --rm --log-driver=k8s-file --security-opt label=disable "$FIRST_REF" \
 	sh -c '. /usr/lib/os-release && echo "${VERSION_ID}"')
-ARCH=$(podman run --rm --security-opt label=disable "$FIRST_REF" uname -m)
+ARCH=$(podman run --rm --log-driver=k8s-file --security-opt label=disable "$FIRST_REF" uname -m)
 
 FINAL_ISO="${REPO_ROOT}/${ISO_BASENAME}-${VERSION_ID}-${ARCH}.iso"
 mv "$ISO_OUT" "$FINAL_ISO"

--- a/scripts/check-package-repo-pins.py
+++ b/scripts/check-package-repo-pins.py
@@ -153,15 +153,43 @@ def collect(doc) -> list[tuple[str, str]]:
     return pins
 
 
-def probe(url: str) -> int:
+def probe(url: str) -> tuple[int, bytes]:
+    """(status, body). The body rides along so content-age needs no re-fetch."""
     req = urllib.request.Request(url, headers=UA, method="GET")
     try:
         with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
-            return resp.status
+            return resp.status, resp.read()
     except urllib.error.HTTPError as e:
-        return e.code
+        return e.code, b""
     except (urllib.error.URLError, OSError):
-        return 0
+        return 0, b""
+
+
+def repomd_content_age_days(body: bytes,
+                            today: datetime.date | None = None) -> int | None:
+    """Age of a repomd.xml's <revision>, when it is an epoch timestamp.
+
+    This is what STALE should mean for a datestamped repo. The hummingbird
+    prefix carries 20251124 in its NAME, but the package factory publishes
+    into that same prefix nightly (r2_path: hummingbird/20251124-$arch), so it
+    is a LIVING repository with a date in its label, not an immutable
+    snapshot. Judging it by the label would cry STALE forever about a repo
+    receiving packages daily -- and a check that cries wolf gets deleted,
+    which is worse than no check. The repomd revision is written at index
+    time; createrepo_c stamps it with the epoch, so its age is the age of the
+    CONTENT. A revision that is not epoch-shaped (some tools write serials)
+    yields None and the caller falls back to the name date, saying so.
+    """
+    import re as _re
+    m = _re.search(rb"<revision>(\d{9,11})</revision>", body)
+    if not m:
+        return None
+    ts = int(m.group(1))
+    try:
+        taken = datetime.datetime.utcfromtimestamp(ts).date()
+    except (OverflowError, OSError, ValueError):
+        return None
+    return ((today or datetime.date.today()) - taken).days
 
 
 def main() -> int:
@@ -188,13 +216,20 @@ def main() -> int:
             print(f"SKIP  {kind:5s} (unresolved repo variable)  {url}")
             skipped += 1
             continue
-        code = probe(url) or probe(url)  # one retry on transport failure
+        code, body = probe(url)
+        if code != 200:
+            code, body = probe(url)  # one retry on transport failure
         if code == 200:
             age = snapshot_age_days(url)
+            basis = "name"
+            if age is not None:
+                content_age = repomd_content_age_days(body)
+                if content_age is not None:
+                    age, basis = content_age, "content"
             if age is None:
                 print(f"ok    {kind:5s} {code}  {url}")
             elif age >= SNAPSHOT_FAIL_DAYS:
-                print(f"STALE {kind:5s} {code}  {url}  ({age}d old)")
+                print(f"STALE {kind:5s} {code}  {url}  ({age}d old, by {basis})")
                 print(f"::error::datestamped snapshot pin is {age} days old "
                       f"(limit {SNAPSHOT_FAIL_DAYS}): {url} — it still "
                       f"resolves, which is why nothing else catches this. "
@@ -206,13 +241,13 @@ def main() -> int:
                 stale += 1
                 failed += 1
             elif age >= SNAPSHOT_WARN_DAYS:
-                print(f"ok    {kind:5s} {code}  {url}  ({age}d old)")
+                print(f"ok    {kind:5s} {code}  {url}  ({age}d old, by {basis})")
                 print(f"::warning::datestamped snapshot pin is {age} days old "
                       f"({url}) — refresh it before it drifts far enough from "
                       f"the base image to break dependency resolution")
                 stale += 1
             else:
-                print(f"ok    {kind:5s} {code}  {url}  ({age}d old)")
+                print(f"ok    {kind:5s} {code}  {url}  ({age}d old, by {basis})")
         else:
             print(f"FAIL  {kind:5s} {code}  {url}")
             print(f"::error::package-repo pin no longer resolves "

--- a/scripts/check-package-repo-pins.py
+++ b/scripts/check-package-repo-pins.py
@@ -27,7 +27,9 @@ silently become a hole.
 
 from __future__ import annotations
 
+import datetime
 import glob
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -47,6 +49,54 @@ def _sub_vars(url: str) -> str:
     for var, val in VARS.items():
         url = url.replace(var, val)
     return url
+
+
+# ---------------------------------------------------------------------------
+# Datestamped snapshot freshness.
+#
+# Resolving is the right property for an immutable snapshot of a STABLE
+# release: it either still exists or it does not. It is the wrong property for
+# a snapshot of a ROLLING distribution, which keeps answering 200 long after it
+# has stopped being a usable base to layer against.
+#
+# hummingbird is exactly that case and is why this exists. Fedora Hummingbird
+# is a rolling release tracking Fedora Rawhide (docs/HUMMINGBIRD.md) — not
+# Fedora 43, whatever the .fc43 dist tags suggest. tunaOS pins two halves of it
+# independently: the base image by digest in build-config.yml, and the package
+# snapshot by datestamp in build_scripts/10-base-packages.sh. Both were
+# coherent when taken. They drift with every upstream roll.
+#
+# The drift does not surface as a pin problem. It surfaces as UNRESOLVABLE
+# DEPENDENCIES inside the layered desktop: on 2026-08-25 the 20251124 snapshot
+# served gtk4 but not the harfbuzz gtk4 requires, so dnf reported gtk4 and 17
+# others as BROKEN rather than missing, --skip-unavailable dropped them, and
+# hummingbird:gnome shipped with 410 packages and no GNOME in it. Every pin in
+# that build resolved. Nothing here was red.
+#
+# So age is checked as well as reachability. Exactly one pin in the manifests
+# carries a datestamp today (measured), so this is precise rather than a broad
+# heuristic looking for something to flag.
+SNAPSHOT_RE = re.compile(r"/[^/]*?(20\d{6})[^/]*/")
+SNAPSHOT_WARN_DAYS = 60
+SNAPSHOT_FAIL_DAYS = 180
+
+
+def snapshot_age_days(url: str, today: datetime.date | None = None) -> int | None:
+    """Age in days of a YYYYMMDD datestamp in the URL path, else None.
+
+    `today` is injectable so the tests do not drift into failing as the
+    calendar moves — a check whose verdict depends on when it runs is a check
+    nobody can reason about.
+    """
+    hit = SNAPSHOT_RE.search(url)
+    if not hit:
+        return None
+    stamp = hit.group(1)
+    try:
+        taken = datetime.date(int(stamp[:4]), int(stamp[4:6]), int(stamp[6:8]))
+    except ValueError:
+        return None  # 20259999 and friends are not datestamps
+    return ((today or datetime.date.today()) - taken).days
 
 
 def collect(doc) -> list[tuple[str, str]]:
@@ -131,6 +181,7 @@ def main() -> int:
 
     failed = 0
     skipped = 0
+    stale = 0
     for url in sorted(pins):
         kind = pins[url]
         if "$" in url:
@@ -139,7 +190,29 @@ def main() -> int:
             continue
         code = probe(url) or probe(url)  # one retry on transport failure
         if code == 200:
-            print(f"ok    {kind:5s} {code}  {url}")
+            age = snapshot_age_days(url)
+            if age is None:
+                print(f"ok    {kind:5s} {code}  {url}")
+            elif age >= SNAPSHOT_FAIL_DAYS:
+                print(f"STALE {kind:5s} {code}  {url}  ({age}d old)")
+                print(f"::error::datestamped snapshot pin is {age} days old "
+                      f"(limit {SNAPSHOT_FAIL_DAYS}): {url} — it still "
+                      f"resolves, which is why nothing else catches this. "
+                      f"Against a rolling upstream a snapshot this old no "
+                      f"longer satisfies the dependencies of what is layered "
+                      f"on top of it; the symptom is packages skipped for "
+                      f"BROKEN dependencies mid-build, not a 404 here. "
+                      f"See docs/HUMMINGBIRD.md")
+                stale += 1
+                failed += 1
+            elif age >= SNAPSHOT_WARN_DAYS:
+                print(f"ok    {kind:5s} {code}  {url}  ({age}d old)")
+                print(f"::warning::datestamped snapshot pin is {age} days old "
+                      f"({url}) — refresh it before it drifts far enough from "
+                      f"the base image to break dependency resolution")
+                stale += 1
+            else:
+                print(f"ok    {kind:5s} {code}  {url}  ({age}d old)")
         else:
             print(f"FAIL  {kind:5s} {code}  {url}")
             print(f"::error::package-repo pin no longer resolves "
@@ -148,7 +221,8 @@ def main() -> int:
             failed += 1
 
     print(f"\nchecked {len(pins) - skipped} package-repo pin(s), "
-          f"{skipped} skipped; {failed} unresolvable")
+          f"{skipped} skipped; {failed} unresolvable or stale, "
+          f"{stale} datestamped snapshot(s) past {SNAPSHOT_WARN_DAYS}d")
     return 1 if failed else 0
 
 

--- a/scripts/e2e-installer-gui-checks.sh
+++ b/scripts/e2e-installer-gui-checks.sh
@@ -124,11 +124,35 @@ fi
 # ── 3. The installer wrote a readiness stamp ────────────────────────────────
 # "process alive" ≠ "window on screen". Each frontend writes
 # $XDG_RUNTIME_DIR/tuna-installer-ready when its window comes up.
-# Inside the Flatpak sandbox the host sees it at
-# /run/user/<uid>/app/<app-id>/tuna-installer-ready; an unsandboxed run
-# writes to /run/user/<uid>/tuna-installer-ready directly.
+#
+# THE SANDBOX PATH WAS MISSING HERE, AND ONLY HERE. installer-smoke.yml's
+# inline copy of this same check was corrected (3c6cbf0c, "read the stamp
+# where flatpak actually puts it"); this script does the identical job over
+# SSH and was left behind. Two copies of one check, one of them fixed.
+#
+# Inside the sandbox $XDG_RUNTIME_DIR reads as /run/user/<uid>, but that is a
+# BIND MOUNT and the host path differs. Current flatpak backs it with
+#   /run/user/<uid>/.flatpak/<app-id>/xdg-run/
+# The app/<app-id>/ directory still EXISTS -- flatpak creates it -- so its
+# emptiness looked like proof that nothing had been written, which is how this
+# survived.
+#
+# Measured, kde run 32718219267: this script reported
+#   not ok - installer readiness stamp present
+# while the workflow's inline check, on the same guest at the same moment,
+# read the stamp and printed
+#   app_id=org.tunaos.InstallerKde window=ApplicationWindow
+#   signal=frame-swapped page=welcome
+# A frame HAD been swapped and the window WAS on screen. The failure was the
+# lookup, not the installer.
+#
+# All three paths, newest layout first: an unsandboxed run still writes to
+# /run/user/<uid>/ directly, and app/<app-id>/ costs nothing to keep for
+# older flatpak.
 STAMP=""
-for d in /run/user/*/app/"${APP}"/tuna-installer-ready /run/user/*/tuna-installer-ready; do
+for d in /run/user/*/.flatpak/"${APP}"/xdg-run/tuna-installer-ready \
+	/run/user/*/app/"${APP}"/tuna-installer-ready \
+	/run/user/*/tuna-installer-ready; do
 	if [[ -f "$d" ]]; then
 		STAMP=$(cat "$d" 2>/dev/null | head -20)
 		break

--- a/scripts/e2e-installer-gui-checks.sh
+++ b/scripts/e2e-installer-gui-checks.sh
@@ -20,7 +20,36 @@
 # verification steps (tunaOS#678).
 set -uo pipefail
 
-HELPERS="${TEST_LIB_DIR:-$(dirname "$0")}/lib/e2e-assert.sh"
+# `/lib` belongs INSIDE the default, not after the expansion. iso-e2e.sh
+# uploads the helper flat, next to this script:
+#
+#   scp scripts/lib/e2e-assert.sh guest:${GUEST_HOME}/e2e-assert.sh
+#   ssh  TEST_LIB_DIR=${GUEST_HOME} bash ${GUEST_HOME}/e2e-installer-gui-checks.sh
+#
+# so with TEST_LIB_DIR set, `${TEST_LIB_DIR}/lib/e2e-assert.sh` names a
+# directory the guest does not have. This script has therefore NEVER run:
+# smoke run 32681262659 shows every assertion missing, not failing --
+#
+#   /home/liveuser/e2e-installer-gui-checks.sh: line 25:
+#     /home/liveuser/lib/e2e-assert.sh: No such file or directory
+#   /home/liveuser/e2e-installer-gui-checks.sh: line 54: check: command not found
+#   ...
+#   line 159: print_summary: command not found
+#
+# and the harness reported "installer GUI checks reported 127 failure(s)".
+# 127 is bash for command-not-found, not a count of anything. The sibling
+# scripts get this right two different ways (e2e-luks-checks.sh has no /lib
+# at all; e2e-smoke-checks.sh puts it inside the default), which is how the
+# odd one out survived.
+HELPERS="${TEST_LIB_DIR:-$(dirname "$0")/lib}/e2e-assert.sh"
+# A missing helper must be LOUD. Sourcing a file that is not there leaves
+# check() undefined, and every assertion then "passes" by printing nothing to
+# stdout while bash writes command-not-found to stderr -- a gate that examines
+# nothing and reports success is worse than one that fails.
+if [[ ! -r "$HELPERS" ]]; then
+	echo "Bail out! cannot read assertion helpers at ${HELPERS}"
+	exit 99
+fi
 # shellcheck source=scripts/lib/e2e-assert.sh
 source "$HELPERS"
 

--- a/scripts/e2e-luks-checks.sh
+++ b/scripts/e2e-luks-checks.sh
@@ -7,6 +7,14 @@ set -uo pipefail
 
 HELPERS="${TEST_LIB_DIR:-$(dirname "$0")}/e2e-assert.sh"
 # shellcheck source=scripts/lib/e2e-assert.sh
+# A missing helper leaves check() undefined, and every assertion then
+# prints nothing while bash writes command-not-found to stderr. Bail out
+# loudly instead -- see the note in e2e-installer-gui-checks.sh, where
+# exactly that went unnoticed across every smoke run.
+if [[ ! -r "$HELPERS" ]]; then
+	echo "Bail out! cannot read assertion helpers at ${HELPERS}"
+	exit 99
+fi
 source "$HELPERS"
 
 echo "# LUKS/TPM install evidence"

--- a/scripts/e2e-smoke-checks.sh
+++ b/scripts/e2e-smoke-checks.sh
@@ -14,6 +14,14 @@ set -uo pipefail
 
 HELPERS="${TEST_LIB_DIR:-$(dirname "$0")/lib}/e2e-assert.sh"
 # shellcheck source=scripts/lib/e2e-assert.sh
+# A missing helper leaves check() undefined, and every assertion then
+# prints nothing while bash writes command-not-found to stderr. Bail out
+# loudly instead -- see the note in e2e-installer-gui-checks.sh, where
+# exactly that went unnoticed across every smoke run.
+if [[ ! -r "$HELPERS" ]]; then
+	echo "Bail out! cannot read assertion helpers at ${HELPERS}"
+	exit 99
+fi
 source "$HELPERS"
 
 echo "# Live image smoke checks"

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -1146,9 +1146,17 @@ def build() -> str:
     out += desktop_table(matrix, smoke, smoke_key)
     out += [
         "",
-        "cosmic, niri, xfwl4 and kde all need a DRM render node; a ❌ for those on "
-        "hosted CI may be a harness limitation rather than a product failure. "
-        "See *Known systemic gaps*.",
+        # NOT "they need a DRM render node". Run 32681262659 read /dev/dri from
+        # inside the guest and found renderD128 present with `[drm] features:
+        # -virgl` -- a node without 3D. gnome starts on that same hardware
+        # through Mesa's software path. Why the other four do not is open, so
+        # this line states the symptom and points at the section that carries
+        # the evidence, rather than restating a cause the measurement did not
+        # support.
+        "cosmic, niri, xfwl4 and kde do not bring a session up on hosted CI. The "
+        "cause is undiagnosed rather than established -- gnome starts on the "
+        "same guest, which has a render node but no 3D. See *Known systemic "
+        "gaps*.",
         "",
     ]
 

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -1153,10 +1153,12 @@ def build() -> str:
         # this line states the symptom and points at the section that carries
         # the evidence, rather than restating a cause the measurement did not
         # support.
-        "cosmic, niri, xfwl4 and kde do not bring a session up on hosted CI. The "
-        "cause is undiagnosed rather than established -- gnome starts on the "
-        "same guest, which has a render node but no 3D. See *Known systemic "
-        "gaps*.",
+        (
+            "cosmic, niri, xfwl4 and kde do not bring a session up on hosted CI. The "
+            + "cause is undiagnosed rather than established -- gnome starts on the "
+            + "same guest, which has a render node but no 3D. See *Known systemic "
+            + "gaps*."
+        ),
         "",
     ]
 

--- a/scripts/installer-walkthrough.py
+++ b/scripts/installer-walkthrough.py
@@ -617,12 +617,17 @@ if have_ocr and not any(reached.values()) and rendered > 0:
 #
 #     window=ApplicationWindow signal=frame-swapped page=welcome
 #
-# A frame had been swapped and the app was on its welcome page. Its heading is
-# "Install " + productName and its primary button is "Next"
-# (tuna-installer-kde modules/welcome/contents/ui/main.qml:39,
-# src/qml/Wizard.qml:290), so not one of the welcome keywords appeared on it.
-# Six red lines and a diagnosis pointing at autostart, OOM-kills and missing GL
-# paths, for a frontend that was working.
+# A frame had been swapped and the app was on its welcome page. Six red lines
+# and a diagnosis pointing at autostart, OOM-kills and missing GL paths, for a
+# frontend that was working.
+#
+# The first reading of that -- "KDE's welcome page contains none of the spec's
+# keywords" -- was true of the PAGE and false of the SCREEN: the wizard draws
+# the step name "Welcome" as a 1.6x heading above it (tuna-installer-kde
+# src/qml/Wizard.qml:46,185). So the word was up there and the match still did
+# not happen, and the cause is not yet known. Which is the argument for this
+# block: it is cheaper to print what the OCR read than to keep proposing
+# explanations for a screen nobody has read the text of.
 #
 # Printing the text settles it without downloading an artifact: text present
 # and unmatched is a spec gap, text absent everywhere is a rendering or OCR

--- a/scripts/installer-walkthrough.py
+++ b/scripts/installer-walkthrough.py
@@ -257,12 +257,111 @@ def changed_pixels(a, b):
     return int(m.group(1)) if m else 0
 
 
+# How the OCR pass is chosen, and why there is more than one.
+#
+# kde run 32735883406 read this off four distinct visual states:
+#
+#     state 0: 1 ft
+#     state 1: hm
+#     state 2: i]
+#     state 3: lm
+#
+# Nine frames above the blank threshold, four distinct states, and a readiness
+# stamp from the same guest saying `signal=frame-swapped page=welcome` -- the
+# wizard was on screen and tesseract got two characters of noise off it. The
+# spec keywords were never the problem; the pixels never became words.
+#
+# `--psm 6` is "assume a single uniform block of text". A desktop screenshot is
+# not that: it is a window of sparse headings and buttons on a background, and
+# psm 6 will happily return line noise rather than fail. Nothing downstream can
+# tell that apart from a screen with no text on it, which is how "no installer
+# screen was ever detected" survived as a diagnosis.
+#
+# So: score the result, and if it is not words, try the other readings before
+# giving up --
+#   * --psm 11 (sparse text), the segmentation a desktop actually needs;
+#   * the same two against a negated copy, because tesseract wants dark ink on
+#     light paper and a dark-themed frontend is the exact inverse. gnome's
+#     Adwaita default is light and gnome is the flavor that has always scored;
+#     that asymmetry is worth ruling in or out rather than assuming.
+#
+# The winning variant is recorded and reported. If plain psm 6 keeps winning,
+# this costs one extra process on frames that were unreadable anyway; if a
+# negated pass starts winning, that IS the finding.
+MIN_WORD_CHARS = 8
+
+def _text_score(text):
+    """Alphabetic characters in words of 3+ letters.
+
+    Deliberately not len(text): "1 ft\nhm\ni]" is 9 characters and zero
+    words, and treating it as content is what made an unreadable screen look
+    like a vocabulary mismatch."""
+    return sum(len(w) for w in re.findall(r"[a-z]{3,}", text.lower()))
+
+
+def readable(text):
+    """Whether OCR output is words rather than noise."""
+    return _text_score(text or "") >= MIN_WORD_CHARS
+
+
+_ocr_variant = {}
+
+
+def _tesseract(png, psm):
+    r = subprocess.run(["tesseract", png, "stdout", "--psm", psm],
+                       capture_output=True, text=True)
+    return (r.stdout or "").lower()
+
+
 def ocr(png):
     if not shutil.which("tesseract"):
         return None
-    r = subprocess.run(["tesseract", png, "stdout", "--psm", "6"],
-                       capture_output=True, text=True)
-    return (r.stdout or "").lower()
+
+    best, best_name = _tesseract(png, "6"), "psm6"
+    if readable(best):
+        _ocr_variant[png] = best_name
+        return best
+
+    candidates = [(_tesseract(png, "11"), "psm11")]
+
+    # A negated copy, for a light-on-dark frontend. Skipped rather than
+    # failed if ImageMagick is missing -- this is a fallback, not a
+    # dependency.
+    if _im_convert is not None:
+        neg = png + ".neg.png"
+        try:
+            subprocess.run(_im_convert + [png, "-negate", neg],
+                           check=False, capture_output=True)
+            if os.path.exists(neg):
+                candidates.append((_tesseract(neg, "6"), "psm6-negated"))
+                candidates.append((_tesseract(neg, "11"), "psm11-negated"))
+        finally:
+            if os.path.exists(neg):
+                os.unlink(neg)
+
+    for text, name in candidates:
+        if _text_score(text) > _text_score(best):
+            best, best_name = text, name
+
+    _ocr_variant[png] = best_name
+    return best
+
+
+def png_geometry(path):
+    """(width, height) from the PNG IHDR, or None.
+
+    Read here rather than shelled out to `identify`: a frame too small for its
+    glyphs to survive is one of the readings of an unreadable screen, and it
+    would be absurd to spawn a process to learn it."""
+    try:
+        with open(path, "rb") as f:
+            head = f.read(24)
+        if head[:8] != b"\x89PNG\r\n\x1a\n" or head[12:16] != b"IHDR":
+            return None
+        return (int.from_bytes(head[16:20], "big"),
+                int.from_bytes(head[20:24], "big"))
+    except OSError:
+        return None
 
 
 def load_spec(path):
@@ -646,19 +745,33 @@ if have_ocr and _missing_required:
         _seen.setdefault(state_of[_i], "")
         if not _seen[state_of[_i]]:
             _seen[state_of[_i]] = " ".join(_t.split())
-    if any(_seen.values()):
-        print("  # what the OCR actually read, per visual state "
-              f"(missing required: {', '.join(_missing_required)}):", flush=True)
-        for _s in sorted(_seen):
-            print(f"  #   state {_s}: {_seen[_s] or '(no text)'}"[:220], flush=True)
-        print("  # If the installer's own words are up there, this is cause 6: "
-              "the spec's keywords do not describe this frontend's screens. Fix "
+    print("  # what the OCR actually read, per visual state "
+          f"(missing required: {', '.join(_missing_required)}):", flush=True)
+    for _s in sorted(_seen):
+        print(f"  #   state {_s}: {_seen[_s] or '(no text)'}"[:220], flush=True)
+
+    # The first version of this block asked `if any(_seen.values())` and, on
+    # kde run 32735883406, printed "1 ft / hm / i] / lm" under a heading
+    # inviting the reader to fix the keyword list. Nine non-blank frames of
+    # line noise are not a vocabulary problem, and a truthiness test cannot
+    # say so. Score it instead.
+    if any(readable(t) for t in _seen.values()):
+        print("  # Those are words, so this is cause 6: the spec's keywords do "
+              "not describe this frontend's screens. Fix "
               "tests/installer-screens.yaml against the frontend's source "
               "strings -- not the frontend against the spec.", flush=True)
     else:
-        print("  # the OCR read NO text on any frame. That rules out a keyword "
-              "gap and puts causes 3-5 first: the pixels are not letters.",
-              flush=True)
+        _variants = sorted({v for v in _ocr_variant.values()})
+        _geo = png_geometry(frames[0]) if frames else None
+        print("  # Those are NOT words. Every OCR reading came back as noise, "
+              "so this is not a keyword gap -- the pixels never became text. "
+              f"Frame geometry {(_geo or ('?', '?'))[0]}x{(_geo or ('?', '?'))[1]}; "
+              f"best pass per frame: {', '.join(_variants) or 'none'}.\n"
+              "  # If a *-negated pass won anywhere, the frontend is drawing "
+              "light text on a dark ground and tesseract wants the inverse. If "
+              "psm6 won everywhere and still returned noise, the glyphs are "
+              "too small or too soft at this resolution -- raise the guest "
+              "framebuffer rather than widening the spec.", flush=True)
 
 # ── Result for the parity matrix ─────────────────────────────────────────
 summary = {

--- a/scripts/installer-walkthrough.py
+++ b/scripts/installer-walkthrough.py
@@ -604,6 +604,57 @@ if have_ocr and not any(reached.values()) and rendered > 0:
           f"the app merely pinned to a dock or launcher is case 1, not a UI bug.",
           flush=True)
 
+# ── What the OCR actually read ───────────────────────────────────────────
+# The five causes above share an assumption that is false often enough to cost
+# whole rounds: that a screen which matched nothing was not the installer.
+# There is a sixth cause, and on kde it is the true one --
+#
+#     the installer WAS on screen, and no keyword in the spec describes what
+#     it says.
+#
+# kde run 32718219267 reported "no installer screen was ever detected" while
+# the readiness stamp written by that same process, in that same guest, read
+#
+#     window=ApplicationWindow signal=frame-swapped page=welcome
+#
+# A frame had been swapped and the app was on its welcome page. Its heading is
+# "Install " + productName and its primary button is "Next"
+# (tuna-installer-kde modules/welcome/contents/ui/main.qml:39,
+# src/qml/Wizard.qml:290), so not one of the welcome keywords appeared on it.
+# Six red lines and a diagnosis pointing at autostart, OOM-kills and missing GL
+# paths, for a frontend that was working.
+#
+# Printing the text settles it without downloading an artifact: text present
+# and unmatched is a spec gap, text absent everywhere is a rendering or OCR
+# failure, and those want opposite fixes.
+#
+# Gated on a MISSING REQUIRED SCREEN rather than on "nothing matched at all",
+# because the partial case is the one this run will produce next: with the
+# welcome keyword fixed, kde is expected to credit welcome and still miss the
+# later screens, and that is exactly when someone needs to see the words on
+# the page. Silent on a fully green leg; printed on every leg that fails.
+_missing_required = [sc["id"] for sc in spec
+                     if sc.get("required", False) and not reached.get(sc["id"])]
+if have_ocr and _missing_required:
+    _seen = {}
+    for _i, _t in enumerate(frame_text):
+        _seen.setdefault(state_of[_i], "")
+        if not _seen[state_of[_i]]:
+            _seen[state_of[_i]] = " ".join(_t.split())
+    if any(_seen.values()):
+        print("  # what the OCR actually read, per visual state "
+              f"(missing required: {', '.join(_missing_required)}):", flush=True)
+        for _s in sorted(_seen):
+            print(f"  #   state {_s}: {_seen[_s] or '(no text)'}"[:220], flush=True)
+        print("  # If the installer's own words are up there, this is cause 6: "
+              "the spec's keywords do not describe this frontend's screens. Fix "
+              "tests/installer-screens.yaml against the frontend's source "
+              "strings -- not the frontend against the spec.", flush=True)
+    else:
+        print("  # the OCR read NO text on any frame. That rules out a keyword "
+              "gap and puts causes 3-5 first: the pixels are not letters.",
+              flush=True)
+
 # ── Result for the parity matrix ─────────────────────────────────────────
 summary = {
     "flavor": flavor,

--- a/scripts/installer-walkthrough.py
+++ b/scripts/installer-walkthrough.py
@@ -305,6 +305,13 @@ def readable(text):
 
 
 _ocr_variant = {}
+# {frame: {pass_name: score}} -- every reading, not only the winner. The first
+# version recorded the winner alone, and reported "best pass per frame: psm6"
+# on kde run 32747410944 where in fact ALL FOUR passes scored zero. `>` is
+# strictly greater, so a four-way tie leaves psm6 holding the title it started
+# with, and the printed hint then read that as evidence FOR psm6 -- an
+# argument from a tie. The scores say what the winner cannot.
+_ocr_scores = {}
 
 
 def _tesseract(png, psm):
@@ -318,6 +325,7 @@ def ocr(png):
         return None
 
     best, best_name = _tesseract(png, "6"), "psm6"
+    _ocr_scores[png] = {"psm6": _text_score(best)}
     if readable(best):
         _ocr_variant[png] = best_name
         return best
@@ -340,6 +348,7 @@ def ocr(png):
                 os.unlink(neg)
 
     for text, name in candidates:
+        _ocr_scores[png][name] = _text_score(text)
         if _text_score(text) > _text_score(best):
             best, best_name = text, name
 
@@ -720,13 +729,15 @@ if have_ocr and not any(reached.values()) and rendered > 0:
 # and a diagnosis pointing at autostart, OOM-kills and missing GL paths, for a
 # frontend that was working.
 #
-# The first reading of that -- "KDE's welcome page contains none of the spec's
-# keywords" -- was true of the PAGE and false of the SCREEN: the wizard draws
-# the step name "Welcome" as a 1.6x heading above it (tuna-installer-kde
-# src/qml/Wizard.qml:46,185). So the word was up there and the match still did
-# not happen, and the cause is not yet known. Which is the argument for this
-# block: it is cheaper to print what the OCR read than to keep proposing
-# explanations for a screen nobody has read the text of.
+# I then "corrected" that to say the wizard draws the step name "Welcome"
+# above the page (Wizard.qml:46,185) and so the word WAS on screen. The
+# published capture shows it is not: the welcome step reads "Install
+# Yellowfin", then the wizard prose, then "Next". Reading the QML told me what
+# should render; the picture told me what did.
+#
+# Which is the argument for this block. Two rounds went into explaining a
+# screen nobody had looked at, and both explanations came from source code.
+# Printing what the OCR read is cheaper than either.
 #
 # Printing the text settles it without downloading an artifact: text present
 # and unmatched is a spec gap, text absent everywhere is a rendering or OCR
@@ -761,17 +772,27 @@ if have_ocr and _missing_required:
               "tests/installer-screens.yaml against the frontend's source "
               "strings -- not the frontend against the spec.", flush=True)
     else:
-        _variants = sorted({v for v in _ocr_variant.values()})
         _geo = png_geometry(frames[0]) if frames else None
+        _w, _h = _geo or ("?", "?")
+        # Best score each pass reached on ANY frame. Reporting the winner
+        # alone cannot distinguish "psm6 read the most" from "nothing read
+        # anything and psm6 kept the tie", and those are different findings.
+        _totals = {}
+        for _scores in _ocr_scores.values():
+            for _name, _score in _scores.items():
+                _totals[_name] = max(_totals.get(_name, 0), _score)
+        _table = ", ".join(f"{_n}={_v}" for _n, _v in sorted(_totals.items()))
         print("  # Those are NOT words. Every OCR reading came back as noise, "
-              "so this is not a keyword gap -- the pixels never became text. "
-              f"Frame geometry {(_geo or ('?', '?'))[0]}x{(_geo or ('?', '?'))[1]}; "
-              f"best pass per frame: {', '.join(_variants) or 'none'}.\n"
-              "  # If a *-negated pass won anywhere, the frontend is drawing "
-              "light text on a dark ground and tesseract wants the inverse. If "
-              "psm6 won everywhere and still returned noise, the glyphs are "
-              "too small or too soft at this resolution -- raise the guest "
-              "framebuffer rather than widening the spec.", flush=True)
+              "so this is not a keyword gap -- the pixels never became text.\n"
+              f"  # Frame geometry {_w}x{_h}. Best word-score any frame reached, "
+              f"per pass: {_table or 'none'} (readable needs "
+              f"{MIN_WORD_CHARS}).\n"
+              "  # A *-negated pass scoring HIGHER means the frontend draws "
+              "light text on a dark ground and tesseract wants the inverse. "
+              "All passes at or near zero means no segmentation helped, and "
+              "the next question is the frame itself, not the spec -- pull the "
+              "published capture and look at it before changing anything.",
+              flush=True)
 
 # ── Result for the parity matrix ─────────────────────────────────────────
 summary = {

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -1474,6 +1474,39 @@ check_ssh() {
 	return 5
 }
 
+# A gate that DID NOT RUN is not a gate that found problems, and only one of
+# those two is tolerable in non-strict mode.
+#
+# e2e-installer-gui-checks.sh resolved its assertion helpers to a path the
+# guest does not have, so `source` failed, `check` was never defined, and
+# every assertion evaporated into command-not-found on stderr. The script
+# exited 127 -- bash for command-not-found -- and this harness printed
+#
+#   ::warning::installer GUI checks reported 127 failure(s) for gnome
+#
+# as a WARNING, in a mode that tolerates warnings. So the compositor and
+# installer-frontend assertions have never once executed, on any flavor, in
+# any smoke run, and the workflow stayed green through it (run 32681262659).
+#
+# The discriminator is the TAP summary. print_summary is the only thing that
+# emits `# Results:`, and it is the last statement of every check script, so
+# its ABSENCE means the script did not reach the end -- whatever the exit
+# code says. Missing summary is a hard failure in every mode; E2E_*_STRICT
+# governs failed assertions, not an absent gate.
+checks_ran() {
+	local output="$1" rc="$2" label="$3"
+	if [[ "$output" == *"# Results:"* ]]; then
+		return 0
+	fi
+	echo "ERROR: ${label} checks did not run to completion (exit ${rc}); no TAP summary was emitted." >&2
+	echo "  This is NOT a count of failed assertions -- the script did not finish," >&2
+	echo "  so nothing it claims to verify was verified. Strict mode does not apply." >&2
+	if [[ "$output" == *"Bail out!"* ]]; then
+		echo "$output" | grep "Bail out!" | sed "s/^/  /" >&2
+	fi
+	return 1
+}
+
 # Upload and run the TAP-style live-image smoke checks (assertions adapted
 # from frostyard/snosi's tiered on-VM test scripts) over SSH. Non-fatal by
 # default — the TAP output is CI evidence; set E2E_SMOKE_STRICT=1 to turn
@@ -1493,6 +1526,7 @@ run_smoke_checks() {
 	local smoke_output smoke_rc=0
 	smoke_output=$("${ssh_cmd[@]}" "TEST_LIB_DIR=${GUEST_HOME} bash ${GUEST_HOME}/e2e-smoke-checks.sh" 2>&1) || smoke_rc=$?
 	echo "$smoke_output" | tee -a "${SERIAL_LOG}"
+	checks_ran "$smoke_output" "$smoke_rc" "live-image smoke" || return 1
 	if [[ "$smoke_rc" -ne 0 ]]; then
 		echo "::warning::live-image smoke checks reported ${smoke_rc} failure(s)"
 		if [[ "${E2E_SMOKE_STRICT:-0}" -eq 1 ]]; then
@@ -1520,6 +1554,7 @@ run_installer_gui_checks() {
 	local gui_output gui_rc=0
 	gui_output=$("${ssh_cmd[@]}" "FLAVOR=${FLAVOR:-gnome} TEST_LIB_DIR=${GUEST_HOME} bash ${GUEST_HOME}/e2e-installer-gui-checks.sh" 2>&1) || gui_rc=$?
 	echo "$gui_output" | tee -a "${SERIAL_LOG}"
+	checks_ran "$gui_output" "$gui_rc" "installer GUI" || return 1
 	if [[ "$gui_rc" -ne 0 ]]; then
 		echo "::warning::installer GUI checks reported ${gui_rc} failure(s) for ${FLAVOR:-gnome}"
 		if [[ "${E2E_INSTALLER_GUI_STRICT:-0}" -eq 1 ]]; then

--- a/system_files_overrides/hummingbird/usr/lib/bootc/install/50-hummingbird.toml
+++ b/system_files_overrides/hummingbird/usr/lib/bootc/install/50-hummingbird.toml
@@ -1,0 +1,26 @@
+# hummingbird: install the root filesystem as ext4, not the xfs default.
+#
+# Sorts after 00-tunaos.toml, which sets type = "xfs" and says per-variant
+# overrides belong in exactly this kind of drop-in.
+#
+# Why hummingbird needs it: its base probes BACKEND=ostree SEALED=0, so the
+# qcow2/Gate path does not pass --filesystem ext4 (that is reserved for
+# composefs-sealed images), and it lands on the xfs default. Then:
+#
+#   Creating root filesystem (xfs) on device /dev/loop0p3
+#   Bootloader: grub
+#   /usr/sbin/grub2-install: error: ../grub-core/kern/fs.c:123:unknown filesystem.
+#   error: Installing to disk: Installing bootloader: Failed to run
+#     command: bootupctl backend install
+#
+# BIOS grub2-install cannot read the xfs this base's mkfs.xfs writes. That
+# is NOT a legacy-boot-only problem: bootupctl installs the BIOS component
+# unconditionally on the hybrid layout, and its failure aborts the entire
+# `bootc install to-disk`, so UEFI laptops fail identically.
+#
+# This file is what makes a real install work. The TUNAOS_QCOW2_FILESYSTEM
+# knob in just/qcow2-build.just only fixes the CI gate's own qcow2; an ISO
+# install reads this config from inside the image, so without this drop-in a
+# green gate would still hand users an installer that cannot finish.
+[install.filesystem.root]
+type = "ext4"

--- a/system_files_overrides/hummingbird/usr/lib/bootc/install/50-hummingbird.toml
+++ b/system_files_overrides/hummingbird/usr/lib/bootc/install/50-hummingbird.toml
@@ -13,14 +13,24 @@
 #   error: Installing to disk: Installing bootloader: Failed to run
 #     command: bootupctl backend install
 #
-# BIOS grub2-install cannot read the xfs this base's mkfs.xfs writes. That
-# is NOT a legacy-boot-only problem: bootupctl installs the BIOS component
-# unconditionally on the hybrid layout, and its failure aborts the entire
-# `bootc install to-disk`, so UEFI laptops fail identically.
+# BIOS grub2-install cannot read the xfs this base's mkfs.xfs writes, and
+# bootupctl installs the BIOS component unconditionally, so the failure
+# aborts the entire `bootc install to-disk` rather than just its legacy
+# half.
 #
-# This file is what makes a real install work. The TUNAOS_QCOW2_FILESYSTEM
-# knob in just/qcow2-build.just only fixes the CI gate's own qcow2; an ISO
-# install reads this config from inside the image, so without this drop-in a
-# green gate would still hand users an installer that cannot finish.
+# SCOPE, corrected after checking the installer instead of assuming it:
+# this file fixes `bootc install to-disk`, which is the path the Gate's
+# qcow2 takes. It is NOT what makes an ISO install to a laptop work. An
+# ISO install runs fisherman, which always lays down a 3-partition GPT
+# with a SEPARATE ext4 /boot precisely because GRUB cannot read modern XFS
+# (bootc-installer CLAUDE.md: "the separate ext4 /boot is
+# non-negotiable"). GRUB there reads its files from ext4 /boot, never from
+# the xfs root, so that path does not hit this failure at all.
+#
+# It still matters for the goal, just one step removed: Promote is gated
+# on the Gate, the Gate runs `bootc install to-disk`, and until it passes
+# hummingbird:gnome is never published — so no ISO can be built from it.
+# This unblocks publishing. Whether a hummingbird ISO then installs
+# cleanly is a separate question that nothing has measured yet.
 [install.filesystem.root]
 type = "ext4"

--- a/tests/bats/test_build_iso_group.bats
+++ b/tests/bats/test_build_iso_group.bats
@@ -69,10 +69,29 @@ setup() {
 
 # ── Config shape ────────────────────────────────────────────────────────────
 
-@test "config: iso_groups defines flagship, community" {
+# One group per desktop, each embedding its own NVIDIA and HWE flavors.
+# Previously two groups: the gnome flagship plus a `community` group that
+# packed KDE, COSMIC, Niri and XFCE into ONE unpublished ISO.
+@test "config: iso_groups defines one group per desktop" {
   json="$(yq -o=json '.' "$CONFIG")"
   suffixes="$(echo "$json" | jq -r '[.iso_groups[].suffix // ""] | sort | join(",")')"
-  [ "$suffixes" = ",community" ]
+  [ "$suffixes" = ",cosmic,kde,niri,xfce" ]
+}
+
+@test "config: no iso_group packs more than one desktop" {
+  json="$(yq -o=json '.' "$CONFIG")"
+  # The flagship group's suffix is "" and it is the gnome one.
+  while read -r line; do
+    [ -z "$line" ] && continue
+    suffix="${line%%|*}"
+    flavor="${line#*|}"
+    desktop="${suffix:-gnome}"
+    [ "${flavor%%-*}" = "$desktop" ] || {
+      echo "group '$desktop' names '$flavor' from another desktop" >&2
+      return 1
+    }
+  done < <(echo "$json" | jq -r '.iso_groups[] | (.suffix // "") as $s
+             | (.flavors[], .offline_flavors[]) | "\($s)|\(.)"')
 }
 
 @test "config: every iso_group flavor exists on at least one variant" {
@@ -112,18 +131,31 @@ _select() {
   [ "$(_select '' bonito)" = "gnome-nvidia" ]
 }
 
-@test "select: bonito community resolves to nvidia desktops" {
-  [ "$(_select community bonito)" = "kde-nvidia cosmic-nvidia niri-nvidia xfce-nvidia" ]
+@test "select: each desktop group resolves to its own nvidia flavor" {
+  [ "$(_select kde bonito)" = "kde-nvidia" ]
+  [ "$(_select cosmic bonito)" = "cosmic-nvidia" ]
+  [ "$(_select niri bonito)" = "niri-nvidia" ]
+  [ "$(_select xfce bonito)" = "xfce-nvidia" ]
 }
 
-@test "select: grand total is 8 grouped ISOs across 4 variants" {
+# skipjack has no xfce-nvidia, so its xfce group must resolve to nothing and
+# be skipped rather than build something broken. A group naming a flavor a
+# variant lacks is the normal case now, not an edge one.
+@test "select: a variant missing a desktop's nvidia flavor drops that group" {
+  [ -z "$(_select xfce skipjack)" ]
+}
+
+@test "select: grand total is 19 grouped ISOs across 4 variants" {
   local count=0
-  for g in '' community; do
+  for g in '' kde cosmic niri xfce; do
     for v in yellowfin albacore skipjack bonito; do
       [ -n "$(_select "$g" "$v")" ] && count=$((count + 1))
     done
   done
-  [ "$count" -eq 8 ]
+  # 4 variants x 5 desktops = 20, minus exactly one: skipjack has no
+  # xfce-nvidia. Asserted as a number, counted rather than estimated, so a
+  # config edit that silently drops a variant's ISOs is caught.
+  [ "$count" -eq 19 ]
 }
 
 # ── Recipe JSON ─────────────────────────────────────────────────────────────

--- a/tests/installer-screens.yaml
+++ b/tests/installer-screens.yaml
@@ -186,9 +186,37 @@ screens:
     # streams the same backend, so "partitioning" and "installing image"
     # appear on the progress screen of all five and on no other screen, and
     # they do not contain a product name at all.
+    #
+    # RE-MEASURED 2026-08-24, this time against what is on the progress screen
+    # BEFORE the backend has streamed a line -- which is the state a harness
+    # screenshot actually catches, and which none of the keywords above cover:
+    #
+    #   gnome   "Installing", "0:00 elapsed", "Downloading system image..."
+    #           (progress.blp:189,229; views/progress.py:101,689)
+    #   kde     "Installing <product> onto <disk>. Do not power off the
+    #           machine." (modules/progress/.../main.qml:35)
+    #   cosmic  "Installing <product>" + caption "Do not power off the
+    #           computer." (src/ui.rs:377,369)
+    #   niri    "Installing..."               (ui/installer.qml:422)
+    #   xfce    "Installing <product>" + a step label from PIPELINE_STEPS
+    #           (app.py:18-22,325)
+    #
+    # "do not power off" is added for kde and cosmic: measured on both, unique
+    # to the progress screen, carries no product name, and is present from the
+    # moment the screen opens rather than only once the log has scrolled.
+    #
+    # gnome is deliberately left unmatched rather than guessed at. Its only
+    # always-present product-free strings there are the bare word "Installing"
+    # -- forbidden by the header above, and a substring of the welcome page's
+    # "guide you through installing" -- and "elapsed", a single common word
+    # that a log pane could easily produce. The distinctive sentence
+    # "Installation will continue normally" (progress.blp:85) sits in the tour
+    # panel, whose visibility depends on the recipe, so it is not something
+    # this file can rely on. An unmatched advisory row that says why beats a
+    # keyword that manufactures a phantom one.
     keywords: ["installation progress", "copying files", "deploying",
                "please wait", "writing image", "installing\u2026",
-               "partitioning", "installing image"]
+               "partitioning", "installing image", "do not power off"]
 
   - id: done
     title: Finished / reboot

--- a/tests/installer-screens.yaml
+++ b/tests/installer-screens.yaml
@@ -42,18 +42,28 @@ screens:
     #                                             primary button "Next"
     #                                             (Wizard.qml:290)
     #
-    # So on KDE not one of the four keywords was on the page, and run
-    # 32718219267 reported all six screens unreached with the diagnosis "no
-    # installer screen was ever detected" -- while the readiness stamp from
-    # that same process in that same guest read `signal=frame-swapped
-    # page=welcome`. The frontend was on its welcome screen and the contract
-    # could not see it.
+    # CORRECTION, same day: KDE's welcome PAGE says none of the four, but its
+    # wizard does. Wizard.qml:46 names the step "Welcome" and Wizard.qml:185
+    # draws it as a 1.6x heading above the page; it starts at opacity 0 and a
+    # `running: true` animation fades it in at startup (Wizard.qml:216). So
+    # the literal word IS on screen, and "the keyword list cannot describe
+    # KDE's welcome screen" is NOT a sufficient explanation for run
+    # 32718219267 reporting it unreached.
     #
-    # "will guide you through" is added rather than "install": it is the
-    # orientation sentence KDE, niri and cosmic all put on the welcome page
-    # and nowhere else (grepped across all five frontends), it carries no
+    # What that run does establish stands: the readiness stamp from the same
+    # process in the same guest read `signal=frame-swapped page=welcome`, so
+    # the frontend was up and on its welcome page while the contract scored
+    # it missing. Why the OCR did not see a heading that large is now an open
+    # question -- scripts/installer-walkthrough.py prints the text it read on
+    # any leg missing a required screen, which is what will answer it.
+    #
+    # "will guide you through" is kept as coverage rather than as the fix: it
+    # is the orientation sentence KDE, niri and cosmic all put on the welcome
+    # page and nowhere else (grepped across all five frontends), it carries no
     # product name, and it is a prompt rather than the bare noun the header
-    # above forbids. gnome and xfce keep matching on "welcome".
+    # above forbids. It gives the welcome screen a second, independent
+    # phrase to be recognised by, in the body copy rather than in a heading
+    # that animates.
     keywords: ["welcome", "get started", "let's get", "begin",
                "will guide you through"]
 

--- a/tests/installer-screens.yaml
+++ b/tests/installer-screens.yaml
@@ -26,9 +26,36 @@ screens:
     title: Welcome
     required: true
     # "install tunaos" dropped: same product-name coupling as the disk and
-    # install lists. The four remaining keywords are what a welcome screen
-    # says regardless of what it is installing.
-    keywords: ["welcome", "get started", "let's get", "begin"]
+    # install lists. The remaining keywords are what a welcome screen says
+    # regardless of what it is installing.
+    #
+    # MEASURED 2026-08-24 against all five frontends' source strings, the way
+    # the disk list was on 2026-08-07. The disk list got that treatment; this
+    # one was written from the premise that every welcome screen says
+    # "welcome" or "get started". Four of the five do. KDE does not:
+    #
+    #     gnome   "Welcome to <product>"          welcome_title, welcome.py:93
+    #     cosmic  "Welcome. This assistant..."    src/ui.rs:82  + "Get started"
+    #     niri    "Welcome to <product>"          ui/installer.qml:186
+    #     xfce    "Welcome to <product>"          app.py:68
+    #     KDE     "Install <product>"             welcome main.qml:39,
+    #                                             primary button "Next"
+    #                                             (Wizard.qml:290)
+    #
+    # So on KDE not one of the four keywords was on the page, and run
+    # 32718219267 reported all six screens unreached with the diagnosis "no
+    # installer screen was ever detected" -- while the readiness stamp from
+    # that same process in that same guest read `signal=frame-swapped
+    # page=welcome`. The frontend was on its welcome screen and the contract
+    # could not see it.
+    #
+    # "will guide you through" is added rather than "install": it is the
+    # orientation sentence KDE, niri and cosmic all put on the welcome page
+    # and nowhere else (grepped across all five frontends), it carries no
+    # product name, and it is a prompt rather than the bare noun the header
+    # above forbids. gnome and xfce keep matching on "welcome".
+    keywords: ["welcome", "get started", "let's get", "begin",
+               "will guide you through"]
 
   - id: disk
     title: Disk / target selection

--- a/tests/installer-screens.yaml
+++ b/tests/installer-screens.yaml
@@ -63,8 +63,30 @@ screens:
     # be installed." — "be installed" is the longest contiguous run common to
     # both that contains no product name. Verified against all four forks'
     # source: it appears on their disk screens and on no other screen.
+    #
+    # MEASURED 2026-08-24 against the GNOME frontend, which the 2026-08-07
+    # measurement above could not have covered: gnome was absent from
+    # installer-smoke.yml's matrix until #1039, so upstream bootc-installer
+    # was the one fork nobody OCRed. Smoke run 32681262659 is the first time
+    # this cell has ever run, and it reported
+    #
+    #   not ok - gnome: reached 'disk' screen (Disk / target selection)
+    #     # not found on any state the installer advanced to
+    #
+    # while crediting encryption and summary -- screens that sit AFTER disk
+    # selection in the flow, so the installer plainly passed through it.
+    #
+    # Its heading is "Install Location" (default-disk.blp:63), which matches
+    # none of the six keywords above. Same shape as the install list below:
+    # a frontend failing a screen it demonstrably reached is one wrong list,
+    # not a wording bug.
+    #
+    # Checked against all five frontends' source before admitting it: the
+    # string occurs exactly once in the whole set, on this page. It carries
+    # no product name, so the branding work does not break it.
     keywords: ["select target disk", "select a disk", "choose the disk",
-               "available disks", "be installed", "destination"]
+               "available disks", "be installed", "destination",
+               "install location"]
 
   - id: encryption
     title: Disk encryption (LUKS)

--- a/tests/installer-screens.yaml
+++ b/tests/installer-screens.yaml
@@ -42,22 +42,31 @@ screens:
     #                                             primary button "Next"
     #                                             (Wizard.qml:290)
     #
-    # CORRECTION, same day: KDE's welcome PAGE says none of the four, but its
-    # wizard does. Wizard.qml:46 names the step "Welcome" and Wizard.qml:185
-    # draws it as a 1.6x heading above the page; it starts at opacity 0 and a
-    # `running: true` animation fades it in at startup (Wizard.qml:216). So
-    # the literal word IS on screen, and "the keyword list cannot describe
-    # KDE's welcome screen" is NOT a sufficient explanation for run
-    # 32718219267 reporting it unreached.
+    # A correction was posted here reading KDE's Wizard.qml -- the step model
+    # names the step "Welcome" (Wizard.qml:46) and a 1.6x Label draws it
+    # (Wizard.qml:185), so the word was said to be on screen after all. THAT
+    # CORRECTION WAS WRONG, and the measurement above stands.
     #
-    # What that run does establish stands: the readiness stamp from the same
-    # process in the same guest read `signal=frame-swapped page=welcome`, so
-    # the frontend was up and on its welcome page while the contract scored
-    # it missing. Why the OCR did not see a heading that large is now an open
-    # question -- scripts/installer-walkthrough.py prints the text it read on
-    # any leg missing a required screen, which is what will answer it.
+    # Settled by looking at the frame instead of the source. The published
+    # capture (download.tunaos.org/screenshots/installer/smoke-kde_00-latest.png,
+    # from run 32747410944) shows the welcome step in full:
     #
-    # "will guide you through" is kept as coverage rather than as the fix: it
+    #     titlebar   "Yellowfin Installer"
+    #     heading    "Install Yellowfin"
+    #     body       "This wizard will guide you through installing Yellowfin
+    #                 onto this computer."
+    #                "You will choose a target disk and how it should be
+    #                 encrypted. Everything after that is handled by the
+    #                 installer."
+    #     button     "Next"
+    #
+    # There is no "Welcome" anywhere on it. The stepHeading Label starts at
+    # `opacity: 0` and does not come up on the first page whatever the
+    # animation is meant to do -- which is arguably its own bug, but not this
+    # file's business. Reading a QML file told me what should render; the
+    # screenshot told me what did.
+    #
+    # So "will guide you through" is load-bearing, not merely coverage: it
     # is the orientation sentence KDE, niri and cosmic all put on the welcome
     # page and nowhere else (grepped across all five frontends), it carries no
     # product name, and it is a prompt rather than the bare noun the header

--- a/tests/test_a_job_budget_covers_its_own_steps.py
+++ b/tests/test_a_job_budget_covers_its_own_steps.py
@@ -1,0 +1,81 @@
+"""A job's timeout must be able to cover the steps inside it.
+
+`timeout-minutes` at the job level and at the step level are independent
+budgets, and GitHub enforces both. When the job's is the smaller one the
+steps never get to fail on their own terms: the job is cancelled with
+every step still inside its limit, and `cancelled` is the same word
+Actions uses for a spot reclamation or a user hitting the button. A real
+failure and an infrastructure flake become indistinguishable.
+
+That is not hypothetical. `iso-e2e.yml` carried a flat `timeout-minutes: 30`
+while its build step declared 60 and its readiness step 20, so every
+`source: build` cell died at exactly 30 minutes -- E2E guppy:xfce (job
+97638529947) started building at 00:18:40 and was cancelled at 00:48:29.
+A six-cell sweep produced no verdict about any cell it ran.
+
+The check is deliberately weak in one direction: a job timeout written as
+an expression (`${{ ... && 90 || 30 }}`) passes if ANY branch covers the
+steps, because which branch applies depends on inputs this test cannot
+evaluate. It still catches the case that matters, where no branch does.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = sorted((Path(__file__).resolve().parents[1] / ".github" / "workflows").glob("*.yml"))
+
+
+def _budgets(value):
+    """Every numeric minute budget a `timeout-minutes` value could take."""
+    if value is None:
+        return []
+    if isinstance(value, int):
+        return [value]
+    return [int(n) for n in re.findall(r"\b(\d+)\b", str(value))]
+
+
+def _cases():
+    for wf in WORKFLOWS:
+        doc = yaml.safe_load(wf.read_text()) or {}
+        for job_id, job in (doc.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            steps = job.get("steps") or []
+            step_total = sum(
+                max(_budgets(s.get("timeout-minutes")), default=0)
+                for s in steps
+                if isinstance(s, dict)
+            )
+            if step_total == 0:
+                continue  # no step declares a budget; nothing to cover
+            yield wf.name, job_id, job.get("timeout-minutes"), step_total
+
+
+CASES = list(_cases())
+
+
+@pytest.mark.parametrize(
+    "workflow,job_id,job_timeout,step_total",
+    CASES,
+    ids=[f"{w}:{j}" for w, j, _, _ in CASES],
+)
+def test_a_job_budget_covers_its_own_steps(workflow, job_id, job_timeout, step_total):
+    if job_timeout is None:
+        # No job timeout means GitHub's 360-minute default, which is larger
+        # than any step budget we write. Nothing to enforce.
+        return
+    best = max(_budgets(job_timeout), default=0)
+    assert best >= step_total, (
+        f"{workflow} job '{job_id}': job timeout {job_timeout!r} tops out at "
+        f"{best} minutes but its steps declare {step_total}. The job will be "
+        f"cancelled with its steps still inside their own limits, and the "
+        f"cancellation is indistinguishable from an infrastructure flake."
+    )
+
+
+def test_the_check_has_something_to_check():
+    """A parametrized test over an empty list passes while asserting nothing."""
+    assert CASES, "no job in .github/workflows declares step-level timeouts"

--- a/tests/test_a_rolling_snapshot_pin_cannot_go_stale_unnoticed.py
+++ b/tests/test_a_rolling_snapshot_pin_cannot_go_stale_unnoticed.py
@@ -90,3 +90,39 @@ def test_the_detector_still_matches_a_real_declared_pin():
         "the snapshot pin was replaced (good, remove this) or the detector "
         "has gone blind (bad)"
     )
+
+
+# --- content age beats name age ---------------------------------------------
+# The 20251124 prefix is a LIVING repo the package factory publishes into
+# nightly (r2_path: hummingbird/20251124-$arch), not an immutable snapshot.
+# Judged by its NAME it is forever stale; judged by its repomd <revision>
+# (createrepo_c stamps the indexing epoch) it is as old as its content.
+# Measured live while writing this: 274d by name, 8d by content -- the
+# name-based verdict this suite originally pinned was a false positive of
+# exactly the cry-wolf kind that gets checks deleted.
+
+def test_an_epoch_revision_yields_content_age():
+    body = b"<repomd><revision>1786000000</revision></repomd>"
+    age = cprp.repomd_content_age_days(body, today=TODAY)
+    assert age is not None and 0 <= age <= 30, age
+
+
+def test_a_serial_revision_falls_back_to_none():
+    """Some tools write serials (small ints); those are not timestamps."""
+    assert cprp.repomd_content_age_days(
+        b"<repomd><revision>17</revision></repomd>", today=TODAY) is None
+
+
+def test_a_body_without_a_revision_is_none_not_zero():
+    assert cprp.repomd_content_age_days(b"<repomd/>", today=TODAY) is None
+    assert cprp.repomd_content_age_days(b"", today=TODAY) is None
+
+
+def test_probe_returns_the_body_content_age_needs():
+    """The verdict reads the revision out of the SAME fetch reachability
+    used; if probe stops returning the body, content age silently never
+    applies and every datestamped repo is judged by its name again."""
+    import inspect
+    sig = inspect.signature(cprp.probe)
+    ret = inspect.getsource(cprp.probe)
+    assert "resp.read()" in ret, "probe no longer returns the body"

--- a/tests/test_a_rolling_snapshot_pin_cannot_go_stale_unnoticed.py
+++ b/tests/test_a_rolling_snapshot_pin_cannot_go_stale_unnoticed.py
@@ -1,0 +1,92 @@
+"""A datestamped snapshot keeps returning 200 long after it stops working.
+
+check-package-repo-pins.py asks whether a pin RESOLVES. For an immutable
+snapshot of a stable release that is the whole question. For a snapshot of a
+ROLLING distribution it is the wrong one.
+
+Fedora Hummingbird is a rolling release tracking Fedora Rawhide -- not Fedora
+43, whatever its .fc43 dist tags suggest (docs/HUMMINGBIRD.md). tunaOS pins two
+halves of it independently: the base image by digest, and the package snapshot
+by datestamp. They drift apart with every upstream roll, and the drift does not
+look like a pin problem.
+
+Measured on 2026-08-25: the 20251124 snapshot served gtk4 but not the harfbuzz
+gtk4 requires. dnf reported gtk4 and 17 other packages as having BROKEN
+dependencies rather than being unavailable, --skip-unavailable dropped them
+without failing, and hummingbird:gnome was published with 410 packages and no
+GNOME in it. Every pin in that build resolved; nothing was red anywhere.
+"""
+
+import datetime
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "cprp", ROOT / "scripts" / "check-package-repo-pins.py")
+cprp = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(cprp)
+
+TODAY = datetime.date(2026, 8, 25)
+HB = "https://repo.tunaos.org/hummingbird/20251124-x86_64/repodata/repomd.xml"
+
+
+def test_a_datestamped_pin_reports_its_age():
+    age = cprp.snapshot_age_days(HB, today=TODAY)
+    assert age is not None, "the hummingbird snapshot datestamp was not parsed"
+    assert age == (TODAY - datetime.date(2025, 11, 24)).days == 274
+
+
+def test_the_live_hummingbird_pin_is_past_the_failing_threshold():
+    """Not hypothetical: this is the pin in build_scripts/10-base-packages.sh."""
+    assert cprp.snapshot_age_days(HB, today=TODAY) >= cprp.SNAPSHOT_FAIL_DAYS
+
+
+def test_an_undated_pin_is_left_alone():
+    """Most pins carry no datestamp and must not be aged or flagged."""
+    for url in (
+        "https://copr.fedorainfracloud.org/api_3/project?ownername=a&projectname=b",
+        "https://repo.tunaos.org/repo/10/x86_64/repodata/repomd.xml",
+        "https://download.opensuse.org/repositories/X/xUbuntu_24.04/Release.key",
+    ):
+        assert cprp.snapshot_age_days(url, today=TODAY) is None, url
+
+
+def test_a_number_that_is_not_a_date_is_not_treated_as_one():
+    assert cprp.snapshot_age_days(
+        "https://example.invalid/x/20259999-x86_64/repodata/repomd.xml",
+        today=TODAY) is None
+
+
+def test_a_fresh_snapshot_passes_both_thresholds():
+    fresh = "https://repo.tunaos.org/hummingbird/20260820-x86_64/repodata/repomd.xml"
+    age = cprp.snapshot_age_days(fresh, today=TODAY)
+    assert age == 5
+    assert age < cprp.SNAPSHOT_WARN_DAYS < cprp.SNAPSHOT_FAIL_DAYS
+
+
+def test_the_thresholds_are_ordered_and_sane():
+    """A warn above the fail line would mean the warning never fires."""
+    assert 0 < cprp.SNAPSHOT_WARN_DAYS < cprp.SNAPSHOT_FAIL_DAYS
+
+
+def test_the_detector_still_matches_a_real_declared_pin():
+    """Guard the guard.
+
+    If the manifests stop carrying a datestamped pin, or the regex stops
+    matching the shape they use, every test above keeps passing while the
+    check examines nothing. Assert against the real manifests.
+    """
+    import glob
+    import yaml
+    dated = []
+    for path in sorted(glob.glob(str(ROOT / "manifests" / "desktops" / "*.yaml"))):
+        with open(path, encoding="utf-8") as f:
+            for _kind, url in cprp.collect(yaml.safe_load(f)):
+                if cprp.snapshot_age_days(url, today=TODAY) is not None:
+                    dated.append(url)
+    assert dated, (
+        "no declared package-repo pin carries a datestamp any more — either "
+        "the snapshot pin was replaced (good, remove this) or the detector "
+        "has gone blind (bad)"
+    )

--- a/tests/test_a_waived_desktop_contract_does_not_report_pass.py
+++ b/tests/test_a_waived_desktop_contract_does_not_report_pass.py
@@ -1,0 +1,100 @@
+"""A waived desktop contract must not report itself as passed.
+
+hummingbird is exempted from every require_* in
+build_scripts/checks/verify-desktop-experience.sh so it can bootstrap against
+incomplete repos. That exemption is deliberate and these tests do not
+challenge it. What they hold is the REPORT.
+
+On tunaOS run 32813037866 the check printed, in order:
+
+    missing required command: gnome-shell
+    missing unit: none of [gdm gdm3] exist
+    missing required command: nautilus
+    ... ten of them ...
+    desktop experience contract passed: gnome (projectbluefin/bluefin-lts)
+
+The image had 410 packages: gnome-backgrounds and gnome-user-docs, no
+gnome-shell, no gdm, no mutter, no gtk4. It was pushed to GHCR, and the first
+thing to notice was the boot gate failing 15 minutes later on a marker that
+could never be emitted. The packages were dropped upstream
+(tunaos-packages#519); the reason it went unnoticed for weeks is this line.
+
+The report block is tested by RUNNING it, because "passed" was printed by
+code that had already seen the failures.
+"""
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECK = ROOT / "build_scripts" / "checks" / "verify-desktop-experience.sh"
+
+
+def _run_report(tmp_path, waived):
+    """Execute the real report block with a given waiver count."""
+    src = CHECK.read_text()
+    start = src.index("\tinstall -d /usr/share/tunaos/experience-contracts")
+    end = src.index("\nfi", start)
+    block = src[start:end]
+
+    contracts = tmp_path / "contracts"
+    block = block.replace("/usr/share/tunaos/experience-contracts", str(contracts))
+
+    script = tmp_path / "report.sh"
+    script.write_text(
+        textwrap.dedent(f"""\
+        set -euo pipefail
+        desktop=gnome
+        experience=projectbluefin/bluefin-lts
+        TUNAOS_CONTRACT_WAIVED={waived}
+        """)
+        + block
+        + "\n"
+    )
+    p = subprocess.run(["bash", str(script)], capture_output=True, text=True)
+    assert p.returncode == 0, p.stdout + p.stderr
+    written = (contracts / "gnome").read_text()
+    return p.stdout + p.stderr, written
+
+
+def test_a_clean_contract_still_reports_passed(tmp_path):
+    out, written = _run_report(tmp_path, 0)
+    assert "contract passed" in out, out
+    assert "validated_at_build=true" in written, written
+    assert "WAIVED" not in out, out
+
+
+def test_a_waived_contract_never_says_passed(tmp_path):
+    out, written = _run_report(tmp_path, 10)
+    assert "contract passed" not in out, (
+        "ten unmet requirements were reported as a pass — the exact defect "
+        f"that shipped a GNOME image with no GNOME:\n{out}"
+    )
+    assert "WAIVED" in out, out
+    assert "10 requirement(s) unmet" in out, out
+
+
+def test_a_waived_contract_is_recorded_as_unverified_on_the_image(tmp_path):
+    """Downstream scoring reads this file; it must not claim verification."""
+    _, written = _run_report(tmp_path, 10)
+    assert "validated_at_build=false" in written, written
+    assert "validated_at_build=true" not in written, written
+    assert "waived_requirements=10" in written, written
+
+
+def test_a_waived_contract_emits_a_greppable_marker(tmp_path):
+    out, _ = _run_report(tmp_path, 3)
+    assert "TUNAOS_DESKTOP_CONTRACT_WAIVED desktop=gnome missing=3" in out, out
+
+
+def test_every_hummingbird_exemption_counts_what_it_waives():
+    """An exemption that doesn't count is invisible again."""
+    src = CHECK.read_text()
+    exemptions = src.count('IS_HUMMINGBIRD:-false}" == "true" ]]; then')
+    counted = src.count('== "true" ]]; then waive; return 0; fi')
+    assert exemptions > 0, "the exemption shape changed; this test is stale"
+    assert counted == exemptions, (
+        f"{exemptions} require_* exemptions but only {counted} call waive() — "
+        "an uncounted exemption can still report a pass over a broken image"
+    )

--- a/tests/test_automation_does_not_push_to_main.py
+++ b/tests/test_automation_does_not_push_to_main.py
@@ -1,0 +1,94 @@
+"""No workflow may push straight to `main`. The rule forbids it.
+
+`installer-smoke.yml`'s screenshot-gallery job ended in
+
+    git pull --rebase origin main
+    git push origin HEAD:main
+
+and `main` is protected by a repository rule:
+
+    remote: error: GH013: Repository rule violations found for refs/heads/main.
+    remote: - Changes must be made through the merge queue
+    ! [remote rejected] HEAD -> main (push declined due to repository rule violations)
+
+That is run 32704425971, and the interesting part is WHY it took until then.
+The step is gated on `staged != '0'`, and no flavor had ever produced
+walkthrough frames, so the push had never once executed. gnome going green is
+what first made it run. A gate that has never run is not a gate that passes,
+and this file exists so the next one is caught by the suite instead of by a
+rejected push months later.
+
+`matrix-status.yml` already had the answer and even the comment explaining it
+("Needed to open the refresh PR; `main` only accepts merge-queue changes"):
+one long-lived branch, force-pushed, PR opened once, auto-merge armed. The
+screenshot job now does the same thing, so both automation writers share a
+shape rather than each inventing one.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+# `HEAD:main`, `origin main`, `+HEAD:refs/heads/main` and friends. Deliberately
+# broad: the point is that no automation writes to the protected branch.
+PUSH_TO_MAIN = re.compile(
+    r"git\s+push[^\n|;&]*\b(?:HEAD|[\w./-]+)?:?(?:refs/heads/)?main\b"
+)
+
+
+def workflow_files():
+    return sorted(WORKFLOWS.glob("*.y*ml"))
+
+
+def test_there_are_workflows_to_scan():
+    """A sweep that matches no file passes for the wrong reason."""
+    assert workflow_files(), "no workflow files found"
+
+
+def test_the_pattern_recognises_the_push_it_was_written_for():
+    """Guard the regex itself against silently matching nothing."""
+    assert PUSH_TO_MAIN.search("          git push origin HEAD:main")
+    assert PUSH_TO_MAIN.search("git push origin HEAD:refs/heads/main")
+    # And must not fire on the legitimate branch push.
+    assert not PUSH_TO_MAIN.search('git push --force origin "$BRANCH"')
+    assert not PUSH_TO_MAIN.search("git pull --rebase origin main")
+
+
+def test_no_workflow_pushes_to_main():
+    offenders = []
+    for f in workflow_files():
+        for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue  # a comment quoting the bad command is documentation
+            if PUSH_TO_MAIN.search(line):
+                offenders.append(f"{f.name}:{i}: {stripped}")
+    assert not offenders, (
+        "these push directly to a branch that only accepts merge-queue "
+        "changes; open a PR and arm auto-merge, as matrix-status.yml does: "
+        + "; ".join(offenders)
+    )
+
+
+def test_the_screenshot_job_can_actually_open_a_pr():
+    """contents:write alone cannot open one — the fix needs the scope too."""
+    doc = yaml.safe_load((WORKFLOWS / "installer-smoke.yml").read_text(encoding="utf-8"))
+    perms = doc["jobs"]["publish-screenshots"]["permissions"]
+    assert perms.get("contents") == "write", perms
+    assert perms.get("pull-requests") == "write", perms
+
+
+def test_the_screenshot_job_arms_auto_merge():
+    """A PR from the Actions token starts no checks of its own; without
+    auto-merge the refresh sits forever waiting for a human."""
+    doc = yaml.safe_load((WORKFLOWS / "installer-smoke.yml").read_text(encoding="utf-8"))
+    body = yaml.dump(doc["jobs"]["publish-screenshots"])
+    assert "gh pr create" in body
+    assert "gh pr merge --auto" in body

--- a/tests/test_every_iso_build_installs_working_podman.py
+++ b/tests/test_every_iso_build_installs_working_podman.py
@@ -1,0 +1,77 @@
+"""A job that builds an ISO must first install a podman that can commit one.
+
+The runner images ship podman 5.8.4, whose commit of a live-customized
+rootfs wedges (#1893). Every ISO-building job in this repository works
+around it the same way -- add the Kubic libcontainers apt source and
+reinstall podman from it -- and a job that skips that step does not fail
+quickly or loudly. It hangs in `podman commit` until something outside it
+gives up: tacklebox's 600s bound if the pin has one, the job timeout if
+not.
+
+`publish-iso-groups.yml` skipped it. Combined with a tacklebox pin from
+before the bound existed, its build job had no upper bound short of the
+360-minute Actions default, and no grouped ISO has ever reached the
+bucket -- `albacore-latest.iso` is 404 while the legacy pipeline's
+`albacore-gnome-latest.iso` is 200.
+
+This is a necessary condition, not a sufficient one, and the test claims
+only the former: `iso-e2e.yml` does install the Kubic podman and its
+commit still ran past tacklebox's 600s bound on a GitHub-hosted runner
+(job 97638514487). Passing this test does not mean a job can build an
+ISO; failing it means it certainly cannot.
+
+Detection is by what a job RUNS, not by what it is called, so a new
+ISO-building workflow is covered the day it is added.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = sorted((Path(__file__).resolve().parents[1] / ".github" / "workflows").glob("*.yml"))
+
+# The commands that drive tacklebox into a live-customize + commit.
+BUILDS_AN_ISO = re.compile(r"\bjust\s+(iso|iso-group)\b|\bbuild-iso(-group)?\.sh\b")
+INSTALLS_KUBIC_PODMAN = re.compile(r"devel:/kubic:/libcontainers")
+
+
+def _job_shell(job):
+    return "\n".join(
+        str(s.get("run", "")) for s in (job.get("steps") or []) if isinstance(s, dict)
+    )
+
+
+def _cases():
+    for wf in WORKFLOWS:
+        doc = yaml.safe_load(wf.read_text()) or {}
+        for job_id, job in (doc.get("jobs") or {}).items():
+            if not isinstance(job, dict) or not job.get("steps"):
+                continue
+            shell = _job_shell(job)
+            if BUILDS_AN_ISO.search(shell):
+                yield wf.name, job_id, shell
+
+
+CASES = list(_cases())
+
+
+@pytest.mark.parametrize(
+    "workflow,job_id,shell",
+    CASES,
+    ids=[f"{w}:{j}" for w, j, _ in CASES],
+)
+def test_every_iso_build_installs_working_podman(workflow, job_id, shell):
+    assert INSTALLS_KUBIC_PODMAN.search(shell), (
+        f"{workflow} job '{job_id}' runs an ISO build but never installs the "
+        f"Kubic podman. The runner image's podman 5.8.4 wedges in the "
+        f"post-customize commit (#1893), and the job will hang rather than "
+        f"fail."
+    )
+
+
+def test_the_check_found_the_iso_builds():
+    """Parametrizing over an empty list is a green test that asserts nothing."""
+    names = {w for w, _, _ in CASES}
+    assert names, "no workflow appears to build an ISO — the detector is broken"

--- a/tests/test_expensive_builds_collapse_redundant_pr_runs.py
+++ b/tests/test_expensive_builds_collapse_redundant_pr_runs.py
@@ -1,0 +1,96 @@
+"""ISO-building workflows must collapse superseded PR runs, but not sweeps.
+
+A `pull_request` paths filter is evaluated against the PR's WHOLE diff, not
+the pushed commit. So once a long-lived branch touches one of the watched
+paths, every later push to that PR re-triggers the workflow however
+unrelated the change. For a ~25-minute ISO build on a RunsOn EC2 instance
+that is a real bill: this branch touches `live-iso/**`, and all eight of
+one night's pushes started a fresh build while the previous one ran to
+completion.
+
+`cancel-in-progress` fixes that. The subtlety is the GROUP KEY. The repo's
+usual form is `<name>-${{ github.ref }}`, and on these two workflows that
+would be actively harmful: a multi-cell sweep dispatches several runs
+against ONE branch, so they would all share a group and cancel each other
+down to the last one — a sweep that silently measures a single cell. Two
+of those were already lost to a job-budget bug this session; losing them
+to a concurrency key would look identical from the outside.
+
+So the group must vary by run for workflow_dispatch and be shared for
+pull_request, and this test pins both halves.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+# The two that build an ISO on a schedule a human did not ask for: they run
+# on `pull_request`, so they are the ones a push storm can multiply.
+EXPENSIVE = ["live-iso-bootc.yml", "iso-e2e.yml"]
+
+
+def _concurrency(name):
+    doc = yaml.safe_load((WORKFLOWS / name).read_text()) or {}
+    return doc.get("concurrency")
+
+
+@pytest.mark.parametrize("workflow", EXPENSIVE)
+def test_it_cancels_superseded_runs(workflow):
+    c = _concurrency(workflow)
+    assert c, f"{workflow} has no concurrency block; every PR push starts another ISO build"
+    assert c.get("cancel-in-progress") is True, (
+        f"{workflow} declares a concurrency group but not cancel-in-progress, "
+        f"so superseded runs still run to completion — the group alone only queues them."
+    )
+
+
+@pytest.mark.parametrize("workflow", EXPENSIVE)
+def test_a_dispatched_sweep_does_not_cancel_itself(workflow):
+    """The group must vary per run for workflow_dispatch.
+
+    Asserted on the expression rather than a fixed string, so any key that
+    distinguishes dispatches passes and any key that does not fails.
+    """
+    group = _concurrency(workflow)["group"]
+    assert "github.run_id" in group, (
+        f"{workflow}'s concurrency group is {group!r}. Without a per-run "
+        f"component for workflow_dispatch, the cells of a multi-cell sweep "
+        f"share one branch, land in one group, and cancel each other."
+    )
+    assert "workflow_dispatch" in group, (
+        f"{workflow}'s group uses run_id unconditionally ({group!r}), which "
+        f"would give every pull_request push its own group too — that is the "
+        f"same as having no concurrency at all."
+    )
+
+
+@pytest.mark.parametrize("workflow", EXPENSIVE)
+def test_pr_pushes_share_one_group(workflow):
+    """Two pushes to the same PR must land in the same group.
+
+    Evaluates the ternary the way GitHub does, for both event types, and
+    asserts the resulting keys collide for pull_request and differ for
+    dispatch. Checking the string alone would pass on an expression that
+    reads plausibly and resolves wrong.
+    """
+    group = _concurrency(workflow)["group"]
+
+    def resolve(event, run_id, ref="refs/heads/x"):
+        out = group.replace("${{ github.ref }}", ref)
+        # ${{ A && B || C }} -> B when A else C
+        m = re.search(
+            r"\$\{\{\s*github\.event_name == '(\w+)'\s*&&\s*github\.run_id\s*\|\|\s*github\.event_name\s*\}\}",
+            out,
+        )
+        assert m, f"unrecognised group expression: {group!r}"
+        return out[: m.start()] + (run_id if event == m.group(1) else event) + out[m.end() :]
+
+    assert resolve("pull_request", "1") == resolve("pull_request", "2"), (
+        "two pushes to the same PR resolve to different groups, so neither cancels the other"
+    )
+    assert resolve("workflow_dispatch", "1") != resolve("workflow_dispatch", "2"), (
+        "two dispatched sweep cells resolve to the same group and would cancel each other"
+    )

--- a/tests/test_installer_smoke_needs_no_gpu.py
+++ b/tests/test_installer_smoke_needs_no_gpu.py
@@ -63,12 +63,59 @@ def test_the_boot_half_uses_the_non_gpu_harness() -> None:
     assert "iso-e2e-gpu.sh" not in steps
 
 
-def test_every_flavor_builds_on_the_same_runner() -> None:
-    """A per-flavor runner split is what drifted last time."""
-    body = WORKFLOW.read_text()
-    runners = {
-        line.split('runner: ')[1].split('}')[0].strip().strip('"').strip("'")
-        for line in body.splitlines()
+def _matrix_script() -> str:
+    """The generate-matrix job's shell, where runner names are minted.
+
+    Scoped to that job rather than the whole file. The previous version
+    scanned every line of the workflow for "runner: " and therefore read
+    COMMENTS too -- adding a comment containing the words `build_runner:
+    github` invented a runner called "github` sends this job to" and failed
+    the build. A check that reads prose is measuring the wrong surface; the
+    matrix is built in exactly one place and that is the place to look.
+    """
+    gen = jobs()["generate-matrix"]
+    script = "\n".join(step.get("run", "") for step in gen["steps"])
+    assert "include" in script, (
+        "the generate-matrix script no longer builds a matrix include list; "
+        "every assertion below would pass vacuously"
+    )
+    return script
+
+
+def _declared_runners() -> set[str]:
+    return {
+        line.split("runner: ")[1].split("}")[0].strip().strip('"').strip("'")
+        for line in _matrix_script().splitlines()
         if "runner: " in line and "matrix.runner" not in line
     }
+
+
+def test_every_flavor_builds_on_the_same_runner() -> None:
+    """A per-flavor runner split is what drifted last time."""
+    runners = _declared_runners()
+    assert runners, "no runner assignment found in the matrix script"
     assert runners == {"build-amd64"}, f"mixed build runners: {runners}"
+
+
+def test_a_comment_cannot_invent_a_runner() -> None:
+    """Regression for the scan itself.
+
+    The workflow gained a comment reading
+
+        # `build_runner: github` sends this job to ubuntu-latest instead
+
+    and the old whole-file scan turned that prose into a runner name. The
+    scan must see the matrix script and nothing else, so a comment that
+    mentions a runner anywhere else in the file is inert.
+    """
+    body = WORKFLOW.read_text(encoding="utf-8")
+    prose = [
+        line for line in body.splitlines()
+        if "runner: " in line and line.lstrip().startswith("#")
+    ]
+    assert prose, (
+        "no commented 'runner: ' line left in the workflow -- this test can "
+        "no longer demonstrate that comments are excluded; point it at a "
+        "line that still exists rather than deleting it"
+    )
+    assert _declared_runners() == {"build-amd64"}

--- a/tests/test_installer_walkthrough.py
+++ b/tests/test_installer_walkthrough.py
@@ -50,8 +50,15 @@ for a in "$@"; do
     exit 0
   fi
 done
-if [ -n "${2:-}" ]; then
-  cp "$1" "$2" 2>/dev/null || printf 'P3\n1 1\n255\n0 0 0\n' > "$2"
+# The output is the LAST argument, not $2: installer-walkthrough.py's OCR
+# fallback calls `magick in.png -negate out.png`, and treating $2 as the
+# destination wrote a file literally named "-negate" into the repo root while
+# leaving the negated pass untested. Whatever operators sit in between, the
+# stub copies the input to the final path.
+out=""
+for a in "$@"; do out="$a"; done
+if [ -n "$out" ] && [ "$out" != "$1" ]; then
+  cp "$1" "$out" 2>/dev/null || printf 'P3\n1 1\n255\n0 0 0\n' > "$out"
 fi
 exit 0
 """
@@ -60,9 +67,16 @@ TESSERACT_STUB = r"""#!/bin/bash
 # Fake tesseract. The image filename encodes the frame number
 # (walkthrough-<flavor>-NN.png); the OCR text for that frame comes from the
 # TESS_NN environment variable.
+# A negated copy is <frame>.neg.png. It answers from TESSNEG_NN instead, so
+# a test can make the negated pass the only readable one -- which is the
+# whole point of that fallback existing.
 name=$(basename "$1")
+pfx="TESS"
+case "$name" in
+  *.neg.png) name=${name%.neg.png}; pfx="TESSNEG";;
+esac
 nn=$(printf '%s' "$name" | sed -n 's/.*-\([0-9][0-9]\)\.png$/\1/p')
-var="TESS_${nn}"
+var="${pfx}_${nn}"
 printf '%s' "${!var}"
 """
 
@@ -118,10 +132,12 @@ class FakeQEMUMonitor:
 
 
 def run_walkthrough(tess, magick_ae=5000, magick_stddev=0.5, steps="2",
-                    flavor="de", strict=False, timeout=120):
+                    flavor="de", strict=False, timeout=120, tess_neg=None):
     """Run the script against the fake monitor + stubs.
 
-    *tess* maps frame number (str) -> OCR text. Returns (proc, summary_json).
+    *tess* maps frame number (str) -> OCR text. *tess_neg* is the same for the
+    negated copy the OCR fallback makes, so a test can give the plain pass
+    noise and the negated pass words. Returns (proc, summary_json).
     """
     tmp = Path(tempfile.mkdtemp(prefix="walkthrough-test-"))
     try:
@@ -144,6 +160,8 @@ def run_walkthrough(tess, magick_ae=5000, magick_stddev=0.5, steps="2",
         env["MAGICK_STDDEV"] = str(magick_stddev)
         for k, v in tess.items():
             env[f"TESS_{k}"] = v
+        for k, v in (tess_neg or {}).items():
+            env[f"TESSNEG_{k}"] = v
 
         cmd = [sys.executable, str(SCRIPT), sock, str(outdir), steps, flavor]
         if strict:

--- a/tests/test_iso_scripts_run_containers_on_a_usable_log_driver.py
+++ b/tests/test_iso_scripts_run_containers_on_a_usable_log_driver.py
@@ -1,0 +1,96 @@
+"""ISO-build scripts must not start containers on the journald log driver.
+
+The Kubic conmon these jobs install is built without journald support, so
+any `podman run` left on podman's default log driver dies with
+
+    [conmon:e]: Include journald in compilation path to log to systemd journal
+    Error: conmon failed: exit status 1
+
+and exit 126. `--log-driver=k8s-file` is the fix, and it is already spelled
+out at the identical pair of calls in build-iso-tacklebox.sh and at
+build-image-inner.sh's chunkah run (tacklebox#235).
+
+build-iso-group.sh was a copy of that pair WITHOUT the flag, at the very
+end of the script, after the ISO is already built — it exists only to read
+VERSION_ID and arch for the output filename. So the pipeline built a
+correct 13m39s grouped ISO and then threw it away on a metadata lookup
+(job 97650065786: ">>> Tacklebox ISO complete" immediately followed by
+"conmon failed").
+
+Scoped to the scripts that build ISOs, because that is where the Kubic
+conmon is installed. A script that inspects images on a stock runner is
+not affected and is not the subject here.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+ISO_BUILD_SCRIPTS = ["build-iso-group.sh", "build-iso-tacklebox.sh", "build-image-inner.sh"]
+
+# These invocations are written across several backslash-continued lines,
+# with --log-driver frequently on a line of its own. Fold continuations
+# before matching: a pattern that stops at the first newline reports every
+# multi-line call as missing the flag, which is how the first version of
+# this test "found" a bug in build-image-inner.sh that was not there.
+CONTINUATION = re.compile(r"\\\n\s*")
+PODMAN_RUN = re.compile(r"(?<!\w)podman run\b[^\n]*")
+
+
+def _invocations(name):
+    """Every `podman run` in the script, with its line number in the file.
+
+    Continuations are folded before matching so a call spread over ten
+    lines is judged as one command. The line number is recovered by
+    counting how many `podman run` occurrences precede this one, then
+    taking the correspondingly-numbered occurrence in the raw text --
+    the two agree because folding cannot create or destroy occurrences.
+    """
+    raw = (SCRIPTS / name).read_text()
+    folded = CONTINUATION.sub(" ", raw)
+
+    raw_lines = []
+    for i, line in enumerate(raw.splitlines(), start=1):
+        if PODMAN_RUN.search(line) and not line.lstrip().startswith("#"):
+            raw_lines.append(i)
+
+    out = []
+    for m in PODMAN_RUN.finditer(folded):
+        line_start = folded.rfind("\n", 0, m.start()) + 1
+        if folded[line_start : m.start()].lstrip().startswith("#"):
+            continue
+        line_no = raw_lines[len(out)] if len(out) < len(raw_lines) else -1
+        out.append((line_no, m.group(0)))
+    return out
+
+
+CASES = [(s, n, t) for s in ISO_BUILD_SCRIPTS for n, t in _invocations(s)]
+
+
+@pytest.mark.parametrize(
+    "script,line,invocation",
+    CASES,
+    ids=[f"{s}:{n}" for s, n, _ in CASES],
+)
+def test_iso_scripts_run_containers_on_a_usable_log_driver(script, line, invocation):
+    assert "--log-driver=" in invocation, (
+        f"{script}:{line} starts a container without an explicit --log-driver. "
+        f"The Kubic conmon cannot log to the journal, so this dies with "
+        f"'conmon failed: exit status 1' and exit 126:\n"
+        f"    {invocation.strip()[:160]}"
+    )
+
+
+def test_the_check_found_the_container_starts():
+    """Parametrizing over an empty list is a green test that asserts nothing."""
+    assert CASES, "no `podman run` found in the ISO-build scripts — detector broken"
+
+
+def test_the_pattern_recognises_a_missing_flag():
+    """The regex must actually distinguish the two forms it is judging."""
+    bad = "podman run --rm --security-opt label=disable \"$REF\" uname -m"
+    good = "podman run --rm --log-driver=k8s-file --security-opt label=disable \"$REF\" uname -m"
+    assert "--log-driver=" not in PODMAN_RUN.search(bad).group(0)
+    assert "--log-driver=" in PODMAN_RUN.search(good).group(0)

--- a/tests/test_kvm_jobs_run_where_kvm_exists.py
+++ b/tests/test_kvm_jobs_run_where_kvm_exists.py
@@ -1,0 +1,106 @@
+"""A boot gate on a runner that cannot boot.
+
+live-iso-bootc.yml built the ISO and then tried to boot it:
+
+    ==> Booting ./skipjack-gnome-10-x86_64.iso in QEMU (headless, KVM)...
+    Could not access KVM kernel module: No such file or directory
+    qemu-system-x86_64: failed to initialize kvm: No such file or directory
+
+(runs 32690010127 and 32696543980, both AFTER the ISO built successfully.)
+
+That was never going to work. The job runs on `runs-on=.../runner=build-amd64`,
+whose families in .github/runs-on.yml are ["c6a", "c6i", "c5a", "c5"] --
+ordinary EC2 instances. EC2 exposes /dev/kvm only on `.metal` instance types.
+So the step could not have passed on any run, on any commit, ever. It is not
+capacity flakiness to retry around, and nothing in this repository can change
+it.
+
+The five boot/screenshot steps were therefore removed rather than repaired:
+installer-smoke.yml already boots the ISO on `ubuntu-latest` -- which does
+provide KVM -- SSHes into the guest, asserts the compositor and installer
+frontend, drives the installer through its screens and captures the session
+journal, across all five flavors instead of one hardcoded flavor.
+
+What is worth keeping is the RULE, because the next person to add a QEMU step
+will pick a runner the same way. Every job in this repository that touches KVM
+must run on a GitHub-hosted `ubuntu-*` runner. Today four do and all four are
+correct; the one that was not is gone.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+RUNS_ON = ROOT / ".github" / "runs-on.yml"
+
+
+def kvm_jobs():
+    """(workflow, job, runs-on) for every job whose body reaches for KVM."""
+    found = []
+    for f in sorted(WORKFLOWS.glob("*.y*ml")):
+        text = f.read_text(encoding="utf-8")
+        if "accel=kvm" not in text and "/dev/kvm" not in text:
+            continue
+        doc = yaml.safe_load(text)
+        for name, job in (doc.get("jobs") or {}).items():
+            body = yaml.dump(job)
+            if "accel=kvm" in body or "/dev/kvm" in body:
+                found.append((f.name, name, job.get("runs-on")))
+    return found
+
+
+def test_the_sweep_examines_something():
+    """A rule that matches no job passes for the wrong reason."""
+    jobs = kvm_jobs()
+    assert jobs, "no KVM-using job found at all; this file would assert nothing"
+
+
+def test_every_kvm_job_runs_on_a_github_hosted_runner():
+    offenders = [
+        (wf, job, runner)
+        for wf, job, runner in kvm_jobs()
+        if not (isinstance(runner, str) and runner.startswith("ubuntu-"))
+    ]
+    assert not offenders, (
+        "these jobs use KVM on a runner that cannot provide /dev/kvm "
+        f"(EC2 exposes it only on .metal instance types): {offenders}"
+    )
+
+
+def test_the_ec2_pool_really_cannot_supply_kvm():
+    """Pin the premise. If a .metal family is ever added, this test should be
+    revisited deliberately rather than the rule above silently over-applying."""
+    cfg = yaml.safe_load(RUNS_ON.read_text(encoding="utf-8"))
+    # The families live under a top-level `runners:` key. Reading cfg.values()
+    # directly finds nothing and makes every assertion below vacuous, which is
+    # how this test first "passed" -- hence the emptiness guard.
+    families = []
+    for runner in (cfg.get("runners") or {}).values():
+        if isinstance(runner, dict) and "family" in runner:
+            families.extend(runner["family"])
+    assert families, "no runner families parsed from runs-on.yml"
+    metal = [f for f in families if str(f).endswith(".metal") or "metal" in str(f)]
+    assert not metal, (
+        f"runs-on.yml now offers a metal family {metal}; a KVM job could "
+        "legitimately run there, so revisit test_every_kvm_job_runs_on_a_"
+        "github_hosted_runner rather than leaving it as a blanket ban"
+    )
+
+
+def test_live_iso_bootc_no_longer_boots_anything():
+    """The specific removal, so it cannot quietly come back on this runner."""
+    doc = yaml.safe_load((WORKFLOWS / "live-iso-bootc.yml").read_text(encoding="utf-8"))
+    body = yaml.dump(doc["jobs"]["build"])
+    assert "accel=kvm" not in body
+    assert "qemu-system" not in body
+    names = [s.get("name", "") for s in doc["jobs"]["build"]["steps"]]
+    assert not any("Boot ISO" in n for n in names), names
+    # It must still do the thing it CAN do, or removing the gate just
+    # removed the job's reason to exist.
+    assert any("Build Live ISO" in n for n in names), names
+    assert any("Upload Artifact" in n for n in names), names

--- a/tests/test_no_workflow_hoards_multi_gigabyte_artifacts.py
+++ b/tests/test_no_workflow_hoards_multi_gigabyte_artifacts.py
@@ -1,0 +1,117 @@
+"""Actions storage is 0.5 GB. One ISO is bigger than that.
+
+On 2026-08-24 the account hit 90% of its included Actions storage. Three
+upload steps were parking ISOs with NO `retention-days`, which means the
+GitHub default of NINETY DAYS:
+
+    live-iso-bootc.yml      path: "*.iso"                      every run, PRs included
+    publish-iso-groups.yml  path: <basename>-*.iso             every grouped cell
+    installer-smoke.yml     path: iso-out/dev.iso              retention-days: 1 (the only one set)
+
+The publish one was the worst of the three on two counts: it uploaded the
+very ISO it had just pushed to R2 — a second copy of the deliverable — and it
+did so once per grouped cell.
+
+This test is the rule rather than the three fixes. Any workflow that uploads
+something ISO-shaped must say how long to keep it, and the answer must be
+short. A default that costs money is not a default anyone chose.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+MAX_RETENTION_DAYS = 7
+
+
+def upload_steps():
+    """(workflow, job, step) for every upload-artifact step in the repo."""
+    found = []
+    for wf in WORKFLOWS:
+        try:
+            doc = yaml.safe_load(wf.read_text(encoding="utf-8"))
+        except yaml.YAMLError:
+            continue
+        for job_name, job in (doc or {}).get("jobs", {}).items():
+            if not isinstance(job, dict):
+                continue
+            for step in job.get("steps", []) or []:
+                if "upload-artifact" in str(step.get("uses", "")):
+                    found.append((wf.name, job_name, step))
+    return found
+
+
+def test_there_are_upload_steps_to_check():
+    """Guard: a sweep that matches nothing passes for the wrong reason.
+
+    This repository has produced that failure repeatedly — a regex that
+    found no workflows, a scan that read comments. Assert the corpus first.
+    """
+    steps = upload_steps()
+    assert len(steps) >= 5, f"only found {len(steps)} upload steps; parser broken?"
+    assert any(wf == "live-iso-bootc.yml" for wf, _, _ in steps)
+
+
+def iso_uploads():
+    for wf, job, step in upload_steps():
+        path = str(step.get("with", {}).get("path", ""))
+        # `.iso.sha256` and `.iso.sigstore.json` are kilobytes — the point is
+        # the image itself, so match a path component ENDING in .iso.
+        lines = [l.strip() for l in path.splitlines() if l.strip()]
+        if any(l.endswith(".iso") for l in lines):
+            yield wf, job, step
+
+
+def test_the_iso_uploads_are_still_findable():
+    assert list(iso_uploads()), (
+        "no ISO upload found — either they are all gone (good, delete this "
+        "test) or the matcher stopped matching (bad, and silent)"
+    )
+
+
+def test_every_iso_upload_sets_a_short_retention():
+    for wf, job, step in iso_uploads():
+        with_ = step.get("with", {})
+        assert "retention-days" in with_, (
+            f"{wf}:{job} uploads an ISO with no retention-days — that is the "
+            "GitHub default of 90 days, on a multi-gigabyte file, against "
+            "0.5 GB of included storage"
+        )
+        days = int(with_["retention-days"])
+        assert 1 <= days <= MAX_RETENTION_DAYS, f"{wf}:{job} keeps an ISO {days} days"
+
+
+def test_iso_uploads_do_not_waste_minutes_compressing():
+    """An ISO is already compressed; level 6 burns runner minutes for ~0%."""
+    for wf, job, step in iso_uploads():
+        level = step.get("with", {}).get("compression-level")
+        assert str(level) == "0", (
+            f"{wf}:{job} compresses an ISO (level={level}); it is already "
+            "compressed, so this costs minutes and saves nothing"
+        )
+
+
+def test_the_publish_job_does_not_also_hoard_what_it_published():
+    """R2 is where the grouped ISO goes. An artifact of the same bytes is a
+    second copy of the deliverable, per cell, and the reason to keep a run's
+    output around is the checksum and signature — not the image."""
+    doc = yaml.safe_load(
+        (ROOT / ".github" / "workflows" / "publish-iso-groups.yml").read_text(
+            encoding="utf-8"))
+    paths = [
+        str(s.get("with", {}).get("path", ""))
+        for job in doc["jobs"].values() if isinstance(job, dict)
+        for s in job.get("steps", []) or []
+        if "upload-artifact" in str(s.get("uses", ""))
+    ]
+    assert paths, "no upload steps in the publish workflow"
+    blob = "\n".join(paths)
+    assert ".iso.sha256" in blob, "the checksum should still be kept"
+    for line in [l.strip() for l in blob.splitlines() if l.strip()]:
+        assert not line.endswith(".iso"), (
+            f"the publish job uploads {line!r} as an artifact as well as to "
+            "R2 — one deliverable, two bills"
+        )

--- a/tests/test_no_workflow_hoards_multi_gigabyte_artifacts.py
+++ b/tests/test_no_workflow_hoards_multi_gigabyte_artifacts.py
@@ -18,13 +18,23 @@ short. A default that costs money is not a default anyone chose.
 """
 from __future__ import annotations
 
+import pathlib
 from pathlib import Path
 
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = sorted((ROOT / ".github" / "workflows").glob("*.yml"))
-MAX_RETENTION_DAYS = 7
+# A DISK IMAGE, not just an ISO. The first version of this rule matched
+# `.iso` — the example that prompted it — and therefore never looked at
+# gdm-paint-benchmark.yml's `base.qcow2`, which is the same shape of object
+# for the same reason. Match the class.
+DISK_IMAGE_SUFFIXES = (".iso", ".qcow2", ".raw", ".img", ".vdi", ".vmdk")
+
+# One day. The earlier ceiling was seven, which reusable-build-artifacts.yml
+# satisfied while keeping a multi-gigabyte ISO for a week — against 0.5 GB of
+# included storage, a week is indistinguishable from forever.
+MAX_RETENTION_DAYS = 1
 
 
 def upload_steps():
@@ -59,10 +69,27 @@ def iso_uploads():
     for wf, job, step in upload_steps():
         path = str(step.get("with", {}).get("path", ""))
         # `.iso.sha256` and `.iso.sigstore.json` are kilobytes — the point is
-        # the image itself, so match a path component ENDING in .iso.
+        # the image itself, so match a path component ENDING in one of the
+        # disk-image suffixes.
         lines = [l.strip() for l in path.splitlines() if l.strip()]
-        if any(l.endswith(".iso") for l in lines):
+        if any(l.endswith(DISK_IMAGE_SUFFIXES) for l in lines):
             yield wf, job, step
+
+
+def test_the_rule_covers_more_than_the_one_example_that_prompted_it():
+    """qcow2 is a disk image too.
+
+    Matching `.iso` alone let gdm-paint-benchmark.yml upload a multi-gigabyte
+    base.qcow2 through this check untouched. A rule written around its
+    motivating example is a rule with a hole in it.
+    """
+    found = {pathlib.Path(str(s.get("with", {}).get("path", "")).strip()).suffix
+             for _, _, s in iso_uploads()}
+    assert ".iso" in found, found
+    assert ".qcow2" in found, (
+        "no qcow2 upload matched — either it is gone (good) or the suffix "
+        "list stopped covering it (bad, and silent)"
+    )
 
 
 def test_the_iso_uploads_are_still_findable():
@@ -115,3 +142,27 @@ def test_the_publish_job_does_not_also_hoard_what_it_published():
             f"the publish job uploads {line!r} as an artifact as well as to "
             "R2 — one deliverable, two bills"
         )
+
+
+def test_frames_are_not_stored_twice_in_two_formats():
+    """iso-e2e converts every PPM screendump to PNG, then uploaded both.
+
+    A 1280x800 PPM is ~3 MB uncompressed against ~100 KB as PNG, so keeping
+    both stored each frame twice and the larger copy was the raw one. The
+    evidence is identical; only the bytes differ.
+    """
+    doc = yaml.safe_load(
+        (ROOT / ".github" / "workflows" / "iso-e2e.yml").read_text(encoding="utf-8"))
+    uploads = [
+        str(s.get("with", {}).get("path", ""))
+        for job in doc["jobs"].values() if isinstance(job, dict)
+        for s in job.get("steps", []) or []
+        if "upload-artifact" in str(s.get("uses", ""))
+    ]
+    assert uploads, "no upload steps found in iso-e2e.yml"
+    blob = "\n".join(uploads)
+    assert "*.png" in blob, "the PNG frames should still be kept"
+    assert "*.ppm" not in blob, (
+        "uploading the PPMs as well as the PNGs converted from them stores "
+        "every frame twice, the bigger copy uncompressed"
+    )

--- a/tests/test_one_iso_per_base_and_desktop.py
+++ b/tests/test_one_iso_per_base_and_desktop.py
@@ -1,0 +1,121 @@
+"""One ISO per base+desktop, each embedding its own NVIDIA and HWE flavors.
+
+`iso_groups` already built deduplicated multi-image ISOs — the GNOME group
+ships `<variant>.iso` carrying gnome, gnome-hwe, gnome-nvidia and
+gnome-nvidia-hwe in one offline store, so a user downloads one ISO and the
+installer picks the right image. That is the shape wanted everywhere.
+
+The other four desktops did not have it. They shared a single `community`
+group that packed KDE, COSMIC, Niri and XFCE into ONE ISO and carried
+`publish: false`, on the reasoning that the browser ISO Builder covers the
+long tail on demand so a five-flavor offline store was not worth the storage.
+
+The cost argument was sound; the conclusion was not. Someone who wants KDE
+should get a KDE ISO, not a four-desktop ISO and not a browser build step.
+And these are deduplicated groups over a shared squashfs, so per-desktop ISOs
+do not multiply storage the way per-flavor ISOs did — that was the thing
+grouping was introduced to stop.
+
+Guarded by tests because the config is what the whole publish pipeline reads,
+and a typo here is a silently missing ISO rather than an error.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / ".github" / "build-config.yml"
+DESKTOPS = ["gnome", "kde", "cosmic", "niri", "xfce"]
+
+
+def config() -> dict:
+    return yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+
+
+def groups() -> list[dict]:
+    g = config()["iso_groups"]
+    assert g, "iso_groups is empty; every assertion below would be vacuous"
+    return g
+
+
+def test_there_is_one_group_per_desktop():
+    by_desktop = {}
+    for g in groups():
+        # The flagship group's suffix is "" and it is the gnome one.
+        desktop = g.get("suffix") or "gnome"
+        assert desktop not in by_desktop, f"two groups claim {desktop}"
+        by_desktop[desktop] = g
+    assert sorted(by_desktop) == sorted(DESKTOPS), sorted(by_desktop)
+
+
+def test_no_group_packs_more_than_one_desktop():
+    """The `community` group put four desktops in one ISO.
+
+    A group is single-desktop when every flavor it names, live and offline,
+    starts with that desktop's id.
+    """
+    for g in groups():
+        desktop = g.get("suffix") or "gnome"
+        named = list(g["flavors"]) + list(g["offline_flavors"])
+        for f in named:
+            assert f.split("-")[0] == desktop, (
+                f"group {desktop!r} names {f!r} from another desktop"
+            )
+
+
+def test_every_group_embeds_its_own_nvidia_and_hwe():
+    """The point of grouping: one download, the installer picks the image."""
+    for g in groups():
+        desktop = g.get("suffix") or "gnome"
+        offline = set(g["offline_flavors"])
+        assert desktop in offline, (desktop, offline)
+        assert any("nvidia" in f for f in offline), (desktop, offline)
+        assert any("hwe" in f for f in offline), (desktop, offline)
+
+
+def test_every_group_is_published():
+    """`publish: false` is what kept four desktops off the download page."""
+    for g in groups():
+        assert g.get("publish", True) is not False, g
+
+
+def test_the_live_flavor_is_the_nvidia_one():
+    """The ISO boots the NVIDIA image so a machine with the card works on
+    first boot; the non-NVIDIA images ride along in the offline store."""
+    for g in groups():
+        assert g["flavors"], g
+        for f in g["flavors"]:
+            assert "nvidia" in f, (g.get("suffix"), f)
+
+
+def test_no_group_names_a_flavor_no_variant_has():
+    """A typo here is a silently missing ISO, not an error.
+
+    Both the matrix generator and build-iso-group.sh intersect group flavors
+    against each variant's real ones, so a flavor that no variant defines is
+    dropped everywhere and the group quietly shrinks or vanishes.
+    """
+    cfg = config()
+    defined = {f["id"] for v in cfg["variants"] for f in v.get("flavors", [])}
+    for g in groups():
+        for f in list(g["flavors"]) + list(g["offline_flavors"]):
+            assert f in defined, f"{f!r} is not a flavor of any variant"
+
+
+def test_the_intersection_that_makes_partial_variants_safe_still_exists():
+    """skipjack has no xfce-nvidia; bonito has no kde-hwe.
+
+    Those groups must shrink or be skipped rather than fail the build. Both
+    halves of that are asserted here because a group referencing a flavor a
+    variant lacks is now the normal case, not an edge one.
+    """
+    builder = (ROOT / "scripts" / "build-iso-group.sh").read_text(encoding="utf-8")
+    assert "Intersect, preserving group/offline order." in builder
+    assert "SELECTED_OFFLINE=()" in builder
+
+    wf = (ROOT / ".github" / "workflows" / "publish-iso-groups.yml").read_text(
+        encoding="utf-8")
+    assert "iso_groups ∩ variant flavors" in wf
+    assert "select(($sel | length) > 0)" in wf

--- a/tests/test_per_variant_install_overrides_reach_the_image.py
+++ b/tests/test_per_variant_install_overrides_reach_the_image.py
@@ -23,7 +23,6 @@ import subprocess
 import textwrap
 from pathlib import Path
 
-import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 DROPIN = ROOT / "system_files_overrides" / "hummingbird" / "usr" / "lib" / "bootc" / "install" / "50-hummingbird.toml"

--- a/tests/test_per_variant_install_overrides_reach_the_image.py
+++ b/tests/test_per_variant_install_overrides_reach_the_image.py
@@ -103,3 +103,55 @@ def test_the_hook_fails_loudly_when_the_variant_is_unknown(tmp_path):
     assert rc != 0, f"unset IMAGE_NAME_VARIANT must fail, not skip:\n{out}"
     assert "IMAGE_NAME_VARIANT" in out
     assert not landed
+
+
+# ---------------------------------------------------------------------------
+# The path mapping the tests above cannot see.
+#
+# _run_hook builds its fake context by hand and STUBS copy_systemfiles_for, so
+# it proves the hook's control flow and nothing about where the overrides
+# actually live. In the real build there are two independent facts that have to
+# agree, and neither is exercised above:
+#
+#   1. Containerfile.el10's context stage does `COPY system_files_overrides
+#      /overrides` -- it RENAMES the directory. The hook probes
+#      /run/context/overrides/<variant>, which is only correct because of that
+#      line.
+#   2. lib.sh's copy_systemfiles_for reads ${CONTEXT_PATH}/overrides/<variant>.
+#      The hook's own `-d` guard must name the SAME directory, or the guard
+#      passes while the copier finds nothing (or vice versa).
+#
+# Change either one and every test above still passes while the drop-in never
+# reaches the image -- a green suite over an installer that cannot finish,
+# which is the precise failure this file exists to prevent.
+# ---------------------------------------------------------------------------
+
+CONTEXT_DIR_IN_REPO = "system_files_overrides"
+CONTEXT_DIR_IN_IMAGE = "/overrides"
+
+
+def test_the_context_stage_publishes_overrides_where_the_hook_looks():
+    cf = (ROOT / "Containerfile.el10").read_text()
+    expected = f"COPY {CONTEXT_DIR_IN_REPO} {CONTEXT_DIR_IN_IMAGE}"
+    assert expected in cf, (
+        f"Containerfile.el10 must contain {expected!r}. The hook probes "
+        f"/run/context{CONTEXT_DIR_IN_IMAGE}/<variant>; renaming the COPY "
+        f"target makes it silently skip every override while exiting 0."
+    )
+    assert (ROOT / CONTEXT_DIR_IN_REPO).is_dir(), (
+        f"{CONTEXT_DIR_IN_REPO}/ is what that COPY reads"
+    )
+
+
+def test_the_hook_guards_the_same_directory_the_copier_reads():
+    """The `-d` test and copy_systemfiles_for must not drift apart."""
+    lib = (ROOT / "build_scripts" / "lib.sh").read_text()
+    assert '"${CONTEXT_PATH}/overrides/$WHAT"' in lib, (
+        "copy_systemfiles_for no longer reads ${CONTEXT_PATH}/overrides/ -- "
+        "the hook's guard below must be updated to match it"
+    )
+    hook = HOOK.read_text()
+    assert f'-d "/run/context{CONTEXT_DIR_IN_IMAGE}/${{VARIANT_KEY}}"' in hook, (
+        "the hook must guard on the same directory copy_systemfiles_for reads, "
+        "or it can pass its guard and still copy nothing"
+    )

--- a/tests/test_per_variant_install_overrides_reach_the_image.py
+++ b/tests/test_per_variant_install_overrides_reach_the_image.py
@@ -1,0 +1,106 @@
+"""hummingbird must ship an ext4 root drop-in, and the hook must deliver it.
+
+`bootc install to-disk` ABORTS for hummingbird: it probes unsealed, takes
+`type = "xfs"` from 00-tunaos.toml, and BIOS grub2-install cannot read the
+xfs this base's mkfs.xfs writes. bootupctl installs the BIOS component
+unconditionally, so the whole install fails -- on UEFI hardware too. Six
+consecutive nightly Gates died on it (run 32786338463, gnome Gate job
+97638679623) and hummingbird:gnome was never promoted.
+
+The CI-only knob (TUNAOS_QCOW2_FILESYSTEM) fixes the gate's own qcow2 and
+NOTHING ELSE: an ISO install reads the config from inside the image. So a
+green gate with no drop-in would hand users an installer that cannot
+finish -- a pass that means the opposite of what it looks like. These
+tests hold the drop-in and the hook that carries it.
+
+The hook is tested by RUNNING it against a fake context, not by grepping
+the Containerfile, because its real failure mode is applying nothing while
+exiting 0.
+"""
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+DROPIN = ROOT / "system_files_overrides" / "hummingbird" / "usr" / "lib" / "bootc" / "install" / "50-hummingbird.toml"
+HOOK = ROOT / "build_scripts" / "92-variant-customizations.sh"
+BASE = ROOT / "system_files" / "usr" / "lib" / "bootc" / "install" / "00-tunaos.toml"
+
+
+def test_hummingbird_ships_an_ext4_root_dropin():
+    assert DROPIN.is_file(), f"missing {DROPIN.relative_to(ROOT)}"
+    text = DROPIN.read_text()
+    assert "[install.filesystem.root]" in text, text
+    assert 'type = "ext4"' in text, text
+
+
+def test_the_dropin_outsorts_the_xfs_default():
+    """bootc reads the directory in sort order; a lower name would lose."""
+    assert BASE.is_file()
+    assert 'type = "xfs"' in BASE.read_text(), "the default this must override changed"
+    assert sorted([BASE.name, DROPIN.name])[-1] == DROPIN.name, (
+        f"{DROPIN.name} must sort after {BASE.name} or the xfs default wins"
+    )
+
+
+def test_the_containerfile_runs_the_hook_after_the_arch_one():
+    cf = (ROOT / "Containerfile.el10").read_text()
+    assert "92-variant-customizations.sh" in cf, "hook is never invoked"
+    assert cf.index("91-arch-customizations.sh") < cf.index("92-variant-customizations.sh"), (
+        "variant overrides must run after arch overrides so a variant can win"
+    )
+
+
+def _run_hook(tmp_path, variant_env, overrides_variant):
+    """Run the hook against a fake /run/context, returning (rc, out, landed)."""
+    ctx = tmp_path / "context"
+    (ctx / "build_scripts").mkdir(parents=True)
+    src = ctx / "overrides" / overrides_variant / "usr" / "lib" / "bootc" / "install"
+    src.mkdir(parents=True)
+    (src / "50-x.toml").write_text('[install.filesystem.root]\ntype = "ext4"\n')
+
+    dest = tmp_path / "rootfs"
+    dest.mkdir()
+    # Stub lib.sh: copy_systemfiles_for into $dest instead of /.
+    (ctx / "build_scripts" / "lib.sh").write_text(textwrap.dedent(f"""
+        canonical_variant() {{ echo "$1"; }}
+        copy_systemfiles_for() {{ cp -rf "{ctx}/overrides/$1/." "{dest}/"; }}
+        run_buildscripts_for() {{ :; }}
+    """))
+
+    hook = ctx / "build_scripts" / "92-variant-customizations.sh"
+    hook.write_text(HOOK.read_text().replace("/run/context", str(ctx)))
+    hook.chmod(0o755)
+
+    env = dict(os.environ)
+    env.pop("IMAGE_NAME_VARIANT", None)
+    if variant_env is not None:
+        env["IMAGE_NAME_VARIANT"] = variant_env
+    p = subprocess.run([str(hook)], capture_output=True, text=True, env=env)
+    landed = (dest / "usr/lib/bootc/install/50-x.toml").is_file()
+    return p.returncode, p.stdout + p.stderr, landed
+
+
+def test_the_hook_applies_the_override_for_the_matching_variant(tmp_path):
+    rc, out, landed = _run_hook(tmp_path, "hummingbird", "hummingbird")
+    assert rc == 0, out
+    assert landed, f"override did not reach the rootfs:\n{out}"
+
+
+def test_the_hook_is_a_noop_for_a_variant_with_no_overrides(tmp_path):
+    rc, out, landed = _run_hook(tmp_path, "yellowfin", "hummingbird")
+    assert rc == 0, out
+    assert not landed, "yellowfin must not pick up hummingbird's override"
+    assert "No variant overrides" in out, out
+
+
+def test_the_hook_fails_loudly_when_the_variant_is_unknown(tmp_path):
+    """Silently skipping every override is how this bug survived six nights."""
+    rc, out, landed = _run_hook(tmp_path, None, "hummingbird")
+    assert rc != 0, f"unset IMAGE_NAME_VARIANT must fail, not skip:\n{out}"
+    assert "IMAGE_NAME_VARIANT" in out
+    assert not landed

--- a/tests/test_the_flatpak_install_names_what_is_available.py
+++ b/tests/test_the_flatpak_install_names_what_is_available.py
@@ -1,0 +1,124 @@
+"""A failure message that names only what it wanted.
+
+The live customize installs the installer flatpak, and when that fails the
+only thing recorded is flatpak's own error:
+
+    error: The application org.bootcinstaller.Installer/x86_64/master requires
+    the runtime org.gnome.Platform/x86_64/50 which was not found
+
+which reads as "flathub is missing". It is not necessarily that. In Live ISOs
+run 32725309736 the `flatpak remote-add ... flathub` immediately above it had
+SUCCEEDED, and an hour earlier installer-smoke run 32704425971 installed the
+same application onto yellowfin-gnome without trouble. Same app, same runtime
+requirement, different base -- and the message cannot tell those apart.
+
+Three different situations produce that one line:
+  * no flathub remote at all;
+  * flathub present but carrying no //50 branch;
+  * the app asking for a branch nobody publishes yet.
+
+So the failure path now lists the configured remotes, the Platform/Sdk
+branches those remotes actually carry, and what the app asks for. Only on
+failure -- it costs nothing when the install works.
+
+Tested by RUNNING the block with flatpak stubbed, because its risk is that a
+diagnostic added to an error path is itself broken and nobody notices until
+the error path runs. Every probe is `|| true`; a probe that fails must not
+become the failure being diagnosed.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "live-iso" / "common" / "src" / "customize-live.sh"
+
+
+def failure_block() -> str:
+    """The `if ! timeout ... flatpak install` block, dedented to run alone."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    start = text.index("\t\tif ! timeout 900 flatpak install")
+    end = text.index("\n\t\tfi\n", start) + len("\n\t\tfi\n")
+    return "\n".join(l[2:] if l.startswith("\t\t") else l
+                     for l in text[start:end].splitlines())
+
+
+def _run(tmp_path: Path, *, install_ok: bool, sshd: bool):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    binb = tmp_path / "bin"
+    binb.mkdir()
+    (binb / "flatpak").write_text(
+        "#!/bin/sh\n"
+        'case "$1" in\n'
+        f"  install) exit {0 if install_ok else 1};;\n"
+        '  remotes) echo "flathub\thttps://dl.flathub.org/repo/";;\n'
+        '  remote-ls) echo "runtime/org.gnome.Platform/x86_64/49";;\n'
+        '  remote-info) echo "Runtime: org.gnome.Platform/x86_64/50";;\n'
+        "esac\n",
+        encoding="utf-8",
+    )
+    (binb / "timeout").write_text('#!/bin/sh\nshift; exec "$@"\n', encoding="utf-8")
+    for f in binb.iterdir():
+        f.chmod(0o755)
+
+    sd = tmp_path / "sd"
+    sd.mkdir()
+    if sshd:
+        (sd / ".enable-sshd").write_text("", encoding="utf-8")
+
+    script = tmp_path / "b.sh"
+    script.write_text(
+        f'SCRIPT_DIR="{sd}"\nINSTALLER_APP=org.bootcinstaller.Installer\n'
+        + failure_block(),
+        encoding="utf-8",
+    )
+    return subprocess.run(
+        ["bash", str(script)], capture_output=True, text=True,
+        env=dict(os.environ, PATH=f"{binb}:/usr/bin:/bin"),
+    )
+
+
+def test_the_block_was_extracted():
+    body = failure_block()
+    assert "flatpak install" in body
+    assert "remote-ls" in body, body
+
+
+def test_the_block_is_valid_shell(tmp_path):
+    f = tmp_path / "b.sh"
+    f.write_text(failure_block(), encoding="utf-8")
+    proc = subprocess.run(["bash", "-n", str(f)], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_a_successful_install_prints_no_diagnostic(tmp_path):
+    """It must stay quiet on the happy path, or it is noise on every build."""
+    proc = _run(tmp_path, install_ok=True, sshd=False)
+    assert proc.returncode == 0, proc.stderr
+    assert "FAILED" not in proc.stdout, proc.stdout
+    assert "what the remotes offer" not in proc.stdout, proc.stdout
+
+
+def test_a_failed_install_names_the_available_branches(tmp_path):
+    """The whole point: report what IS there, not only what was wanted."""
+    proc = _run(tmp_path, install_ok=False, sshd=True)
+    out = proc.stdout
+    assert "what the remotes offer" in out, out
+    assert "flathub" in out, out
+    # The branch actually carried (49) is what distinguishes the three cases.
+    assert "org.gnome.Platform/x86_64/49" in out, out
+    # And what the app asked for (50), so the mismatch is visible in one place.
+    assert "50" in out, out
+
+
+def test_the_dev_iso_still_continues_and_the_production_iso_still_fails(tmp_path):
+    """The diagnostic must not change the outcome it is diagnosing."""
+    dev = _run(tmp_path / "dev", install_ok=False, sshd=True)
+    assert dev.returncode == 0, dev.stdout + dev.stderr
+    assert "continuing (dev/e2e ISO)" in dev.stdout, dev.stdout
+
+    prod = _run(tmp_path / "prod", install_ok=False, sshd=False)
+    assert prod.returncode != 0, prod.stdout

--- a/tests/test_the_flatpak_install_names_what_is_available.py
+++ b/tests/test_the_flatpak_install_names_what_is_available.py
@@ -29,6 +29,7 @@ become the failure being diagnosed.
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -54,8 +55,9 @@ def _run(tmp_path: Path, *, install_ok: bool, sshd: bool):
         'case "$1" in\n'
         f"  install) exit {0 if install_ok else 1};;\n"
         '  remotes) echo "flathub\thttps://dl.flathub.org/repo/";;\n'
-        '  remote-ls) echo "runtime/org.gnome.Platform/x86_64/49";;\n'
-        '  remote-info) echo "Runtime: org.gnome.Platform/x86_64/50";;\n'
+        # remote-info succeeds only for //49, so the probe must report
+        # PRESENT for 49 and absent for 50 -- the mismatch under diagnosis.
+        '  remote-info) case "$4" in *//49) exit 0;; *) exit 1;; esac;;\n'
         "esac\n",
         encoding="utf-8",
     )
@@ -107,10 +109,12 @@ def test_a_failed_install_names_the_available_branches(tmp_path):
     out = proc.stdout
     assert "what the remotes offer" in out, out
     assert "flathub" in out, out
-    # The branch actually carried (49) is what distinguishes the three cases.
-    assert "org.gnome.Platform/x86_64/49" in out, out
-    # And what the app asked for (50), so the mismatch is visible in one place.
-    assert "50" in out, out
+    # The probe must report BOTH branches per remote, so "//50 absent while
+    # //49 is present" is readable off one block rather than inferred.
+    assert re.search(r"flathub\s+org\.gnome\.Platform//50\s+absent", out), out
+    assert re.search(r"flathub\s+org\.gnome\.Platform//49\s+PRESENT", out), out
+    # And it must name every remote it asked, not just the first.
+    assert "tuna-os" in out, out
 
 
 def test_the_dev_iso_still_continues_and_the_production_iso_still_fails(tmp_path):
@@ -121,3 +125,49 @@ def test_the_dev_iso_still_continues_and_the_production_iso_still_fails(tmp_path
 
     prod = _run(tmp_path / "prod", install_ok=False, sshd=False)
     assert prod.returncode != 0, prod.stdout
+
+
+def test_every_network_probe_is_time_bounded():
+    """The probe must not be able to outlive the runner.
+
+    The first version ran a bare `flatpak remote-ls --system`, which pulls the
+    full index of every configured remote. Run 32728454277 was killed during
+    exactly that command --
+
+        + flatpak remote-ls --system --columns=ref
+        ##[error]The runner has received a shutdown signal.
+
+    -- so the listing never printed and the question it was added to answer
+    stayed open. `|| true` guards a non-zero exit, not a probe slow enough to
+    lose the runner, and I had claimed the former covered the latter.
+
+    A diagnostic on an error path must be cheap, or it replaces one unanswered
+    failure with another. This is asserted on the script text rather than by
+    running it, because what matters is that no unbounded network call can
+    reach production -- a stub cannot demonstrate the absence of one.
+    """
+    body = failure_block()
+
+    calls = [
+        l.strip()
+        for l in body.splitlines()
+        # Comments quote the very command this test forbids, as the record of
+        # why it is forbidden. Match executable lines only.
+        if not l.strip().startswith("#")
+        and re.search(r"\bflatpak\s+(remote-ls|remote-info|remote-add)\b", l)
+    ]
+    assert calls, "no flatpak remote call found in the failure block"
+
+    for call in calls:
+        assert call.startswith("timeout ") or "timeout " in call, (
+            f"unbounded flatpak network call on the failure path: {call!r}"
+        )
+
+    # remote-ls over every remote is the specific shape that cost a runner.
+    executable = "\n".join(
+        l for l in body.splitlines() if not l.strip().startswith("#")
+    )
+    assert not re.search(r"flatpak remote-ls --system\s+--columns", executable), (
+        "bare `remote-ls --system` pulls every remote's full index; ask about "
+        "the specific ref with remote-info instead"
+    )

--- a/tests/test_the_flatpak_install_names_what_is_available.py
+++ b/tests/test_the_flatpak_install_names_what_is_available.py
@@ -29,7 +29,6 @@ become the failure being diagnosed.
 from __future__ import annotations
 
 import os
-import re
 import subprocess
 from pathlib import Path
 

--- a/tests/test_the_iso_build_runner_is_switchable.py
+++ b/tests/test_the_iso_build_runner_is_switchable.py
@@ -165,35 +165,61 @@ def test_the_live_iso_build_can_opt_in_to_a_github_runner():
     assert set(spec["options"]) == {"runs-on", "github"}, spec
 
 
-def test_the_live_iso_build_still_defaults_to_runs_on():
-    """Unmeasured, so unchanged.
+def test_the_live_iso_build_defaults_to_github_hosted():
+    """GitHub-hosted is the default; RunsOn is the opt-out.
 
-    installer-smoke was flipped on numbers from its own build. This job
-    builds a full OS image plus a live ISO -- different work, never timed on
-    ubuntu-latest -- and #1823's rpmdb claim is about storage rather than
-    podman, so the installer-smoke measurement does not carry over to it.
+    This asserted the opposite until 2026-08-25, on the grounds that the
+    installer-smoke measurement was about a different shape of work and
+    this job had never been timed on ubuntu-latest. Two things changed.
+
+    The measurement arrived from iso-e2e.yml: the same tacklebox
+    customize-and-commit completes in 133s on ubuntu-latest and the cell
+    boots (skipjack:kde, job 97648442043) once the build runs in one root
+    context instead of being handed through rootless storage. This job now
+    does exactly that.
+
+    And the cost of the old default became visible: RunsOn is billed EC2,
+    the PR trigger fires on the PR's whole diff rather than the pushed
+    commit, and a day of pushes to one branch put spend at $9.87 against a
+    $5.00 budget. GitHub-hosted runners are included, with 60 concurrent
+    jobs.
     """
     wf = yaml.safe_load(LIVE_ISO.read_text(encoding="utf-8"))
     spec = wf[True]["workflow_dispatch"]["inputs"]["build_runner"]
-    assert spec["default"] == "runs-on", spec
-    expr = str(live_iso_build_job()["runs-on"])
-    assert "inputs.build_runner == 'github'" in expr, expr
+    assert spec["default"] == "github", spec
+    assert set(spec["options"]) == {"github", "runs-on"}, spec
 
 
-def test_the_pull_request_trigger_still_builds_on_runs_on():
-    """The reason for the opposite comparison, asserted rather than trusted.
+def test_an_input_less_trigger_gets_the_github_default():
+    """The comparison has to be `!= 'runs-on'`, and this pins WHY.
 
-    This workflow runs on `pull_request`, which passes no inputs. Under
-    installer-smoke's `!= 'runs-on'` form that empty value would evaluate
-    true and move every PR build to ubuntu-latest without anyone choosing
-    it. Here the opt-in must stay explicit.
+    `pull_request` and `schedule` pass no inputs, so the expression sees an
+    empty string. Under `== 'github'` that is false and every input-less
+    run lands on RunsOn — which is precisely how the PR trigger came to
+    bill an EC2 ISO build on every push. Under `!= 'runs-on'` it is true
+    and they get the default.
+
+    Resolved rather than string-matched: an expression can read correctly
+    and evaluate the wrong way.
     """
     wf = yaml.safe_load(LIVE_ISO.read_text(encoding="utf-8"))
     assert "pull_request" in wf[True], sorted(wf[True])
-    expr = str(live_iso_build_job()["runs-on"])
-    assert "!= 'runs-on'" not in expr, (
-        "the != form sends PR builds to ubuntu-latest, which nothing has "
-        "measured for this job; keep the opt-in explicit"
+    expr = " ".join(str(live_iso_build_job()["runs-on"]).split())
+
+    def resolve(build_runner):
+        m = re.search(
+            r"\$\{\{ inputs\.build_runner (!=|==) '([\w-]+)' "
+            r"&& '([^']+)' \|\| (.+?) \}\}$",
+            expr,
+        )
+        assert m, f"unrecognised runs-on expression: {expr!r}"
+        op, operand, true_arm, false_arm = m.groups()
+        hit = (build_runner != operand) if op == "!=" else (build_runner == operand)
+        return true_arm if hit else false_arm.strip()
+
+    assert resolve("") == "ubuntu-latest", (
+        "an input-less trigger (pull_request, schedule) does not get the "
+        "GitHub-hosted default — this is the case that was billing EC2"
     )
-    false_arm = expr.index("||")
-    assert "runs-on={0}/runner=build-amd64" in expr[false_arm:], expr
+    assert resolve("github") == "ubuntu-latest", "explicit github must be GitHub-hosted"
+    assert "runner=build-amd64" in resolve("runs-on"), "the opt-out must still reach RunsOn"

--- a/tests/test_the_iso_build_runner_is_switchable.py
+++ b/tests/test_the_iso_build_runner_is_switchable.py
@@ -1,27 +1,29 @@
-"""Whether the ISO build actually needs AWS, made answerable.
+"""Whether the ISO build needs AWS — measured, then acted on.
 
-installer-smoke.yml routes `build-iso` to RunsOn with this reason:
+installer-smoke.yml routed `build-iso` to RunsOn with this reason:
 
     RunsOn for all cells: the ISO build (tacklebox + podman) cannot work on
     the GitHub runner's podman 5.8.4 (tunaOS#1893).
 
-Three steps later, in the same job, the podman setup step says:
+Three steps later, in the same job, the podman setup step said "both runner
+images ship podman 5.8.4 ... install the Kubic podman". The wedge was never a
+GitHub-runner property, and tunaOS#1893's root cause turned out to be a
+`podman commit --quiet` wedge inside tacklebox, fixed in tacklebox#231.
 
-    Both runner images ship podman 5.8.4 ... install the Kubic podman
+What was genuinely unknown was disk and cores. Run 32747410944 settled both,
+same commit and same steps as the RunsOn runs it is compared against:
 
-Both runner images. The wedge is not a GitHub-runner property, and the fix is
-a plain apt install with nothing runner-specific in it. tunaOS#1893's own root
-cause turned out to be a `podman commit --quiet` wedge inside tacklebox, fixed
-upstream in tacklebox#231 -- not a runner at all.
+    Build dev ISO      ubuntu-latest      RunsOn (c6a, 8 vCPU)
+    gnome              38m46s             48m18s
+    kde                41m16s             59m53s
 
-What genuinely differs is disk (80GB gp3 against ~14GB free of ~65GB) and
-cores (8 against 4). Both are measurable, and neither has been measured. So
-this adds a `build_runner` dispatch input rather than an opinion: same commit,
-same steps, one flag.
+Faster on both flavors with half the cores, no disk failure, and the gnome
+leg green end to end including the walkthrough. So ubuntu-latest is the
+default and RunsOn is the escape hatch.
 
-These tests exist to stop the experiment from quietly becoming a change. The
-default must stay RunsOn, and the weekly schedule -- which passes no inputs at
-all -- must be untouchable from here.
+These tests hold the switch honest in the new direction: the default really
+is the GitHub runner, `build_runner: runs-on` really does route back, and the
+two cannot drift apart.
 """
 from __future__ import annotations
 
@@ -44,6 +46,9 @@ def build_job() -> dict:
     return job
 
 
+GUARD = "inputs.build_runner != 'runs-on'"
+
+
 def test_the_input_exists_and_offers_both_runners():
     # `on` parses as the boolean True in YAML 1.1, which is why this is not
     # spelled wf["on"] -- a lookup that would KeyError and take the suite
@@ -52,54 +57,73 @@ def test_the_input_exists_and_offers_both_runners():
     inputs = triggers["workflow_dispatch"]["inputs"]
     assert "build_runner" in inputs, sorted(inputs)
     spec = inputs["build_runner"]
-    assert spec["default"] == "runs-on", spec
+    assert spec["default"] == "github", spec
     assert set(spec["options"]) == {"runs-on", "github"}, spec
 
 
-def test_the_default_is_still_runs_on():
-    """The experiment must not become the change by accident."""
+def test_the_default_is_the_github_runner():
     expr = str(build_job()["runs-on"])
-    # The false branch of the ternary -- what an empty input falls through to.
-    assert "runs-on={0}/runner={1}" in expr, expr
-    assert "format(" in expr, expr
-
-
-def test_asking_for_github_selects_a_github_runner():
-    expr = str(build_job()["runs-on"])
-    assert "inputs.build_runner == 'github'" in expr, expr
-    # Order matters: the github branch must be the TRUE arm. Reversing them
-    # would send every default run to ubuntu-latest, which is the mistake
-    # this whole file is guarding.
+    # The guard is written as != 'runs-on' rather than == 'github' on
+    # purpose: `schedule` passes no inputs at all, so an == comparison would
+    # send the weekly run down the RunsOn path while every dispatch went to
+    # ubuntu-latest. One default, both triggers.
+    assert GUARD in expr, expr
     true_arm = expr.index("&&")
     false_arm = expr.index("||")
     assert true_arm < false_arm, expr
     assert "ubuntu-latest" in expr[true_arm:false_arm], expr
-    assert "runs-on=" in expr[false_arm:], expr
+
+
+def test_asking_for_runs_on_routes_back_to_aws():
+    """The escape hatch has to survive, or reverting needs a code change."""
+    expr = str(build_job()["runs-on"])
+    false_arm = expr.index("||")
+    assert "runs-on={0}/runner={1}" in expr[false_arm:], expr
+    assert "format(" in expr[false_arm:], expr
 
 
 def test_the_timeout_moves_with_the_runner():
-    """Half the cores against a 75-minute cap would cancel the build and be
-    read as "GitHub runners cannot do this" -- a timeout is not a
-    measurement. The two must be driven by the same condition, or a later
-    edit to one silently invalidates the experiment."""
-    job = build_job()
-    timeout = str(job["timeout-minutes"])
-    assert "inputs.build_runner == 'github'" in timeout, timeout
+    """A cap close to the observed build time turns a slow build into a
+    cancellation and reports the wrong thing. The two must be driven by the
+    same condition, or a later edit to one silently invalidates the other."""
+    timeout = str(build_job()["timeout-minutes"])
+    assert GUARD in timeout, timeout
     assert "75" in timeout, timeout
     minutes = [int(m) for m in re.findall(r"\b(\d{2,3})\b", timeout)]
-    assert max(minutes) > 75, timeout
+    # Measured builds are 38-41 minutes; the cap must leave real headroom.
+    assert max(minutes) >= 120, timeout
 
 
-def test_the_weekly_schedule_cannot_be_switched_from_here():
-    """`schedule` passes no inputs, so the expression evaluates empty and
-    falls through to RunsOn. Asserted because the cost of being wrong is a
-    weekly run silently changing platform with nobody watching."""
+def test_the_weekly_schedule_takes_the_same_default():
+    """`schedule` passes no inputs, so `inputs.build_runner` is empty.
+
+    Under the != comparison that lands on ubuntu-latest, which is the
+    intended behaviour now -- one default for both triggers. Asserted
+    because switching it back to == would silently split them, and the
+    weekly run is the one nobody watches.
+    """
     triggers = workflow()[True]
     assert "schedule" in triggers, triggers
     sched = triggers["schedule"]
     assert isinstance(sched, list) and sched, sched
     for entry in sched:
         assert set(entry) == {"cron"}, entry
+    expr = str(build_job()["runs-on"])
+    assert "== 'github'" not in expr, (
+        "an == comparison sends the scheduled run to RunsOn while every "
+        "dispatch goes to ubuntu-latest; use != 'runs-on' so both triggers "
+        "share one default"
+    )
+
+
+def test_the_measurement_is_recorded_next_to_the_switch():
+    """The numbers are the entire argument for the default.
+
+    Without them the next reader sees an unexplained platform choice and the
+    old "RunsOn is required" comment reads as still true."""
+    body = WORKFLOW.read_text(encoding="utf-8")
+    for token in ("38m46s", "48m18s", "32747410944"):
+        assert token in body, f"{token} missing from the workflow rationale"
 
 
 def test_the_podman_step_is_not_advertised_as_runs_on_only():
@@ -117,3 +141,59 @@ def test_the_podman_step_is_not_advertised_as_runs_on_only():
     # tests a job that no longer does the thing under test.
     body = next(s for s in steps if s.get("name") == "setup working podman")
     assert "kubic" in body["run"].lower(), body["run"][:200]
+
+
+# ── live-iso-bootc.yml ───────────────────────────────────────────────────
+# The same switch, deliberately wired the OTHER way round. Two workflows with
+# opposite comparisons is exactly the kind of asymmetry that gets "tidied" into
+# a bug, so it is pinned here with the reason attached.
+
+LIVE_ISO = (Path(__file__).resolve().parents[1]
+            / ".github" / "workflows" / "live-iso-bootc.yml")
+
+
+def live_iso_build_job() -> dict:
+    wf = yaml.safe_load(LIVE_ISO.read_text(encoding="utf-8"))
+    job = wf["jobs"]["build"]
+    assert job, "live-iso build job not found; the assertions below are vacuous"
+    return job
+
+
+def test_the_live_iso_build_can_opt_in_to_a_github_runner():
+    wf = yaml.safe_load(LIVE_ISO.read_text(encoding="utf-8"))
+    spec = wf[True]["workflow_dispatch"]["inputs"]["build_runner"]
+    assert set(spec["options"]) == {"runs-on", "github"}, spec
+
+
+def test_the_live_iso_build_still_defaults_to_runs_on():
+    """Unmeasured, so unchanged.
+
+    installer-smoke was flipped on numbers from its own build. This job
+    builds a full OS image plus a live ISO -- different work, never timed on
+    ubuntu-latest -- and #1823's rpmdb claim is about storage rather than
+    podman, so the installer-smoke measurement does not carry over to it.
+    """
+    wf = yaml.safe_load(LIVE_ISO.read_text(encoding="utf-8"))
+    spec = wf[True]["workflow_dispatch"]["inputs"]["build_runner"]
+    assert spec["default"] == "runs-on", spec
+    expr = str(live_iso_build_job()["runs-on"])
+    assert "inputs.build_runner == 'github'" in expr, expr
+
+
+def test_the_pull_request_trigger_still_builds_on_runs_on():
+    """The reason for the opposite comparison, asserted rather than trusted.
+
+    This workflow runs on `pull_request`, which passes no inputs. Under
+    installer-smoke's `!= 'runs-on'` form that empty value would evaluate
+    true and move every PR build to ubuntu-latest without anyone choosing
+    it. Here the opt-in must stay explicit.
+    """
+    wf = yaml.safe_load(LIVE_ISO.read_text(encoding="utf-8"))
+    assert "pull_request" in wf[True], sorted(wf[True])
+    expr = str(live_iso_build_job()["runs-on"])
+    assert "!= 'runs-on'" not in expr, (
+        "the != form sends PR builds to ubuntu-latest, which nothing has "
+        "measured for this job; keep the opt-in explicit"
+    )
+    false_arm = expr.index("||")
+    assert "runs-on={0}/runner=build-amd64" in expr[false_arm:], expr

--- a/tests/test_the_iso_build_runner_is_switchable.py
+++ b/tests/test_the_iso_build_runner_is_switchable.py
@@ -1,0 +1,119 @@
+"""Whether the ISO build actually needs AWS, made answerable.
+
+installer-smoke.yml routes `build-iso` to RunsOn with this reason:
+
+    RunsOn for all cells: the ISO build (tacklebox + podman) cannot work on
+    the GitHub runner's podman 5.8.4 (tunaOS#1893).
+
+Three steps later, in the same job, the podman setup step says:
+
+    Both runner images ship podman 5.8.4 ... install the Kubic podman
+
+Both runner images. The wedge is not a GitHub-runner property, and the fix is
+a plain apt install with nothing runner-specific in it. tunaOS#1893's own root
+cause turned out to be a `podman commit --quiet` wedge inside tacklebox, fixed
+upstream in tacklebox#231 -- not a runner at all.
+
+What genuinely differs is disk (80GB gp3 against ~14GB free of ~65GB) and
+cores (8 against 4). Both are measurable, and neither has been measured. So
+this adds a `build_runner` dispatch input rather than an opinion: same commit,
+same steps, one flag.
+
+These tests exist to stop the experiment from quietly becoming a change. The
+default must stay RunsOn, and the weekly schedule -- which passes no inputs at
+all -- must be untouchable from here.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = (Path(__file__).resolve().parents[1]
+            / ".github" / "workflows" / "installer-smoke.yml")
+
+
+def workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def build_job() -> dict:
+    job = workflow()["jobs"]["build-iso"]
+    assert job, "build-iso job not found; every assertion below is vacuous"
+    return job
+
+
+def test_the_input_exists_and_offers_both_runners():
+    # `on` parses as the boolean True in YAML 1.1, which is why this is not
+    # spelled wf["on"] -- a lookup that would KeyError and take the suite
+    # with it.
+    triggers = workflow()[True]
+    inputs = triggers["workflow_dispatch"]["inputs"]
+    assert "build_runner" in inputs, sorted(inputs)
+    spec = inputs["build_runner"]
+    assert spec["default"] == "runs-on", spec
+    assert set(spec["options"]) == {"runs-on", "github"}, spec
+
+
+def test_the_default_is_still_runs_on():
+    """The experiment must not become the change by accident."""
+    expr = str(build_job()["runs-on"])
+    # The false branch of the ternary -- what an empty input falls through to.
+    assert "runs-on={0}/runner={1}" in expr, expr
+    assert "format(" in expr, expr
+
+
+def test_asking_for_github_selects_a_github_runner():
+    expr = str(build_job()["runs-on"])
+    assert "inputs.build_runner == 'github'" in expr, expr
+    # Order matters: the github branch must be the TRUE arm. Reversing them
+    # would send every default run to ubuntu-latest, which is the mistake
+    # this whole file is guarding.
+    true_arm = expr.index("&&")
+    false_arm = expr.index("||")
+    assert true_arm < false_arm, expr
+    assert "ubuntu-latest" in expr[true_arm:false_arm], expr
+    assert "runs-on=" in expr[false_arm:], expr
+
+
+def test_the_timeout_moves_with_the_runner():
+    """Half the cores against a 75-minute cap would cancel the build and be
+    read as "GitHub runners cannot do this" -- a timeout is not a
+    measurement. The two must be driven by the same condition, or a later
+    edit to one silently invalidates the experiment."""
+    job = build_job()
+    timeout = str(job["timeout-minutes"])
+    assert "inputs.build_runner == 'github'" in timeout, timeout
+    assert "75" in timeout, timeout
+    minutes = [int(m) for m in re.findall(r"\b(\d{2,3})\b", timeout)]
+    assert max(minutes) > 75, timeout
+
+
+def test_the_weekly_schedule_cannot_be_switched_from_here():
+    """`schedule` passes no inputs, so the expression evaluates empty and
+    falls through to RunsOn. Asserted because the cost of being wrong is a
+    weekly run silently changing platform with nobody watching."""
+    triggers = workflow()[True]
+    assert "schedule" in triggers, triggers
+    sched = triggers["schedule"]
+    assert isinstance(sched, list) and sched, sched
+    for entry in sched:
+        assert set(entry) == {"cron"}, entry
+
+
+def test_the_podman_step_is_not_advertised_as_runs_on_only():
+    """The step name said "on RunsOn" while its own comment said both images
+    need it. A name that contradicts the body is how the RunsOn requirement
+    went unexamined for as long as it did."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "setup working podman on RunsOn" not in text
+    assert "name: setup working podman" in text
+
+    steps = build_job()["steps"]
+    names = [s.get("name", "") for s in steps]
+    assert "setup working podman" in names, names
+    # And it must still actually install the Kubic podman, or the experiment
+    # tests a job that no longer does the thing under test.
+    body = next(s for s in steps if s.get("name") == "setup working podman")
+    assert "kubic" in body["run"].lower(), body["run"][:200]

--- a/tests/test_the_iso_e2e_can_address_every_cell.py
+++ b/tests/test_the_iso_e2e_can_address_every_cell.py
@@ -227,6 +227,80 @@ def test_the_build_step_fails_when_it_produces_no_iso():
 
 
 def test_the_r2_step_still_guards_the_published_path():
-    """Adding a second source must not weaken the first."""
+    """Adding a second source must not weaken the first.
+
+    The message moved when the lookup learned the grouped naming scheme;
+    what must not move is that a missing published ISO is still a hard
+    failure rather than a silently skipped cell.
+    """
     body = WORKFLOW.read_text(encoding="utf-8")
-    assert "No ISO found in R2 at live-isos/" in body
+    assert "::error::No ISO in R2 under either name" in body
+
+
+# ── Two naming schemes in one bucket ─────────────────────────────────────
+# The legacy per-flavor pipeline wrote `<variant>-<flavor>-latest.iso`; the
+# grouped dedup pipeline that replaced it writes `<basename>-latest.iso`,
+# where basename is the VARIANT ALONE for the gnome group. Measured against
+# the live bucket on 2026-08-24:
+#
+#     albacore-gnome-latest.iso   200   (legacy)
+#     albacore-kde-latest.iso     200   (legacy; grouped agrees by accident)
+#     albacore-latest.iso         404   (grouped gnome — never published)
+#     yellowfin-latest.iso        404
+#
+# So publishing the grouped ISOs would NOT have turned E2E yellowfin:gnome
+# green on its own: the object lands under a key nothing looks up.
+
+def download_step() -> dict:
+    steps = workflow()["jobs"]["e2e"]["steps"]
+    step = next(s for s in steps if "rclone copy" in str(s.get("run", "")))
+    assert "live-isos" in step["run"], step["run"][:200]
+    return step
+
+
+def test_the_lookup_tries_both_naming_schemes():
+    run = download_step()["run"]
+    assert '${VARIANT}-${FLAVOR}-latest.iso' in run, run[-800:]
+    assert '${VARIANT}-latest.iso' in run, run[-800:]
+    assert '${VARIANT}-${DESKTOP}-latest.iso' in run, run[-800:]
+
+
+def test_gnome_maps_to_the_bare_variant_name():
+    """The whole asymmetry. Every other desktop keeps its suffix; gnome's
+    grouped ISO is `<variant>-latest.iso` with no desktop in the name."""
+    run = download_step()["run"]
+    assert 'DESKTOP="${FLAVOR%%-*}"' in run, run[-800:]
+    gnome_branch = run[run.index('if [[ "$DESKTOP" == "gnome" ]]'):]
+    head = gnome_branch[:gnome_branch.index("else")]
+    assert '${VARIANT}-latest.iso' in head, head
+    assert "${DESKTOP}" not in head, head
+
+
+def test_a_flavor_variant_resolves_to_its_group():
+    """gnome-hwe and kde-nvidia ride inside their group's offline store, so
+    they must resolve to that group's ISO rather than to a per-flavor image
+    that the grouped pipeline never publishes."""
+    run = download_step()["run"]
+    # `%%-*` strips at the FIRST hyphen: gnome-nvidia-hwe -> gnome.
+    assert "%%-*" in run, run[-800:]
+
+
+def test_it_still_fails_loudly_when_neither_name_exists():
+    """Two chances to find it is not a licence to boot nothing."""
+    run = download_step()["run"]
+    assert "::error::No ISO in R2 under either name" in run, run[-800:]
+    assert "exit 1" in run
+    # And it must name BOTH keys it tried, or the next reader cannot tell
+    # which pipeline was supposed to have produced the ISO.
+    err = run[run.index("::error::No ISO in R2"):]
+    assert "${OBJECT}" in err and "${GROUP_OBJECT}" in err, err[:300]
+
+
+def test_the_rclone_failure_does_not_abort_before_the_fallback():
+    """`set -euo pipefail` plus a failing rclone would kill the step before
+    the second candidate was ever tried — the fallback would be dead code."""
+    run = download_step()["run"]
+    copy_lines = [l for l in run.splitlines() if "rclone copy" in l]
+    assert copy_lines, run[-800:]
+    idx = run.index("for candidate in")
+    assert "|| true" in run[idx:], run[idx:idx + 600]

--- a/tests/test_the_iso_e2e_can_address_every_cell.py
+++ b/tests/test_the_iso_e2e_can_address_every_cell.py
@@ -112,18 +112,24 @@ def test_whitespace_and_empty_entries_do_not_become_cells(tmp_path):
 
 
 @needs_jq
-def test_no_dispatch_keeps_the_original_two_cells(tmp_path):
+def test_no_dispatch_runs_one_small_fixed_cell_list(tmp_path):
     """The pull_request and schedule triggers pass no inputs.
 
-    They must keep testing exactly what they always did: widening the inputs
-    must not turn the harness smoke test into a fifty-cell sweep that would
-    also fail on every unpublished ISO.
+    Two properties, and the second is why this test changed. Widening the
+    dispatch inputs must not turn the harness smoke test into a fifty-cell
+    sweep -- so the list stays small and fixed. And with no inputs there is
+    no `source`, so the ISO must come from R2, which means every cell here
+    must be one R2 actually holds.
+
+    It used to be yellowfin:gnome + albacore:gnome. Measured against the
+    live bucket on 2026-08-25, albacore-gnome-latest.iso is 200 and
+    yellowfin-gnome-latest.iso is 404 (#2027), so that cell could only ever
+    fail -- on every PR that touched this workflow, for a publishing gap
+    rather than a harness regression.
     """
     m = run_generator("", "", tmp_path)
-    assert m["include"] == [
-        {"variant": "yellowfin", "flavor": "gnome"},
-        {"variant": "albacore", "flavor": "gnome"},
-    ], m
+    assert m["include"] == [{"variant": "albacore", "flavor": "gnome"}], m
+    assert len(m["include"]) <= 2, "the no-input default must stay a smoke test"
 
 
 @needs_jq

--- a/tests/test_the_iso_e2e_can_address_every_cell.py
+++ b/tests/test_the_iso_e2e_can_address_every_cell.py
@@ -148,21 +148,74 @@ def test_the_generator_never_emits_an_empty_matrix(tmp_path):
     assert "no cells to test" in proc.stdout + proc.stderr, proc.stdout
 
 
-def test_the_stale_dispatch_filter_cannot_skip_every_cell():
-    """The preflight compared one flavor against the matrix cell.
+def preflight_script() -> str:
+    steps = workflow()["jobs"]["e2e"]["steps"]
+    body = next(s["run"] for s in steps if s.get("id") == "filter")
+    assert "NEEDS_R2" in body, body
+    return body
 
-    The input is a LIST now, so feeding `inputs.flavors` into that
-    comparison would skip every cell but the first — a sweep reporting one
-    result and calling it five. The matrix is already filtered, so the
-    filter's variant/flavor halves are fed empty on purpose.
+
+def run_preflight(tmp_path: Path, needs_r2: str, creds: bool) -> dict:
+    """Run the real preflight body and return what it wrote to GITHUB_OUTPUT."""
+    out = tmp_path / "gh_output"
+    out.write_text("", encoding="utf-8")
+    script = tmp_path / "filter.sh"
+    script.write_text(preflight_script(), encoding="utf-8")
+    env = dict(os.environ, NEEDS_R2=needs_r2, GITHUB_OUTPUT=str(out))
+    for name in ("R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY",
+                 "R2_ENDPOINT", "R2_BUCKET"):
+        env[name] = "set" if creds else ""
+    proc = subprocess.run(["bash", str(script)], capture_output=True,
+                          text=True, env=env)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    return dict(
+        l.split("=", 1) for l in out.read_text(encoding="utf-8").splitlines() if "=" in l
+    )
+
+
+def test_a_dispatched_cell_is_not_skipped():
+    """The bug this replaces, asserted by RUNNING the filter.
+
+    The dispatch filter compared `inputs.variant` against `matrix.variant`
+    back when the matrix was two hardcoded cells. Once the matrix was
+    generated from those same inputs the comparison was redundant, and
+    blanking its inputs rather than deleting it made `"" != "marlin"` true —
+    so it set skip=true on EVERY dispatched cell. Every later step was
+    skipped and the job reported SUCCESS. Run 32791464847 swept six cells
+    that way and came back green in twenty seconds having booted nothing.
+
+    The previous guard asserted the OLD wiring string was absent from the
+    file. That is the shape of the old symptom, not the property that
+    matters, and it passed while the workflow skipped everything.
     """
-    body = WORKFLOW.read_text(encoding="utf-8")
-    assert "DISPATCH_FLAVOR: ${{ inputs.flavor }}" not in body
-    assert "DISPATCH_FLAVORS: ${{ inputs.flavors }}" not in re.sub(
-        r"(?s)jobs:\s*\n\s*e2e:.*", "", body).split("generate-matrix")[-1] or True
-    # The R2-credential half of that preflight must survive: it is what keeps
-    # fork PRs from burning 3.5 minutes on a bogus S3 endpoint (#1129).
-    assert "R2_ACCESS_KEY_ID" in body
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        # source=build: NEEDS_R2 is false, and no cell may be skipped.
+        got = run_preflight(Path(td), needs_r2="false", creds=False)
+    assert got.get("skip") != "true", got
+
+
+def test_the_r2_credential_guard_survived():
+    """The half that must NOT be deleted: fork PRs get no secrets, and
+    without this they burn ~3.5 minutes on a bogus S3 endpoint (#1129)."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        got = run_preflight(Path(td), needs_r2="true", creds=False)
+    assert got.get("skip") == "true", got
+    assert got.get("no_r2_credentials") == "true", got
+
+    with tempfile.TemporaryDirectory() as td:
+        ok = run_preflight(Path(td), needs_r2="true", creds=True)
+    assert ok.get("skip") != "true", ok
+
+
+def test_nothing_compares_dispatch_inputs_to_a_matrix_cell_any_more():
+    """Belt and braces: the comparison itself must be gone from the job,
+    not merely neutralised, since neutralising it is what broke the sweep."""
+    steps = workflow()["jobs"]["e2e"]["steps"]
+    blob = yaml.dump(steps)
+    assert "DISPATCH_FLAVOR:" not in blob, blob[:400]
+    assert "matrix.variant }}\" ]]" not in blob
 
 
 # ── Testing without paying to publish ────────────────────────────────────

--- a/tests/test_the_iso_e2e_can_address_every_cell.py
+++ b/tests/test_the_iso_e2e_can_address_every_cell.py
@@ -177,7 +177,6 @@ def test_the_never_implemented_artifact_source_is_gone():
     skipped the R2 fetch and left ISO_PATH unset — the job then booted
     nothing. An option that cannot work must not be offered.
     """
-    body = WORKFLOW.read_text(encoding="utf-8")
     opts = workflow()[True]["workflow_dispatch"]["inputs"]["source"]["options"]
     assert "artifact" not in opts, opts
     assert "build" in opts, opts

--- a/tests/test_the_iso_e2e_can_address_every_cell.py
+++ b/tests/test_the_iso_e2e_can_address_every_cell.py
@@ -1,0 +1,233 @@
+"""The iso criterion is 0-for-66, and the harness could only reach two cells.
+
+docs/matrix-provenance.json (2026-08-23): of 143 cells, 66 carry an `iso`
+verdict and NONE of them passes -- 61 fail, 5 untested. Six boot-green cells
+are exactly one criterion short of fully green, and in every one of the six
+that criterion is `iso`:
+
+    guppy:xfce      iso never measured      marlin:xfce     iso never measured
+    marlin:gnome    iso:fail                skipjack:kde    iso:fail
+    marlin:kde      iso:untested            skipjack:xfce   iso:fail
+
+Part of that is that only albacore's ISOs are published (#2027). The other
+part is this workflow: its dispatch inputs were `choice` lists offering
+yellowfin|albacore and gnome|gnome-hwe, and its job matrix was two hardcoded
+cells. So `albacore:kde` was not merely unpublished -- it was unaddressable.
+Nothing could have measured it.
+
+The matrix is generated now: a dispatch tests exactly the cells named, and
+every other trigger keeps the original two cells so a harness smoke test
+cannot silently become a fifty-cell sweep.
+
+The generator is TESTED BY RUNNING ITS SHELL, not by reading the YAML. Its
+risk is a jq expression that produces a syntactically valid but empty matrix,
+which GitHub renders as "no cells ran" -- a green check that tested nothing,
+which is the exact failure mode this repository keeps finding.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "iso-e2e.yml"
+
+
+def workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def generator_script() -> str:
+    steps = workflow()["jobs"]["generate-matrix"]["steps"]
+    body = next(s["run"] for s in steps if s.get("id") == "gen")
+    assert "include" in body, "the generator no longer builds an include list"
+    return body
+
+
+def run_generator(variant: str, flavors: str, tmp_path: Path,
+                  expect_fail: bool = False) -> dict | subprocess.CompletedProcess:
+    """Run the real step body with the dispatch env it would receive."""
+    out = tmp_path / "gh_output"
+    out.write_text("", encoding="utf-8")
+    script = tmp_path / "gen.sh"
+    script.write_text(generator_script(), encoding="utf-8")
+    proc = subprocess.run(
+        ["bash", str(script)], capture_output=True, text=True,
+        env=dict(os.environ, DISPATCH_VARIANT=variant, DISPATCH_FLAVORS=flavors,
+                 GITHUB_OUTPUT=str(out)),
+    )
+    if expect_fail:
+        return proc
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    line = next(l for l in out.read_text(encoding="utf-8").splitlines()
+                if l.startswith("matrix="))
+    return json.loads(line.split("=", 1)[1])
+
+
+needs_jq = pytest.mark.skipif(shutil.which("jq") is None, reason="jq not installed")
+
+
+def test_the_inputs_are_no_longer_a_two_item_choice_list():
+    triggers = workflow()[True]
+    inputs = triggers["workflow_dispatch"]["inputs"]
+    assert inputs["variant"]["type"] == "string", inputs["variant"]
+    assert "options" not in inputs["variant"], inputs["variant"]
+    assert "flavors" in inputs, sorted(inputs)
+    assert inputs["flavors"]["type"] == "string", inputs["flavors"]
+
+
+def test_the_matrix_is_generated_not_hardcoded():
+    e2e = workflow()["jobs"]["e2e"]
+    assert "generate-matrix" in e2e["needs"], e2e.get("needs")
+    assert "fromJson" in str(e2e["strategy"]["matrix"]), e2e["strategy"]
+
+
+@needs_jq
+def test_a_dispatch_reaches_a_cell_that_was_previously_unaddressable(tmp_path):
+    """albacore:kde — a published ISO with no cell to run in."""
+    m = run_generator("albacore", "kde", tmp_path)
+    assert m["include"] == [{"variant": "albacore", "flavor": "kde"}], m
+
+
+@needs_jq
+def test_a_dispatch_sweeps_several_flavors_at_once(tmp_path):
+    m = run_generator("albacore", "gnome,kde,cosmic,niri,xfce", tmp_path)
+    assert [c["flavor"] for c in m["include"]] == [
+        "gnome", "kde", "cosmic", "niri", "xfce"], m
+    assert {c["variant"] for c in m["include"]} == {"albacore"}, m
+
+
+@needs_jq
+def test_whitespace_and_empty_entries_do_not_become_cells(tmp_path):
+    """`gnome, kde,` is what a human types. A cell named "" would download
+    `<variant>--latest.iso` and fail for a reason nobody could read."""
+    m = run_generator("marlin", "gnome, kde,", tmp_path)
+    assert [c["flavor"] for c in m["include"]] == ["gnome", "kde"], m
+
+
+@needs_jq
+def test_no_dispatch_keeps_the_original_two_cells(tmp_path):
+    """The pull_request and schedule triggers pass no inputs.
+
+    They must keep testing exactly what they always did: widening the inputs
+    must not turn the harness smoke test into a fifty-cell sweep that would
+    also fail on every unpublished ISO.
+    """
+    m = run_generator("", "", tmp_path)
+    assert m["include"] == [
+        {"variant": "yellowfin", "flavor": "gnome"},
+        {"variant": "albacore", "flavor": "gnome"},
+    ], m
+
+
+@needs_jq
+def test_the_generator_never_emits_an_empty_matrix(tmp_path):
+    """An empty include list is a green check that ran nothing.
+
+    Asserted across every shape a caller can produce, because this is the
+    failure that would make the sweep look complete while measuring nothing.
+    """
+    for variant, flavors in (("", ""), ("albacore", "gnome"),
+                             ("guppy", "xfce")):
+        m = run_generator(variant, flavors, tmp_path)
+        assert m["include"], (variant, flavors, m)
+
+    # And where it genuinely cannot build one, it must FAIL rather than emit
+    # an empty list. Found by this test on the first run: `flavors=" , "`
+    # produced {"include": []}, which GitHub renders as a passing job with no
+    # cells -- a sweep that reports complete having measured nothing.
+    proc = run_generator("marlin", " , ", tmp_path, expect_fail=True)
+    assert proc.returncode != 0, proc.stdout
+    assert "no cells to test" in proc.stdout + proc.stderr, proc.stdout
+
+
+def test_the_stale_dispatch_filter_cannot_skip_every_cell():
+    """The preflight compared one flavor against the matrix cell.
+
+    The input is a LIST now, so feeding `inputs.flavors` into that
+    comparison would skip every cell but the first — a sweep reporting one
+    result and calling it five. The matrix is already filtered, so the
+    filter's variant/flavor halves are fed empty on purpose.
+    """
+    body = WORKFLOW.read_text(encoding="utf-8")
+    assert "DISPATCH_FLAVOR: ${{ inputs.flavor }}" not in body
+    assert "DISPATCH_FLAVORS: ${{ inputs.flavors }}" not in re.sub(
+        r"(?s)jobs:\s*\n\s*e2e:.*", "", body).split("generate-matrix")[-1] or True
+    # The R2-credential half of that preflight must survive: it is what keeps
+    # fork PRs from burning 3.5 minutes on a bogus S3 endpoint (#1129).
+    assert "R2_ACCESS_KEY_ID" in body
+
+
+# ── Testing without paying to publish ────────────────────────────────────
+# "I want to test all images without having to upload them all to R2, that's
+# too expensive." R2 storage for ~50 five-gigabyte ISOs is a real bill, and
+# most of those images are being tested, not shipped.
+
+def test_the_never_implemented_artifact_source_is_gone():
+    """`source: artifact` was in the dispatch UI with no implementation.
+
+    There is no download-artifact step in this workflow, so choosing it
+    skipped the R2 fetch and left ISO_PATH unset — the job then booted
+    nothing. An option that cannot work must not be offered.
+    """
+    body = WORKFLOW.read_text(encoding="utf-8")
+    opts = workflow()[True]["workflow_dispatch"]["inputs"]["source"]["options"]
+    assert "artifact" not in opts, opts
+    assert "build" in opts, opts
+    assert "r2-latest" in opts, opts
+
+
+def test_build_is_not_the_default():
+    """r2-latest stays the default: it tests the artefact users download.
+
+    `build` is for sweeping cells that are not published, which is most of
+    them — but a release check that quietly stopped testing the released
+    ISO would be worse than no check.
+    """
+    spec = workflow()[True]["workflow_dispatch"]["inputs"]["source"]
+    assert spec["default"] == "r2-latest", spec
+
+
+def test_the_build_source_never_touches_r2():
+    """The whole point. If the build path read or wrote R2 it would cost
+    exactly what it was added to avoid."""
+    steps = workflow()["jobs"]["e2e"]["steps"]
+    build = next(s for s in steps
+                 if s.get("name") == "Build the ISO on this runner")
+    blob = yaml.dump(build)
+    for token in ("rclone", "R2_BUCKET", "RCLONE_CONFIG", "upload-artifact"):
+        assert token not in blob, f"the build path references {token}"
+
+
+def test_the_build_step_only_runs_when_asked():
+    """It must not fire on the pull_request or schedule triggers, which
+    exist to check the harness in minutes, not to build an ISO."""
+    steps = workflow()["jobs"]["e2e"]["steps"]
+    build = next(s for s in steps
+                 if s.get("name") == "Build the ISO on this runner")
+    cond = str(build["if"])
+    assert "workflow_dispatch" in cond, cond
+    assert "inputs.source == 'build'" in cond, cond
+
+
+def test_the_build_step_fails_when_it_produces_no_iso():
+    """A build that silently produced nothing would hand the boot step an
+    empty ISO_PATH and fail somewhere far away from the cause."""
+    steps = workflow()["jobs"]["e2e"]["steps"]
+    build = next(s for s in steps
+                 if s.get("name") == "Build the ISO on this runner")
+    assert "build produced no ISO" in build["run"], build["run"][-400:]
+    assert "exit 1" in build["run"]
+
+
+def test_the_r2_step_still_guards_the_published_path():
+    """Adding a second source must not weaken the first."""
+    body = WORKFLOW.read_text(encoding="utf-8")
+    assert "No ISO found in R2 at live-isos/" in body

--- a/tests/test_the_iso_e2e_can_address_every_cell.py
+++ b/tests/test_the_iso_e2e_can_address_every_cell.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import shutil
 import subprocess
 from pathlib import Path

--- a/tests/test_the_on_guest_checks_actually_run.py
+++ b/tests/test_the_on_guest_checks_actually_run.py
@@ -45,6 +45,7 @@ the odd one out went unnoticed. This file holds all three to one rule.
 """
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -183,8 +184,6 @@ SCREENS = ROOT / "tests" / "installer-screens.yaml"
 
 
 def _screen(sid):
-    import yaml
-
     doc = yaml.safe_load(SCREENS.read_text())
     return next(s for s in doc["screens"] if s["id"] == sid)
 
@@ -310,12 +309,57 @@ def _rootless_setup_step():
     raise AssertionError("no rootless-podman setup step found")
 
 
-def test_the_setup_step_runs_before_the_first_rootless_command():
-    """Configuring userns after the thing that needs it would prove nothing."""
-    names = [s.get("name", "") for s in _live_iso_steps()]
+def test_the_setup_step_runs_before_any_rootless_command():
+    """Configuring userns after the thing that needs it would prove nothing.
+
+    This used to key off a `Sync image into rootless storage` step by name.
+    That step is gone: the build now runs image and ISO in one ROOT context,
+    because the rootless commit ran past tacklebox's hardcoded 600s bound on
+    a GitHub-hosted runner while the root one takes 133s (#1893). Keying on
+    a step name meant the test broke the moment the step was removed rather
+    than the moment the PROPERTY was violated, so it keys on the property
+    now: whatever rootless commands exist, the setup precedes all of them.
+
+    A rootless command here is a `podman` invocation NOT under sudo. The
+    setup step is exempt — proving rootless podman works is what it is for.
+    """
+    steps = _live_iso_steps()
+    names = [s.get("name", "") for s in steps]
     setup = next(i for i, n in enumerate(names) if "Setup rootless podman" in n)
-    sync = next(i for i, n in enumerate(names) if "Sync image into rootless storage" in n)
-    assert setup < sync, names
+
+    rootless = []
+    for i, step in enumerate(steps):
+        if i == setup:
+            continue
+        for line in str(step.get("run", "")).splitlines():
+            code = line.split("#", 1)[0].strip()
+            if not code:
+                continue
+            # `sudo podman ...` and `sudo -E env ... podman` are root; a bare
+            # `podman` or one on the right of a pipe is not.
+            for fragment in code.split("|"):
+                fragment = fragment.strip()
+                if re.match(r"^podman\b", fragment):
+                    rootless.append((i, names[i], fragment[:60]))
+
+    for i, name, fragment in rootless:
+        assert setup < i, (
+            f"step {i} ({name!r}) runs rootless podman ({fragment!r}) before "
+            f"the setup step at index {setup}; configuring userns afterwards "
+            f"proves nothing"
+        )
+
+
+def test_the_rootless_setup_step_is_still_present_as_a_guard():
+    """It is kept deliberately even though nothing rootless remains.
+
+    Nothing in this workflow needs rootless podman any more. The step costs
+    a fraction of a second and its `podman unshare true` probe fails loudly,
+    so if anyone restores a bare `just iso` it fails HERE naming the cause
+    instead of twelve minutes into a build. Removing it would make that
+    regression silent, so its presence is asserted rather than assumed.
+    """
+    assert _rootless_setup_step()["run"], "the rootless setup step has no body"
 
 
 def test_the_setup_step_proves_rootless_podman_works(tmp_path):

--- a/tests/test_the_on_guest_checks_actually_run.py
+++ b/tests/test_the_on_guest_checks_actually_run.py
@@ -367,3 +367,73 @@ def test_the_setup_step_passes_when_the_namespace_can_be_created(tmp_path):
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert "can create a user namespace" in proc.stdout, proc.stdout
+
+
+def test_the_gate_values_survive_log_truncation(tmp_path):
+    """The diagnostic must land somewhere the job log's truncation cannot eat.
+
+    `Build OS image` emits tens of thousands of lines, and the log download for
+    that job comes back starting PART-WAY THROUGH it -- everything steps 1-6
+    printed is simply absent. On run 32690010127 step 8 went from failing to
+    passing across this change and the evidence for WHY was in the cut region,
+    which is the same defect as never capturing it.
+    """
+    import os
+    import subprocess
+
+    step = tmp_path / "step.sh"
+    step.write_text(_rootless_setup_step()["run"], encoding="utf-8")
+
+    shims = tmp_path / "bin"
+    shims.mkdir()
+    (shims / "sudo").write_text('#!/bin/sh\nexec "$@"\n')
+    (shims / "podman").write_text("#!/bin/sh\nexit 0\n")
+    (shims / "sysctl").write_text('#!/bin/sh\n[ "$1" = "-n" ] && { echo 1; exit 0; }\nexit 0\n')
+    (shims / "tee").write_text("#!/bin/sh\ncat >/dev/null\n")
+    for f in shims.iterdir():
+        f.chmod(0o755)
+
+    summary = tmp_path / "summary.md"
+    env = dict(
+        os.environ,
+        PATH=f"{shims}:/usr/bin:/bin",
+        USER="runner",
+        GITHUB_STEP_SUMMARY=str(summary),
+    )
+    proc = subprocess.run(["bash", str(step)], capture_output=True, text=True, env=env)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    written = summary.read_text(encoding="utf-8")
+    assert "apparmor_restrict_unprivileged_userns" in written, written
+    # The VALUE, not just the key -- a summary naming the gate without saying
+    # what it was set to settles nothing.
+    assert "`1`" in written, written
+
+
+def test_the_step_survives_a_missing_step_summary(tmp_path):
+    """`set -u` plus an unset GITHUB_STEP_SUMMARY must not kill the step.
+
+    Caught by this suite rather than by a run: the first version referenced the
+    variable unguarded and died with `unbound variable` after the probe had
+    already passed.
+    """
+    import os
+    import subprocess
+
+    step = tmp_path / "step.sh"
+    step.write_text(_rootless_setup_step()["run"], encoding="utf-8")
+
+    shims = tmp_path / "bin"
+    shims.mkdir()
+    (shims / "sudo").write_text('#!/bin/sh\nexec "$@"\n')
+    (shims / "podman").write_text("#!/bin/sh\nexit 0\n")
+    (shims / "sysctl").write_text('#!/bin/sh\n[ "$1" = "-n" ] && { echo 0; exit 0; }\nexit 0\n')
+    (shims / "tee").write_text("#!/bin/sh\ncat >/dev/null\n")
+    for f in shims.iterdir():
+        f.chmod(0o755)
+
+    env = {k: v for k, v in os.environ.items() if k != "GITHUB_STEP_SUMMARY"}
+    env.update(PATH=f"{shims}:/usr/bin:/bin", USER="runner")
+    proc = subprocess.run(["bash", str(step)], capture_output=True, text=True, env=env)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "unbound variable" not in proc.stderr, proc.stderr

--- a/tests/test_the_on_guest_checks_actually_run.py
+++ b/tests/test_the_on_guest_checks_actually_run.py
@@ -1,0 +1,267 @@
+"""The gate that never executed, and reported 127 failures while not doing so.
+
+scripts/e2e-installer-gui-checks.sh is the assertion that the right compositor
+is running and the right installer frontend launched -- the per-flavor half of
+the ISO axis. It has never run.
+
+iso-e2e.sh uploads the TAP helpers FLAT, beside the check script:
+
+    scp scripts/lib/e2e-assert.sh guest:${GUEST_HOME}/e2e-assert.sh
+    ssh  TEST_LIB_DIR=${GUEST_HOME} bash ${GUEST_HOME}/e2e-installer-gui-checks.sh
+
+and the script resolved them as `${TEST_LIB_DIR}/lib/e2e-assert.sh`, putting
+`/lib` AFTER the expansion instead of inside the default. With TEST_LIB_DIR
+set -- which is always, from the harness -- that names a directory the guest
+does not have. From smoke run 32681262659:
+
+    /home/liveuser/e2e-installer-gui-checks.sh: line 25:
+      /home/liveuser/lib/e2e-assert.sh: No such file or directory
+    /home/liveuser/e2e-installer-gui-checks.sh: line 54: check: command not found
+    ...
+    line 159: print_summary: command not found
+
+`source` failed, `check` was never defined, every assertion evaporated onto
+stderr, and bash exited 127. The harness printed that as
+
+    ::warning::installer GUI checks reported 127 failure(s) for gnome
+
+127 is bash for command-not-found. It is not a count of anything, and it was
+a WARNING, in a mode that tolerates warnings.
+
+Two properties, and the second matters more than the first:
+
+1. THE SCRIPT RESOLVES ITS HELPERS TO WHERE THEY ARE UPLOADED. Tested by
+   building the guest's layout on disk and RUNNING the script, because the bug
+   was in a shell expansion -- reading the line is how it survived review.
+
+2. A GATE THAT DID NOT RUN IS NOT A GATE THAT FOUND PROBLEMS. Non-strict mode
+   exists to tolerate failed assertions, not an absent gate. The discriminator
+   is the TAP summary: `# Results:` comes only from print_summary, the last
+   statement of every check script, so its absence means the script never
+   reached the end whatever the exit code claims.
+
+The two sibling scripts get (1) right two different ways, which is exactly how
+the odd one out went unnoticed. This file holds all three to one rule.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+HARNESS = SCRIPTS / "iso-e2e.sh"
+CHECK_SCRIPTS = [
+    "e2e-installer-gui-checks.sh",
+    "e2e-smoke-checks.sh",
+    "e2e-luks-checks.sh",
+]
+
+
+def _guest_layout(tmp_path: Path, script: str) -> Path:
+    """Reproduce what iso-e2e.sh actually puts on the guest: both files flat."""
+    home = tmp_path / "liveuser"
+    home.mkdir()
+    shutil.copy(SCRIPTS / script, home / script)
+    shutil.copy(SCRIPTS / "lib" / "e2e-assert.sh", home / "e2e-assert.sh")
+    return home
+
+
+@pytest.mark.parametrize("script", CHECK_SCRIPTS)
+def test_the_check_script_runs_in_the_layout_the_harness_creates(tmp_path, script):
+    """Run it. A path bug in a shell expansion is invisible to reading."""
+    home = _guest_layout(tmp_path, script)
+    proc = subprocess.run(
+        ["bash", str(home / script)],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "TEST_LIB_DIR": str(home), "FLAVOR": "gnome"},
+    )
+    combined = proc.stdout + proc.stderr
+    # The assertions themselves are expected to FAIL here -- this machine is
+    # not a booted live guest. What must not happen is the helpers going
+    # missing, which is the difference between a red gate and no gate.
+    assert "No such file or directory" not in combined, combined
+    assert "command not found" not in combined, combined
+    assert "Bail out!" not in combined, combined
+    # print_summary ran, so the exit status is a failure COUNT.
+    assert "# Results:" in proc.stdout, combined
+    assert proc.returncode != 127, "127 is command-not-found, not a count"
+
+
+@pytest.mark.parametrize("script", CHECK_SCRIPTS)
+def test_a_missing_helper_bails_out_instead_of_evaporating(tmp_path, script):
+    """The guard: no helpers must be loud, not silently assertion-free."""
+    home = tmp_path / "liveuser"
+    home.mkdir()
+    shutil.copy(SCRIPTS / script, home / script)  # helper deliberately absent
+    proc = subprocess.run(
+        ["bash", str(home / script)],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "TEST_LIB_DIR": str(home), "FLAVOR": "gnome"},
+    )
+    out = proc.stdout + proc.stderr
+    assert "Bail out!" in out, out
+    # And it must NOT look like a completed run of zero failures.
+    assert "# Results:" not in proc.stdout, out
+    assert proc.returncode != 0
+
+
+def _checks_ran(tmp_path, output: str, rc: str) -> subprocess.CompletedProcess:
+    """Run the harness's own discriminator, lifted out of iso-e2e.sh."""
+    text = HARNESS.read_text()
+    start = text.index("checks_ran() {")
+    end = text.index("\n}\n", start) + len("\n}\n")
+    script = tmp_path / "cr.sh"
+    script.write_text(text[start:end] + f'\nchecks_ran "$1" "$2" "installer GUI"\n')
+    return subprocess.run(
+        ["bash", str(script), output, rc], capture_output=True, text=True
+    )
+
+
+def test_a_run_with_no_tap_summary_is_a_hard_failure(tmp_path):
+    """The exact pre-fix output, which the harness called a warning."""
+    proc = _checks_ran(
+        tmp_path,
+        "# Installer GUI checks — flavor=gnome\n"
+        "/home/liveuser/e2e-installer-gui-checks.sh: line 54: check: command not found\n",
+        "127",
+    )
+    assert proc.returncode != 0
+    assert "did not run to completion" in proc.stderr, proc.stderr
+    # It must say plainly that 127 is not a count, or the next reader repeats
+    # the reading that let this sit.
+    assert "NOT a count of failed assertions" in proc.stderr, proc.stderr
+
+
+def test_a_completed_run_with_failures_is_not_treated_as_absent(tmp_path):
+    """It must be able to say YES, or every real red leg becomes 'did not run'."""
+    proc = _checks_ran(
+        tmp_path, "ok - a\nnot ok - b\n# Results: 1 passed, 1 failed, 2 total\n", "1"
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stderr == "", proc.stderr
+
+
+def test_a_bail_out_reason_is_surfaced(tmp_path):
+    """When the script said why, repeat it -- do not make someone find it."""
+    proc = _checks_ran(
+        tmp_path, "Bail out! cannot read assertion helpers at /home/liveuser/lib\n", "99"
+    )
+    assert proc.returncode != 0
+    assert "cannot read assertion helpers" in proc.stderr, proc.stderr
+
+
+@pytest.mark.parametrize("phase", ["run_smoke_checks", "run_installer_gui_checks"])
+def test_both_on_guest_gates_are_wired_to_the_discriminator(phase):
+    """A discriminator nothing calls is the same bug one level up."""
+    text = HARNESS.read_text()
+    start = text.index(f"{phase}() {{")
+    end = text.index("\n}\n", start)
+    assert "checks_ran " in text[start:end], f"{phase} does not call checks_ran"
+
+
+# ── The screen contract had never seen the GNOME frontend ───────────────────
+#
+# tests/installer-screens.yaml was measured on 2026-08-07 against KDE, Niri,
+# XFCE and COSMIC. gnome was absent from installer-smoke.yml's matrix until
+# #1039, so upstream bootc-installer -- the frontend gnome actually runs -- was
+# never OCRed. Run 32681262659 is the first time that cell has ever run, and it
+# reported no 'disk' screen while crediting encryption and summary, which both
+# sit after disk selection. Its heading is "Install Location".
+#
+# The same shape as the 'install' list before it: a frontend failing a screen it
+# demonstrably reached is one wrong list, not a wording bug.
+
+SCREENS = ROOT / "tests" / "installer-screens.yaml"
+
+
+def _screen(sid):
+    import yaml
+
+    doc = yaml.safe_load(SCREENS.read_text())
+    return next(s for s in doc["screens"] if s["id"] == sid)
+
+
+def test_the_disk_contract_matches_the_gnome_frontends_own_heading():
+    kws = [k.lower() for k in _screen("disk")["keywords"]]
+    assert any(k in "install location" for k in kws), (
+        "the gnome frontend's disk page is headed 'Install Location' "
+        "(bootc_installer/gtk/default-disk.blp); no keyword matches it"
+    )
+
+
+def test_no_disk_keyword_carries_a_product_name():
+    """The branding work must not be able to break this contract."""
+    for k in _screen("disk")["keywords"]:
+        low = k.lower()
+        for name in ("tunaos", "bluefin", "aurora", "bazzite"):
+            assert name not in low, f"{k!r} embeds a product name"
+
+
+def test_the_required_screens_are_the_ones_a_walkthrough_can_reach():
+    """install/done stay optional: a walkthrough stops at the summary rather
+    than confirming a destructive install, so it cannot reach either."""
+    import yaml
+
+    doc = yaml.safe_load(SCREENS.read_text())
+    required = {s["id"] for s in doc["screens"] if s["required"]}
+    assert required == {"welcome", "disk", "summary"}, required
+
+
+# ── The compositor's own reason for exiting ─────────────────────────────────
+#
+# greetd captures nothing from the session it runs. When xfwl4 exits at once,
+# the journal holds greetd's bookkeeping and not one line from the process
+# that died (run 32681262659):
+#
+#   greetd: pam_unix(greetd-greeter:session): session closed for user liveuser
+#   greetd: error: check_children: greeter exited without creating a session
+#
+# repeated to start-limit-hit. That message is the entire evidence base on
+# which this failure has been attributed to a missing DRM render node, and the
+# same run disproves the attribution: the guest HAS /dev/dri/renderD128, and
+# the kernel reports `[drm] features: -virgl`. Node present, 3D absent --
+# different claims needing different evidence.
+#
+# So the session runs under systemd-cat and the workflow reads the tag. A log
+# nobody prints is worth no more than no log, which is why both halves are
+# pinned here.
+
+LIVE_SRC = ROOT / "live-iso" / "common" / "src"
+SESSION_TAG = "tunaos-live-session"
+GREETD_ADAPTERS = ["desktop-xfce.sh", "desktop-niri.sh", "desktop-cosmic.sh"]
+
+
+@pytest.mark.parametrize("adapter", GREETD_ADAPTERS)
+def test_every_greetd_session_command_is_journal_captured(adapter):
+    """Every one -- initial_session AND default_session, in every branch."""
+    lines = [
+        ln.strip()
+        for ln in (LIVE_SRC / adapter).read_text().splitlines()
+        if ln.strip().startswith("command = ")
+    ]
+    assert lines, f"{adapter} writes no greetd command; this test found nothing"
+    for ln in lines:
+        assert f"systemd-cat -t {SESSION_TAG}" in ln, ln
+
+
+def test_the_adapters_checked_are_the_ones_that_write_greetd_configs():
+    """Guard against the list above going stale as adapters are added."""
+    writers = {
+        p.name
+        for p in LIVE_SRC.glob("desktop-*.sh")
+        if "command = " in p.read_text()
+    }
+    assert writers == set(GREETD_ADAPTERS), writers
+
+
+def test_the_workflow_prints_the_session_journal():
+    body = (ROOT / ".github" / "workflows" / "installer-smoke.yml").read_text()
+    assert f"journalctl -t {SESSION_TAG}" in body, (
+        "the session now logs under a tag nothing reads"
+    )

--- a/tests/test_the_on_guest_checks_actually_run.py
+++ b/tests/test_the_on_guest_checks_actually_run.py
@@ -51,6 +51,8 @@ from pathlib import Path
 
 import pytest
 
+yaml = pytest.importorskip("yaml")
+
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS = ROOT / "scripts"
 HARNESS = SCRIPTS / "iso-e2e.sh"
@@ -265,3 +267,103 @@ def test_the_workflow_prints_the_session_journal():
     assert f"journalctl -t {SESSION_TAG}" in body, (
         "the session now logs under a tag nothing reads"
     )
+
+
+# ── A setup step that configures something and never checks it ──────────────
+#
+# `Sync image into rootless storage` runs `sudo podman save ... | podman load`.
+# The second half is rootless, and on Ubuntu 24.04 -- which is the distro the
+# kubic repo pins podman against in this very workflow -- an unprivileged
+# clone(CLONE_NEWUSER) is refused by default:
+#
+#   kernel.apparmor_restrict_unprivileged_userns = 1
+#
+# podman reports that without naming it:
+#
+#   cannot clone: Permission denied
+#   Error: cannot re-exec process
+#   ##[error]Process completed with exit code 125
+#
+# (run 32688258870). Twelve minutes of image build happen first, because the
+# first rootless command in the job is the one immediately after `Build OS
+# image` -- so the cost of the missing diagnosis is a whole build, and the
+# message names neither namespaces nor AppArmor nor the sysctl.
+#
+# The subuid/subgid step already existed to make rootless podman work. It set
+# a precondition and never verified the thing it was a precondition FOR, which
+# is the same shape as the helper-path bug above: configuration present,
+# behaviour absent, nobody looking. So the step now PROVES it with the cheapest
+# possible instance of the operation everything downstream needs.
+
+LIVE_ISO_WORKFLOW = ROOT / ".github" / "workflows" / "live-iso-bootc.yml"
+
+
+def _live_iso_steps():
+    doc = yaml.safe_load(LIVE_ISO_WORKFLOW.read_text())
+    return doc["jobs"]["build"]["steps"]
+
+
+def _rootless_setup_step():
+    for s in _live_iso_steps():
+        if "Setup rootless podman" in s.get("name", ""):
+            return s
+    raise AssertionError("no rootless-podman setup step found")
+
+
+def test_the_setup_step_runs_before_the_first_rootless_command():
+    """Configuring userns after the thing that needs it would prove nothing."""
+    names = [s.get("name", "") for s in _live_iso_steps()]
+    setup = next(i for i, n in enumerate(names) if "Setup rootless podman" in n)
+    sync = next(i for i, n in enumerate(names) if "Sync image into rootless storage" in n)
+    assert setup < sync, names
+
+
+def test_the_setup_step_proves_rootless_podman_works(tmp_path):
+    """Run the body with podman shimmed to fail; it must exit nonzero and SAY why."""
+    import os
+    import subprocess
+
+    step = tmp_path / "step.sh"
+    step.write_text(_rootless_setup_step()["run"], encoding="utf-8")
+
+    shims = tmp_path / "bin"
+    shims.mkdir()
+    (shims / "sudo").write_text('#!/bin/sh\nexec "$@"\n')
+    (shims / "podman").write_text("#!/bin/sh\nexit 1\n")  # userns refused
+    (shims / "sysctl").write_text('#!/bin/sh\n[ "$1" = "-n" ] && { echo 1; exit 0; }\nexit 0\n')
+    (shims / "tee").write_text("#!/bin/sh\ncat >/dev/null\n")
+    for f in shims.iterdir():
+        f.chmod(0o755)
+
+    env = dict(os.environ, PATH=f"{shims}:/usr/bin:/bin", USER="runner")
+    proc = subprocess.run(["bash", str(step)], capture_output=True, text=True, env=env)
+
+    assert proc.returncode != 0, proc.stdout
+    assert "cannot create a user namespace" in proc.stdout, proc.stdout
+    # The values that identify WHICH gate is closed must be printed, or the
+    # step just relocates an unexplained failure instead of explaining it.
+    assert "apparmor_restrict_unprivileged_userns" in proc.stdout, proc.stdout
+
+
+def test_the_setup_step_passes_when_the_namespace_can_be_created(tmp_path):
+    """It must also be able to succeed, or it is a permanently red gate."""
+    import os
+    import subprocess
+
+    step = tmp_path / "step.sh"
+    step.write_text(_rootless_setup_step()["run"], encoding="utf-8")
+
+    shims = tmp_path / "bin"
+    shims.mkdir()
+    (shims / "sudo").write_text('#!/bin/sh\nexec "$@"\n')
+    (shims / "podman").write_text("#!/bin/sh\nexit 0\n")  # userns allowed
+    (shims / "sysctl").write_text('#!/bin/sh\n[ "$1" = "-n" ] && { echo 0; exit 0; }\nexit 0\n')
+    (shims / "tee").write_text("#!/bin/sh\ncat >/dev/null\n")
+    for f in shims.iterdir():
+        f.chmod(0o755)
+
+    env = dict(os.environ, PATH=f"{shims}:/usr/bin:/bin", USER="runner")
+    proc = subprocess.run(["bash", str(step)], capture_output=True, text=True, env=env)
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "can create a user namespace" in proc.stdout, proc.stdout

--- a/tests/test_the_progress_screen_keywords_were_measured.py
+++ b/tests/test_the_progress_screen_keywords_were_measured.py
@@ -1,0 +1,114 @@
+"""The install screen, measured against what is on it before the log scrolls.
+
+The `install` row of tests/installer-screens.yaml carries a 2026-08-07 note
+that ZERO of the four forks matched it, and the fix chosen then was to match
+the backend's own step lines -- "partitioning", "installing image" -- on the
+reasoning that every frontend streams the same backend.
+
+That covers the screen once fisherman has emitted a step. It does not cover
+the screen the moment it opens, which is the state a harness screenshot
+actually catches, and it is the state three of five frontends spend the whole
+walkthrough in:
+
+    gnome   "Installing", "0:00 elapsed"      progress.blp:189,229
+    kde     "Installing <p> onto <d>. Do not power off the machine."
+    cosmic  "Installing <p>" + "Do not power off the computer."
+    niri    "Installing..."                   ui/installer.qml:422
+    xfce    "Installing <p>" + a PIPELINE_STEPS label
+
+"do not power off" is on kde and cosmic, on that screen and no other, and
+carries no product name. gnome is left unmatched on purpose -- see the file's
+comment -- because the alternatives are a bare word the header forbids and a
+string whose visibility depends on the recipe.
+
+Run against the harness, not grepped: the install screen is index 4 in the
+spec, so a match confined to visual state 0 is discarded by design, and a
+test that only checked the keyword list would miss that entirely.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_installer_walkthrough import run_walkthrough  # noqa: E402
+
+SPEC = Path(__file__).resolve().parents[1] / "tests" / "installer-screens.yaml"
+
+WELCOME = "Welcome to Yellowfin"
+DISK = "Select Target Disk"
+
+KDE_PROGRESS = ("Installing Yellowfin onto /dev/vda. Do not power off the "
+                "machine.")
+COSMIC_PROGRESS = "Installing Yellowfin Do not power off the computer."
+
+
+def install_keywords() -> list[str]:
+    spec = yaml.safe_load(SPEC.read_text(encoding="utf-8"))["screens"]
+    row = next(s for s in spec if s["id"] == "install")
+    # Still advisory. This change records drift; it does not make a frontend
+    # fail for wording, which is a separate decision nobody has taken.
+    assert row["required"] is False, row
+    return [k.lower() for k in row["keywords"]]
+
+
+def test_the_added_keyword_carries_no_product_name():
+    assert "do not power off" in install_keywords()
+    for kw in install_keywords():
+        for banned in ("tunaos", "yellowfin", "skipjack", "bluefin"):
+            assert banned not in kw, kw
+
+
+def test_kdes_progress_screen_is_now_credited():
+    proc, summary = run_walkthrough(
+        {"00": WELCOME, "01": KDE_PROGRESS, "02": KDE_PROGRESS},
+    )
+    assert summary is not None, proc.stdout + proc.stderr
+    assert summary["screens"]["install"] is True, (summary["screens"],
+                                                   proc.stdout)
+
+
+def test_cosmics_progress_screen_is_now_credited():
+    proc, summary = run_walkthrough(
+        {"00": WELCOME, "01": COSMIC_PROGRESS, "02": COSMIC_PROGRESS},
+        flavor="cosmic",
+    )
+    assert summary is not None, proc.stdout + proc.stderr
+    assert summary["screens"]["install"] is True, (summary["screens"],
+                                                   proc.stdout)
+
+
+def test_it_does_not_credit_an_install_to_a_disk_screen():
+    """The phantom-row failure this list's comments are entirely about.
+
+    Run 29681255102 credited 'install' to Select Target Disk off a single
+    "%". A keyword added years later must not reopen that.
+    """
+    proc, summary = run_walkthrough(
+        {"00": WELCOME, "01": DISK, "02": "Choose the disk where Yellowfin "
+                                          "will be installed."},
+    )
+    assert summary is not None, proc.stdout + proc.stderr
+    assert summary["screens"]["install"] is False, proc.stdout
+    assert summary["screens"]["disk"] is True, proc.stdout
+
+
+def test_the_added_keyword_is_what_does_the_work():
+    """Mutation, with the substitution asserted before it is trusted."""
+    original = SPEC.read_text(encoding="utf-8")
+    mutated = original.replace(
+        '"installing image", "do not power off"]', '"installing image"]')
+    assert mutated != original, "the mutation matched nothing; it proves nothing"
+    try:
+        SPEC.write_text(mutated, encoding="utf-8")
+        proc, summary = run_walkthrough(
+            {"00": WELCOME, "01": KDE_PROGRESS, "02": KDE_PROGRESS},
+        )
+        assert summary is not None, proc.stdout + proc.stderr
+        assert summary["screens"]["install"] is False, (
+            "kde matched without the added keyword, so it is not what fixed it"
+        )
+    finally:
+        SPEC.write_text(original, encoding="utf-8")

--- a/tests/test_the_seat_diagnostic_collects_evidence.py
+++ b/tests/test_the_seat_diagnostic_collects_evidence.py
@@ -158,3 +158,15 @@ def test_the_journal_capture_covers_every_display_manager():
     units = set(re.findall(r"-u (\S+)", m.group(0)))
     for dm in ("greetd", "cosmic-greeter", "plasmalogin", "gdm"):
         assert dm in units, f"{dm} is not captured; units are {sorted(units)}"
+    # systemd-logind is the one that survives the session it describes.
+    # `loginctl` is read minutes after the compositor died and greetd gave up,
+    # so it reports whatever is left -- the SSH login and the user manager,
+    # both of which legitimately have no seat. logind's journal records "New
+    # session N of user ..." WITH the seat and VT at the moment the session was
+    # created, which is the only post-mortem-proof answer to whether the
+    # compositor's session was ever seated.
+    assert "systemd-logind" in units, (
+        "systemd-logind is not captured; without it the seat question can only "
+        "be answered from post-mortem loginctl output, which cannot see the "
+        f"session that already exited. units are {sorted(units)}"
+    )

--- a/tests/test_the_seat_diagnostic_collects_evidence.py
+++ b/tests/test_the_seat_diagnostic_collects_evidence.py
@@ -1,0 +1,137 @@
+"""Why four of five desktops fail, and the one line that will settle it.
+
+Run 32691426582's xfce leg produced the first compositor stderr this project
+has ever captured, and it points somewhere nobody was looking:
+
+    INFO  xfwl4::backend::udev: Using renderD128 as primary GPU
+    INFO  xfwl4::core::state: Listening on wayland socket name="wayland-1"
+    WARN  smithay::backend::drm::device::fd: Unable to become drm master,
+          assuming unprivileged mode
+    INFO  smithay::backend::egl::display: EGL Initialized
+    WARN  xfwl4::backend::udev::device: failed to initialize gpu err=NoRenderNode
+    ERROR xfwl4: Failed to initialize primary GPU node
+
+NoRenderNode for a device it had already selected and NAMED. /dev/dri in the
+same guest confirms the node is there and world readable:
+
+    crw-rw----+ 1 root video  226,   1 card1
+    crw-rw-rw-. 1 root render 226, 128 renderD128
+
+The unifying fact is in loginctl, from the same capture:
+
+    SESSION  UID USER     SEAT LEADER CLASS   TTY IDLE SINCE
+          2 1000 liveuser -    1273   manager -   no   -
+         24 1000 liveuser -    3469   user    -   no   -
+
+EVERY session has an empty SEAT and an empty TTY. logind hands DRM master to
+the active session ON A SEAT; with no seat there is no DRM master, which is
+precisely what the compositor reports one line before it dies. It also fits
+the matrix: gnome -- the only flavor that works -- is the only one on gdm
+rather than greetd.
+
+So "cosmic, niri, xfwl4 and kde need a DRM render node" is contradicted by the
+render node being present and named. WHY the seat is missing is NOT settled,
+and this file does not encode a guess about it. It pins the DIAGNOSTIC that
+will settle it: greetd's PAM stack, and per-session Seat/VTNr/Active.
+
+The payload is asserted by RUNNING it with loginctl shimmed, because its trap
+is quoting -- an `awk "{print \\$1}"` nested inside a single-quoted ssh
+argument inside a YAML block scalar. A grep for "loginctl" in the workflow
+would pass on a loop that silently iterates over nothing, which is the exact
+defect class this branch keeps finding.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "installer-smoke.yml"
+
+
+def capture_step() -> str:
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    for s in doc["jobs"]["smoke"]["steps"]:
+        if "Capture installer stderr" in s.get("name", ""):
+            return s["run"]
+    raise AssertionError("capture step not found")
+
+
+def seat_payload() -> str:
+    """The inner ssh command, unwrapped so it can be executed directly."""
+    body = capture_step()
+    m = re.search(
+        r"\$SSH 'echo \"-- /etc/pam\.d/greetd --\".*?' 2>/dev/null \|\| true", body, re.S
+    )
+    assert m, "the seat diagnostic is not in the capture step"
+    inner = m.group(0)[len("$SSH '") : -len("' 2>/dev/null || true")]
+    return inner.replace("\\\n", "\n")
+
+
+def test_the_capture_step_is_valid_shell(tmp_path):
+    f = tmp_path / "cap.sh"
+    f.write_text(capture_step(), encoding="utf-8")
+    proc = subprocess.run(["bash", "-n", str(f)], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+
+
+def _run_payload(tmp_path, sessions: str):
+    shims = tmp_path / "bin"
+    shims.mkdir()
+    (shims / "loginctl").write_text(
+        "#!/bin/sh\n"
+        'case "$1" in\n'
+        f"  list-sessions) {sessions};;\n"
+        '  show-session)  echo "Id=$2"; echo "Seat="; echo "VTNr=0"; echo "Active=no";;\n'
+        '  list-seats)    echo "seat0";;\n'
+        "esac\n",
+        encoding="utf-8",
+    )
+    (shims / "loginctl").chmod(0o755)
+    script = tmp_path / "p.sh"
+    script.write_text(seat_payload(), encoding="utf-8")
+    env = dict(os.environ, PATH=f"{shims}:/usr/bin:/bin")
+    return subprocess.run(
+        ["bash", str(script)], capture_output=True, text=True, env=env
+    )
+
+
+def test_the_payload_actually_iterates_sessions(tmp_path):
+    """The quoting trap: a loop that reads no session ids prints no seats."""
+    proc = _run_payload(
+        tmp_path, 'echo "      2 1000 liveuser -    1273   manager -   no   -"'
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "session 2:" in proc.stdout, proc.stdout
+    # The three fields that decide it must all be reported.
+    assert "Seat=" in proc.stdout, proc.stdout
+    assert "VTNr=" in proc.stdout, proc.stdout
+    assert "Active=" in proc.stdout, proc.stdout
+
+
+def test_the_payload_reads_the_pam_stack(tmp_path):
+    """greetd's PAM config is the leading candidate; it must be printed, and
+    its absence must be stated rather than rendering as blank."""
+    proc = _run_payload(tmp_path, "true")
+    assert "/etc/pam.d/greetd" in proc.stdout, proc.stdout
+    assert "(absent)" in proc.stdout, proc.stdout
+
+
+def test_the_reasoning_is_recorded_next_to_the_diagnostic():
+    """The next reader must not have to re-derive why seats are suspected."""
+    body = capture_step()
+    assert "NoRenderNode" in body
+    assert "DRM master" in body
+    # And it must NOT assert a cause it has not measured.
+    assert "pam_systemd" in body, "the candidate should be named as a candidate"
+    assert "NOT established" in body or "not guessed" in body, (
+        "the comment must mark the cause as unestablished; this branch has "
+        "been wrong five times by asserting one"
+    )

--- a/tests/test_the_seat_diagnostic_collects_evidence.py
+++ b/tests/test_the_seat_diagnostic_collects_evidence.py
@@ -135,3 +135,26 @@ def test_the_reasoning_is_recorded_next_to_the_diagnostic():
         "the comment must mark the cause as unestablished; this branch has "
         "been wrong five times by asserting one"
     )
+
+
+def test_the_journal_capture_covers_every_display_manager():
+    """gnome and kde are the two top-priority flavors and the two the capture
+    could not see.
+
+    The journal line named only `greetd` and `cosmic-greeter`. cosmic, niri and
+    xfce all run under greetd and additionally wrap their session command in
+    `systemd-cat -t tunaos-live-session`, so their compositor stderr is
+    reachable two ways. gnome and kde do neither: gnome autologins through gdm
+    and kde through plasmalogin, so for those two the capture named no unit at
+    all and the session's own words went unrecorded.
+
+    That is why kde's only diagnosis on file is a second-hand
+    `plasmalogin-helper exited with 5` from run 30234237855, attributed to a
+    render-node theory the xfce evidence has since contradicted.
+    """
+    body = capture_step()
+    m = re.search(r"journalctl (-u \S+ )+--no-pager", body)
+    assert m, "no display-manager journalctl invocation found in the capture step"
+    units = set(re.findall(r"-u (\S+)", m.group(0)))
+    for dm in ("greetd", "cosmic-greeter", "plasmalogin", "gdm"):
+        assert dm in units, f"{dm} is not captured; units are {sorted(units)}"

--- a/tests/test_the_seat_diagnostic_collects_evidence.py
+++ b/tests/test_the_seat_diagnostic_collects_evidence.py
@@ -170,3 +170,89 @@ def test_the_journal_capture_covers_every_display_manager():
         "be answered from post-mortem loginctl output, which cannot see the "
         f"session that already exited. units are {sorted(units)}"
     )
+
+
+# ── The installer's own log, looked for under one flavor's app id ───────────
+#
+# The capture step calls this file "the thing that answers it directly": it
+# records do_activate being called, which window class was constructed, "Main
+# window created", and any traceback. Its own comment says "running but never
+# reported a window" has stayed undiagnosable across runs 63-66 without it.
+#
+# It was read from ~/.var/app/org.bootcinstaller.Installer/... — a hardcoded
+# app id that only GNOME uses. kde runs org.tunaos.InstallerKde, and
+# cosmic/niri/xfce their own. So on four of five flavors the step printed
+#
+#     (no installer-debug.log found)
+#
+# and nobody noticed, because that string reads like a fact about the guest
+# rather than a fact about the path. kde run 32704425971 is the proof: the
+# frontend launched (org.tunaos.InstallerKde asserted OK), the readiness stamp
+# was absent, and the one file that would say why was sought under gnome's id.
+
+INSTALLER_APPS = [
+    "org.bootcinstaller.Installer",
+    "org.tunaos.InstallerKde",
+    "org.tunaos.InstallerCosmic",
+    "org.tunaos.InstallerNiri",
+    "org.tunaos.InstallerXfce",
+]
+
+
+def debug_log_payload() -> str:
+    body = capture_step()
+    m = re.search(r"\$SSH 'found=0;.*?' 2>/dev/null \|\| true", body, re.S)
+    assert m, "the installer-debug.log capture is not in the expected shape"
+    return m.group(0)[len("$SSH '") : -len("' 2>/dev/null || true")]
+
+
+def test_the_debug_log_payload_is_valid_shell(tmp_path):
+    f = tmp_path / "p.sh"
+    f.write_text(debug_log_payload(), encoding="utf-8")
+    proc = subprocess.run(["bash", "-n", str(f)], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+
+
+@pytest.mark.parametrize("app", INSTALLER_APPS)
+def test_every_frontend_app_id_is_searched(tmp_path, app):
+    """Run it with only THIS flavor's log present. All five must be found."""
+    import os as _os
+
+    home = tmp_path / app
+    d = home / ".var/app" / app / "cache/bootc-installer"
+    d.mkdir(parents=True)
+    (d / "installer-debug.log").write_text("do_activate called\n", encoding="utf-8")
+
+    script = tmp_path / f"p-{app}.sh"
+    script.write_text(debug_log_payload(), encoding="utf-8")
+    proc = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=dict(_os.environ, HOME=str(home)),
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "do_activate called" in proc.stdout, (
+        f"{app}'s installer-debug.log was not found; output was {proc.stdout!r}"
+    )
+    assert "no installer-debug.log" not in proc.stdout, proc.stdout
+
+
+def test_a_genuinely_absent_log_says_what_is_there_instead(tmp_path):
+    """"Not found" must be distinguishable from "looked in the wrong place"."""
+    import os as _os
+
+    home = tmp_path / "empty"
+    (home / ".var/app/org.tunaos.InstallerNiri").mkdir(parents=True)
+    script = tmp_path / "p.sh"
+    script.write_text(debug_log_payload(), encoding="utf-8")
+    proc = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=dict(_os.environ, HOME=str(home)),
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "no installer-debug.log under any known app id" in proc.stdout
+    # The listing is the half that makes the negative result actionable.
+    assert "org.tunaos.InstallerNiri" in proc.stdout, proc.stdout

--- a/tests/test_the_stamp_lookup_matches_flatpak.py
+++ b/tests/test_the_stamp_lookup_matches_flatpak.py
@@ -1,0 +1,134 @@
+"""One check, two copies, one of them fixed.
+
+`installer-smoke.yml` reads the installer's readiness stamp inline, and
+`scripts/e2e-installer-gui-checks.sh` reads it again over SSH as a TAP
+assertion. Commit 3c6cbf0c corrected the inline one -- "read the stamp where
+flatpak actually puts it" -- and left the script alone.
+
+Inside the sandbox `$XDG_RUNTIME_DIR` reads as `/run/user/<uid>`, but that is
+a bind mount; current flatpak backs it with
+
+    /run/user/<uid>/.flatpak/<app-id>/xdg-run/
+
+The `app/<app-id>/` directory still EXISTS, because flatpak creates it, so an
+empty listing of it looked like proof that nothing had been written. That is
+how a lookup missing its only correct path survived.
+
+Measured on kde run 32718219267. The script said
+
+    not ok - installer readiness stamp present
+
+while the workflow's inline check, on the same guest at the same moment, read
+
+    app_id=org.tunaos.InstallerKde
+    window=ApplicationWindow
+    signal=frame-swapped
+    page=welcome
+
+A frame had been swapped, the window was on screen, and it had reached the
+welcome page. The installer was fine; the lookup was looking in the wrong
+place, and the resulting `not ok` was read for weeks as a fact about kde.
+
+The stamp is armed on `QQuickWindow::frameSwapped` (tuna-installer-kde
+src/readiness.cpp), so its presence is positive proof that a frame reached the
+screen -- which is exactly why a false negative here is expensive.
+
+These tests build the real directory layout and RUN the loop, because the bug
+was a missing glob and a grep for ".flatpak" would pass on a lookup that never
+executes.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "e2e-installer-gui-checks.sh"
+WORKFLOW = ROOT / ".github" / "workflows" / "installer-smoke.yml"
+
+APP = "org.tunaos.InstallerKde"
+STAMP_BODY = (
+    "app_id=org.tunaos.InstallerKde\nwindow=ApplicationWindow\n"
+    "signal=frame-swapped\nmapped_at=1787572116.536\npage=welcome\n"
+)
+
+
+def lookup_loop() -> str:
+    """The `for d in ...` stamp loop, lifted out of the script."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    start = text.index("STAMP=\"\"\nfor d in /run/user/")
+    end = text.index("\ndone\n", start) + len("\ndone\n")
+    return text[start:end]
+
+
+def _run_lookup(tmp_path: Path, stamp_at: str | None) -> subprocess.CompletedProcess:
+    """Run the loop with /run/user rerooted into tmp_path."""
+    if stamp_at:
+        f = tmp_path / stamp_at
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(STAMP_BODY, encoding="utf-8")
+    # flatpak creates app/<id>/ regardless — its emptiness is the trap.
+    (tmp_path / f"run/user/1000/app/{APP}").mkdir(parents=True, exist_ok=True)
+
+    body = lookup_loop().replace("/run/user/", f"{tmp_path}/run/user/")
+    script = tmp_path / "lookup.sh"
+    script.write_text(f'APP={APP}\n{body}\nprintf "%s" "$STAMP"\n', encoding="utf-8")
+    return subprocess.run(["bash", str(script)], capture_output=True, text=True)
+
+
+def test_the_loop_was_extracted():
+    """Every assertion below is vacuous if this found nothing."""
+    body = lookup_loop()
+    assert "for d in /run/user/" in body
+    assert body.count("tuna-installer-ready") >= 3, body
+
+
+def test_the_sandbox_path_is_searched(tmp_path):
+    """The path flatpak actually uses — the one that was missing."""
+    proc = _run_lookup(tmp_path, f"run/user/1000/.flatpak/{APP}/xdg-run/tuna-installer-ready")
+    assert proc.returncode == 0, proc.stderr
+    assert "signal=frame-swapped" in proc.stdout, proc.stdout
+    assert "page=welcome" in proc.stdout, proc.stdout
+
+
+def test_the_older_layout_still_works(tmp_path):
+    proc = _run_lookup(tmp_path, f"run/user/1000/app/{APP}/tuna-installer-ready")
+    assert "signal=frame-swapped" in proc.stdout, proc.stdout
+
+
+def test_the_unsandboxed_layout_still_works(tmp_path):
+    proc = _run_lookup(tmp_path, "run/user/1000/tuna-installer-ready")
+    assert "signal=frame-swapped" in proc.stdout, proc.stdout
+
+
+def test_a_genuinely_absent_stamp_still_reads_empty(tmp_path):
+    """It must be able to find nothing, or it can never fail honestly."""
+    proc = _run_lookup(tmp_path, None)
+    assert proc.stdout.strip() == "", proc.stdout
+
+
+def test_both_copies_of_the_lookup_agree():
+    """The defect was divergence between two implementations of one check.
+
+    Whatever paths the workflow reads, the script must read too -- otherwise
+    the next correction lands on one copy again."""
+    wf = WORKFLOW.read_text(encoding="utf-8")
+    inline = re.search(r'cat (/run/user/\S+tuna-installer-ready(?: \S+)*)', wf)
+    assert inline, "the workflow's inline stamp read was not found"
+    wf_paths = {
+        p.replace("${APP}", "APP")
+        for p in inline.group(1).split()
+        if p.startswith("/run/user/")
+    }
+    script = lookup_loop()
+    for p in wf_paths:
+        stem = p.replace("APP", "").replace('"', "")
+        # compare on the distinguishing directory component
+        key = stem.split("tuna-installer-ready")[0].rstrip("/").split("/")[-1]
+        assert key in script or ".flatpak" in script, (
+            f"the workflow reads {p} but the script does not; the two copies "
+            "have diverged again"
+        )

--- a/tests/test_the_stamp_lookup_matches_flatpak.py
+++ b/tests/test_the_stamp_lookup_matches_flatpak.py
@@ -43,8 +43,6 @@ import re
 import subprocess
 from pathlib import Path
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "e2e-installer-gui-checks.sh"
 WORKFLOW = ROOT / ".github" / "workflows" / "installer-smoke.yml"

--- a/tests/test_the_welcome_keywords_match_what_kde_says.py
+++ b/tests/test_the_welcome_keywords_match_what_kde_says.py
@@ -206,14 +206,96 @@ class TestTheDiagnosisPrintsWhatItRead:
         assert "what the OCR actually read" in proc.stdout, proc.stdout
         # ocr() lowercases what it reads, so the excerpt does too.
         assert "underground empire" in proc.stdout, proc.stdout
+        # Real words, so it must reach cause 6 rather than the noise branch.
         assert "cause 6" in proc.stdout, proc.stdout
+        assert "Those are NOT words" not in proc.stdout, proc.stdout
 
     def test_empty_ocr_is_reported_as_a_different_cause(self):
         """Text absent everywhere and text present but unmatched want
         opposite fixes, so they must not print the same thing."""
         proc, _ = run_walkthrough({"00": "", "01": "", "02": ""})
-        assert "read NO text on any frame" in proc.stdout, proc.stdout
+        assert "Those are NOT words" in proc.stdout, proc.stdout
         assert "cause 6" not in proc.stdout, proc.stdout
+
+    def test_noise_is_not_reported_as_a_vocabulary_problem(self):
+        """The exact output kde run 32735883406 produced.
+
+        Four distinct visual states, nine frames above the blank threshold,
+        and a readiness stamp saying the wizard was on screen -- and this is
+        what tesseract returned:
+
+            state 0: 1 ft
+            state 1: hm
+            state 2: i]
+
+        The first version of the block asked `if any(_seen.values())`, so it
+        printed those three fragments under a heading inviting the reader to
+        go fix the keyword list. They are not a vocabulary problem. A
+        truthiness test cannot tell noise from words; a score can.
+        """
+        proc, _ = run_walkthrough({"00": "1 ft", "01": "hm", "02": "i]"})
+        assert "Those are NOT words" in proc.stdout, proc.stdout
+        assert "cause 6" not in proc.stdout, proc.stdout
+        # The noise itself is still printed -- it is the evidence.
+        assert "1 ft" in proc.stdout, proc.stdout
+
+    def test_the_noise_report_names_what_it_tried(self):
+        """It must say which OCR pass won and how big the frame was, or the
+        reader is back to guessing between "dark theme" and "too small"."""
+        proc, _ = run_walkthrough({"00": "1 ft", "01": "hm", "02": "i]"})
+        assert "Frame geometry" in proc.stdout, proc.stdout
+        assert "best pass per frame" in proc.stdout, proc.stdout
+
+    def test_a_negated_pass_can_win_and_is_named(self):
+        """The dark-theme fallback, exercised rather than assumed.
+
+        tesseract wants dark ink on light paper. gnome -- the only flavor
+        that has ever scored screens -- defaults to Adwaita light, so
+        "kde draws light text on a dark ground" is a live reading of the
+        noise, and the harness has to be able to act on it.
+
+        Here the plain pass returns noise and only the negated copy returns
+        words. If the escalation works, the screen is credited AND the
+        report says which pass won, because "psm6-negated won" is the
+        finding, not an implementation detail.
+        """
+        proc, summary = run_walkthrough(
+            {"00": "1 ft", "01": "hm", "02": "i]"},
+            tess_neg={"00": KDE_WELCOME_FULL, "01": "Select Target Disk",
+                      "02": "Confirm Installation"},
+        )
+        assert summary is not None, proc.stdout + proc.stderr
+        assert summary["screens"]["welcome"] is True, (summary["screens"],
+                                                       proc.stdout)
+        assert summary["screens"]["disk"] is True, proc.stdout
+
+    def test_without_the_negated_fallback_the_same_frames_stay_unread(self):
+        """The other half: identical noise, no readable negated copy, and
+        the run must still report unreadable rather than inventing a
+        match."""
+        proc, summary = run_walkthrough({"00": "1 ft", "01": "hm", "02": "i]"})
+        assert summary["screens"]["welcome"] is False, proc.stdout
+        assert "Those are NOT words" in proc.stdout, proc.stdout
+
+    def test_the_negation_leaves_no_file_behind(self):
+        """The first version wrote its temporary next to the frame and a
+        stub bug dropped a file called "-negate" into the repo root. The
+        negated copy must be cleaned up whatever the pass returns."""
+        proc, _ = run_walkthrough(
+            {"00": "1 ft", "01": "hm", "02": "i]"},
+            tess_neg={"00": KDE_WELCOME_FULL, "01": DISK, "02": DISK},
+        )
+        assert not list(ROOT.glob("*negate*")), list(ROOT.glob("*negate*"))
+        assert not list(ROOT.glob("**/*.neg.png")), "negated copies left behind"
+
+    def test_a_frame_that_is_not_a_png_does_not_crash_the_diagnosis(self):
+        """The stub writes PPM bytes into .png files, so the geometry read
+        gets a file with no IHDR. A diagnostic that raised here would take
+        out the run it was added to explain."""
+        proc, _ = run_walkthrough({"00": "1 ft", "01": "hm", "02": "i]"})
+        assert proc.returncode in (0, 1), proc.stderr
+        assert "Traceback" not in proc.stderr, proc.stderr
+        assert "?x?" in proc.stdout, proc.stdout
 
     def test_it_stays_quiet_when_every_required_screen_was_found(self):
         """Quiet on a green leg, or it is noise on every run."""

--- a/tests/test_the_welcome_keywords_match_what_kde_says.py
+++ b/tests/test_the_welcome_keywords_match_what_kde_says.py
@@ -58,8 +58,12 @@ KDE_WELCOME_BODY = (
     "should be encrypted. Everything after that is handled by the installer. "
     "Next"
 )
-# The whole screen, heading included. This is what a screenshot contains.
-KDE_WELCOME_FULL = "Welcome " + KDE_WELCOME_BODY
+# What the published capture actually contains, window title included:
+# download.tunaos.org/screenshots/installer/smoke-kde_00-latest.png, run
+# 32747410944. Note what is NOT in it -- the word "Welcome". The wizard's
+# stepHeading Label (Wizard.qml:185) starts at opacity 0 and does not come up
+# on the first page, whatever its animation intends.
+KDE_WELCOME_FULL = "Yellowfin Installer " + KDE_WELCOME_BODY
 NIRI_WELCOME = (
     "Welcome to Yellowfin This wizard will guide you through installing "
     "Yellowfin onto your computer. Get Started"
@@ -128,14 +132,26 @@ def test_kdes_page_body_alone_is_now_enough():
     )
 
 
-def test_the_heading_would_always_have_matched():
-    """The correction, asserted rather than only written down.
+def test_the_whole_screen_still_needs_the_added_keyword():
+    """The correction to the correction, held by a test.
 
-    KDE's wizard heading IS the literal word "welcome", so a frame that
-    contains it matches on the ORIGINAL keyword list. That is why "the spec
-    cannot describe KDE's welcome screen" does not explain the failing run,
-    and why the cause is recorded as open instead of closed.
+    A comment once claimed KDE's wizard draws the word "Welcome" above the
+    page, so the original keyword list would have matched after all. The
+    published capture shows otherwise: the welcome step reads "Install
+    Yellowfin", the wizard prose, and "Next". Nothing on it is in the
+    original list.
+
+    So the ENTIRE screen -- window title included -- is recognisable only
+    through "will guide you through". Asserted on the full-screen text
+    rather than the page body so a future reader cannot re-derive the wrong
+    correction from the fact that the body test is narrowly scoped.
     """
+    lowered = KDE_WELCOME_FULL.lower()
+    for old_kw in ("welcome", "get started", "let's get", "begin"):
+        assert old_kw not in lowered, (
+            f"{old_kw!r} appears on KDE's welcome screen after all -- "
+            "re-measure against a fresh capture"
+        )
     proc, summary = run_walkthrough(
         {"00": KDE_WELCOME_FULL, "01": DISK, "02": DISK},
     )
@@ -239,12 +255,37 @@ class TestTheDiagnosisPrintsWhatItRead:
         # The noise itself is still printed -- it is the evidence.
         assert "1 ft" in proc.stdout, proc.stdout
 
-    def test_the_noise_report_names_what_it_tried(self):
-        """It must say which OCR pass won and how big the frame was, or the
-        reader is back to guessing between "dark theme" and "too small"."""
+    def test_the_noise_report_scores_every_pass(self):
+        """Not the winner -- the scores.
+
+        The first version printed "best pass per frame: psm6", and on kde
+        run 32747410944 that was true while all four passes scored ZERO:
+        the comparison is strictly greater, so a tie leaves psm6 holding the
+        title it started with. The printed hint then read that as evidence
+        FOR psm6 and told the reader to raise the framebuffer. An argument
+        from a tie.
+
+        Every pass must report its own number, so "psm6 read the most" and
+        "nothing read anything" cannot be confused again.
+        """
         proc, _ = run_walkthrough({"00": "1 ft", "01": "hm", "02": "i]"})
         assert "Frame geometry" in proc.stdout, proc.stdout
-        assert "best pass per frame" in proc.stdout, proc.stdout
+        assert "Best word-score any frame reached" in proc.stdout, proc.stdout
+        assert re.search(r"psm6=\d+", proc.stdout), proc.stdout
+        assert re.search(r"psm11=\d+", proc.stdout), proc.stdout
+        # And it must not go back to naming a winner as if that settled it.
+        assert "best pass per frame" not in proc.stdout, proc.stdout
+
+    def test_a_tie_at_zero_does_not_read_as_a_verdict(self):
+        """The specific misreading, pinned.
+
+        All passes at zero must print zeros the reader can see, and must not
+        claim the resolution is the problem -- that conclusion needed psm6 to
+        have actually beaten the others, which it had not.
+        """
+        proc, _ = run_walkthrough({"00": "1 ft", "01": "hm", "02": "i]"})
+        assert "psm6=0" in proc.stdout, proc.stdout
+        assert "raise the guest framebuffer" not in proc.stdout, proc.stdout
 
     def test_a_negated_pass_can_win_and_is_named(self):
         """The dark-theme fallback, exercised rather than assumed.

--- a/tests/test_the_welcome_keywords_match_what_kde_says.py
+++ b/tests/test_the_welcome_keywords_match_what_kde_says.py
@@ -1,16 +1,6 @@
 """A contract that could not see the screen it was pointed at.
 
-`tests/installer-screens.yaml` says a welcome screen is one whose text
-contains "welcome", "get started", "let's get" or "begin". Four of the five
-frontends satisfy that. KDE's welcome page says none of them: its heading is
-
-    text: "Install " + InstallerController.productName
-                    -- tuna-installer-kde modules/welcome/.../main.qml:39
-
-its body is "This wizard will guide you through installing <product> onto this
-computer.", and its primary button is "Next" (src/qml/Wizard.qml:290).
-
-So run 32718219267 reported all six screens unreached for kde, with
+kde run 32718219267 scored all six screens unreached and printed
 
     # DIAGNOSIS: kde -- no installer screen was ever detected
 
@@ -19,11 +9,25 @@ read `window=ApplicationWindow signal=frame-swapped page=welcome`. The
 installer was up and on its welcome page. Six red lines, a diagnosis pointing
 at autostart, OOM-kills and missing GL paths, and a working frontend.
 
-The keyword list was never measured -- the disk list was measured against the
-frontends' real headings on 2026-08-07, this one was written from the premise
-that a welcome screen says "welcome". These tests hold the two halves of the
-fix in place: the measurement (KDE really does say none of the old keywords)
-and the behaviour (the harness now credits KDE's welcome page).
+The first explanation -- "KDE's welcome page contains none of the spec's
+keywords" -- was true of the PAGE and false of the SCREEN. Its body copy
+really does say none of "welcome", "get started", "let's get" or "begin"
+(modules/welcome/contents/ui/main.qml:39,48,56, primary button "Next" at
+Wizard.qml:290), but the wizard draws the step name "Welcome" as a 1.6x
+heading above it (Wizard.qml:46,185), faded in at startup by a `running: true`
+animation. So the word was on screen and the match still did not happen, and
+WHY is not yet known.
+
+What these tests do hold:
+
+  * the measurement, scoped honestly -- KDE's welcome page body carries none
+    of the four original keywords, so the screen was recognisable only by a
+    heading that animates;
+  * the coverage added for it -- "will guide you through", the orientation
+    sentence KDE, niri and cosmic all put on the welcome page and nowhere
+    else, giving the screen a second and independent phrase to be found by;
+  * the diagnostic that will actually answer the open question -- the harness
+    now prints the text OCR read, on any leg missing a required screen.
 
 They RUN the harness rather than grepping the spec, because a keyword list
 that parses is not a keyword list that matches.
@@ -44,12 +48,18 @@ SPEC = ROOT / "tests" / "installer-screens.yaml"
 
 # Verbatim from the frontends' sources, with the product name filled in the way
 # the branding pipeline fills it. These are the strings OCR sees.
-KDE_WELCOME = (
+# The page body ONLY -- what modules/welcome/contents/ui/main.qml draws. The
+# wizard's own "Welcome" heading is drawn by Wizard.qml above it and is kept
+# out of this constant deliberately, so the tests below can say which half of
+# the screen carries which evidence.
+KDE_WELCOME_BODY = (
     "Install Yellowfin This wizard will guide you through installing "
     "Yellowfin onto this computer. You will choose a target disk and how it "
     "should be encrypted. Everything after that is handled by the installer. "
     "Next"
 )
+# The whole screen, heading included. This is what a screenshot contains.
+KDE_WELCOME_FULL = "Welcome " + KDE_WELCOME_BODY
 NIRI_WELCOME = (
     "Welcome to Yellowfin This wizard will guide you through installing "
     "Yellowfin onto your computer. Get Started"
@@ -71,14 +81,18 @@ def welcome_keywords() -> list[str]:
 
 
 def test_the_measurement_that_started_this():
-    """KDE's welcome page contains not one of the four original keywords.
+    """KDE's welcome PAGE contains not one of the four original keywords.
 
-    Asserted directly, because it is the fact the whole change rests on. If a
-    future edit to the KDE frontend makes one of them true, this test failing
-    is the signal that the added keyword is no longer load-bearing -- not a
-    reason to delete it, but a reason to re-measure.
+    Scoped to the page body on purpose. The claim that KDE's welcome SCREEN
+    said none of them was wrong -- the wizard heading above it is the literal
+    word -- and this test is what keeps that correction from being lost: it
+    asserts only what was actually measured in the page source.
+
+    If a future edit to the KDE frontend puts one of the four into the body,
+    this failing is the signal that the added keyword is no longer
+    load-bearing -- a reason to re-measure, not to delete it.
     """
-    lowered = KDE_WELCOME.lower()
+    lowered = KDE_WELCOME_BODY.lower()
     for old in ("welcome", "get started", "let's get", "begin"):
         assert old not in lowered, (
             f"{old!r} is on KDE's welcome page after all -- re-measure the "
@@ -99,15 +113,34 @@ def test_the_spec_still_forbids_a_bare_product_noun():
             assert banned not in kw, kw
 
 
-def test_kde_welcome_is_now_credited():
-    """The behaviour: run the harness on KDE's real text."""
+def test_kdes_page_body_alone_is_now_enough():
+    """The behaviour the added keyword buys.
+
+    If the animated heading is missed -- for whatever reason run 32718219267
+    missed it -- the body copy still identifies the screen.
+    """
     proc, summary = run_walkthrough(
-        {"00": KDE_WELCOME, "01": DISK, "02": DISK},
+        {"00": KDE_WELCOME_BODY, "01": DISK, "02": DISK},
     )
     assert summary is not None, proc.stdout + proc.stderr
     assert summary["screens"]["welcome"] is True, (
         summary["screens"], proc.stdout
     )
+
+
+def test_the_heading_would_always_have_matched():
+    """The correction, asserted rather than only written down.
+
+    KDE's wizard heading IS the literal word "welcome", so a frame that
+    contains it matches on the ORIGINAL keyword list. That is why "the spec
+    cannot describe KDE's welcome screen" does not explain the failing run,
+    and why the cause is recorded as open instead of closed.
+    """
+    proc, summary = run_walkthrough(
+        {"00": KDE_WELCOME_FULL, "01": DISK, "02": DISK},
+    )
+    assert summary is not None, proc.stdout + proc.stderr
+    assert summary["screens"]["welcome"] is True, proc.stdout
 
 
 def test_every_other_frontend_still_matches():
@@ -144,7 +177,7 @@ def test_the_added_keyword_is_what_does_the_work():
     try:
         SPEC.write_text(mutated, encoding="utf-8")
         proc, summary = run_walkthrough(
-            {"00": KDE_WELCOME, "01": DISK, "02": DISK},
+            {"00": KDE_WELCOME_BODY, "01": DISK, "02": DISK},
         )
         assert summary is not None, proc.stdout + proc.stderr
         assert summary["screens"]["welcome"] is False, (
@@ -185,7 +218,7 @@ class TestTheDiagnosisPrintsWhatItRead:
     def test_it_stays_quiet_when_every_required_screen_was_found(self):
         """Quiet on a green leg, or it is noise on every run."""
         proc, summary = run_walkthrough(
-            {"00": KDE_WELCOME, "01": "Select Target Disk",
+            {"00": KDE_WELCOME_BODY, "01": "Select Target Disk",
              "02": "Confirm Installation"},
         )
         for req in ("welcome", "disk", "summary"):
@@ -202,7 +235,7 @@ class TestTheDiagnosisPrintsWhatItRead:
         fixed, which is when the remaining words on the page start to
         matter."""
         proc, summary = run_walkthrough(
-            {"00": KDE_WELCOME, "01": "Select Target Disk",
+            {"00": KDE_WELCOME_BODY, "01": "Select Target Disk",
              "02": "Select Target Disk"},
         )
         assert summary["screens"]["welcome"] is True, proc.stdout

--- a/tests/test_the_welcome_keywords_match_what_kde_says.py
+++ b/tests/test_the_welcome_keywords_match_what_kde_says.py
@@ -1,0 +1,219 @@
+"""A contract that could not see the screen it was pointed at.
+
+`tests/installer-screens.yaml` says a welcome screen is one whose text
+contains "welcome", "get started", "let's get" or "begin". Four of the five
+frontends satisfy that. KDE's welcome page says none of them: its heading is
+
+    text: "Install " + InstallerController.productName
+                    -- tuna-installer-kde modules/welcome/.../main.qml:39
+
+its body is "This wizard will guide you through installing <product> onto this
+computer.", and its primary button is "Next" (src/qml/Wizard.qml:290).
+
+So run 32718219267 reported all six screens unreached for kde, with
+
+    # DIAGNOSIS: kde -- no installer screen was ever detected
+
+while the readiness stamp written by that same process, in that same guest,
+read `window=ApplicationWindow signal=frame-swapped page=welcome`. The
+installer was up and on its welcome page. Six red lines, a diagnosis pointing
+at autostart, OOM-kills and missing GL paths, and a working frontend.
+
+The keyword list was never measured -- the disk list was measured against the
+frontends' real headings on 2026-08-07, this one was written from the premise
+that a welcome screen says "welcome". These tests hold the two halves of the
+fix in place: the measurement (KDE really does say none of the old keywords)
+and the behaviour (the harness now credits KDE's welcome page).
+
+They RUN the harness rather than grepping the spec, because a keyword list
+that parses is not a keyword list that matches.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_installer_walkthrough import run_walkthrough  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = ROOT / "tests" / "installer-screens.yaml"
+
+# Verbatim from the frontends' sources, with the product name filled in the way
+# the branding pipeline fills it. These are the strings OCR sees.
+KDE_WELCOME = (
+    "Install Yellowfin This wizard will guide you through installing "
+    "Yellowfin onto this computer. You will choose a target disk and how it "
+    "should be encrypted. Everything after that is handled by the installer. "
+    "Next"
+)
+NIRI_WELCOME = (
+    "Welcome to Yellowfin This wizard will guide you through installing "
+    "Yellowfin onto your computer. Get Started"
+)
+COSMIC_WELCOME = (
+    "Welcome. This assistant will guide you through installing Yellowfin onto "
+    "this computer. Get started"
+)
+GNOME_WELCOME = "Welcome to Yellowfin Install Yellowfin Credits"
+XFCE_WELCOME = "Welcome to Yellowfin"
+
+DISK = "Select Target Disk"
+
+
+def welcome_keywords() -> list[str]:
+    spec = yaml.safe_load(SPEC.read_text(encoding="utf-8"))["screens"]
+    assert spec[0]["id"] == "welcome", spec[0]
+    return [k.lower() for k in spec[0]["keywords"]]
+
+
+def test_the_measurement_that_started_this():
+    """KDE's welcome page contains not one of the four original keywords.
+
+    Asserted directly, because it is the fact the whole change rests on. If a
+    future edit to the KDE frontend makes one of them true, this test failing
+    is the signal that the added keyword is no longer load-bearing -- not a
+    reason to delete it, but a reason to re-measure.
+    """
+    lowered = KDE_WELCOME.lower()
+    for old in ("welcome", "get started", "let's get", "begin"):
+        assert old not in lowered, (
+            f"{old!r} is on KDE's welcome page after all -- re-measure the "
+            "spec against the frontends rather than trusting this file"
+        )
+
+
+def test_the_spec_still_forbids_a_bare_product_noun():
+    """The added keyword must not smuggle the product name back in.
+
+    Three keywords were removed from the disk and install lists precisely
+    because they embedded "tunaos", which would have punished the branding
+    fix. A keyword containing a product name is the same mistake.
+    """
+    for kw in welcome_keywords():
+        for banned in ("tunaos", "yellowfin", "skipjack", "albacore",
+                       "bonito", "bluefin"):
+            assert banned not in kw, kw
+
+
+def test_kde_welcome_is_now_credited():
+    """The behaviour: run the harness on KDE's real text."""
+    proc, summary = run_walkthrough(
+        {"00": KDE_WELCOME, "01": DISK, "02": DISK},
+    )
+    assert summary is not None, proc.stdout + proc.stderr
+    assert summary["screens"]["welcome"] is True, (
+        summary["screens"], proc.stdout
+    )
+
+
+def test_every_other_frontend_still_matches():
+    """A keyword added for one fork must not cost another its match."""
+    for name, text in (("niri", NIRI_WELCOME), ("cosmic", COSMIC_WELCOME),
+                       ("gnome", GNOME_WELCOME), ("xfce", XFCE_WELCOME)):
+        proc, summary = run_walkthrough(
+            {"00": text, "01": DISK, "02": DISK}, flavor=name,
+        )
+        assert summary is not None, proc.stdout + proc.stderr
+        assert summary["screens"]["welcome"] is True, (name, proc.stdout)
+
+
+def test_a_screen_that_is_not_a_welcome_screen_still_does_not_match():
+    """It must still be able to say no, or it credits every frame."""
+    proc, summary = run_walkthrough(
+        {"00": "greetd 09:41 Tuesday 24 August", "01": "", "02": ""},
+    )
+    assert summary is not None, proc.stdout + proc.stderr
+    assert summary["screens"]["welcome"] is False, proc.stdout
+
+
+def test_the_added_keyword_is_what_does_the_work():
+    """Mutation: drop it from the list and KDE goes back to unmatched.
+
+    Guarded by asserting the substitution actually applied -- a mutation that
+    silently matches nothing "passes" and proves the opposite of what it
+    claims, which this repository has now produced twice.
+    """
+    original = SPEC.read_text(encoding="utf-8")
+    mutated = original.replace(
+        '"begin",\n               "will guide you through"]', '"begin"]')
+    assert mutated != original, "the mutation matched nothing; it proves nothing"
+    try:
+        SPEC.write_text(mutated, encoding="utf-8")
+        proc, summary = run_walkthrough(
+            {"00": KDE_WELCOME, "01": DISK, "02": DISK},
+        )
+        assert summary is not None, proc.stdout + proc.stderr
+        assert summary["screens"]["welcome"] is False, (
+            "KDE matched without the added keyword, so the keyword is not "
+            "what fixed it"
+        )
+    finally:
+        SPEC.write_text(original, encoding="utf-8")
+
+
+class TestTheDiagnosisPrintsWhatItRead:
+    """Cause 6 was missing from a list of five.
+
+    Every cause the diagnosis named assumed the installer was not on screen.
+    None of them was "it is on screen and the spec cannot describe it", which
+    is the one that was true. Printing the OCR text tells the two apart in one
+    line, without downloading an artifact.
+    """
+
+    def test_unmatched_text_is_printed(self):
+        proc, _ = run_walkthrough(
+            {"00": "Zork the Great Underground Empire",
+             "01": "Zork the Great Underground Empire",
+             "02": "Zork the Great Underground Empire"},
+        )
+        assert "what the OCR actually read" in proc.stdout, proc.stdout
+        # ocr() lowercases what it reads, so the excerpt does too.
+        assert "underground empire" in proc.stdout, proc.stdout
+        assert "cause 6" in proc.stdout, proc.stdout
+
+    def test_empty_ocr_is_reported_as_a_different_cause(self):
+        """Text absent everywhere and text present but unmatched want
+        opposite fixes, so they must not print the same thing."""
+        proc, _ = run_walkthrough({"00": "", "01": "", "02": ""})
+        assert "read NO text on any frame" in proc.stdout, proc.stdout
+        assert "cause 6" not in proc.stdout, proc.stdout
+
+    def test_it_stays_quiet_when_every_required_screen_was_found(self):
+        """Quiet on a green leg, or it is noise on every run."""
+        proc, summary = run_walkthrough(
+            {"00": KDE_WELCOME, "01": "Select Target Disk",
+             "02": "Confirm Installation"},
+        )
+        for req in ("welcome", "disk", "summary"):
+            assert summary["screens"][req] is True, (req, proc.stdout)
+        assert "what the OCR actually read" not in proc.stdout, proc.stdout
+
+    def test_a_partial_match_still_prints_the_text(self):
+        """The shape kde is expected to land in next: welcome credited, the
+        later screens missing.
+
+        Gated on a MISSING REQUIRED SCREEN rather than on "nothing matched
+        at all" for exactly this case -- a diagnostic that only fires when
+        the score is zero would go silent the moment the first keyword was
+        fixed, which is when the remaining words on the page start to
+        matter."""
+        proc, summary = run_walkthrough(
+            {"00": KDE_WELCOME, "01": "Select Target Disk",
+             "02": "Select Target Disk"},
+        )
+        assert summary["screens"]["welcome"] is True, proc.stdout
+        assert summary["screens"]["summary"] is False, proc.stdout
+        assert "what the OCR actually read" in proc.stdout, proc.stdout
+        assert "missing required: summary" in proc.stdout, proc.stdout
+
+    def test_the_excerpt_is_bounded(self):
+        """A diagnostic on an error path must stay cheap to print."""
+        proc, _ = run_walkthrough({"00": "Q" * 5000, "01": "Q" * 5000,
+                                   "02": "Q" * 5000})
+        for line in proc.stdout.splitlines():
+            if re.match(r"\s*#\s+state \d+:", line):
+                assert len(line) < 260, len(line)

--- a/tests/test_workflow_conditions_name_real_inputs.py
+++ b/tests/test_workflow_conditions_name_real_inputs.py
@@ -1,0 +1,57 @@
+"""A workflow expression must not test an input that does not exist.
+
+`${{ inputs.foo == 'x' && 'a' || 'b' }}` on an UNDECLARED input is not an
+error. GitHub evaluates the missing input to empty, the comparison is
+false, and the expression quietly takes its else-branch forever. The
+workflow stays valid, the step runs, and the thing you thought you had
+switched on is simply off.
+
+That is not hypothetical: the hummingbird qcow2 filesystem override was
+first written as `inputs.variant`, and `reusable-build-image.yml` declares
+`image-variant`, not `variant`. It would have run every gate with the
+override unset and produced a "the fix did not work" result from a fix
+that never applied.
+
+Checks reusable workflows, where the input list is declared and therefore
+checkable. `github.event.inputs` on workflow_dispatch is a different
+surface and is out of scope here.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = sorted((Path(__file__).resolve().parents[1] / ".github" / "workflows").glob("*.yml"))
+INPUT_REF = re.compile(r"inputs\.([A-Za-z_][A-Za-z0-9_-]*)")
+
+
+def _reusable():
+    for wf in WORKFLOWS:
+        doc = yaml.safe_load(wf.read_text()) or {}
+        on = doc.get("on", doc.get(True)) or {}
+        call = on.get("workflow_call") if isinstance(on, dict) else None
+        if isinstance(call, dict):
+            yield wf, set((call.get("inputs") or {}).keys()), wf.read_text()
+
+
+CASES = list(_reusable())
+
+
+@pytest.mark.parametrize(
+    "wf,declared,text", CASES, ids=[w.name for w, _, _ in CASES]
+)
+def test_workflow_conditions_name_real_inputs(wf, declared, text):
+    referenced = set(INPUT_REF.findall(text))
+    unknown = sorted(referenced - declared)
+    assert not unknown, (
+        f"{wf.name} references undeclared input(s) {unknown}. Declared: "
+        f"{sorted(declared)}. A missing input evaluates empty rather than "
+        f"failing, so any condition on it silently takes its else-branch."
+    )
+
+
+def test_the_check_examined_something():
+    assert CASES, "no reusable workflow found — the detector is broken"
+    assert any(d for _, d, _ in CASES), "no workflow_call inputs found"


### PR DESCRIPTION
## 0. The hummingbird desktops cannot be published at all, and this is why

Measured against the registry on 2026-08-25, not inferred:

```
ghcr.io/tuna-os/hummingbird:base    200   (dated tags through base-20260819)
ghcr.io/tuna-os/hummingbird:gnome   404
```

The full tag list carries `gnome-linux-amd64` and `gnome-testing` but **no promoted desktop tag for any flavor** — gnome, kde, cosmic and niri have never been published. `docs/MATRIX-STATUS.md` records the consequence one step further out: live-overlay tags are missing for `hummingbird-gnome`, `hummingbird-kde`, `hummingbird-cosmic` and `hummingbird-niri`, because `live-overlay.yml` builds each overlay **from the published flavor image**, and there isn&#39;t one. No overlay, no ISO.

The cause is a single abort in the Gate&#39;s `bootc install to-disk`, in last night&#39;s run ([32786338463](https://github.com/tuna-os/tunaOS/actions/runs/32786338463), gnome Gate job [97638679623](https://github.com/tuna-os/tunaOS/actions/runs/32786338463/job/97638679623)) and in the five nightlies before it:

```
Creating root filesystem (xfs) on device /dev/loop0p3
Bootloader: grub
Installing for i386-pc platform.
/usr/sbin/grub2-install: error: ../grub-core/kern/fs.c:123:unknown filesystem.
error: boot data installation failed: installing component BIOS to device /dev/loop0
error: Recipe `qcow2` failed with exit code 1
```

hummingbird probes `BACKEND=ostree SEALED=0`, so the qcow2 path does not pass `--filesystem ext4` (that is reserved for composefs-sealed images) and it lands on the `type = "xfs"` default in `00-tunaos.toml`. BIOS `grub2-install` cannot read the xfs this base&#39;s `mkfs.xfs` writes, and `bootupctl` installs the BIOS component unconditionally on a hybrid layout — so the failure aborts the **whole** install, not just its legacy half. The Gate then produces no serial log and no screenshots, Promote never runs, and nothing is published.

`system_files_overrides/hummingbird/usr/lib/bootc/install/50-hummingbird.toml` sets `type = "ext4"` for hummingbird only, which is exactly the mechanism `00-tunaos.toml` prescribes for a per-variant override (&#34;a higher-sorting drop-in … so they win over this file&#34;).

**Status of that claim: being measured now, not proven.** The run that was supposed to prove it ([32809685474](https://github.com/tuna-os/tunaOS/actions/runs/32809685474)) was **cancelled** mid-`Build Image` — this workflow&#39;s concurrency group is keyed on `github.ref` with `cancel-in-progress: true`, so later pushes to this branch evicted it before it ever reached the Gate. A clean `flavor=gnome` dispatch is in flight and this section will be updated with what the Gate actually says.

Scope, checked rather than assumed: this fixes `bootc install to-disk`, which is the path the Gate takes. It is **not** what makes an ISO install to a laptop work — that path runs fisherman, which always lays down a 3-partition GPT with a separate ext4 `/boot` precisely because GRUB cannot read modern XFS, so it never touches the xfs root. What this unblocks is **publishing**, which everything downstream is waiting on.

---

Run [32681262659](https://github.com/tuna-os/tunaOS/actions/runs/32681262659) is the **first time the gnome smoke cell has ever run**. It answered three separate questions.

## 1. A gate that examined nothing

`e2e-installer-gui-checks.sh` resolved its TAP helpers as `${TEST_LIB_DIR}/lib/e2e-assert.sh` — `/lib` **after** the expansion instead of inside the default. `iso-e2e.sh` uploads the helper flat beside the script and sets `TEST_LIB_DIR` to the guest home, so that names a directory the guest does not have:

```
/home/liveuser/e2e-installer-gui-checks.sh: line 25:
  /home/liveuser/lib/e2e-assert.sh: No such file or directory
... line 54: check: command not found
... line 159: print_summary: command not found
```

`source` failed, `check()` was never defined, every assertion evaporated onto stderr, and bash exited 127. The harness printed that as:

```
::warning::installer GUI checks reported 127 failure(s) for gnome
```

**127 is bash for command-not-found.** It is not a count of anything, and it was a *warning*, in a mode that tolerates warnings. The per-flavor compositor and installer-frontend assertions have never executed, on any flavor, in any smoke run — and the workflow stayed green through it.

Both halves are fixed:

- the path matches where the file is uploaded, and all three sibling check scripts now bail out loudly on an unreadable helper rather than silently disarming every assertion;
- the harness distinguishes *did not run* from *found problems*. The TAP summary is the discriminator — `# Results:` comes only from `print_summary`, the last statement of every check script — so its absence is a hard failure in every mode. `E2E_*_STRICT` governs failed assertions, not an absent gate.

## 2. The disk screen gnome reaches and the contract cannot see

```
not ok - gnome: reached &#39;disk&#39; screen (Disk / target selection)
  # not found on any state the installer advanced to
```

…while crediting encryption and summary, both of which sit *after* disk selection. `tests/installer-screens.yaml` was measured on 2026-08-07 against KDE, Niri, XFCE and COSMIC; gnome was absent from the matrix until #1039, so upstream `bootc-installer` was the one fork nobody OCRed. Its heading is **&#34;Install Location&#34;**, matching none of the six keywords — the same shape as the `install` list before it. Checked against all five frontends before admitting it: the string occurs exactly once in the whole set, and carries no product name.

## 3. Why a compositor exits, which nothing recorded

greetd reports only its own bookkeeping — `greeter exited without creating a session`, five times to `start-limit-hit` — and the compositor&#39;s reason went nowhere. That message is the entire evidence base on which four desktops have been written off as needing a DRM render node, and **this run disproves the attribution**. Read from inside the guest:

```
crw-rw-rw-. 1 root render 226, 128 renderD128
[drm] pci: virtio-vga detected at 0000:00:02.0
[drm] features: -virgl +edid -resource_blob -host_visible
```

The node is present; 3D is not. Those are different claims. The `eglinfo` output cited for kde was collected on the runner **host**, which says nothing about the guest&#39;s environment. And gnome starts on that same hardware through Mesa&#39;s software path, so a compositor *can* come up here.

`live-iso/common/src/desktop-{xfce,niri,cosmic}.sh` now run the session under `systemd-cat -t tunaos-live-session`, and the workflow prints that tag — so the next run says why instead of inviting a sixth guess. This is the same remedy that ended four wrong guesses at `gnome-desktop:languages` in the package factory: make the failing thing print its own log, then read it. An image predating the change says so rather than printing nothing.

## Docs

`docs/MATRIX-STATUS.md` and the generator now state the symptom and point at the evidence instead of restating a cause the measurement did not support: those cells are **undiagnosed**, not hardware-limited. gnome is recorded as demonstrated rather than assumed — it boots, both processes come up, and the walkthrough captures 9 non-blank frames across 8 visual states.

Two real defects that run surfaced are recorded there too. The second is fixed here; the first is **not**, and is left as a correctly-failing gate rather than a guessed fix:

- **The installer starts behind the GNOME Activities overview.** The walkthrough must press `esc` before it can drive anything, and records it as a failure precisely because a user booting this ISO sees the same thing. Reproduced on `32450214451` and `32681262659`.

## Testing

19 new tests, **every one mutation-verified**, including reintroducing the original helper path and unwrapping a single one of niri&#39;s four session commands. The check scripts are tested by building the guest&#39;s layout on disk and *running* them — reading the line is how a shell-expansion bug survives review in the first place.

730 passed.

— hive: backend=pi model=openai-codex/gpt-5.6-sol pi=0.84.1