### PR TITLE
fix(test): assert the session bus by behaviour, not by a spelling that moved

### DIFF
--- a/tests/bats/test_customize_live.bats
+++ b/tests/bats/test_customize_live.bats
@@ -85,7 +85,16 @@ detect() {
 
 @test "customize-live.sh: gives headless Flatpak an explicit session bus" {
   grep -q 'DBUS_SESSION_BUS_ADDRESS' "${SCRIPT}"
-  grep -q 'dbus-daemon --session' "${SCRIPT}"
+  # Assert the behaviour, not the spelling. This used to grep for the literal
+  # `dbus-daemon --session`, which the script no longer contains: the call was
+  # refactored into the _start_bus helper when dbus-broker images made the bare
+  # binary unsafe to assume (every cosmic flavor plus sailfin/grouper/guppy/
+  # marlin died with "dbus-daemon: command not found", exit 127). The session
+  # bus is still started, and still with --session — only contiguously no
+  # longer. The stale assertion failed on every PR in the repo, not just the
+  # ones touching live-iso, because Unit Tests runs the whole bats suite.
+  grep -q 'dbus-daemon "$@"' "${SCRIPT}"
+  grep -qE '_start_bus [^|]*--session' "${SCRIPT}"
 }
 
 @test "customize-live.sh: initializes D-Bus identity before Flatpak installation" {


### PR DESCRIPTION
**The `Unit Tests` gate is red on main, and this is the only thing holding it there.**

`tests/bats/test_customize_live.bats` test 10 greps `customize-live.sh` for the contiguous literal `dbus-daemon --session`. That string is no longer in the script, so the test fails — on main, on every open PR, and on anything touching any file at all, because `Unit Tests` runs the whole bats suite.

```
not ok 10 customize-live.sh: gives headless Flatpak an explicit session bus
# (in test file tests/bats/test_customize_live.bats, line 88)
#   `grep -q 'dbus-daemon --session' "${SCRIPT}"' failed
```

## The script is right; the test is stale

The literal went away when the bare binary stopped being safe to assume. The script's own comment records why:

> Modern desktop images ship dbus-broker as the bus implementation and no longer pull in the classic `dbus-daemon` binary … every cosmic flavor plus sailfin/grouper/guppy/marlin died here with "dbus-daemon: command not found" (exit 127)

The call moved into a helper, and the behaviour the test **names** is fully intact:

```bash
_start_bus() {
    local _pidfile="$1"; shift
    _live_bus_pidfiles+=("$_pidfile")
    dbus-daemon "$@" --fork --pidfile="$_pidfile" >/dev/null 2>&1
}
...
_start_bus /tmp/live-session-bus.pid --session --address="unix:path=${SESSION_BUS_SOCK}"
export DBUS_SESSION_BUS_ADDRESS="unix:path=${SESSION_BUS_SOCK}"
```

Headless Flatpak still gets an explicit session bus, still via `dbus-daemon`, still with `--session`. Only the spelling stopped being contiguous.

So this asserts the two halves that actually carry the behaviour — the helper execs `dbus-daemon`, and the session bus is started through it with `--session` — instead of one string any refactor can break without changing what the script does. The `DBUS_SESSION_BUS_ADDRESS` assertion above it is untouched.

## Evidence

A/B against pristine `origin/main` in a worktree, same machine, same tools (mikefarah `yq` and `shellcheck` on PATH so the environmental noise is identical):

| | failing bats tests |
|---|---:|
| `origin/main` | **11** |
| this branch | **10** |
| difference | only `customize-live.sh: gives headless Flatpak an explicit session bus` |

Nothing else moved. The other 10 are pre-existing and environmental in this sandbox (root-check tests that assume a non-root user, e2e stub harnesses); they fail identically on main and are not this change's business.

Also ran the five pytest modules that read `customize-live.sh` — **24 passed**.

## Provenance

Found while diagnosing [#2103](https://github.com/tuna-os/tunaOS/pull/2103), whose `Unit Tests` job this was failing. Kept out of that PR deliberately: it is unrelated to a variant change and would have muddied review. The full diagnosis is in [this comment](https://github.com/tuna-os/tunaOS/pull/2103#issuecomment-5433837838).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvHdxf4BacZVvvMG35qkVG)_