### PR TITLE
feat(wahoo): add COSMIC and KDE — every desktop ELN actually composes

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -636,10 +636,18 @@ variants:
     # publishes no ELN branch). See docs/GREEN-MASTER-PLAN.md's wahoo section
     # and the TUNAOS_CODEC_GAP marker in verify-desktop-experience.sh.
     #
-    # MVP scope: base + GNOME only. ELN AppStream carries GNOME 51~beta;
-    # KDE/COSMIC/Niri/XFCE are not measured here and must not be declared
-    # before they are (#858: an image tagged for a desktop that contains no
-    # desktop). No ISO and no qcow2 — a preview lane publishes images to
+    # Scope: every desktop ELN actually composes, and no others. GNOME 51~beta
+    # and COSMIC 1.6.0 come from eln-appstream/eln-extras; KDE comes from the
+    # `kde-desktop` group (86 entries, Plasma 6.7.4). Each was repodata-measured
+    # before its row was added — #858 is an image tagged for a desktop that
+    # contains no desktop, and the guard against it is measuring first.
+    #
+    # Niri and XFCE are deliberately NOT here and must not be added by analogy:
+    # ELN ships one package of the Niri stack (`swaybg`) and ZERO `xfce*`
+    # packages at all. Both need packages built before a row is honest —
+    # tracked in #2051 / #2052 and in tunaos-packages.
+    #
+    # No ISO and no qcow2 on any flavor — a preview lane publishes images to
     # `bootc switch` onto, not installer media.
     flavors:
       - id: base
@@ -648,6 +656,23 @@ variants:
         build_iso: false
         build_qcow2: false
       - id: gnome
+        stage: 2
+        build_image: true
+        build_iso: false
+        build_qcow2: false
+      # COSMIC 1.6.0 from eln-extras — 23 of 24 manifest packages present
+      # (only cosmic-wallpapers absent). Notably needs NO copr and no
+      # repo.tunaos.org fprintd repo, both of which the el10 section carries:
+      # ELN has fprintd-1.94.5-6.eln158 in eln-appstream (#2049).
+      - id: cosmic
+        stage: 2
+        build_image: true
+        build_iso: false
+        build_qcow2: false
+      # Plasma 6.7.4 via the eln-extras `kde-desktop` group; 16 of 23 explicit
+      # packages present, the seven misses are peripheral input/security-key
+      # extras carried as `optional:` (#2050).
+      - id: kde
         stage: 2
         build_image: true
         build_iso: false

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -83,7 +83,7 @@ Scored against `.github/green-criteria.yml`: a cell is green only when every **b
 | **marlin** | ✅ | ✅ | ❌ | ❌ | ✅ |
 | **sailfin** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | **skipjack** | ❌ | ⬜ | ❌ | ❌ | ✅ |
-| **wahoo** | ⬜ | — | — | — | — |
+| **wahoo** | ⬜ | ⬜ | ⬜ | — | — |
 | **yellowfin** | ✅ | ✅ | ❌ | ❌ | ✅ |
 
 Cells outside the desktop columns (base, hwe, nvidia and friends) are in the count above but not the table; only `builds` applies to them today.
@@ -109,7 +109,7 @@ Green criterion 8 (`no_silent_omissions`): the sweep runs `checks/verify-package
 | **marlin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **sailfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **skipjack** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **wahoo** | ⬜ | — | — | — | — |
+| **wahoo** | ⬜ | ⬜ | ⬜ | — | — |
 | **yellowfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ## Package parity
@@ -131,7 +131,7 @@ Green criterion 7 (`parity`), first cadence: every desktop's package set audited
 | **marlin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **sailfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **skipjack** | ✅ | ✅ | ✅ | ✅ | ❌ |
-| **wahoo** | ⬜ | — | — | — | — |
+| **wahoo** | ⬜ | ⬜ | ⬜ | — | — |
 | **yellowfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ## LUKS E2E
@@ -154,7 +154,7 @@ Measured against the set `luks-e2e.yml` schedules: every published desktop image
 | **marlin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **sailfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **skipjack** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **wahoo** | ⬜ | — | — | — | — |
+| **wahoo** | ⬜ | ⬜ | ⬜ | — | — |
 | **yellowfin** | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 NVIDIA cells are **out of scope** for this workflow — `luks-e2e.yml` excludes them deliberately, because `-nvidia` takes the identical LUKS path in headless QEMU. 25 stale pre-exclusion result(s) remain from before that change; they are not a gap and will age out.
@@ -182,7 +182,7 @@ Pulls the **published** image and runs the contract script against it directly (
 | **marlin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **sailfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **skipjack** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **wahoo** | ⬜ | — | — | — | — |
+| **wahoo** | ⬜ | ⬜ | ⬜ | — | — |
 | **yellowfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 5 cell(s) in the most recent sweep are missing (no published image), errored (registry/runner trouble), or lost (job produced no result) rather than a clean pass or fail — not counted above; see that sweep's own `desktop-contract-baseline` artifact for which.
@@ -209,7 +209,7 @@ Validates bootc image update, rebase, rollback, alias resolution, and post-switc
 | **marlin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **sailfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **skipjack** | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **wahoo** | ⬜ | — | — | — | — |
+| **wahoo** | ⬜ | ⬜ | ⬜ | — | — |
 | **yellowfin** | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 Newest result 2026-08-20.

--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -212,6 +212,54 @@ packages:
       - xdg-desktop-portal-cosmic
       - pop-icon-theme
 
+  # ── Wahoo (Fedora ELN) ─────────────────────────────────────────────────
+  # ELN carries COSMIC natively, in eln-extras, at 1.6.0 — and that is the
+  # headline finding of the whole lane so far, not just a convenience.
+  # `cosmic.el10` above sources COSMIC from COPR `yselkowitz/cosmic-epel`
+  # (twice) and fprintd from repo.tunaos.org, both tier-3 migration
+  # inventory under PACKAGE-SOURCING.md. On this base neither is needed:
+  # the compose ships cosmic-session/comp/panel/files/greeter/settings and
+  # xdg-desktop-portal-cosmic, and `fprintd-1.94.5-6.eln158` resolves from
+  # eln-appstream, so the aarch64 fprintd gap that pinned cosmic off arm64
+  # on EL10 (tunaOS#732) does not reproduce here either.
+  #
+  # Measured with `dnf repoquery` against the pinned eln-bootc digest on
+  # 2026-08-26: 23 of 24 present. If EL11 keeps this, the COSMIC COPR
+  # dependency retires itself at the EL10 -> EL11 transition rather than
+  # needing a Tideforge migration (#2048, #2049).
+  #
+  # NO copr: block here, deliberately — ELN needs none, and a new one
+  # fails scripts/check-package-sources.py.
+  eln:
+    packages:
+      - dconf
+      - cosmic-session
+      - cosmic-comp
+      - cosmic-panel
+      - cosmic-app-library
+      - cosmic-applets
+      - cosmic-bg
+      - cosmic-files
+      - cosmic-idle
+      - cosmic-launcher
+      - cosmic-notifications
+      - cosmic-osd
+      - cosmic-randr
+      - cosmic-screenshot
+      - cosmic-settings
+      - cosmic-settings-daemon
+      - cosmic-term
+      - cosmic-workspaces
+      - cosmic-greeter
+      - cosmic-icon-theme
+      - greetd
+      - xdg-desktop-portal-cosmic
+      - pop-icon-theme
+    # Absent from ELN on 2026-08-26 (cosmic-icons likewise, and it is not
+    # in the fedora list either). Best-effort so it lands by itself when
+    # the compose grows it — tracked in tunaos-packages.
+    optional:
+      - cosmic-wallpapers
   el10:
     # cosmic-greeter hard-requires fprintd-pam, which CentOS Stream 10 only
     # builds for x86_64 -- that gap is why aarch64 cosmic was pinned off in

--- a/manifests/desktops/kde.yaml
+++ b/manifests/desktops/kde.yaml
@@ -51,6 +51,59 @@ packages:
       - PackageKit
       - PackageKit-command-not-found
 
+  # ── Wahoo (Fedora ELN) ─────────────────────────────────────────────────
+  # ELN defines the `kde-desktop` group (86 entries, eln-extras) and ships
+  # Plasma 6.7.4 — plasma-desktop, plasma-workspace, kwin, kscreen,
+  # plasma-nm — plus sddm 0.21.0 and dolphin/konsole/kate at 26.08. So the
+  # group install this section leans on resolves, unlike xfce-desktop,
+  # which ELN does not define at all (#2052).
+  #
+  # Measured with `dnf repoquery` against the pinned eln-bootc digest on
+  # 2026-08-26: 16 of 23 explicit packages present. The seven misses are
+  # all peripheral input / security-key extras — none is needed for a
+  # session to start — so they go under optional: rather than blocking the
+  # flavor. Listing them strictly would fail the build over a fingerprint
+  # helper; dropping them silently would be the #1555 shape. Neither.
+  #
+  # Note for whoever reads a Gate failure here first: the group makes
+  # `plasma-login-manager` mandatory (Plasma 6.7 ships its own), while
+  # this manifest also installs sddm and declares display_manager: sddm.
+  # Both packages resolve. If the session comes up on the wrong greeter,
+  # that is the thing to look at, and it is an ELN/Plasma-6.7 signal
+  # worth reporting upstream rather than a tunaOS packaging bug.
+  eln:
+    groups:
+      - kde-desktop
+    packages:
+      - sddm
+      - dolphin
+      - konsole
+      - kate
+      - ark
+      - plasma-discover
+      - kde-connect
+      - xdg-desktop-portal-kde
+      - qt5-qtwayland
+      - qt6-qtwayland
+      - ksshaskpass
+      - ksystemlog
+      - tesseract
+      - pam-u2f
+      - pam_yubico
+      - nvtop
+    # Absent from ELN on 2026-08-26 — peripheral input/security-key extras.
+    # Best-effort so they land by themselves when the compose grows them.
+    optional:
+      - input-remapper
+      - evtest
+      - libratbag-ratbagd
+      - solaar-udev
+      - openrgb-udev-rules
+      - pamu2fcfg
+      - yubikey-manager
+    exclude:
+      - PackageKit
+      - PackageKit-command-not-found
   # ── DNF: EL10 (AlmaLinux, CentOS Stream, RHEL) ────────────────────
   el10:
     groups:

--- a/tests/test_matrix_status.py
+++ b/tests/test_matrix_status.py
@@ -332,7 +332,7 @@ class UndeclaredCellsAreNotCountedAgainstUs(unittest.TestCase):
             gms.VOLATILE_LINE,
         )
 
-    def test_the_real_build_config_declares_51_luks_cells(self):
+    def test_the_real_build_config_declares_53_luks_cells(self):
         """Ties the unit tests above to the actual denominator on disk.
 
         If this number moves, the LUKS total moves with it, and that should be
@@ -353,13 +353,24 @@ class UndeclaredCellsAreNotCountedAgainstUs(unittest.TestCase):
         those two cells were counted as owed and could never be paid, and
         while they failed beside gnome they also skipped gnome's ISO
         (tuna-os/tunaOS#2059). Re-declaring either flavor puts its cell back.
+
+        51 -> 53 on 2026-08-26: wahoo declares cosmic and kde. Both were
+        repodata-measured against the pinned eln-bootc digest before the rows
+        were added -- COSMIC 1.6.0 from eln-extras at 23/24 packages, Plasma
+        6.7.4 via the eln-extras `kde-desktop` group at 16/23 explicit
+        packages -- which is the distinction the hummingbird drop above draws:
+        a cell is only honest when a package set exists to pay it. Niri and
+        XFCE stay undeclared for exactly that reason (ELN ships one package of
+        the Niri stack and zero `xfce*`), so they add nothing here.
         """
         matrix = gms.luks_matrix()
-        self.assertEqual(sum(len(v) for v in matrix.values()), 51)
+        self.assertEqual(sum(len(v) for v in matrix.values()), 53)
         # The control that makes the drop specific rather than merely smaller:
         # hummingbird keeps exactly the desktops it has package sets for.
         self.assertEqual(matrix.get("hummingbird"), {"gnome", "cosmic"})
-        self.assertEqual(matrix.get("wahoo"), {"gnome"})
+        # wahoo carries exactly the desktops ELN composes -- and notably NOT
+        # niri or xfce, which is what keeps this an honest denominator.
+        self.assertEqual(matrix.get("wahoo"), {"gnome", "cosmic", "kde"})
         self.assertNotIn("cosmic", matrix.get("flounder", set()))
         self.assertNotIn("cosmic", matrix.get("flounder-sid", set()))
         # A control: the flavours flounder DOES declare are still there, so


### PR DESCRIPTION
Follows [#2042](https://github.com/tuna-os/tunaOS/pull/2042) (base + gnome). The four remaining desktops were measured in [#2048](https://github.com/tuna-os/tunaOS/issues/2048); **two need no new packages at all**, so they land here. The other two stay filed rather than declared.

## Measured, then actually depsolved

`dnf repoquery` against the pinned `eln-bootc` digest, 2026-08-26:

| flavor | packages | source |
|---|---|---|
| `cosmic` | **23/24** | COSMIC **1.6.0**, `eln-extras` |
| `kde` | **16/23** + the `kde-desktop` group (86 entries) | Plasma **6.7.4**, `eln-extras` |

Then — because "the names resolve" is weaker evidence than it looks — I ran a real `dnf install` of each new section against live ELN repos:

```
===== cosmic: depsolve test =====
  packages OK (23 names)
===== kde: depsolve test =====
  group OK: kde-desktop
  packages OK (16 names)
```

Both transactions resolved clean. That is a stronger check than the GNOME section shipped with.

## The COSMIC result is worth more than the flavor

`cosmic.el10` sources COSMIC from COPR `yselkowitz/cosmic-epel` (**twice**) and `fprintd` from `https://repo.tunaos.org/fprintd/10-stream-aarch64/` — both tier-3 migration inventory under [PACKAGE-SOURCING.md](../blob/main/PACKAGE-SOURCING.md).

On ELN **neither is needed**. The compose carries `cosmic-session`/`comp`/`panel`/`files`/`greeter`/`settings` and `xdg-desktop-portal-cosmic` natively, and `fprintd-1.94.5-6.eln158` resolves from `eln-appstream` — so even the aarch64 fprintd gap that pinned cosmic off arm64 on EL10 ([#732](https://github.com/tuna-os/tunaOS/issues/732)) does not reproduce here.

If EL11 keeps this, **that COPR dependency retires itself at the EL10 → EL11 transition** rather than needing a Tideforge migration. That is exactly the class of early signal the preview lane exists to produce, and it showed up before the lane has even booted.

Neither new section declares a `copr:` block. ELN needs none, and a new one would fail `scripts/check-package-sources.py` — correctly.

## Misses go under `optional:`, not into the bin

- **cosmic**: `cosmic-wallpapers`
- **kde**: `evtest`, `input-remapper`, `libratbag-ratbagd`, `openrgb-udev-rules`, `pamu2fcfg`, `solaar-udev`, `yubikey-manager`

All seven KDE ones are peripheral input / security-key extras — none is needed for a session to start. Listing them strictly would fail a build over a fingerprint helper; dropping them silently would be the [#1555](https://github.com/tuna-os/tunaOS/issues/1555) shape, where a `--skip-unavailable` shipped ten nightlies with no tailscale. `optional:` is neither: they install themselves the week ELN grows them, with no edit here.

## Niri and XFCE are deliberately absent

ELN ships **one** package of the Niri stack (`swaybg`) and **zero** `xfce*` packages. Adding either row would be [#858](https://github.com/tuna-os/tunaOS/issues/858) — an image tagged for a desktop that contains no desktop. They need packages built first: [#2051](https://github.com/tuna-os/tunaOS/issues/2051), [#2052](https://github.com/tuna-os/tunaOS/issues/2052), and issues now filed in `tunaos-packages`.

## LUKS denominator 51 → 53

Recorded in the test with its reasoning. This is the same distinction the `53 → 51` hummingbird drop directly above it drew: **a cell is only honest when a package set exists to pay it.** Hummingbird's kde/niri came out because they had 0 packages; wahoo's cosmic/kde go in because they have measured, depsolving ones.

The test now also asserts `matrix["wahoo"] == {"gnome", "cosmic", "kde"}`, so the absence of niri and xfce is pinned rather than incidental — re-declaring either puts its cell back and trips the assertion.

## One thing left for whoever reads a Gate failure first

Noted in `kde.yaml`: the `kde-desktop` group makes `plasma-login-manager` mandatory (Plasma 6.7 ships its own) while this manifest also installs `sddm` and declares `display_manager: sddm`. Both packages resolve. If a session ever comes up on the wrong greeter, that is the thing to look at — and it would be an ELN/Plasma-6.7 signal worth reporting upstream, not a tunaOS packaging bug.

## Testing

`pytest tests/` — **897 passed, 2 skipped**.

Not claimed: neither new flavor has been built in CI or booted. `Gate` is skipped on a dispatch, same as the existing wahoo flavors. A `build-wahoo.yml` dispatch after merge is what turns these into build evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvHdxf4BacZVvvMG35qkVG)_