### PR TITLE
fix(overlay): recompile glib schemas and dconf databases in desktop stage

### DIFF
--- a/Containerfile.overlay
+++ b/Containerfile.overlay
@@ -144,11 +144,16 @@ RUN --mount=type=tmpfs,dst=/tmp \
     --mount=type=bind,from=context,source=/,target=/run/context \
     /run/context/build_scripts/00-copy-files.sh
 
-# The published base may predate 90-image-info.sh (identity/logo/image-info),
-# so re-run it on the overlay to guarantee the branding contract passes
-# regardless of base freshness.
 RUN --mount=type=bind,from=context,source=/,target=/run/context \
     /run/context/build_scripts/90-image-info.sh
+
+# Recompile glib schemas and dconf databases: 00-copy-files.sh refreshes system_files
+# and package transactions during the overlay (e.g. nvidia/hwe drivers) may lay down
+# gschema overrides or dconf keyfiles (e.g. /etc/dconf/db/gdm.d). Without recompiling,
+# GDM and GNOME services ignore the keyfiles at runtime and verify-desktop-experience
+# / verify-branding fail on uncompiled databases (#1751, #1820).
+RUN if command -v glib-compile-schemas >/dev/null 2>&1; then glib-compile-schemas /usr/share/glib-2.0/schemas; fi && \
+    if command -v dconf >/dev/null 2>&1 && compgen -G "/etc/dconf/db/*.d/*" >/dev/null 2>&1; then dconf update || true; fi
 
 RUN dnf versionlock add glib2 2>/dev/null || true
 RUN rm -rf /opt && ln -s /var/opt /opt

--- a/tests/bats/test_overlay_refreshes_system_files.bats
+++ b/tests/bats/test_overlay_refreshes_system_files.bats
@@ -82,3 +82,12 @@ desktop_stage() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"exit 1"* ]]
 }
+
+@test "the overlay desktop stage recompiles glib schemas and dconf databases" {
+  # Without this, overlay-added keyfiles in /etc/dconf/db/*.d (e.g. gdm.d) are
+  # uncompiled, causing GDM/GNOME runtime contract failures (#1751, #1820).
+  run desktop_stage
+  [[ "$output" == *"glib-compile-schemas"* ]]
+  [[ "$output" == *"dconf update"* ]]
+}
+


### PR DESCRIPTION
## Summary
Fixes the boot Gate timeout / missing contract marker failure on layered overlay desktop images (e.g. `albacore:gnome-nvidia-hwe`).

### Root Cause
Overlay stages (`Containerfile.overlay`, including HWE and NVIDIA layers) build on top of published parent desktop images without re-running the full DE installation. When `00-copy-files.sh` refreshes system files or package transactions introduce new/updated keyfiles (such as `/etc/dconf/db/gdm.d` or `/usr/share/glib-2.0/schemas`), the compiled dconf database (`/etc/dconf/db/gdm`) and glib schemas were left uncompiled.

At runtime, GDM and GNOME services fail or ignore the uncompiled configuration, causing the desktop contract check in `verify-desktop-experience.sh` and `verify-branding.sh` to fail and preventing the boot gate marker from being emitted.

### Changes
- Recompile glib schemas (`glib-compile-schemas /usr/share/glib-2.0/schemas`) and dconf databases (`dconf update`) in the desktop stage of `Containerfile.overlay`.
- Added unit test in `tests/bats/test_overlay_refreshes_system_files.bats` to ensure the overlay desktop stage always runs schema and dconf recompilation.

Closes #1751, #1820.

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `69b09dd0`