### PR TITLE
fix(ci): exclude undeclared Asahi flavors from scheduled verify sweep

### DIFF
--- a/.github/workflows/verify-asahi.yml
+++ b/.github/workflows/verify-asahi.yml
@@ -35,8 +35,10 @@ permissions:
   packages: read
 
 jobs:
-  # Sweep mode: every flavor that publishes a :gnome-asahi tag.
-  # guppy is intentionally absent — its asahi overlay is stubbed, not broken.
+  # Sweep mode: every flavor that declares and publishes a :gnome-asahi tag.
+  # marlin and flounder are excluded as their gnome-asahi flavors are not declared in
+  # build-config.yml until complete distro Asahi stacks are available (tunaOS#911, #1738).
+  # guppy is absent as its asahi overlay is stubbed, not broken.
   sweep:
     # Explicit on the schedule path: a `schedule` event has no `inputs` context
     # at all, and relying on null == '' to pick the sweep is exactly how you get
@@ -52,8 +54,6 @@ jobs:
           - albacore
           - yellowfin
           - sailfin
-          - flounder
-          - marlin
           - skipjack
     uses: ./.github/workflows/verify-asahi-one.yml
     with:


### PR DESCRIPTION
## Summary
Fixes the persistent failure of the scheduled `Verify Asahi image` daily workflow sweep (#1738).

### Root Cause
`marlin:gnome-asahi` and `flounder:gnome-asahi` are not declared flavors in `.github/build-config.yml` (per tunaOS#911) because their base distributions lack complete upstream Asahi kernel/DTB/module stacks. Consequently, their tags are either unpromoted or stale non-Asahi images. Including them in the daily `.github/workflows/verify-asahi.yml` sweep matrix caused the workflow to permanently fail every day, obscuring regressions in active, supported variants.

### Changes
- Updated the sweep matrix in `.github/workflows/verify-asahi.yml` to only sweep variants that actually declare `gnome-asahi` (`bonito`, `grouper`, `albacore`, `yellowfin`, `sailfin`, `skipjack`), matching `build-config.yml`.

Closes #1738.

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `05b57c10`