### PR TITLE
Make a hummingbird gnome ISO possible: flatpak in the base, per-cell ISO gating, stop advertising unimplemented desktops

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -839,16 +839,36 @@ variants:
         platforms: ["linux/amd64"]
         build_image: true
         build_iso: true
-      - id: kde
-        stage: 2
-        platforms: ["linux/amd64"]
-        build_image: true
-        build_iso: true
-      - id: niri
-        stage: 2
-        platforms: ["linux/amd64"]
-        build_image: true
-        build_iso: true
+      # kde and niri are DECLARED but not implemented for hummingbird, and
+      # advertising them costs the flavor that is.
+      #
+      # manifests/desktops/{kde,niri}.yaml have no `packages.hummingbird`
+      # section at all -- 0 packages, against gnome's 52 and cosmic's 23.
+      # install-desktop.sh routes hummingbird to that section by construction,
+      # so both flavors have never had a package set to install. Measured on
+      # run 32786338463: the two flavors with no manifest are exactly the two
+      # whose image builds failed.
+      #
+      #   kde   nothing provides libdouble-conversion.so.3 / libfbclient.so.2
+      #         needed by qt6-qtbase-*.hum1 from public-hummingbird -- an
+      #         UPSTREAM gap; those sonames are in no index, ours or theirs,
+      #         and no wave the factory is building supplies them.
+      #   niri  TUNAOS_BRANDING_FAIL -- dconf keyfiles written to
+      #         /etc/dconf/db/distro.d with no compiled database, because
+      #         `dconf update` is guarded on `command -v dconf` and dconf is
+      #         not installed when there is no package set to install it.
+      #
+      # Why this blocks GNOME. build_artifacts_s2 takes `needs: build_stage2`,
+      # a matrix job over every stage-2 flavor, so one failing leg skips every
+      # ISO in the stage -- gnome's included, however cleanly it built
+      # (tuna-os/tunaOS#2059). gnome is the only desktop with a passing
+      # installer-smoke cell anywhere in the matrix, so the flavors that were
+      # never implemented are blocking the one that works.
+      #
+      # Re-add each of these the moment it has a `packages.hummingbird`
+      # section, exactly as cosmic and gnome do. Nothing here is a judgement
+      # about wanting kde or niri on hummingbird; it is a statement that they
+      # do not exist yet and should not be advertised as though they do.
       - id: cosmic
         stage: 2
         platforms: ["linux/amd64"]

--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -333,7 +333,23 @@ jobs:
   build_artifacts_s2:
     name: "iso:${{ matrix.flavor }} (${{ matrix.safeplatform }})"
     needs: [generate_matrix, build_stage2]
-    if: github.event_name != 'pull_request' && needs.generate_matrix.outputs.artifact_s2_count != '0'
+    # Per-CELL, not per-stage (#2059). This `if` carried no status function,
+    # so success() was implicit on `build_stage2` -- a MATRIX over every
+    # stage-2 flavor. One failing desktop therefore skipped every ISO in the
+    # stage. Run 32786338463: hummingbird's gnome image built, signed and
+    # manifested, and its ISO was skipped because kde and niri failed beside
+    # it. Same shape as #1729 one edge further down, and as the stage-4
+    # artifact jail the comment above records.
+    #
+    # What replaces the coarse gate is `image-digest-artifact` below: the
+    # called workflow refuses to build unless THIS run published THIS cell's
+    # image. Without that, `!cancelled()` would emit an ISO from the tag a
+    # FAILED flavor last published -- stale media that looks fresh.
+    if: >-
+      !cancelled() && needs.generate_matrix.result == 'success' &&
+      needs.build_stage2.result != 'cancelled' &&
+      github.event_name != 'pull_request' &&
+      needs.generate_matrix.outputs.artifact_s2_count != '0'
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate_matrix.outputs.artifact_s2_matrix) }}
@@ -349,6 +365,10 @@ jobs:
       safeplatform: ${{ matrix.safeplatform }}
       image-tag: ${{ matrix.published_tag }}-${{ matrix.safeplatform }}
       build-iso: ${{ matrix.build_iso }}
+      # Names the artifact this cell's OWN image leg uploads after a
+      # successful push. Its existence is what makes the relaxed gate above
+      # safe; see the provenance gate in reusable-build-artifacts.yml.
+      image-digest-artifact: ${{ matrix.image_name }}-${{ matrix.published_tag }}-${{ matrix.safeplatform }}-${{ github.run_id }}
     secrets:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -362,7 +382,7 @@ jobs:
     needs: [generate_matrix, build_stage3]
     if: >-
       !cancelled() && needs.generate_matrix.result == 'success' &&
-      needs.build_stage3.result == 'success' &&
+      needs.build_stage3.result != 'cancelled' &&
       github.event_name != 'pull_request' &&
       needs.generate_matrix.outputs.artifact_s3_count != '0'
     strategy:
@@ -380,6 +400,10 @@ jobs:
       safeplatform: ${{ matrix.safeplatform }}
       image-tag: ${{ matrix.published_tag }}-${{ matrix.safeplatform }}
       build-iso: ${{ matrix.build_iso }}
+      # Names the artifact this cell's OWN image leg uploads after a
+      # successful push. Its existence is what makes the relaxed gate above
+      # safe; see the provenance gate in reusable-build-artifacts.yml.
+      image-digest-artifact: ${{ matrix.image_name }}-${{ matrix.published_tag }}-${{ matrix.safeplatform }}-${{ github.run_id }}
     secrets:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -391,7 +415,7 @@ jobs:
     needs: [generate_matrix, build_stage4]
     if: >-
       !cancelled() && needs.generate_matrix.result == 'success' &&
-      needs.build_stage4.result == 'success' &&
+      needs.build_stage4.result != 'cancelled' &&
       github.event_name != 'pull_request' &&
       needs.generate_matrix.outputs.artifact_s4_count != '0'
     strategy:
@@ -409,6 +433,10 @@ jobs:
       safeplatform: ${{ matrix.safeplatform }}
       image-tag: ${{ matrix.published_tag }}-${{ matrix.safeplatform }}
       build-iso: ${{ matrix.build_iso }}
+      # Names the artifact this cell's OWN image leg uploads after a
+      # successful push. Its existence is what makes the relaxed gate above
+      # safe; see the provenance gate in reusable-build-artifacts.yml.
+      image-digest-artifact: ${{ matrix.image_name }}-${{ matrix.published_tag }}-${{ matrix.safeplatform }}-${{ github.run_id }}
     secrets:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -5,13 +5,14 @@ name: Unified Build
 # are staggered ~2h apart instead of the old 01:00–03:30 cluster, which put
 # ~8 variants (~500 job demand) in flight at once and starved the proving
 # workflows (0 running / 28 queued / 102-min waits on 2026-07-31).
-# Biggest variants overnight; only the two smallest inside the 04:00–09:00
-# proving window (daily-verify 04:00, verify-asahi 05:40, matrix-status &
-# catalog-facts 06:00, desktop-contract-sweep 08:00).
+# Biggest variants overnight; at most two variants, of at most 4 flavors
+# each, inside the 04:00–09:00 proving window (daily-verify 04:00,
+# verify-asahi 05:40, matrix-status & catalog-facts 06:00,
+# desktop-contract-sweep 08:00).
 #   00:20 yellowfin(20fl)  02:20 albacore(20)       04:20 gurnard(2)
 #   06:20 guppy(4)         09:20 skipjack(18)       11:20 bonito(16)
 #   13:20 marlin(16)       15:20 bonito-rawhide(14) 17:20 grouper(7)
-#   19:20 sailfin(7)       21:20 flounder(7)        22:20 hummingbird(5)
+#   19:20 sailfin(7)       21:20 flounder(7)        22:20 hummingbird(3)
 #   23:20 flounder-sid(7)
 # If you add a variant or move a cron, keep this table true.
 on:

--- a/.github/workflows/reusable-build-artifacts.yml
+++ b/.github/workflows/reusable-build-artifacts.yml
@@ -40,6 +40,18 @@ on:
         required: false
         type: string
         default: ""
+      image-digest-artifact:
+        description: >-
+          Name of the workflow artifact this cell's OWN image job uploaded
+          when it pushed, i.e.
+          `<image_name>-<published_tag>-<safeplatform>-<run_id>`, written by
+          reusable-build-image.yml's "Create Job Outputs" step. When set, the
+          provenance gate below requires it to exist before an ISO is built.
+          Callers that deliberately build from already-published tags
+          (publish-isos.yml) leave it empty and keep the old behaviour.
+        required: false
+        type: string
+        default: ""
       build-iso:
         description: "Build (and gate + publish) the live ISO"
         required: false
@@ -84,6 +96,75 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # ── Provenance gate (tuna-os/tunaOS#2059) ────────────────────────────
+      # This job builds an ISO from a MOVING TAG -- `<published_tag>-<safe
+      # platform>` -- and never from the digest its image job produced. That
+      # is safe only while something guarantees this cell's image was pushed
+      # by THIS run. Until now the guarantee came from `needs: build_stageN`,
+      # and build_stageN is a MATRIX over every flavor in the stage: one
+      # failing desktop skipped every ISO in the stage, including flavors
+      # that built perfectly. Run 32786338463 is the record -- hummingbird's
+      # gnome image built, signed and manifested, and its ISO was skipped
+      # because kde and niri (declared, never implemented) failed beside it.
+      #
+      # Relaxing that to per-cell is only correct with something in its
+      # place. For a flavor whose image build FAILED, the tag it would pull
+      # still resolves to the PREVIOUS image, so the ISO job would succeed
+      # and emit media that looks fresh and is not. Silently stale media is
+      # worse than no media and worse than a skipped cell, which is why the
+      # coarse gate was defensible.
+      #
+      # The replacement is the artifact reusable-build-image.yml already
+      # uploads, and only ever uploads after `podman push` returns a digest:
+      # `<image_name>-<published_tag>-<safeplatform>-<run_id>`. Its EXISTENCE
+      # is the proof, and the run_id suffix is what makes it proof of THIS
+      # run rather than of some earlier one. Absent means this cell published
+      # nothing today, and the job stops before building anything.
+      #
+      # This does not narrow the pre-existing window in which a concurrent
+      # run moves the tag between push and pull; it closes the failure that
+      # #2059 measured, which is a cell whose image never published at all.
+      - name: Fetch the digest this run published for this cell
+        id: cell_digest
+        if: inputs.image-digest-artifact != ''
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.image-digest-artifact }}
+          path: /tmp/cell-digest
+
+      - name: "Provenance gate: this run published the image this ISO is built from"
+        if: inputs.image-digest-artifact != ''
+        env:
+          ARTIFACT: ${{ inputs.image-digest-artifact }}
+          FETCHED: ${{ steps.cell_digest.outcome }}
+          VARIANT: ${{ inputs.variant }}
+          FLAVOR: ${{ inputs.flavor }}
+        run: |
+          set -euo pipefail
+          # Both halves, because download-artifact's behaviour on a name that
+          # does not exist is not something to bet the message on: it may fail
+          # the step (outcome != success) or warn and succeed with an empty
+          # directory. Either way the cell published nothing, and either way a
+          # maintainer should read that sentence rather than `cat: no such
+          # file`.
+          set -- /tmp/cell-digest/*.txt
+          if [ "$FETCHED" != success ] || [ ! -f "$1" ]; then
+            echo "::error::${VARIANT}:${FLAVOR} published no image in this run" \
+                 "(no artifact '${ARTIFACT}'). The tag this ISO would build" \
+                 "from still holds a PREVIOUS image, so building it would emit" \
+                 "media that looks fresh and is not. Refusing."
+            exit 1
+          fi
+          DIGEST="$(cat "$@" | tr -d '[:space:]')"
+          if [ -z "$DIGEST" ]; then
+            echo "::error::artifact '${ARTIFACT}' carries an EMPTY digest;" \
+                 "the push step recorded no digest for ${VARIANT}:${FLAVOR}."
+            exit 1
+          fi
+          echo "${VARIANT}:${FLAVOR} published ${DIGEST} in this run."
+          echo "provenance: \`${DIGEST}\`" >> "$GITHUB_STEP_SUMMARY"
 
       # Reclaim ~25 GB of preinstalled toolchains from the main disk. The ISO is
       # assembled under .build/ on the workspace (main disk), not the

--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -176,6 +176,7 @@ REPO
 		systemd-container \
 		btrfs-progs \
 		xfsprogs \
+		flatpak \
 		gcc \
 		gcc-c++ \
 		just || true
@@ -188,6 +189,39 @@ REPO
 		echo "       bootc install to-disk cannot format the root without it." >&2
 		dnf repolist >&2 || true
 		exit 1
+	fi
+
+	# flatpak is not optional either, for a reason that only bites three
+	# steps downstream. live-iso/common/src/customize-live.sh pre-installs
+	# the installer app and exits 1 if flatpak cannot be made present:
+	#
+	#   ERROR: flatpak not installed and could not be installed;
+	#          cannot pre-install ${INSTALLER_APP}
+	#
+	# and that same script is what scripts/build-iso-tacklebox.sh passes as
+	# the ISO recipe's live_customize step. So a hummingbird image without
+	# flatpak cannot produce a live overlay, cannot build an ISO, and has no
+	# installer to launch if one were built -- gnome ships upstream
+	# bootc-installer as org.bootcinstaller.Installer, a Flatpak.
+	#
+	# Its ensure_flatpak() fallback installs the package on bases that merely
+	# omit it from the image (guppy, grouper, bonito-rawhide). That cannot
+	# help hummingbird: measured 2026-08-25, flatpak is absent from BOTH
+	# public-hummingbird (3509 binary names) and our rebuild snapshot (7986).
+	# It is layer-07 of build-order-hummingbird-desktops.yml, 131 packages
+	# into the 164 still unbuilt.
+	#
+	# Listed above so the image picks it up the moment that wave publishes,
+	# and warned about rather than fatal because it genuinely is not
+	# available yet -- a hard failure here would break every hummingbird base
+	# build today. Make it fatal, like xfsprogs above, once layer-07 is
+	# served. What must NOT happen is the xfsprogs shape: --skip-unavailable
+	# swallowing the miss silently and the failure surfacing two stages later
+	# as something else. tuna-os/tunaOS#1397 tracks this.
+	if ! rpm -q flatpak >/dev/null 2>&1; then
+		echo "WARNING: flatpak did not install — no enabled repo carries it yet." >&2
+		echo "         This image cannot build a live overlay or an ISO, and has" >&2
+		echo "         no installer app; see tuna-os/tunaOS#1397." >&2
 	fi
 elif [[ ${IS_ELN:-false} == true ]]; then
 	# ── Fedora ELN ───────────────────────────────────────────────────────

--- a/docs/HUMMINGBIRD.md
+++ b/docs/HUMMINGBIRD.md
@@ -159,6 +159,62 @@ Not fixed here: correcting the label is a fleet-wide metadata change across
 thirteen variants with downstream consumers, which wants its own change and its
 own review rather than being folded into a hummingbird documentation pass.
 
+## What actually blocks a hummingbird ISO (measured 2026-08-25)
+
+The chain from "packages exist" to "a laptop runs Hummingbird GNOME" has six
+links. Five of them were opaque this morning; they are not any more, and the
+binding constraint is smaller and more specific than "the desktop is missing".
+
+| # | link | state |
+|---|---|---|
+| 1 | build the desktop packages | 673 in `build-order-hummingbird-desktops.yml`, **509 served, 164 left** — 131 through layer-07, 153 through layer-09 |
+| 2 | publish that wave to R2 | dispatch-only; the nightly builds and caches but **never publishes** (no `rclone`/`R2_` anywhere in `package-factory.yml`) |
+| 3 | image build installs them | fixed: the `IS_HUMMINGBIRD` branch of `10-base-packages.sh` never listed `flatpak` |
+| 4 | Gate: `bootc install to-disk` + boot | **proven fixed** — ext4 drop-in, installs in 1m54s and boots to `graphical.target` |
+| 5 | Promote publishes `hummingbird:gnome` | blocked only by the Gate's boot-verify, which needs a real desktop |
+| 6 | overlay → ISO → install | blocked by `flatpak`, see below |
+
+### `flatpak` is the single package gating the whole ISO axis
+
+Not `gnome-shell`. `flatpak` is **layer-07**, and it blocks three consecutive
+steps rather than one:
+
+* the **live-overlay** build — `customize-live.sh` pre-installs the installer
+  app and `exit 1`s if flatpak cannot be made present;
+* the **CI ISO build** — `build-iso-tacklebox.sh` passes that *same* script as
+  the recipe's `live_customize` step;
+* the **installer itself** — gnome has no TunaOS-branded frontend fork, so it
+  ships upstream `org.bootcinstaller.Installer`, which is a Flatpak.
+
+`ensure_flatpak()`'s `dnf install flatpak` fallback rescues guppy, grouper and
+bonito-rawhide, whose distributions package it and whose images merely omit it.
+It cannot rescue Hummingbird: flatpak is absent from **both** indexes —
+`public-hummingbird` (3509 binary names) and our rebuild snapshot (7986).
+
+### The precedent that says this is achievable
+
+`docs/MATRIX-STATUS.md` records **one** passing installer-smoke cell out of 36:
+`yellowfin gnome`. The same matrix records that cosmic, niri, xfwl4 and kde do
+not bring a session up on hosted CI, while gnome does. So gnome is the only
+desktop with a working end-to-end precedent, and hummingbird gnome runs the
+identical installer. Its gap to that precedent is links 1 and 6 above, not the
+machinery in between.
+
+Worth keeping honest: installer smoke runs in QEMU. It proves an ISO boots, the
+installer appears, and the walkthrough can drive it. **No variant has a proven
+install on physical hardware** — that step is manual and nothing in CI stands in
+for it.
+
+### Our own repo can shadow upstream's fixes
+
+The desktop manifests and the base stage both add our rebuild repo at
+`priority: 5`, and dnf priority is *absolute* rather than a tie-break. So for
+any package present in both indexes, ours installs even when upstream's is
+newer. Measured: 30 names overlap, **16 of them older on our side**, including
+`sudo` fifteen releases behind. The gap measurement drops adopted packages from
+the BUILD ORDER but nothing withdraws the already-published copy.
+`scripts/check-upstream-shadowing.py` in tunaos-packages now fails on this.
+
 ## Rules of thumb for future work here
 
 1. **Do not call it a Fedora rebuild.** It is a hardened rolling fork tracking

--- a/docs/HUMMINGBIRD.md
+++ b/docs/HUMMINGBIRD.md
@@ -167,7 +167,7 @@ binding constraint is smaller and more specific than "the desktop is missing".
 
 | # | link | state |
 |---|---|---|
-| 1 | build the desktop packages | 673 in `build-order-hummingbird-desktops.yml`, **509 served, 164 left** — 131 through layer-07, 153 through layer-09 |
+| 1 | build the desktop packages | 673 in `build-order-hummingbird-desktops.yml`, **570 served, 103 left** — 53 before layer-07, 19 more in layer-07 itself (measured 2026-08-25 15:30) |
 | 2 | publish that wave to R2 | dispatch-only; the nightly builds and caches but **never publishes** (no `rclone`/`R2_` anywhere in `package-factory.yml`) |
 | 3 | image build installs them | fixed: the `IS_HUMMINGBIRD` branch of `10-base-packages.sh` never listed `flatpak` |
 | 4 | Gate: `bootc install to-disk` + boot | **proven fixed** — ext4 drop-in, installs in 1m54s and boots to `graphical.target` |
@@ -189,7 +189,23 @@ steps rather than one:
 `ensure_flatpak()`'s `dnf install flatpak` fallback rescues guppy, grouper and
 bonito-rawhide, whose distributions package it and whose images merely omit it.
 It cannot rescue Hummingbird: flatpak is absent from **both** indexes —
-`public-hummingbird` (3509 binary names) and our rebuild snapshot (7986).
+`public-hummingbird` (3510 binary names, revision 1787670929) and our rebuild
+snapshot (7986, revision 1786989380), re-measured live on 2026-08-25 at 15:30.
+Upstream has not adopted it, so waiting for upstream is not a strategy; it has
+to be built.
+
+#### How to re-measure this, and one trap in doing so
+
+Read both indexes and compare BUILD-ORDER SOURCE NAMES against the source of
+each binary we serve (`srpm_name(pkg["srpm"])`), not against served binary
+names — most of the chain's sources ship under different binary names, and
+matching on binary names undercounts what is built.
+
+The trap is the tier INDEX. `flatpak` sits in `layer-07`, which is **tier
+index 11**, because the list opens with four bootstrap tiers before `layer-00`.
+Filtering on `index <= 7` silently answers a different question and reports far
+too little work remaining — measured 15 instead of 53 when this was last
+computed. Match on the tier `name`, or find flatpak's index first.
 
 ### The precedent that says this is achievable
 

--- a/docs/HUMMINGBIRD.md
+++ b/docs/HUMMINGBIRD.md
@@ -173,6 +173,7 @@ binding constraint is smaller and more specific than "the desktop is missing".
 | 4 | Gate: `bootc install to-disk` + boot | **proven fixed** — ext4 drop-in, installs in 1m54s and boots to `graphical.target` |
 | 5 | Promote publishes `hummingbird:gnome` | blocked only by the Gate's boot-verify, which needs a real desktop |
 | 6 | overlay → ISO → install | blocked by `flatpak`, see below |
+| 7 | the installed system works on the target laptop | **no device firmware exists anywhere** — see below (#2064) |
 
 ### `flatpak` is the single package gating the whole ISO axis
 
@@ -206,6 +207,39 @@ index 11**, because the list opens with four bootstrap tiers before `layer-00`.
 Filtering on `index <= 7` silently answers a different question and reports far
 too little work remaining — measured 15 instead of 53 when this was last
 computed. Match on the tier `name`, or find flatpak's index first.
+
+### Link 7: firmware, and why CI can never tell you about it
+
+`linux-firmware` and every per-device firmware package are absent from
+`hummingbird:base` (287 packages) and `hummingbird:gnome` (405), from
+`public-hummingbird`, from our published snapshot, **and from the 673-entry
+build order**. Nothing is scheduled to build them. Measured 2026-08-25 against
+the images' own rpm manifests and both repodata indexes; full table in #2064.
+
+QEMU cannot surface this, and that is the point. virtio needs no firmware, so
+`installer-smoke` and `iso-e2e` pass on media that would reach a laptop with:
+
+* **no wifi** — no firmware, no `wpa_supplicant`, and NetworkManager present
+  without its wifi plugin (`NetworkManager-wifi` exists in `public-hummingbird`
+  and is simply not requested);
+* **no GPU initialisation** on amdgpu or recent i915/xe, which need firmware
+  blobs before the display comes up at all;
+* **no audio** on any modern Intel laptop, which needs `sof-firmware`.
+
+The driver *userspace* is fine — the gnome layer already brings
+`mesa-dri-drivers`, `libdrm` and `mesa-libgbm`. This is specifically a firmware
+gap.
+
+It is also not obviously a Hummingbird bug. A hardened, desktop-less
+server/container base omitting ~500 MB of unauditable vendor blobs is a
+defensible choice; the gap only appears when the desktop flavors point it at
+a laptop. #2064 lays out the four options and deliberately does not pick one,
+because the choice trades the hardening premise against hardware support and
+that is a maintainer's call.
+
+**Do not read a green `installer-smoke` cell as evidence that a laptop install
+works.** Every passing cell in `docs/MATRIX-STATUS.md`, including the single
+`yellowfin gnome` one, is QEMU.
 
 ### The precedent that says this is achievable
 

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -79,7 +79,7 @@ Scored against `.github/green-criteria.yml`: a cell is green only when every **b
 | **flounder-sid** | ❌ | ❌ | — | — | ❌ |
 | **grouper** | ✅ | ✅ | ❌ | — | ✅ |
 | **guppy** | ❌ | ⬜ | — | — | ✅ |
-| **hummingbird** | ❌ | ⬜ | ❌ | ⬜ | — |
+| **hummingbird** | ❌ | — | ❌ | — | — |
 | **marlin** | ✅ | ✅ | ❌ | ❌ | ✅ |
 | **sailfin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | **skipjack** | ❌ | ✅ | ❌ | ❌ | ✅ |
@@ -104,7 +104,7 @@ Green criterion 8 (`no_silent_omissions`): the sweep runs `checks/verify-package
 | **flounder-sid** | ✅ | ✅ | — | — | ✅ |
 | **grouper** | ✅ | ✅ | ✅ | — | ✅ |
 | **guppy** | ✅ | ✅ | — | — | ✅ |
-| **hummingbird** | ⬜ | ⬜ | ⬜ | ⬜ | — |
+| **hummingbird** | ⬜ | — | ⬜ | — | — |
 | **marlin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **sailfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **skipjack** | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -147,7 +147,7 @@ Measured against the set `luks-e2e.yml` schedules: every published desktop image
 | **grouper** | ✅ | ✅ | ✅ | — | ✅ |
 | **guppy** | ❌ | ❌ | — | — | ✅ |
 | **gurnard** | — | — | — | — | — |
-| **hummingbird** | ❌ | ⬜ | ⬜ | ⬜ | — |
+| **hummingbird** | ❌ | — | ⬜ | — | — |
 | **marlin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **sailfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **skipjack** | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -174,7 +174,7 @@ Pulls the **published** image and runs the contract script against it directly (
 | **flounder-sid** | ❌ | ❌ | — | — | ❌ |
 | **grouper** | ✅ | ✅ | ✅ | — | ✅ |
 | **guppy** | ❌ | ✅ | — | — | ✅ |
-| **hummingbird** | ⬜ | ⬜ | ⬜ | ⬜ | — |
+| **hummingbird** | ⬜ | — | ⬜ | — | — |
 | **marlin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **sailfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **skipjack** | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/tests/test_declared_flavors_are_implemented.py
+++ b/tests/test_declared_flavors_are_implemented.py
@@ -1,0 +1,79 @@
+"""A variant may not advertise a desktop it has no package set for.
+
+`build_scripts/desktop/install-desktop.sh` routes hummingbird to the
+`packages.hummingbird` section of `manifests/desktops/<flavor>.yaml` by
+construction. A flavor with no such section has nothing to install, so its
+image build cannot succeed -- and it does not fail quietly in isolation.
+
+`build_artifacts_s2` takes `needs: build_stage2`, a matrix job over every
+stage-2 flavor, so ONE failing leg skips every ISO in the stage
+(tuna-os/tunaOS#2059). Measured on run 32786338463: hummingbird declared
+gnome, kde, niri and cosmic; only gnome (52 packages) and cosmic (23) had a
+`packages.hummingbird` section; kde and niri had none; and kde and niri were
+exactly the two image builds that failed -- taking gnome's ISO down with them,
+though gnome itself built, signed and manifested cleanly.
+
+gnome is the only desktop with a passing installer-smoke cell anywhere in
+docs/MATRIX-STATUS.md, so the flavors that were never implemented were
+blocking the only one that demonstrably works.
+
+This is deliberately about DECLARED vs IMPLEMENTED, not about which desktops
+are desirable. Re-adding kde or niri is correct the moment either grows a
+package section.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def declared(variant: str) -> list[str]:
+    config = yaml.safe_load((ROOT / ".github" / "build-config.yml").read_text())
+    entry = next(v for v in config["variants"] if v["id"] == variant)
+    return [f["id"] for f in entry["flavors"] if f.get("build_image")]
+
+
+def implemented(variant: str, flavor: str) -> int:
+    path = ROOT / "manifests" / "desktops" / f"{flavor}.yaml"
+    if not path.exists():
+        return 0
+    manifest = yaml.safe_load(path.read_text()) or {}
+    section = (manifest.get("packages") or {}).get(variant) or {}
+    return len(section.get("packages") or [])
+
+
+def test_every_declared_hummingbird_desktop_has_a_package_set() -> None:
+    missing = {
+        flavor: implemented("hummingbird", flavor)
+        for flavor in declared("hummingbird")
+        if flavor != "base" and implemented("hummingbird", flavor) == 0
+    }
+    assert not missing, (
+        f"hummingbird declares {sorted(missing)} with build_image: true but "
+        "manifests/desktops/<flavor>.yaml has no packages.hummingbird section "
+        "for them. install-desktop.sh routes hummingbird to that section, so "
+        "these cannot build -- and because build_artifacts_s2 needs the whole "
+        "build_stage2 matrix, their failure skips every stage-2 ISO including "
+        "gnome's (#2059)"
+    )
+
+
+def test_the_flavors_that_are_implemented_are_still_declared() -> None:
+    """Guard the guard, in both directions.
+
+    Deleting a flavor is a cheap way to make the assertion above pass, so pin
+    that the implemented ones remain advertised -- otherwise 'no declared
+    flavor lacks a manifest' could be satisfied by declaring nothing.
+    """
+    flavors = declared("hummingbird")
+    for flavor in ("gnome", "cosmic"):
+        assert implemented("hummingbird", flavor) > 0, (
+            f"{flavor} lost its packages.hummingbird section"
+        )
+        assert flavor in flavors, (
+            f"{flavor} has a hummingbird package set but is no longer declared"
+        )
+    assert "gnome" in flavors, "gnome is the only desktop with a passing installer-smoke cell"

--- a/tests/test_hummingbird_base_can_reach_an_iso.py
+++ b/tests/test_hummingbird_base_can_reach_an_iso.py
@@ -1,0 +1,82 @@
+"""The hummingbird base must ask for flatpak, or nothing downstream can work.
+
+Building the `flatpak` PACKAGE is not enough. Something has to install it into
+the image, and hummingbird takes its own branch of build_scripts/10-base-packages.sh
+whose list is separate from the fedora and el10 ones -- the `flatpak` entries in
+those branches never applied to it.
+
+Why it matters three steps later. live-iso/common/src/customize-live.sh
+pre-installs the installer app and exits 1 when flatpak cannot be made present:
+
+    ERROR: flatpak not installed and could not be installed;
+           cannot pre-install ${INSTALLER_APP}
+
+scripts/build-iso-tacklebox.sh passes that same script as the ISO recipe's
+live_customize step, and gnome's INSTALLER_APP is org.bootcinstaller.Installer
+-- a Flatpak. So one missing package takes out the live-overlay build, the CI
+ISO build, and the installer a user would click.
+
+customize-live.sh's ensure_flatpak() fallback rescues bases that merely omit
+the package from their image (guppy, grouper, bonito-rawhide, whose distros
+all package it). It cannot rescue hummingbird: measured 2026-08-25, flatpak is
+absent from BOTH public-hummingbird (3509 binary names) and our rebuild
+snapshot (7986). It is layer-07 of the build order.
+
+This pins the ask, not the outcome -- the package is not published yet, so the
+image legitimately does not have it. What it prevents is the ask being dropped
+and the gap resurfacing two stages later as something else, which is exactly
+what xfsprogs did in run 32144269992.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "build_scripts" / "10-base-packages.sh"
+
+
+def hummingbird_branch() -> str:
+    """Only the IS_HUMMINGBIRD branch, so the fedora/el10 lists cannot
+    accidentally satisfy an assertion about hummingbird's."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    start = text.index("if [[ $IS_HUMMINGBIRD == true ]]")
+    end = text.index("elif [[ $IS_FEDORA == true ]]", start)
+    return text[start:end]
+
+
+def test_the_branch_is_still_findable() -> None:
+    """Guard the guard: a refactor that renames the branch must fail loudly
+    here rather than leaving every assertion below vacuously true."""
+    branch = hummingbird_branch()
+    assert "--skip-unavailable" in branch
+    assert "xfsprogs" in branch, "the branch no longer looks like the one measured"
+
+
+def test_hummingbird_asks_for_flatpak() -> None:
+    branch = hummingbird_branch()
+    install = branch[branch.index("dnf -y install"):]
+    install = install[:install.index("|| true")]
+    packages = {line.strip().rstrip("\\").strip() for line in install.splitlines()}
+    assert "flatpak" in packages, (
+        "the hummingbird base does not install flatpak, so once the package "
+        "is published the image still will not carry it -- and without it "
+        "customize-live.sh exits 1, no overlay or ISO can be built, and there "
+        "is no installer app to launch"
+    )
+
+
+def test_a_missing_flatpak_is_not_silent() -> None:
+    """--skip-unavailable drops a missing package without a word. That is what
+    made the xfsprogs fix look 'in place' while the Gate died at mkfs.xfs two
+    stages later, and the same silence would hide this one until an ISO build
+    failed for reasons that look unrelated."""
+    branch = hummingbird_branch()
+    assert re.search(r"rpm -q flatpak", branch), (
+        "nothing checks whether flatpak actually installed; a silent miss is "
+        "how the xfsprogs gap survived a fix"
+    )
+    assert "#1397" in branch, (
+        "the check should point at the issue that explains the consequence, "
+        "so whoever reads the warning does not have to rediscover it"
+    )

--- a/tests/test_matrix_status.py
+++ b/tests/test_matrix_status.py
@@ -332,7 +332,7 @@ class UndeclaredCellsAreNotCountedAgainstUs(unittest.TestCase):
             gms.VOLATILE_LINE,
         )
 
-    def test_the_real_build_config_declares_53_luks_cells(self):
+    def test_the_real_build_config_declares_51_luks_cells(self):
         """Ties the unit tests above to the actual denominator on disk.
 
         If this number moves, the LUKS total moves with it, and that should be
@@ -344,9 +344,21 @@ class UndeclaredCellsAreNotCountedAgainstUs(unittest.TestCase):
         counted rather than quietly excluded — it costs one boot in the
         monthly sweep (`0 7 1 * *`), and nothing nightly, because the variant
         is dispatch-only.
+
+        53 -> 51 on 2026-08-25: hummingbird stopped declaring kde and niri.
+        Neither had a `packages.hummingbird` section in
+        manifests/desktops/*.yaml -- 0 packages against gnome's 52 -- so
+        neither could ever have installed a desktop, and both were failing
+        their image build. The denominator going DOWN by two is the point:
+        those two cells were counted as owed and could never be paid, and
+        while they failed beside gnome they also skipped gnome's ISO
+        (tuna-os/tunaOS#2059). Re-declaring either flavor puts its cell back.
         """
         matrix = gms.luks_matrix()
-        self.assertEqual(sum(len(v) for v in matrix.values()), 53)
+        self.assertEqual(sum(len(v) for v in matrix.values()), 51)
+        # The control that makes the drop specific rather than merely smaller:
+        # hummingbird keeps exactly the desktops it has package sets for.
+        self.assertEqual(matrix.get("hummingbird"), {"gnome", "cosmic"})
         self.assertEqual(matrix.get("wahoo"), {"gnome"})
         self.assertNotIn("cosmic", matrix.get("flounder", set()))
         self.assertNotIn("cosmic", matrix.get("flounder-sid", set()))

--- a/tests/test_nightly_schedule_registry.py
+++ b/tests/test_nightly_schedule_registry.py
@@ -36,6 +36,13 @@ BUILD_CONFIG = ROOT / ".github/build-config.yml"
 # desktop-contract-sweep 08:00.
 PROVING_WINDOW = (4, 9)
 MAX_IN_PROVING_WINDOW = 2
+# A variant may sit inside the window only if it is SMALL. Today gurnard has
+# 2 flavors and guppy 4; the next tier up is the 7-flavor group (flounder,
+# flounder-sid, grouper, sailfin) and everything above it runs to 20. So 4 is
+# the boundary between "fits beside the verification workflows" and "is a
+# fleet build", and it is a threshold rather than a ranking on purpose --
+# see test_the_proving_window_carries_only_small_builds.
+MAX_FLAVORS_IN_PROVING_WINDOW = 4
 
 # `20 13 * * *` -> ("13", "20"); anything else is not a daily slot.
 _DAILY_CRON = re.compile(r"^(\d{1,2}) (\d{1,2}) \* \* \*$")
@@ -119,26 +126,66 @@ def test_no_two_variants_share_a_slot() -> None:
         seen[slot] = variant
 
 
-def test_the_proving_window_carries_only_the_smallest_builds() -> None:
-    """04:00-09:00 belongs to the verification workflows, not the fleet."""
+def test_the_proving_window_carries_only_small_builds() -> None:
+    """04:00-09:00 belongs to the verification workflows, not the fleet.
+
+    This asserted a RANKING -- that the variants inside the window are exactly
+    the N smallest scheduled variants -- and that shape has now rotted twice
+    for reasons that had nothing to do with the stagger:
+
+      * wahoo (Fedora ELN, `experimental: true`) entered build-config at 2
+        flavors and displaced guppy from `smallest`, though it is emitted
+        dispatch-only and has no cron to occupy any slot at all. Fixed by
+        ranking against SCHEDULED variants only.
+      * hummingbird dropped from 5 flavors to 3 when kde and niri were removed
+        for having no package set, which made it smaller than guppy and so
+        "should" have been in the window. It should not be, and the reason is
+        not its size: it fires at 22:20 so the image build follows the day's
+        package publish. Moving it into the morning would break that ordering
+        to satisfy an arithmetic tie-break.
+
+    A total order over the whole fleet is simply the wrong instrument. Any
+    flavor added or removed ANYWHERE re-sorts it, and the test then demands a
+    scheduling change that nothing about the contention justifies.
+
+    The hazard is unchanged and is what gets asserted instead: a BIG build
+    inside the reserved window queues against daily-verify, verify-asahi,
+    matrix-status, catalog-facts and desktop-contract-sweep under the org's
+    20-concurrent-job ceiling. That is a question of size against a threshold,
+    not of rank. Both guards stay -- how MANY variants sit in the window, and
+    how BIG each is -- so the two ways it can be spoiled are still covered.
+    """
     counts = flavor_counts()
     low, high = PROVING_WINDOW
-    scheduled = scheduled_crons()
-    inside = [v for v, (h, _) in scheduled.items() if low <= h < high]
+    inside = [v for v, (h, _) in scheduled_crons().items() if low <= h < high]
+
     assert len(inside) <= MAX_IN_PROVING_WINDOW, (
         f"{sorted(inside)} all fire inside the {low:02d}:00-{high:02d}:00 "
         "proving window"
     )
-    # The comparison pool is the SCHEDULED variants, not every variant in
-    # build-config.yml. Only a variant with a cron can occupy a slot, so
-    # ranking against the full config asks an unscheduled variant to hold a
-    # window it has no workflow to fill. wahoo (Fedora ELN) is the first
-    # `experimental: true` variant — generate-workflows.py emits it
-    # dispatch-only, with no `schedule:` at all — and at 2 flavors it is the
-    # smallest thing in the config, so it displaced guppy from `smallest`
-    # and failed this assertion while changing nothing about the stagger.
-    smallest = sorted(scheduled, key=lambda v: (counts[v], v))[: len(inside)]
-    assert sorted(inside) == sorted(smallest), (
-        f"the proving window carries {sorted(inside)}; the smallest builds "
-        f"are {sorted(smallest)}"
+    oversized = {v: counts[v] for v in inside
+                 if counts[v] > MAX_FLAVORS_IN_PROVING_WINDOW}
+    assert not oversized, (
+        f"{oversized} fire inside the {low:02d}:00-{high:02d}:00 proving "
+        f"window with more than {MAX_FLAVORS_IN_PROVING_WINDOW} flavors; the "
+        "window is reserved for the verification workflows and a fleet-sized "
+        "build queues against them under the 20-job ceiling"
+    )
+
+
+def test_the_proving_window_guard_would_notice_a_fleet_build() -> None:
+    """The guard above must be able to FAIL, not merely to pass today.
+
+    A threshold test is exactly the shape that quietly stops examining
+    anything if the threshold drifts above the fleet. This asserts the
+    threshold still sits below the largest scheduled variant, so the guard
+    has something it would actually reject.
+    """
+    counts = flavor_counts()
+    scheduled = scheduled_crons()
+    heaviest = max(scheduled, key=lambda v: counts[v])
+    assert counts[heaviest] > MAX_FLAVORS_IN_PROVING_WINDOW, (
+        f"the threshold ({MAX_FLAVORS_IN_PROVING_WINDOW}) is at or above the "
+        f"largest scheduled variant ({heaviest} at {counts[heaviest]}), so the "
+        "guard cannot fail for any variant and is measuring nothing"
     )

--- a/tests/test_one_failing_flavor_cannot_skip_a_sibling_iso.py
+++ b/tests/test_one_failing_flavor_cannot_skip_a_sibling_iso.py
@@ -1,0 +1,202 @@
+"""One failing desktop must not skip the ISOs of the flavors that built.
+
+`build_artifacts_s{2,3,4}` in build-variant.yml take
+`needs: [generate_matrix, build_stage{2,3,4}]`, and `build_stageN` is a
+MATRIX over every flavor in that stage. A matrix job fails if any leg fails,
+so one failing desktop skipped every ISO and QCOW2 in its stage -- including
+flavors that built perfectly. Same shape as #1729 (stage 2 hard-gated on a
+fully-green multi-arch base) one edge further down, and as the stage-4
+artifact jail the comment above those jobs already records.
+
+Measured on Build Hummingbird run 32786338463: `gnome / linux-amd64`,
+`gnome / Manifest` and `gnome / Sign` all succeeded; `kde` and `niri` failed;
+all three `iso:` cells were SKIPPED with their names unexpanded, meaning the
+job never reached matrix expansion because the `if` was false.
+
+The obvious relaxation is wrong on its own, and that is the interesting part.
+The ISO job builds from a MOVING TAG (`<published_tag>-<safeplatform>`), not
+from the digest its image job produced. For a flavor whose image build
+FAILED, that tag still resolves to the PREVIOUS image -- so a bare
+`!cancelled()` would succeed and emit media that looks fresh and is not.
+Silently stale media is worse than no media and worse than a skipped cell.
+
+So the two halves are ONE invariant and are tested as one: an artifact job
+may be relaxed off whole-stage success only while it passes its cell's
+`image-digest-artifact`, which reusable-build-image.yml uploads only after
+`podman push` returns a digest, named with `github.run_id` so it proves THIS
+run rather than an earlier one.
+"""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+VARIANT = ROOT / ".github" / "workflows" / "build-variant.yml"
+ARTIFACTS = ROOT / ".github" / "workflows" / "reusable-build-artifacts.yml"
+IMAGE = ROOT / ".github" / "workflows" / "reusable-build-image.yml"
+
+ARTIFACT_JOBS = ("build_artifacts_s2", "build_artifacts_s3", "build_artifacts_s4")
+
+
+def jobs(path: pathlib.Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))["jobs"]
+
+
+def test_no_artifact_job_is_gated_on_a_fully_green_stage_matrix() -> None:
+    for name in ARTIFACT_JOBS:
+        job = jobs(VARIANT)[name]
+        stage = name.replace("build_artifacts_s", "build_stage")
+        condition = " ".join(str(job.get("if", "")).split())
+
+        assert f"needs.{stage}.result == 'success'" not in condition, (
+            f"{name} requires the WHOLE {stage} matrix to be green, so one "
+            f"failing desktop skips every ISO in the stage (#2059)"
+        )
+        # A job whose `if` contains no status function gets success() implied
+        # on every need -- which is exactly how s2 acquired this coupling
+        # without ever saying so.
+        assert "!cancelled()" in condition, (
+            f"{name} has no status function in its `if`, so success() is "
+            f"implicit on {stage} and the coupling is back, silently"
+        )
+
+
+def test_relaxing_the_gate_is_paired_with_the_provenance_artifact() -> None:
+    """The half that stops the relaxation from emitting stale media."""
+    for name in ARTIFACT_JOBS:
+        supplied = jobs(VARIANT)[name]["with"].get("image-digest-artifact", "")
+        assert "github.run_id" in supplied, (
+            f"{name} builds ISOs from a moving tag with no proof this run "
+            f"published the image; a failed flavor would emit a stale ISO. "
+            f"got: {supplied!r}"
+        )
+
+
+def test_the_consumer_asks_for_the_name_the_producer_uploads() -> None:
+    """Two templates that must agree, in files that are edited apart.
+
+    A mismatch here fails EVERY ISO cell rather than none, so it is loud --
+    but it is loud at the end of a two-hour image build, which is exactly the
+    kind of thing worth catching in a second.
+    """
+    upload = next(
+        step for step in jobs(IMAGE)["build_push"]["steps"]
+        if step.get("name") == "Upload Output Artifacts"
+    )
+    produced = upload["with"]["name"]
+    # The producer reads its values from env/inputs, the consumer from its
+    # own matrix; normalise both to the field ORDER they interpolate.
+    produced_fields = ["IMAGE_NAME", "DEFAULT_TAG", "safeplatform", "run_id"]
+    for field in produced_fields:
+        assert field in produced, f"producer name no longer carries {field}: {produced}"
+
+    consumed = jobs(VARIANT)["build_artifacts_s2"]["with"]["image-digest-artifact"]
+    for field in ["matrix.image_name", "matrix.published_tag",
+                  "matrix.safeplatform", "github.run_id"]:
+        assert field in consumed, f"consumer name no longer carries {field}: {consumed}"
+
+    assert consumed.index("matrix.image_name") < consumed.index("matrix.published_tag") \
+        < consumed.index("matrix.safeplatform") < consumed.index("github.run_id"), (
+        "consumer interpolates the fields in a different ORDER than the "
+        f"producer ({produced}); the names cannot match: {consumed}"
+    )
+
+
+def test_the_producer_only_uploads_after_a_real_push() -> None:
+    """Pin the PREMISE that makes the artifact's existence mean anything.
+
+    If the upload ever became unconditional, or moved ahead of the push, the
+    gate would still be present and would prove nothing -- the exact shape of
+    check this repository keeps re-learning to distrust.
+    """
+    steps = jobs(IMAGE)["build_push"]["steps"]
+    names = [s.get("name") for s in steps]
+    push_at = names.index("Create Job Outputs")
+    upload_at = names.index("Upload Output Artifacts")
+    assert push_at < upload_at
+
+    create = steps[push_at]
+    assert "remote_image_digest" in str(create.get("env", {})), (
+        "the digest file no longer comes from the push step's digestfile, so "
+        "the artifact no longer evidences a successful push"
+    )
+    assert steps[upload_at]["with"]["if-no-files-found"] == "error", (
+        "an empty upload would create the artifact anyway and the gate would "
+        "pass for a cell that pushed nothing"
+    )
+
+
+def _run_gate(fetched: str, digest: str | None,
+              tmp_path: pathlib.Path) -> tuple[int, str]:
+    """Run the gate's OWN shell out of the workflow, against a fixture.
+
+    Asserting on the step's text would pass just as happily with the gate
+    unreachable. This executes it.
+    """
+    step = next(
+        s for s in jobs(ARTIFACTS)["iso"]["steps"]
+        if str(s.get("name", "")).startswith("Provenance gate")
+    )
+    script = step["run"]
+    cell = tmp_path / "cell-digest"
+    cell.mkdir()
+    if digest is not None:
+        (cell / "img.txt").write_text(digest)
+    # The step reads /tmp/cell-digest; point it at the fixture instead.
+    script = script.replace("/tmp/cell-digest", str(cell))
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        env={"PATH": "/usr/bin:/bin", "ARTIFACT": "img-gnome-linux-amd64-42",
+             "FETCHED": fetched, "VARIANT": "hummingbird", "FLAVOR": "gnome",
+             "GITHUB_STEP_SUMMARY": str(tmp_path / "summary.md")},
+        capture_output=True, text=True,
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def test_the_gate_refuses_a_cell_that_published_nothing(tmp_path) -> None:
+    """A VALID digest file is planted deliberately, and the gate must still
+    refuse.
+
+    The obvious fixture -- fetch failed, no file -- proves nothing: `cat` of
+    an unmatched glob under `set -e` exits non-zero on its own, so the test
+    passes identically with the outcome check deleted. Verified: it did.
+    Planting a good digest leaves the fetch OUTCOME as the only thing that
+    can fail the step.
+    """
+    code, output = _run_gate("failure", "sha256:" + "b" * 64 + "\n", tmp_path)
+    assert code != 0, (
+        "a flavor whose image build failed would build an ISO from the tag "
+        "its PREVIOUS run published -- stale media that looks fresh"
+    )
+    assert "published no image in this run" in output, (
+        "the gate stopped the build but not with the sentence that explains "
+        f"why; a maintainer reads this one: {output!r}"
+    )
+
+
+def test_the_gate_refuses_when_the_artifact_carries_no_digest_file(tmp_path) -> None:
+    code, output = _run_gate("success", None, tmp_path)
+    assert code != 0, "the artifact existed but held no digest file at all"
+    assert "published no image in this run" in output, (
+        "download-artifact can warn-and-succeed on a missing name instead of "
+        "failing; that path must reach the same explanation, not `cat: no "
+        f"such file`: {output!r}"
+    )
+
+
+def test_the_gate_refuses_an_empty_digest(tmp_path) -> None:
+    code, _ = _run_gate("success", "\n", tmp_path)
+    assert code != 0, (
+        "the artifact existed but recorded no digest, so nothing was pushed"
+    )
+
+
+def test_the_gate_passes_a_cell_this_run_published(tmp_path) -> None:
+    code, _ = _run_gate("success", "sha256:" + "a" * 64 + "\n", tmp_path)
+    assert code == 0, (
+        "the gate rejects a legitimate cell, which would fail every ISO"
+    )


### PR DESCRIPTION
Seven commits, one goal: remove every reason a hummingbird **gnome** ISO cannot be *attempted*, so that when the factory publishes layer-07 the answer is a build rather than another skipped job.

This does **not** build an ISO. The packages still have to be built by `tuna-os/tunaos-packages` and published.

## What was actually blocking it (re-measured live 2026-08-25 15:30)

| link | state |
|---|---|
| desktop packages built | **103 of 673 left** — 53 before layer-07, 19 more inside layer-07 |
| `flatpak` in the image | **absent** — nothing installed it |
| live overlay | blocked on flatpak |
| CI ISO build | blocked on flatpak (`build-iso-tacklebox.sh` runs the same `customize-live.sh`) |
| installer app | blocked on flatpak (`org.bootcinstaller.Installer` *is* a Flatpak) |
| gnome's ISO job | **skipped** even when gnome built, because kde and niri failed beside it |

### `fba4fee2` — ask the base for flatpak

`build_scripts/10-base-packages.sh`'s `IS_HUMMINGBIRD` branch never listed `flatpak`, so one missing package gated three separate steps. `ensure_flatpak()`'s dnf fallback cannot help: flatpak is in neither index. Added, with a non-fatal check that says so explicitly rather than failing three steps later for reasons that read as unrelated.

### `6713406b` — stop advertising two desktops that were never implemented

hummingbird declared `gnome, kde, niri, cosmic`. Only gnome (52 packages) and cosmic (23) have a `packages.hummingbird` section in `manifests/desktops/*.yaml`; kde and niri have **none**, and `install-desktop.sh` routes hummingbird to that section by construction. Measured on run 32786338463: the two flavors with no manifest are exactly the two whose image builds failed.

- **kde** — nothing provides `libdouble-conversion.so.3` / `libfbclient.so.2`, needed by `qt6-qtbase-*.hum1`. An **upstream** gap: those sonames are in no index, ours or theirs.
- **niri** — `TUNAOS_BRANDING_FAIL`: dconf keyfiles written with no compiled database, because `dconf update` is guarded on `command -v dconf` and dconf is not installed when there is no package set to install it.

Nothing here is a judgement about wanting kde or niri. Re-add each the moment it grows a package section.

### `747a0d3a` — one failing desktop must not skip the ISOs of the flavors that built

This is **#2059**, and it is the coupling that made the flavor removal necessary rather than merely tidy.

`build_artifacts_s{2,3,4}` take `needs: build_stage{2,3,4}`, and `build_stageN` is a **matrix** over every flavor in the stage. s3 and s4 said so explicitly; s2's `if` carried no status function at all, so `success()` was implicit and the coupling was there without being written down. On run 32786338463 gnome built, signed and manifested cleanly and all three `iso:` cells were skipped with their names unexpanded — the job never reached matrix expansion.

**Why the one-line relaxation is wrong.** The ISO job builds from a moving tag, `<published_tag>-<safeplatform>`, never from the digest its image job produced. For a flavor whose build *failed*, that tag still resolves to the **previous** image — so a bare `!cancelled()` would succeed and emit media that looks fresh and is not. Silently stale media is worse than no media and worse than a skipped cell.

**What replaces it.** The evidence already existed and was unused: `reusable-build-image.yml` uploads `<image_name>-<published_tag>-<safeplatform>-<run_id>` from a digest file written out of `podman push --digestfile`, and only after that push returns. Its existence is proof the cell published; the `run_id` suffix makes it proof of *this* run. The caller names it per cell, and the called workflow refuses to build without it — absent, or present with an empty digest, both stop the job in seconds rather than after a two-hour build. Callers with no same-run image job (`publish-isos.yml`) pass nothing and keep today's behaviour.

This does not narrow the pre-existing window in which a concurrent run moves the tag between push and pull. It closes the failure #2059 measured: a cell whose image never published at all.

### `7cb824fb` and `49a091be` — the fallout, and one test that was the wrong shape

Removing two flavors moved numbers that three other things depended on.

**`docs/MATRIX-STATUS.md`** is generated from build-config. Four sections change (Composite green, Silent omissions, LUKS E2E, Desktop Contract Sweep) — exactly those whose applicability comes from build-config; Package parity, Bootc Lifecycle and Installer smoke enumerate from published images and run results instead. `gh` was unavailable, so the four were identified by running the generator's own `structural()` masking over the committed document and matching its line numbers against the diff the job printed. CI's `regenerate` check now passes, confirming all four and the three left alone. The LUKS denominator moves 53 → 51, and that is the point rather than a cost: neither cell could ever have been paid.

**The nightly schedule registry** said `hummingbird(5)`. A test enforces that table against build-config, and it did its job. Now `(3)`.

**The proving-window test** was not a stale number. It asserted a **ranking** — that the variants inside 04:00–09:00 are exactly the N smallest — and at 3 flavors hummingbird is now smaller than guppy, so the ranking claimed hummingbird belongs in the morning window. It does not: it fires at 22:20 so the image build follows the day's package publish, and moving it would break that ordering for an arithmetic tie-break. That shape had already rotted once before for an unrelated reason (wahoo, `experimental: true`, no cron at all), so twice is enough to call the instrument wrong rather than the numbers.

It now asserts the hazard directly — at most 2 variants in the window, each at most 4 flavors — with 4 justified by the real distribution (gurnard 2, guppy 4, next tier 7, rest to 20). A threshold is exactly the shape that can quietly stop examining anything, so a companion test asserts the threshold still sits below the largest scheduled variant.

### `5f981f4c` and `fed6085d` — record the critical path, then correct its headline number

`docs/HUMMINGBIRD.md` gains "What actually blocks a hummingbird ISO", including the `yellowfin gnome` precedent — **1 passing installer-smoke cell of 36**, on the same gnome path with the same installer — and the `priority: 5` shadowing that makes our repo win over upstream even when upstream is newer.

`fed6085d` then corrects that document's own figures. It said 509 served / 164 left, 131 through layer-07. Re-measured live against both indexes: **570 served, 103 left, 53 before layer-07**. Two things are written down because I got the second wrong first: the comparison must be build-order **source** names against `srpm_name(pkg["srpm"])` of each served binary, not against served binary names; and the tier **index** is not the layer number — `flatpak` is in `layer-07`, which is tier index **eleven**, because four bootstrap tiers precede `layer-00`. Filtering on `index <= 7` reported 15 packages remaining instead of 53, a four-fold understatement in the optimistic direction. Caught by printing the per-tier breakdown instead of trusting the total.

## Verification

- **Full local suite: 922 passed.**
- 8 new tests for the #2059 gate. Three read the workflows; one pins the premise that gives the artifact meaning (the upload stays after the push, still sources the digestfile, keeps `if-no-files-found: error`); four **run the gate's own shell** out of the workflow against fixtures, because a gate that is parsed and never fires passes any textual check. Seven mutations, each caught by a distinct test.
- One of those seven was caught only after fixing the test. The obvious missing-artifact fixture — fetch failed, no file — proves nothing: `cat` of an unmatched glob under `set -e` exits non-zero on its own, so the test passed identically with the outcome check deleted, and it did. The fixture now plants a valid digest and fails only the fetch.
- The proving-window rewrite is mutation-verified three ways: moving yellowfin's cron to 07:20 fails the window guard, raising the threshold to 99 fails the companion, reverting the registry to `(5)` fails the registry test.
- 5 tests for the flatpak and flavor changes, mutation-verified both directions.

## Still open, deliberately

- The packages themselves: 103 left, 53 before layer-07, then a publish dispatch.
- `status: scaffold` on the hummingbird factory target — a maintainer policy call.
- No variant has a proven install on physical hardware anywhere in the matrix; installer smoke is QEMU. Nothing in this PR changes that.
