### PR TITLE
fix: let Renovate bump the remora pin, and guard the checksums it cannot

### DIFF
--- a/.github/workflows/check-download-checksums.yml
+++ b/.github/workflows/check-download-checksums.yml
@@ -1,0 +1,43 @@
+name: Check download checksums
+
+# Several downloads are pinned twice: a version, and a per-architecture sha256
+# of the asset at that version. Renovate maintains the version and cannot
+# maintain the checksums -- both custom managers in renovate.json capture a
+# single version line, so a sibling `_sha256` map is outside the match.
+#
+# That gap has already bitten: Renovate bumped chezmoi v2.71.0 -> v2.72.0 and
+# left chezmoi_sha256 on v2.71.0's hashes, so the Ubuntu/niri build downloaded
+# a v2.72.0 .deb and checked it against a v2.71.0 hash. It fails closed, so
+# nothing bad shipped -- but the build died and nothing named the cause.
+#
+# Running on pull requests is the point: `automerge: true` covers patch
+# updates, and platformAutomerge waits on checks, so a Renovate bump that
+# leaves checksums behind cannot merge itself. The schedule catches the other
+# case -- a release re-published under the same tag with different content.
+on:
+  pull_request:
+    paths:
+      - 'image-versions.yaml'
+      - 'build_scripts/install-remora.sh'
+      - 'scripts/check-download-checksums.py'
+      - '.github/workflows/check-download-checksums.yml'
+  schedule:
+    - cron: '35 22 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-download-checksums-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checksums:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify every pinned checksum matches its pinned release
+        run: python3 scripts/check-download-checksums.py

--- a/build_scripts/install-remora.sh
+++ b/build_scripts/install-remora.sh
@@ -14,18 +14,30 @@
 # The binary is static Go and works on every base (dnf/zypper/pacman/apt),
 # so there is nothing distro-specific to guard here.
 #
-# The version is pinned for reproducible image builds. Deliberately NO
-# `# renovate:` marker: the custom manager for build_scripts/*.sh would bump
-# REMORA_VERSION without touching the checksums below, and the sha256 check
-# would then fail every build.
+# The version is pinned for reproducible image builds, and the binary is
+# checked against a pinned sha256 so a re-published release cannot change what
+# lands in the image without someone noticing.
+#
+# Renovate bumps REMORA_VERSION but CANNOT bump the checksums below: the
+# custom manager for build_scripts/*.sh captures the version line only. That
+# used to be the reason this file carried no `# renovate:` marker at all --
+# with the marker, a bump would leave the checksums pointing at the previous
+# release and every build would fail the sha256 check.
+#
+# scripts/check-download-checksums.py now closes that gap: it verifies these
+# checksums against the pinned release's published checksums.txt, and runs on
+# every pull request that touches this file. A Renovate bump with stale
+# checksums fails that check and cannot auto-merge; `--fix` rewrites them.
+# So the marker is safe to have, and the pin no longer silently rots.
 
 set -xeuo pipefail
 
-REMORA_VERSION="v0.2.0"
+# renovate: datasource=github-releases depName=tuna-os/remora
+REMORA_VERSION="v0.4.0"
 REMORA_ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
 case "${REMORA_ARCH}" in
-amd64) REMORA_SHA256="39c774ab76dbdbf95ff11a32e5083e24fa01f88804161c24998c0a21e368175a" ;;
-arm64) REMORA_SHA256="3454ac72a376c974f433b5c8db14470d908dd43fc3ddc27e19e47e70c5ab2c3b" ;;
+amd64) REMORA_SHA256="790e80b5901c8f146047c7fd2708af4a912303a6ed48b289654700945cee98de" ;;
+arm64) REMORA_SHA256="9613d37236d6ef78c46f49d4458c1a6c88e9299f6070c8d02eeb4870a209898a" ;;
 *)
 	echo "ERROR: unsupported Remora architecture: ${REMORA_ARCH}" >&2
 	exit 1
@@ -44,9 +56,10 @@ rm "$REMORA_DOWNLOADS_DIR/remora"
 
 # Treat the downloaded binary as an image contract, not merely a successful
 # HTTP transfer. This catches wrong-architecture assets, truncated releases,
-# and release drift before an image can be published. Remora v0.2.0 has no
-# version subcommand, so its pinned release checksum proves the version while
-# this smoke test proves the installed binary can execute on the target arch.
+# and release drift before an image can be published. Remora still has no
+# version subcommand as of v0.4.0, so its pinned release checksum proves the
+# version while this smoke test proves the installed binary can execute on the
+# target arch.
 remora --help | grep -Fq 'Usage: remora <command> [args]'
 install -d /usr/share/tunaos/experience-contracts
 printf 'version=%s\nvalidated_at_build=true\n' "${REMORA_VERSION}" \

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -28,8 +28,8 @@ downloads:
   # renovate: datasource=github-releases depName=twpayne/chezmoi
   chezmoi: "v2.72.0"
   chezmoi_sha256:
-    amd64: "a8880a1b01e877c3e5da250b9f882ce9fa39962686d75f436fa21e021fa092b1"
-    arm64: "ea9389f4efdc26d74bf9b4cc73db8f3a529e1e6effb5703e438117ea3f095439"
+    amd64: "6023435f5393553345ec10c75cd8160658c415f2bf9c3d8def3e120c92faf629"
+    arm64: "9acbc4676bf257002a3439fc0936a9e3553e20ac51573214b7e7a6ef156d5ca1"
   # renovate: datasource=git-refs depName=tuna-os/tacklebox
   # This is the fallback every caller that does not set TACKLEBOX_SHA gets
   # (scripts/lib/common.sh:229) — installer-smoke.yml among them.

--- a/scripts/check-download-checksums.py
+++ b/scripts/check-download-checksums.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Verify pinned binary checksums against the pinned release's published sums.
+
+Several downloads here are pinned twice: a version, and a per-architecture
+sha256 of the asset at that version. Renovate maintains the version and cannot
+maintain the checksums -- both custom managers in renovate.json capture a
+single version line, so a sibling `_sha256` map is outside the match and is
+left untouched by a bump.
+
+That is not theoretical. Renovate bumped chezmoi v2.71.0 -> v2.72.0 and left
+chezmoi_sha256 on v2.71.0's hashes; the Ubuntu/niri build then downloaded a
+v2.72.0 .deb and checked it against a v2.71.0 hash. It fails closed, so no bad
+binary ships -- but the build dies, and nothing pointed at the cause.
+
+This script closes the loop: it fetches the checksums.txt published for the
+*pinned* version and asserts each pinned hash matches. It catches
+  - a version bump that left checksums behind (the Renovate case), and
+  - a re-published release whose asset content changed under the same tag.
+
+Run with --fix to rewrite the pinned checksums in place.
+
+Exits non-zero if any pin disagrees. Prints one line per pin either way,
+because "which ones are fine" is as useful as "which one broke".
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ARCHES = ("amd64", "arm64")
+
+
+@dataclass
+class Pin:
+    """One pinned download: where its version and checksums live, and which
+    published asset each checksum is supposed to be for."""
+
+    name: str
+    # File holding the version, and a regex with one group capturing it.
+    version_file: str
+    version_re: str
+    # File holding the checksums, and a regex template per arch. {arch} is
+    # substituted; the regex must have exactly one group: the hash itself.
+    checksum_file: str
+    checksum_re: str
+    # {version} is the tag (v1.2.3); {num} is the tag without the leading v.
+    checksums_url: str
+    asset: str
+    versions: dict = field(default_factory=dict)
+
+
+PINS = [
+    Pin(
+        name="remora",
+        version_file="build_scripts/install-remora.sh",
+        version_re=r'^REMORA_VERSION="(v[^"]+)"',
+        checksum_file="build_scripts/install-remora.sh",
+        checksum_re=r'^{arch}\) REMORA_SHA256="([0-9a-f]{{64}})"',
+        checksums_url="https://github.com/tuna-os/remora/releases/download/{version}/checksums.txt",
+        asset="remora-linux-{arch}",
+    ),
+    Pin(
+        name="chezmoi",
+        version_file="image-versions.yaml",
+        version_re=r'^\s+chezmoi:\s*"(v[^"]+)"',
+        checksum_file="image-versions.yaml",
+        checksum_re=r'^\s+{arch}:\s*"([0-9a-f]{{64}})"',
+        checksums_url="https://github.com/twpayne/chezmoi/releases/download/{version}/chezmoi_{num}_checksums.txt",
+        asset="chezmoi_{num}_linux_{arch}.deb",
+    ),
+]
+
+
+def read(path: str) -> str:
+    return (REPO_ROOT / path).read_text()
+
+
+def find_version(pin: Pin) -> str:
+    m = re.search(pin.version_re, read(pin.version_file), re.MULTILINE)
+    if not m:
+        sys.exit(f"::error::could not find {pin.name}'s version in {pin.version_file}")
+    return m.group(1)
+
+
+def find_checksum(pin: Pin, arch: str) -> tuple[str, str]:
+    """Return (regex-used, pinned-hash) for one architecture."""
+    pattern = pin.checksum_re.format(arch=arch)
+    m = re.search(pattern, read(pin.checksum_file), re.MULTILINE)
+    if not m:
+        sys.exit(f"::error::could not find {pin.name}'s {arch} checksum in {pin.checksum_file}")
+    return pattern, m.group(1)
+
+
+def fetch_published(pin: Pin, version: str) -> dict[str, str]:
+    """Map asset filename -> sha256, from the release's published checksums."""
+    url = pin.checksums_url.format(version=version, num=version.lstrip("v"))
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            body = resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        sys.exit(
+            f"::error::{pin.name} {version}: cannot fetch {url} ({exc.code}). "
+            "Either the version pin names a release that does not exist, or the "
+            "release did not publish a checksums file."
+        )
+    except urllib.error.URLError as exc:
+        sys.exit(f"::error::{pin.name} {version}: cannot reach {url} ({exc.reason})")
+
+    sums = {}
+    for line in body.splitlines():
+        parts = line.split()
+        if len(parts) == 2:
+            sums[parts[1].lstrip("*")] = parts[0]
+    return sums
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--fix",
+        action="store_true",
+        help="rewrite stale checksums in place instead of only reporting them",
+    )
+    ap.add_argument("--only", help="check a single pin by name")
+    args = ap.parse_args()
+
+    failed = 0
+    fixed = 0
+
+    for pin in PINS:
+        if args.only and pin.name != args.only:
+            continue
+        version = find_version(pin)
+        published = fetch_published(pin, version)
+
+        for arch in ARCHES:
+            pattern, pinned = find_checksum(pin, arch)
+            asset = pin.asset.format(arch=arch, num=version.lstrip("v"))
+            want = published.get(asset)
+
+            if want is None:
+                print(f"FAIL {pin.name} {arch}: {version} publishes no asset named {asset}")
+                print(
+                    f"::error::{pin.name} {arch}: the pinned release {version} has no "
+                    f"asset {asset}. The asset naming may have changed upstream."
+                )
+                failed += 1
+                continue
+
+            if pinned == want:
+                print(f"ok   {pin.name} {arch}: {version} {pinned[:12]}…")
+                continue
+
+            print(f"FAIL {pin.name} {arch}: pinned {pinned[:12]}… but {version} publishes {want[:12]}…")
+            if not args.fix:
+                print(
+                    f"::error::{pin.name} {arch} checksum does not match the pinned "
+                    f"version {version}. This is what a version bump that left the "
+                    f"checksums behind looks like. Run "
+                    f"`python3 scripts/check-download-checksums.py --fix` to correct it."
+                )
+                failed += 1
+                continue
+
+            path = REPO_ROOT / pin.checksum_file
+            text = path.read_text()
+            # Replace only the captured hash, leaving surrounding syntax alone,
+            # so this works for both the shell case arm and the YAML mapping.
+            m = re.search(pattern, text, re.MULTILINE)
+            start, end = m.span(1)
+            path.write_text(text[:start] + want + text[end:])
+            print(f"fix  {pin.name} {arch}: -> {want[:12]}…")
+            fixed += 1
+
+    if fixed:
+        print(f"\nrewrote {fixed} checksum(s); re-run without --fix to confirm")
+        return 0
+    if failed:
+        print(f"\n{failed} checksum pin(s) disagree with their pinned release")
+        return 1
+    print("\nall checksum pins match their pinned release")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the gap behind #2083, and fixes a live breakage found while doing it.

## The chezmoi pins are stale on `main` right now

Renovate bumped `chezmoi: "v2.71.0"` → `"v2.72.0"` and left `chezmoi_sha256` untouched. `build_scripts/desktop/niri.sh` therefore downloads `chezmoi_2.72.0_linux_amd64.deb` and checks it against **v2.71.0's** hash, so `sha256sum -c -` fails and the Ubuntu/niri build dies.

Verified against upstream rather than inferred:

| | |
|---|---|
| pinned amd64 | `a8880a1b…` |
| in `chezmoi_2.72.0_checksums.txt` | **absent entirely** |
| what `a8880a1b…` actually is | `chezmoi_2.71.0_linux_amd64.deb` |

It fails closed, so nothing bad shipped — but the build breaks and nothing named the cause. Both hashes are corrected here.

## Why it happened, and why it will happen again without a guard

Both custom managers in `renovate.json` capture a **single version line**:

```
"#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)\\n\\s+[\\w-]+:\\s*\"(?<currentValue>[^\"]+)\""
```

A sibling `_sha256` map falls outside that match. Renovate maintains the version and *cannot* maintain the checksums. `postUpgradeTasks` would solve it, but this repo uses the Mend-hosted app where that isn't available.

This is exactly why `install-remora.sh` deliberately carried **no** `# renovate:` marker — the comment there is correct. But the cost was that nothing bumped it at all: it sat on v0.2.0 for six weeks, which is #2083.

## The fix: guard the half Renovate can't maintain

`scripts/check-download-checksums.py` fetches the `checksums.txt` published for the **pinned** version and asserts every pinned hash matches. That catches both:

- a version bump that left checksums behind (the Renovate case), and
- a release re-published under the same tag with different content, which nothing checked before.

With that guard, the `# renovate:` marker is safe to add — so remora now bumps automatically, and a bump with stale checksums **cannot merge itself**: `automerge: true` covers patch updates and `platformAutomerge` waits on checks. `--fix` rewrites them, so correcting a bump is one command instead of a hunt through release pages.

Follows the existing `check-*-pins` convention: a script that names the problem in one line, driven by a small workflow (PR-triggered to gate, plus nightly for the re-publish case).

## remora v0.2.0 → v0.4.0

Not the reason #2083's parent issue gives — that framing conflated remora's README snippet with this script, which was never vulnerable (see tuna-os/remora#32). The real reason:

- **v0.2.0** rebases to a bare tag, handing bootc the same image specification every run, so a rebuild with new content under an unchanged tag can fail to stage — layered packages quietly stop updating behind a green timer.
- **v0.3.0** fixed that but carried a second defect: scheduled builds never regenerated the Containerfile after moving the base pin, so the base never updated on the timer path.
- **v0.4.0** is the first release with both fixed.

## Testing

- Script run before the fix: **caught the chezmoi bug**, remora green.
- `--fix` applied, re-run clean — all four pins match.
- Renovate's `build_scripts` manager regex verified to match the new marker, capturing `datasource=github-releases`, `depName=tuna-os/remora`, `currentValue=v0.4.0`.
- `actionlint` clean on the new workflow; `bash -n` clean on the modified script.
- Both remora checksums cross-checked two ways: the release's `checksums.txt` and the release API's per-asset `digest`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0157X4TYXBuFmh7yAjsbNZr5)_