### PR TITLE
fix(desktops): the hummingbird repo must resolve on aarch64 too

### DIFF
--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -181,7 +181,7 @@ packages:
   hummingbird:
     repos:
       - name: tunaos-hummingbird
-        baseurl: https://repo.tunaos.org/hummingbird/20251124-x86_64/
+        baseurl: https://repo.tunaos.org/hummingbird/20251124-$basearch/
         priority: 5
     packages:
       # See the fedora list's dconf note — needed here for real (the rebuild

--- a/manifests/desktops/gnome.yaml
+++ b/manifests/desktops/gnome.yaml
@@ -125,7 +125,7 @@ packages:
   hummingbird:
     repos:
       - name: tunaos-hummingbird
-        baseurl: https://repo.tunaos.org/hummingbird/20251124-x86_64/
+        baseurl: https://repo.tunaos.org/hummingbird/20251124-$basearch/
         priority: 5
     packages: *fedora_gnome_packages
 

--- a/tests/bats/test_hummingbird_desktop_wiring.bats
+++ b/tests/bats/test_hummingbird_desktop_wiring.bats
@@ -47,11 +47,17 @@ yq_bin() { command -v yq; }
 	[ "$status" -eq 0 ]
 }
 
+# `$basearch`, not a literal arch. install-desktop.sh writes this baseurl
+# VERBATIM into /etc/yum.repos.d, and dnf expands $basearch when it reads the
+# file. Pinned to x86_64 (as this assertion used to require), the aarch64
+# desktop lane pointed at the x86_64 prefix, which serves no aarch64 RPMs --
+# and because these lanes install with --skip-unavailable, that produced a
+# GREEN build carrying no desktop rather than a red one.
 @test "gnome.yaml declares a hummingbird repo at the measured target path" {
 	[ -n "$(yq_bin)" ] || skip "yq not available"
 	run yq -r '.packages.hummingbird.repos[0].baseurl' "$GNOME"
 	[ "$status" -eq 0 ]
-	[[ "$output" == *"hummingbird/20251124-x86_64"* ]]
+	[[ "$output" == *'hummingbird/20251124-$basearch'* ]]
 }
 
 # The assertion this file exists for: the hummingbird package list must BE the
@@ -98,7 +104,7 @@ yq_bin() { command -v yq; }
 	local cosmic_yaml="${REPO_ROOT}/manifests/desktops/cosmic.yaml"
 	run yq -r '.packages.hummingbird.repos[0].baseurl' "$cosmic_yaml"
 	[ "$status" -eq 0 ]
-	[[ "$output" == *"hummingbird/20251124-x86_64"* ]]
+	[[ "$output" == *'hummingbird/20251124-$basearch'* ]]
 	local fedora hummingbird diff
 	fedora="$(yq -r '.packages.fedora.packages[]' "$cosmic_yaml" | sort)"
 	hummingbird="$(yq -r '.packages.hummingbird.packages[]' "$cosmic_yaml" | sort)"

--- a/tests/test_desktop_repo_urls_are_arch_neutral.py
+++ b/tests/test_desktop_repo_urls_are_arch_neutral.py
@@ -1,0 +1,87 @@
+"""The hummingbird desktop repo must resolve on every arch it is built for.
+
+install-desktop.sh writes the manifest's `baseurl` VERBATIM into
+/etc/yum.repos.d/<name>.repo:
+
+    echo "baseurl=${_TD_RB}"
+
+dnf expands $basearch when it reads that file, so an arch-neutral URL is not
+merely tidier -- it is the only form that works on more than one arch.
+
+gnome.yaml and cosmic.yaml both hardcoded `.../hummingbird/20251124-x86_64/`.
+On aarch64 that points at the x86_64 prefix, which serves no aarch64 RPMs. The
+desktop lanes install with --skip-unavailable, so the result is not a loud
+failure: it is an image that builds green and silently contains no desktop --
+the exact shape verify-desktop-experience.sh records for hummingbird:gnome
+("410 packages -- gnome-backgrounds and gnome-user-docs, no gnome-shell, no
+gdm, no mutter, no gtk4 -- and this check called it passed").
+
+build_scripts/10-base-packages.sh already writes the same repo correctly:
+
+    baseurl=https://repo.tunaos.org/hummingbird/20251124-$basearch/
+
+so the manifests were the odd ones out, not the pattern. Both prefixes were
+confirmed served (HTTP 200 on repodata/repomd.xml for x86_64 and aarch64)
+before this was changed -- $basearch is only right if both actually exist.
+
+## Why this is scoped to hummingbird
+
+A broader "no manifest may hardcode an arch" rule sounds better and is wrong.
+Two other pins are deliberate and say so in their own comments:
+
+  * cosmic.yaml el10 `tuna-os-fprintd` -> .../fprintd/10-stream-aarch64/
+    "only aarch64 RPMs are published here, so this is harmless to enable
+    unconditionally on x86_64 -- dnf just finds no matching-arch packages and
+    falls back to CentOS Stream's own x86_64 fprintd-pam". $basearch there
+    would point x86_64 at a prefix that does not exist, and the repo writer
+    sets skip_if_unavailable=False, so it would hard-fail the build.
+  * xfce.yaml el10 `tunaos-xfce` -> .../xfce/10-stream-x86_64/, an
+    x86_64-only lane.
+
+Pinning a rule those two must violate would either red-line them or invite
+someone to "fix" them into a broken state.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MANIFESTS = sorted((ROOT / "manifests" / "desktops").glob("*.yaml"))
+ARCHES = ("x86_64", "aarch64", "arm64", "amd64", "ppc64le", "s390x")
+
+
+def hummingbird_repos(path: pathlib.Path):
+    doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    section = (doc.get("packages") or {}).get("hummingbird")
+    if not isinstance(section, dict):
+        return
+    for repo in section.get("repos") or []:
+        if isinstance(repo, dict) and repo.get("baseurl"):
+            yield repo.get("name"), repo["baseurl"]
+
+
+def test_some_manifest_actually_declares_a_hummingbird_repo():
+    """Guard against a check that passes because it examined nothing."""
+    found = [row for path in MANIFESTS for row in hummingbird_repos(path)]
+    assert found, (
+        "no packages.hummingbird.repos[].baseurl found in any "
+        "manifests/desktops/*.yaml -- the check below is vacuous"
+    )
+
+
+@pytest.mark.parametrize("manifest", MANIFESTS, ids=lambda p: p.name)
+def test_the_hummingbird_repo_is_arch_neutral(manifest):
+    for name, url in hummingbird_repos(manifest):
+        hardcoded = [a for a in ARCHES if re.search(rf"[-/]{a}(/|$)", url)]
+        assert not hardcoded, (
+            f"{manifest.name}: packages.hummingbird.repos[{name}].baseurl "
+            f"hardcodes {hardcoded[0]!r}:\n    {url}\n"
+            "install-desktop.sh writes this verbatim into a .repo file, so on "
+            "any other arch it serves no matching RPMs and the desktop "
+            "silently installs nothing. Use $basearch, as "
+            "build_scripts/10-base-packages.sh already does for this repo."
+        )


### PR DESCRIPTION
`install-desktop.sh` writes a manifest's `baseurl` **verbatim** into `/etc/yum.repos.d/<name>.repo`:

```sh
echo "baseurl=${_TD_RB}"
```

dnf expands `$basearch` when it reads that file. But `gnome.yaml` and `cosmic.yaml` both hardcoded

```
https://repo.tunaos.org/hummingbird/20251124-x86_64/
```

so on aarch64 the desktop lane pointed at the **x86_64** prefix, which serves no aarch64 RPMs.

## Why this is quiet rather than loud

Those lanes install with `--skip-unavailable`. So the failure mode is not a red build — it is an image that builds **green and silently contains no desktop**. That is the exact shape `build_scripts/checks/verify-desktop-experience.sh` already records for `hummingbird:gnome`:

> the image carried 410 packages — gnome-backgrounds and gnome-user-docs, **no gnome-shell, no gdm, no mutter, no gtk4** — and this check called it passed

`build_scripts/10-base-packages.sh:167` already writes the same repo the right way, so the manifests were the odd ones out, not the pattern.

## Verified before changing anything

`$basearch` is only correct if both prefixes exist. Both are served:

```
20251124-x86_64  -> HTTP 200   repodata/repomd.xml
20251124-aarch64 -> HTTP 200   repodata/repomd.xml
```

## Two pins deliberately left alone

The first version of the test asserted that **no** desktop manifest may hardcode an arch. It failed two more, and checking them showed both are deliberate and documented — I would have broken working lanes:

- **`cosmic.yaml` el10 `tuna-os-fprintd`** → `fprintd/10-stream-aarch64/`. Its own comment explains only aarch64 RPMs are published there, and that x86_64 correctly falls back to CentOS Stream's `fprintd-pam`. `$basearch` would point x86_64 at a prefix that does not exist — and the repo writer sets `skip_if_unavailable=False`, so it would **hard-fail** the build rather than degrade.
- **`xfce.yaml` el10 `tunaos-xfce`** → `xfce/10-stream-x86_64/`, an x86_64-only lane.

So the test is scoped to the `hummingbird:` sections, where both arch prefixes demonstrably exist. A rule those two must violate would either red-line them or invite someone to "fix" them into a broken state.

## Tests

Mutation-verified:

- restoring either hardcoded URL fails the test for that manifest
- a separate test fails if the extraction ever finds no hummingbird repo at all, so the check cannot pass by examining nothing

## Context

This is one half of getting `hummingbird:gnome` to actually reach gdm. The other half is upstream: the package factory has not published since 2026-08-21 because a single package (`dconf`) fails the build cell, which exits non-zero and skips the publish — so `gnome-shell`, `gdm` and `mutter` are not in the repo for any arch to install. That is tuna-os/tunaos-packages#545. This change makes sure that once they are published, aarch64 can see them.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_