### PR TITLE
docs(wahoo): replace the pre-dispatch predictions with build results

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ Bring a modern, cloud-native experience to the Enterprise Linux Desktop. tunaOS 
 | Flounder / Flounder Sid | Debian 13 Trixie / Sid | GNOME, KDE, COSMIC, Niri, XFCE | Beta |
 | Hummingbird | Fedora Hummingbird (container-native bootc) | Base, GNOME, KDE, COSMIC, Niri | Experimental (see #1341) |
 | Gurnard | Ubuntu 24.04 Noble | Base, Pantheon | Experimental (see #1341) |
-| Wahoo | Fedora ELN (EL11 preview, rolling) | Base, GNOME | Proposal — dispatch-only, no cron (fedora-eln/eln#214) |
+| Wahoo | Fedora ELN (EL11 preview, rolling) | Base, GNOME | Experimental — both flavors built and published 08-25 (dispatch-only, no cron); **not booted**, Gate is skipped on dispatch (fedora-eln/eln#214, desktops #2048) |
 
 **Status terms** follow [VARIANT-LIFECYCLE.md](VARIANT-LIFECYCLE.md): `Stable`
 means GA, `Beta` means published for testing on tunaos.org/download. This

--- a/VARIANT-LIFECYCLE.md
+++ b/VARIANT-LIFECYCLE.md
@@ -72,6 +72,25 @@ must not be promoted or gain additional ISO coverage.
 | `flounder:gnome-nvidia` | #1191 | ci-maintainer | 1 image + 1 ISO (amd64) | NVIDIA driver load, boot gate, LUKS E2E, desktop contract | Held pending capacity sign-off |
 | `flounder-sid:gnome-nvidia` | #1191 | ci-maintainer | 1 image; 0 ISO (amd64) | NVIDIA driver load, boot gate, LUKS E2E, desktop contract | Held pending capacity sign-off |
 
+| Addition (opened 2026-08-25) | Tracker | Owner | Incremental cells | Acceptance evidence | Status |
+|---|---|---|---:|---|---|
+| `wahoo` (Fedora ELN / EL11 preview) — `base`, `gnome` | #2048; fedora-eln/eln#214 | hanthor | 0 nightly; 0 ISO; **1 LUKS** (wahoo:gnome, monthly) | Base availability measured before the first commit (`eln-bootc` OCI index, 4 arches); both flavors built + Promoted on amd64/arm64 (run 32833686631); desktop contract + branding pass; `TUNAOS_WISHLIST_OK misses=0`. **Boot gate NOT run** — Gate is skipped on dispatch | Admitted as experimental, dispatch-only. Not eligible for Beta: VARIANT-LIFECYCLE §2 requires boot-gate green and a download entry, and neither exists |
+
+Wahoo is recorded here for the opposite reason to the four rows above: those
+were grandfathered in and needed a gate applied retroactively, whereas this
+one cleared the gate before its first commit — upstream base availability was
+measured, not assumed, and the flavor set was cut to what the compose actually
+carries. It is dispatch-only precisely so it consumes none of the nightly
+capacity the interim freeze protects. Its one non-zero cell is the monthly
+LUKS sweep, which `luks-e2e.yml` derives from `build_image` with no
+experimental filter; that is counted rather than excluded, and pinned by the
+denominator in `tests/test_matrix_status.py`.
+
+The ELN codec gap is a portfolio constraint, not just a build detail: ELN
+publishes no functional H.264/H.265 decoder, so no wahoo flavor may be
+promoted or marketed as media-capable regardless of how green it goes. See
+the wahoo section of docs/GREEN-MASTER-PLAN.md.
+
 The cell count is the minimum incremental matrix impact, not a claim that the
 work is free: an ISO cell also consumes grouped-ISO or on-demand publishing
 and boot-gate capacity. The owner must attach a capacity note to the tracker

--- a/docs/GREEN-MASTER-PLAN.md
+++ b/docs/GREEN-MASTER-PLAN.md
@@ -349,28 +349,39 @@ The fully-diagnosed one: **#1755**.
 | dconf branding failure | **deliberately left failing** — guarding it would green cells that contain no desktop | fix only after manifest sections exist |
 | convergence | tunaos-packages seed grew for the first time since 08-09 (7170→7673); reserve budget stops *between* tiers (tunaos-packages#401), cosmic/niri/kde runs lost to the 6h ceiling | in-loop deadline check (#401), tier failures layer-00/01/02/07/10/11 to classify (#402/#403/#404 candidates) |
 
-### wahoo (Fedora ELN, experimental) — 0/2 build, never dispatched
-New 2026-08-25. The EL11 early-warning lane: ELN is Rawhide sources built with
-Enterprise Linux macros, and its os-release already reads `ID=eln`,
+### wahoo (Fedora ELN, experimental) — 2/2 build, both promoted (08-25, first dispatch)
+New 2026-08-25 (#2042). The EL11 early-warning lane: ELN is Rawhide sources
+built with Enterprise Linux macros, and its os-release already reads `ID=eln`,
 `VERSION_ID=11`, `ID_LIKE="rhel centos fedora"` — the same 11 c11s and
 almalinux-bootc:11-kitten will carry. Nothing else in the matrix sees EL11, so
 today an EL11 break surfaces the day a base flips rather than months earlier.
 
-Dispatch-only (`experimental: true`), so it adds **0 nightly cells, 0 ISO
-cells and 0 boot-gate cells**; its one incremental scheduled cell is
-wahoo:gnome in the monthly LUKS sweep. Nothing below is a build result yet —
-every row is a repodata measurement against the pinned `eln-bootc` digest,
-and the first dispatch is what turns them into evidence.
+Dispatch-only (`experimental: true`): 0 nightly cells, 0 ISO cells; its one
+incremental scheduled cell is wahoo:gnome in the monthly LUKS sweep.
+
+**First dispatch, run 32833686631, on 80bc855 — conclusion success.** Both
+flavors built, manifested, cosign-signed and Promoted on amd64 AND arm64, and
+`ghcr.io/tuna-os/wahoo` now serves `base`, `gnome` and their dated/per-arch
+tags (the `gnome` index carries both arches, verified against the registry).
+The rows below were repodata predictions when this section was written; they
+are build results now, and where the two differ the build wins.
+
+**Not proven: this lane has never booted.** The Gate job is `skipped` on a
+dispatch, so build-green here means "the image assembles and the desktop
+contract passes", not "it boots". Nothing should read a promoted wahoo tag as
+a boot claim until a Gate or LUKS run says so.
 
 | area | state | action |
 |---|---|---|
-| base image | `registry.fedoraproject.org/eln-bootc` exists (fedora-eln/eln#214) — OCI index with amd64/arm64/ppc64le/s390x, 480 pkgs, bootc-1.16.7, dnf5-5.4.3.0, kernel-7.3.0-rc | first `base` dispatch |
+| base amd64/arm64 | **built and Promoted** (33m / 28m). `TUNAOS_BRANDING_OK variant=wahoo`, `TUNAOS_BASE_CONTRACT_BUILDCHECK_OK` | keep |
+| gnome amd64/arm64 | **built and Promoted**, `desktop experience contract passed: gnome`; installed gnome-shell 51~beta-3.eln158, gdm 1:51~beta-1, mutter 51~beta-1, nautilus 51~beta-1 | keep |
+| package measurement | `TUNAOS_WISHLIST_OK misses=0` — every name listed strictly resolved, nothing silently skipped. The pre-merge repodata measurement (40/48 base, 42/52 gnome) was exact | re-measure when ELN moves |
 | repos | `/etc/yum.repos.d` is EMPTY on this base; `fedora-repos-eln` ships the repo file at `/usr/share/dnf5/repos.d/fedora-eln.repo`, which dnf5 reads — eln-{baseos,appstream,crb,extras} enabled by default, so no `crb enable` and no EPEL step | none — the build adds no repo of its own |
-| base packages | 40 of the 48 EL/Fedora base names resolve; `systemd-oomd`, `just`, `tailscale`, `epel-release` do not, and are omitted rather than `--skip-unavailable`'d (the #1555 failure shape) | re-measure when ELN grows them |
-| codecs | **no working H.264 or H.265 at all** — measured, not assumed. RPM Fusion publishes no ELN branch; ELN carries no `ffmpeg` and no `gstreamer1-plugins-ugly`; `ffmpeg-free` 8.1.2's only h264 entry is `libopenh264`, and the sole openh264 provider in ELN is `noopenh264-2.6.0-5.eln158`, Fedora's **stub** — encoding a 1s testsrc through it wrote a 0-byte file. No hevc decoder is listed. The desktop contract fires correctly here and is let through ELN-only with a `TUNAOS_CODEC_GAP` marker (`tests/bats/test_eln_codec_gap.bats` pins that it stays loud and never widens to accept the stub's name) | needs an ELN codec source; until then wahoo must never be promoted as media-capable, and this row is the reason it stays experimental |
-| gnome amd64 | 42 of the 52 fedora-list packages resolve, GNOME 51~beta (gnome-shell 51~beta-3, gdm 51~beta-1, mutter 51~beta-1); the 10 misses are best-effort `optional:` | first `gnome` dispatch → desktop contract |
-| gnome arm64 | same six core packages resolve on aarch64 (`dnf repoquery --forcearch=aarch64`) — the measurement #1755 §3 skipped, done before declaring the platform | first arm64 dispatch |
-| kde/cosmic/niri/xfce | **not declared** — unmeasured on ELN, and declaring an undertested desktop is the #858 shape | measure repodata before adding a flavor row |
+| base packages | `systemd-oomd`, `just`, `tailscale`, `epel-release` are absent from ELN and omitted rather than `--skip-unavailable`'d (the #1555 failure shape). `misses=0` confirms nothing else was | re-measure when ELN grows them |
+| codecs | **no working H.264 or H.265 at all** — measured, not assumed. RPM Fusion publishes no ELN branch; ELN carries no `ffmpeg` and no `gstreamer1-plugins-ugly`; `ffmpeg-free` 8.1.2's only h264 entry is `libopenh264`, and the sole openh264 provider in ELN is `noopenh264-2.6.0-5.eln158`, Fedora's **stub** — encoding a 1s testsrc through it wrote a 0-byte file. `TUNAOS_CODEC_GAP` fired on the green gnome build exactly as designed; `tests/bats/test_eln_codec_gap.bats` pins that it stays loud and never widens to accept the stub's name | needs an ELN codec source; until then wahoo must never be promoted as media-capable, and this row is the reason it stays experimental |
+| boot gate | **never run** — `Gate` is skipped on dispatch | dispatch a boot gate before any promotion claim |
+| SBOM attestation | **missing on both flavors.** Both `Attest SBOM` jobs failed against `rekor.sigstore.dev` (14x 502 plus 429s, twice each, including a re-run at 12:52-13:01Z) and ended in the workflow's own `SIGSTORE_OUTAGE` classifier. Upstream outage, non-blocking by design; the SBOMs were generated and uploaded, just not countersigned. Note the images ARE cosign-signed — that is a different path | attests on the next dispatch once Sigstore's write path recovers |
+| kde/cosmic/niri/xfce | **not declared** — measured 08-25 and tracked in #2048: COSMIC 23/24 and KDE 16/23 with their groups present (ready to attempt); Niri and XFCE blocked, XFCE because ELN composes **zero** `xfce*` packages | #2049 (cosmic), #2050 (kde); #2051/#2052 stay filed until their blockers clear |
 
 ### sailfin (openSUSE Tumbleweed) — 0/7 → **all five desktops promoted with Gates green (08-18)**
 | area | state | action |

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -72,6 +72,7 @@ A TunaOS image is named `<variant>:<desktop>[-hardware]`.
 | 🦈 **sailfin** | openSUSE Tumbleweed | Rolling |
 | 🌈 **guppy** | Gentoo | Binary-package Gentoo, the adventurous pick |
 | 🐦 **hummingbird** | Fedora Hummingbird | Experimental next-gen Fedora base |
+| 🎏 **wahoo** | Fedora ELN | Experimental EL11 preview — what c11s/Kitten 11 will be like, months early. **No H.264/H.265**: ELN ships no working video decoder, so this is a testing lane, not a daily driver |
 | 🔒 **redfin** | RHEL 10 | Local-build only (EULA) — see [rhel-setup.md](rhel-setup.md) |
 
 ### The desktop — `gnome`, `kde`, `cosmic`, `niri`, `xfce`


### PR DESCRIPTION
The wahoo section of `docs/GREEN-MASTER-PLAN.md` was written before the lane had ever been dispatched, and said so in as many words:

> `### wahoo (Fedora ELN, experimental) — 0/2 build, never dispatched`
> "Nothing below is a build result yet — every row is a repodata measurement against the pinned `eln-bootc` digest, and the first dispatch is what turns them into evidence."

That dispatch has happened. The section now asserts things that are no longer true, which is exactly the staleness [AGENTS.md](../blob/main/AGENTS.md) rule 3 is about.

## What the first dispatch actually produced

[Run 32833686631](https://github.com/tuna-os/tunaOS/actions/runs/32833686631), on `80bc855` — conclusion **success**:

```
base  amd64 33m / arm64 28m   built, manifested, cosign-signed, Promoted
gnome amd64    / arm64        built, manifested, cosign-signed, Promoted

TUNAOS_BRANDING_OK variant=wahoo
desktop experience contract passed: gnome (projectbluefin/bluefin-lts)
TUNAOS_BASE_CONTRACT_BUILDCHECK_OK
TUNAOS_WISHLIST_OK misses=0
TUNAOS_CODEC_GAP: ELN publishes no functional H.264/H.265 decoder …

gnome-shell 51~beta-3.eln158   gdm 1:51~beta-1.eln158
mutter 51~beta-1.eln158        nautilus 51~beta-1.eln158
```

`ghcr.io/tuna-os/wahoo` serves `base`, `gnome` and their dated/per-arch tags. The `gnome` index carries `['amd64', 'arm64']` — read back from the registry, not inferred from the job log.

**`misses=0` is the load-bearing number.** Every name the manifests list strictly resolved, so the pre-merge repodata measurement (40/48 base, 42/52 gnome) was exact and nothing was silently skipped — the failure mode #1555 paid for.

## Two things these docs deliberately do NOT claim

Both are stated in the files rather than left for a reader to assume:

- **The lane has never booted.** `Gate` is `skipped` on a dispatch, so build-green means the image assembles and the desktop contract passes — not that it boots. No promotion claim until a Gate or LUKS run says otherwise.
- **Neither flavor has an SBOM attestation.** Both `Attest SBOM` jobs failed against `rekor.sigstore.dev` — 14 × 502 plus 429s, twice each including a re-run at 12:52–13:01Z — ending in the workflow's own `SIGSTORE_OUTAGE` classifier. Upstream and non-blocking by design. The images **are** cosign-signed; that is a separate path.

## Files

| file | change |
|---|---|
| `docs/GREEN-MASTER-PLAN.md` | predictions → results; adds explicit "never booted" and attestation-missing rows; points the desktop row at #2048 |
| `ROADMAP.md` | Wahoo moves off **Proposal** (which means *planned, not yet built*) to Experimental-and-published, not-booted caveat inline |
| `VARIANT-LIFECYCLE.md` | wahoo recorded in the admission record. The four rows above it were grandfathered in and had the gate applied retroactively; this one cleared the gate *before* its first commit, and the record says so. Its one non-zero cell is the monthly LUKS sweep — counted, not excluded. Explicitly **not** eligible for Beta: §2 wants boot-gate green and a download entry, and neither exists |
| `docs/USER-GUIDE.md` | wahoo added to the variant table it was missing from, with the codec gap stated where it matters most to a user: no H.264/H.265, so it is a testing lane, not a daily driver |

## Not touched, on purpose

`docs/MATRIX-STATUS.md` and the README build-status block are **generated**. Both already carry wahoo rows at `⬜`, and the daily 06:00 UTC regeneration moves them on its own. Hand-editing them is the anti-pattern AGENTS.md rule 3 names. The README's "Choose your image" row needed no change — it already said `ghcr.io/tuna-os/wahoo`, Base + GNOME, x86_64 + arm64, and all three are now verified true rather than aspirational.

## Testing

`pytest tests/` — **883 passed, 2 skipped**. Includes `test_green_master_plan.py::test_every_variant_has_a_section`, which is what pins the file this PR is mostly editing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvHdxf4BacZVvvMG35qkVG)_