### PR TITLE
"N packages left" is not a measure of progress

### DIFF
--- a/docs/HUMMINGBIRD.md
+++ b/docs/HUMMINGBIRD.md
@@ -167,7 +167,7 @@ binding constraint is smaller and more specific than "the desktop is missing".
 
 | # | link | state |
 |---|---|---|
-| 1 | build the desktop packages | 673 in `build-order-hummingbird-desktops.yml`, **570 served, 103 left** — 53 before layer-07, 19 more in layer-07 itself (measured 2026-08-25 15:30) |
+| 1 | build the desktop packages | 673 in `build-order-hummingbird-desktops.yml`, 570 served, 103 left — 53 before layer-07, 19 more in layer-07 itself (measured 2026-08-25 15:30). **Read the caveat below before using this number.** |
 | 2 | publish that wave to R2 | dispatch-only; the nightly builds and caches but **never publishes** (no `rclone`/`R2_` anywhere in `package-factory.yml`) |
 | 3 | image build installs them | fixed: the `IS_HUMMINGBIRD` branch of `10-base-packages.sh` never listed `flatpak` |
 | 4 | Gate: `bootc install to-disk` + boot | **proven fixed** — ext4 drop-in, installs in 1m54s and boots to `graphical.target` |
@@ -217,6 +217,47 @@ then reports itself as a timeout. Fixed by redirecting the daemons' output to
 reap them; `tests/test_a_failing_live_customize_fails_fast.py` runs the script's
 own helpers against a daemon that outlives its caller and fails if the wedge
 returns.
+
+### "N packages left" is not a measure of progress
+
+That figure counts the **served index**, which is cumulative across past
+publishes. It says nothing about what a chain run accomplishes, and on
+2026-08-25 the two came apart completely.
+
+Run [32842254545](https://github.com/tuna-os/tunaos-packages/actions/runs/32842254545)
+built for **4h01m** and reached **tier 5 of 22**:
+
+```
+11:27:19  [resume] found `hummingbird-x86_64-partial` from 11:26:17Z (429 MB)
+11:27:24  [resume] action key differs — the inputs changed, so building from scratch
+11:28:58  ===== Tier: bootstrap-00 =====
+11:40:54  ===== Tier: layer-00 =====
+          (still in layer-00 when cancelled at 15:28:55)
+```
+
+`Skipping: 0`. It rejected a 429 MB partial written **thirty-four seconds
+earlier** and rebuilt from nothing, because the action key included the whole
+of `manifests/package-factory.yaml` — twice, by two independent paths — and an
+unrelated edit to another target had moved it.
+
+**The chain was not failing to finish. It was failing to accumulate.** Every
+merge that touched the manifest sent a 22-tier chain back to tier 0, which is
+why the remaining count never moved however many nightlies ran.
+
+Both manifest paths are closed in tunaos-packages#529. One coupling remains
+and is deliberately open in tunaos-packages#528: `scripts/build-chain.sh` is a
+whole-file `renderer_inputs` entry, so *any* factory improvement still costs a
+full chain restart — #512's mock root-cache change was a pure speedup with no
+effect on any package's contents and invalidated every partial in the
+repository.
+
+Practical consequence while that stands: **do not edit
+`manifests/package-factory.yaml`, `scripts/build-chain.sh`, or
+`scripts/run-package-factory-cell.sh` while a chain is converging.** And when
+reading a chain run, the `[resume]` line is the single most informative line
+in the log — it is the difference between a run that accumulates and one that
+starts over, and it went unnoticed for as long as it did because a restarted
+run looks identical to a merely slow one.
 
 ### `flatpak` is the single package gating the whole ISO axis
 


### PR DESCRIPTION
`docs/HUMMINGBIRD.md` is the document the standing guidance says to read *before* reasoning about hummingbird packages. Its link 1 has been the headline number for the ISO all session, and it was misleading in a way that cost a day.

## The number describes the wrong thing

> 673 in `build-order-hummingbird-desktops.yml`, **570 served, 103 left**

That counts the **served index**, which is cumulative across past publishes. It says nothing about what a chain run accomplishes — and on 2026-08-25 the two came apart completely.

Run [32842254545](https://github.com/tuna-os/tunaos-packages/actions/runs/32842254545) built for **4h01m** and reached **tier 5 of 22**:

```
11:27:19  [resume] found `hummingbird-x86_64-partial` from 11:26:17Z (429 MB)
11:27:24  [resume] action key differs — the inputs changed, so building from scratch
11:28:58  ===== Tier: bootstrap-00 =====
11:40:54  ===== Tier: layer-00 =====
          (still in layer-00 when cancelled at 15:28:55)
```

`Skipping: 0`. It rejected a 429 MB partial written **thirty-four seconds earlier** and rebuilt from nothing.

**The chain was not failing to finish. It was failing to accumulate.** Every merge touching `manifests/package-factory.yaml` sent a 22-tier chain back to tier 0 — which is exactly why the remaining count never moved however many nightlies ran, and why "53 packages before flatpak" read as nearly-there when nothing was converging at all.

## Why this belongs in *this* file rather than only in the packages repo

The count in link 1 is what a reader takes away, and every symptom got attributed to something else along the way — each attribution locally reasonable, each a real bug that is now fixed, none of them this one:

- "six hours reached only layer-00" → blamed on the artifact-download 401, real and fixed;
- "the chain dies at the 6 h ceiling" → fixed with `CHAIN_BUDGET_SECONDS`;
- "runs cancel each other" → fixed with concurrency groups and the canary-form planner.

A restarted run looks identical to a merely slow one. That is why the section now says plainly that **the `[resume]` line is the single most informative line in a chain log**.

## What it records

- the caveat above, with the measurement;
- that both manifest paths into the action key are closed in tuna-os/tunaos-packages#529, and that one coupling remains deliberately open in tuna-os/tunaos-packages#528 — `scripts/build-chain.sh` is a whole-file `renderer_inputs` entry, so any factory improvement still costs a full chain restart (#512's mock root-cache change was a pure speedup with no effect on any package's contents and invalidated every partial in the repository);
- the practical rule that follows: **do not edit `manifests/package-factory.yaml`, `scripts/build-chain.sh`, or `scripts/run-package-factory-cell.sh` while a chain is converging.**

The number itself is kept — it is still the right answer to "how much is left to build" — but it loses the bold emphasis it had not earned and now points at the caveat.

Docs only; no behaviour change. 88 related tests pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_