### PR TITLE
A failed live-customize must end the ISO build, not wedge it for an hour

### DIFF
--- a/docs/HUMMINGBIRD.md
+++ b/docs/HUMMINGBIRD.md
@@ -175,6 +175,49 @@ binding constraint is smaller and more specific than "the desktop is missing".
 | 6 | overlay → ISO → install | blocked by `flatpak`, see below |
 | 7 | the installed system works on the target laptop | **no device firmware exists anywhere** — see below (#2064) |
 
+### Confirmed by running it: iso-e2e run 32866334376
+
+Link 6 is no longer inferred. A gate dispatch of `iso-e2e.yml`
+(`variant=hummingbird, flavors=base, source=build`) built the ISO on the runner
+and reached exactly the predicted line, from inside the real base image:
+
+```
+15:35:46  + dnf5 install -y flatpak
+15:35:46  No match for argument: flatpak
+15:35:46  ERROR: flatpak not installed and could not be installed;
+          cannot pre-install org.bootcinstaller.Installer
+15:35:46  + exit 1
+```
+
+Two things follow. First, **everything before flatpak works**: the base image
+pulls, buildah builds, `ensure_dbus_daemon` installs and starts the classic bus,
+and the whole customize path runs — in 3.5 minutes. flatpak is the *first* thing
+to fail, not one of many. Second, the "No match for argument" comes from dnf
+inside the image itself, which is stronger evidence than index scraping that
+flatpak is in neither repository.
+
+### A second, independent blocker the same run exposed
+
+The run did not fail at 15:35:46. It failed at **16:32:26**, on
+`##[error]The action 'Build the ISO on this runner' has timed out after 60
+minutes` — 57 minutes of complete silence after the script exited 1.
+
+The cause is in our script, not in tacklebox. `customize-live.sh` forks a system
+`dbus-daemon` before the flatpak block. A forked bus outlives the script, and
+the stdout it inherited keeps the build's output pipe open, so the reader waits
+long after the script is gone. Demonstrated in isolation: a shell that forks a
+child and exits returns immediately when the child is reaped and blocks for the
+child's full lifetime when it is not.
+
+This matters beyond one misleading message. `build_artifacts_s2` allows an ISO
+cell **90 minutes**. Any failure below that fork — today's missing flatpak, or
+whatever fails next once flatpak lands — consumes the cell's entire budget and
+then reports itself as a timeout. Fixed by redirecting the daemons' output to
+`/dev/null` so they cannot pin the pipe, plus pidfiles and an `EXIT` trap to
+reap them; `tests/test_a_failing_live_customize_fails_fast.py` runs the script's
+own helpers against a daemon that outlives its caller and fails if the wedge
+returns.
+
 ### `flatpak` is the single package gating the whole ISO axis
 
 Not `gnome-shell`. `flatpak` is **layer-07**, and it blocks three consecutive

--- a/live-iso/common/src/customize-live.sh
+++ b/live-iso/common/src/customize-live.sh
@@ -393,10 +393,56 @@ if [[ -n "${INSTALLER_APP}" ]]; then
 		}
 	}
 
+	# A forked bus OUTLIVES this script. If it inherits this script's stdout
+	# and stderr it keeps the build's output pipe OPEN, so a failure below does
+	# not end the build -- it wedges whatever is reading that pipe.
+	#
+	# Measured on iso-e2e run 32866334376 (hummingbird:base): ensure_flatpak
+	# printed its error and exited 1 at 15:35:46, and the step then produced not
+	# one further line until the 60-minute timeout killed it at 16:32:26. Three
+	# and a half minutes of correct, specific diagnosis became an hour of dead
+	# air, and the failure GitHub reported was "has timed out after 60 minutes"
+	# rather than "flatpak not installed".
+	#
+	# The cost is more than a confusing message: build_artifacts_s2 allows an
+	# ISO cell 90 minutes, so ANY failure below this line -- today's missing
+	# flatpak, or whatever fails next once flatpak lands -- burns the cell's
+	# whole budget and then misattributes itself to a timeout.
+	#
+	# Two changes, and the redirection is the load-bearing one. Sending the
+	# daemons' output to /dev/null means they cannot hold the pipe no matter how
+	# long they live. The pidfiles are hygiene on top: reap them on the way out
+	# rather than leaving buses running in the layer.
+	#
+	# Deliberately NOT `--print-pid` through a command substitution: `$( )` waits
+	# for the pipe to close, which is the very thing a forked daemon holds, so
+	# capturing the pid that way hangs the script AT THE FORK -- earlier and
+	# harder than the bug being fixed. That is not hypothetical; it is what the
+	# first version of this did, and tests/test_a_failing_live_customize_fails_fast.py
+	# caught it.
+	_live_bus_pidfiles=()
+	_reap_live_buses() {
+		local _f _pid
+		for _f in ${_live_bus_pidfiles[@]+"${_live_bus_pidfiles[@]}"}; do
+			[[ -s "$_f" ]] || continue
+			read -r _pid <"$_f" || continue
+			[[ -n "${_pid//[!0-9]/}" ]] || continue
+			kill "$_pid" 2>/dev/null || true
+		done
+	}
+	trap _reap_live_buses EXIT
+
+	_start_bus() {
+		local _pidfile="$1"
+		shift
+		_live_bus_pidfiles+=("$_pidfile")
+		dbus-daemon "$@" --fork --pidfile="$_pidfile" >/dev/null 2>&1
+	}
+
 	mkdir -p /var/lib/dbus
 	ln -sf /etc/machine-id /var/lib/dbus/machine-id
 	ensure_dbus_daemon
-	dbus-daemon --system --fork --nopidfile || true
+	_start_bus /tmp/live-system-bus.pid --system || true
 
 	# grouper (Ubuntu/apt) and bonito-rawhide (Fedora/dnf) don't ship flatpak
 	# in their base image, so the pre-install below always died with "flatpak
@@ -465,7 +511,7 @@ if [[ -n "${INSTALLER_APP}" ]]; then
 	# bus) rather than the dbus-run-session wrapper — some flavors (niri,
 	# cosmic) don't pull in the package that ships dbus-run-session.
 	SESSION_BUS_SOCK="${HOME}/session-bus.sock"
-	dbus-daemon --session --fork --nopidfile --address="unix:path=${SESSION_BUS_SOCK}"
+	_start_bus /tmp/live-session-bus.pid --session --address="unix:path=${SESSION_BUS_SOCK}"
 	export DBUS_SESSION_BUS_ADDRESS="unix:path=${SESSION_BUS_SOCK}"
 	if [[ "${INSTALLER_APP}" == "org.bootcinstaller.Installer" ]]; then
 		# gnome: mirrors projectbluefin/dakota-iso's install-flatpaks.sh —

--- a/tests/test_a_failing_live_customize_fails_fast.py
+++ b/tests/test_a_failing_live_customize_fails_fast.py
@@ -1,0 +1,166 @@
+"""A failure inside customize-live.sh must END the build, not wedge it.
+
+customize-live.sh forks a system dbus-daemon so flatpak has a bus. A forked
+bus OUTLIVES the script, and the stdout it inherited keeps the build's output
+pipe open -- so when the script exits non-zero, whatever is reading that pipe
+keeps waiting.
+
+Measured on tunaOS iso-e2e run 32866334376 (hummingbird:base). The script
+printed a correct, specific diagnosis and exited:
+
+    15:35:46  dnf5 install -y flatpak -> No match for argument: flatpak
+    15:35:46  ERROR: flatpak not installed and could not be installed
+    15:35:46  + exit 1
+      ...     (not one line of output for 57 minutes)
+    16:32:26  ##[error]The action 'Build the ISO on this runner' has timed
+              out after 60 minutes.
+
+Three and a half minutes of signal became an hour of dead air, and the
+failure GitHub reported was a timeout rather than the missing package.
+
+The cost is not just a confusing message. `build_artifacts_s2` allows an ISO
+cell 90 minutes, so ANY failure below the fork -- today's missing flatpak, or
+whatever fails next once flatpak lands -- consumes the cell's whole budget
+and then misattributes itself.
+
+These tests run the script's OWN bus helpers against a fake dbus-daemon that
+daemonizes a long-lived child holding stdout, which is what a real bus does.
+Asserting that the file contains the word `trap` would pass just as happily
+with a reaper that reaps nothing -- and "captures a pid that is already gone"
+is the specific way this fix can be silently inert, so it is what the fake is
+built to expose.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "live-iso" / "common" / "src" / "customize-live.sh"
+
+# Long enough that a wedge is unmistakable, short enough not to slow the suite.
+FAKE_BUS_LIFETIME = 25
+WEDGE_TIMEOUT = 10
+FAST_ENOUGH = 5.0
+
+
+def bus_helpers() -> str:
+    """The real `_live_bus_pids` / `_reap_live_buses` / `_start_bus` block.
+
+    Extracted from the script rather than copied, so a rename or a rewrite
+    breaks this file loudly instead of leaving it testing a stale duplicate.
+    """
+    text = SCRIPT.read_text(encoding="utf-8")
+    start = text.index("\t_live_bus_pidfiles=()")
+    end = text.index("\tmkdir -p /var/lib/dbus", start)
+    block = text[start:end]
+    for name in ("_reap_live_buses", "_start_bus", "trap _reap_live_buses EXIT"):
+        assert name in block, f"bus helper block no longer defines {name}"
+    # The block is indented inside `if [[ -n "${INSTALLER_APP}" ]]`.
+    return "\n".join(line[1:] if line.startswith("\t") else line
+                     for line in block.splitlines())
+
+
+def fake_dbus_daemon(tmp_path: Path) -> Path:
+    """A stand-in for `dbus-daemon --fork`.
+
+    The realistic part is that the daemonized child INHERITS whatever stdout
+    the caller gave it and outlives the caller — which is precisely how a real
+    bus can pin the build's output pipe. It honours --pidfile so the reaper has
+    something to read.
+    """
+    binder = tmp_path / "bin"
+    binder.mkdir(exist_ok=True)
+    shim = binder / "dbus-daemon"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        "pidfile=\n"
+        'for arg in "$@"; do\n'
+        '  case "$arg" in --pidfile=*) pidfile="${arg#--pidfile=}" ;; esac\n'
+        "done\n"
+        f"sleep {FAKE_BUS_LIFETIME} &\n"
+        'child=$!\n'
+        '[[ -n "$pidfile" ]] && echo "$child" >"$pidfile"\n'
+        "exit 0\n"
+    )
+    shim.chmod(0o755)
+    return binder
+
+
+def run_failing_customize(tmp_path: Path, helpers: str) -> tuple[float, int]:
+    """Start a bus, then fail -- and time how long the READER waits."""
+    script = tmp_path / "harness.sh"
+    script.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -uo pipefail\n"
+        f"{helpers}\n"
+        "_start_bus \"$HOME/bus.pid\" --system || true\n"
+        "echo 'ERROR: something failed after the bus started' >&2\n"
+        "exit 1\n"
+    )
+    script.chmod(0o755)
+    env = {"PATH": f"{fake_dbus_daemon(tmp_path)}:/usr/bin:/bin", "HOME": str(tmp_path)}
+    started = time.monotonic()
+    try:
+        # Capturing output is exactly what the build does, and is what blocks
+        # on a pipe an orphaned daemon still holds.
+        proc = subprocess.run(["bash", str(script)], capture_output=True,
+                              text=True, env=env, timeout=WEDGE_TIMEOUT)
+        return time.monotonic() - started, proc.returncode
+    except subprocess.TimeoutExpired:
+        return time.monotonic() - started, -1
+
+
+def test_the_script_reaps_its_bus_so_a_failure_ends_the_build(tmp_path) -> None:
+    elapsed, code = run_failing_customize(tmp_path, bus_helpers())
+    assert code == 1, (
+        f"harness did not fail cleanly (rc={code}); after {elapsed:.1f}s the "
+        "reader was still waiting on a pipe the forked bus holds open — this "
+        "is the 57-minute wedge from run 32866334376"
+    )
+    assert elapsed < FAST_ENOUGH, (
+        f"the failure took {elapsed:.1f}s to surface; it must be immediate, "
+        "or an ISO cell burns its 90-minute budget and reports a timeout "
+        "instead of the real cause"
+    )
+
+
+def test_the_wedge_is_real_without_the_reaper(tmp_path) -> None:
+    """Guard the guard: prove the fixture reproduces the bug it claims to.
+
+    Without this, the test above passes on any machine where the fake bus
+    fails to start at all — measuring nothing, which is the exact defect
+    class the fix is about.
+    """
+    # Remove the redirection, which is the load-bearing half: without it the
+    # forked bus inherits the build's stdout and pins the pipe open.
+    crippled = bus_helpers().replace(
+        'dbus-daemon "$@" --fork --pidfile="$_pidfile" >/dev/null 2>&1',
+        'dbus-daemon "$@" --fork --pidfile="$_pidfile"',
+    ).replace("trap _reap_live_buses EXIT", "true")
+    elapsed, code = run_failing_customize(tmp_path, crippled)
+    assert code == -1, (
+        f"with the reaper removed the harness still returned in {elapsed:.1f}s "
+        "(rc=%s), so the fixture does not reproduce the wedge and the test "
+        "above proves nothing" % code
+    )
+
+
+def test_the_fix_keeps_the_bus_off_the_build_pipe(tmp_path) -> None:
+    """Pin the two properties that make this work, and one that would break it."""
+    block = bus_helpers()
+    assert ">/dev/null 2>&1" in block, (
+        "the forked bus inherits the build's stdout again, which is what pins "
+        "the output pipe open and turns a fast failure into a step timeout"
+    )
+    assert "--print-pid" not in block, (
+        "`_pid=$(dbus-daemon ... --print-pid)` cannot be used here: command "
+        "substitution waits for the pipe to close, which is exactly what a "
+        "forked daemon holds, so it hangs AT THE FORK -- earlier and harder "
+        "than the bug being fixed. The first version of this fix did that and "
+        "this suite caught it; --pidfile is why it is gone."
+    )


### PR DESCRIPTION
Found by *dispatching* `iso-e2e.yml` for `hummingbird:base` to see **where** the ISO path breaks before layer-07 lands, rather than assuming flatpak was the only thing in the way. It was not.

## The predicted half — link 6 is now confirmed by execution

Run [32866334376](https://github.com/tuna-os/tunaOS/actions/runs/32866334376) reached the expected gate in **3.5 minutes**, from inside the real base image:

```
15:35:46  + dnf5 install -y flatpak
15:35:46  No match for argument: flatpak
15:35:46  ERROR: flatpak not installed and could not be installed;
          cannot pre-install org.bootcinstaller.Installer
15:35:46  + exit 1
```

Worth stating plainly, because it is the good news: **everything before flatpak works.** The base image pulls, buildah builds, `ensure_dbus_daemon` installs and starts the classic bus, the whole customize path runs. flatpak is the *first* thing to fail, not one of several. And `No match for argument` from dnf *inside the image* is stronger evidence than index scraping that flatpak is in neither repository.

## The half that was not predicted

The job did not fail at 15:35:46. It failed at **16:32:26**:

```
##[error]The action 'Build the ISO on this runner' has timed out after 60 minutes.
```

— with **57 minutes of complete silence** in between.

The cause is in this script, not in tacklebox. `customize-live.sh` forks a system `dbus-daemon` before the flatpak block so flatpak has a bus. A forked bus **outlives the script**, and the stdout it inherited keeps the build's output pipe open, so the reader goes on waiting long after the script has exited.

Demonstrated in isolation rather than asserted — a shell that forks a child and exits:

| | elapsed |
|---|---|
| no fork | 0s |
| forked child outliving the script | blocks for the child's **full lifetime** |
| same, child reaped on exit | 0s |

This costs more than one misleading message. `build_artifacts_s2` allows an ISO cell **90 minutes**, so *any* failure below that fork — today's missing flatpak, or whatever fails next once flatpak lands — burns the cell's entire budget and then misattributes itself to a timeout. A build that fails in three minutes and a build that fails in ninety are very different things to iterate against.

## The fix

Redirect both daemons' output to `/dev/null`, so they cannot pin the pipe however long they live. That is the load-bearing half. Pidfiles plus an `EXIT` trap are hygiene on top: reap the buses rather than leaving them running in the layer.

Deliberately **not** `_pid=$(dbus-daemon … --print-pid)`. Command substitution waits for the pipe to close, which is precisely what a forked daemon holds — so capturing the pid that way hangs the script *at the fork*, earlier and harder than the bug being fixed. That is not hypothetical: it is what the first version of this change did, and the test caught it before it was pushed. `--pidfile` is why it is gone, and a test now pins `--print-pid` out.

## Tests

Three, and they run the script's **own** helper block — extracted from the file, not copied, so a rewrite breaks them loudly instead of leaving a stale duplicate under test. The fake `dbus-daemon` daemonizes a child that outlives its caller and inherits its stdout, which is the behaviour that matters. Asserting the file contains the word `trap` would pass just as happily with a reaper that reaps nothing.

The second test is the guard on the guard: it strips the redirection and **requires the harness to wedge**. Without it, the first test would pass on any machine where the fake bus failed to start at all — measuring nothing, which is the exact defect class this PR is about.

Mutation-verified: dropping the redirection fails one test; restoring the `--print-pid` command substitution fails two.

## Not in scope

This does not build an ISO, and it does not make flatpak available — 103 packages remain in the chain, 53 before layer-07, then a publish. What it does is make the next attempt fail *fast and accurately* instead of consuming an ISO cell's whole budget and blaming the clock.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_