### PR TITLE
docs: add wootc as an option for people moving from Windows

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration Guide — Moving to tunaOS
 
-This guide helps you migrate to tunaOS from other Linux distributions.
+This guide helps you migrate to tunaOS from Windows or other Linux distributions.
 
 ## Overview
 
@@ -150,6 +150,28 @@ Vanilla OS 2 (Orchid) uses ABRoot, not rpm-ostree. Direct migration is not suppo
 ### Endless OS
 
 Endless OS uses OSTree but with a different deployment model. Migration is not tested or supported.
+
+---
+
+## From Windows (wootc)
+
+If you are currently running Windows (Windows 10 or 11), you can migrate to TunaOS directly using **[wootc](https://github.com/tuna-os/wootc)** without needing to burn a USB flash drive or repartition your drive in advance.
+
+wootc is a Windows installer application for TunaOS:
+- **No USB stick required**: Runs directly within Windows and prepares a bootable environment.
+- **Safe alongside Windows**: Installs to a loop root disk (`root.disk`) on your existing drive while keeping Windows intact in the UEFI boot menu. BitLocker partitions remain safe.
+- **Migration assistance**: Can import Wi-Fi networks, wallpaper, browser profiles, keyboard layouts, WSL configurations, and user documents.
+- **Full TunaOS catalog**: Choose from GNOME, KDE Plasma, COSMIC, Niri, or XFCE editions across supported TunaOS bases.
+- **Honest rollback / uninstall**: Uninstall cleanly from Windows Settings / Add or Remove Programs, leaving no residual partition state.
+
+### Getting Started with wootc
+
+1. Download the latest installer from the [wootc releases page](https://github.com/tuna-os/wootc/releases) (e.g. `tunaos-installer.exe`).
+2. Run the installer in Windows with administrator privileges.
+3. Select your desired TunaOS desktop environment and variant, configure username and password, and allocate disk space.
+4. Reboot your system and select TunaOS from the boot menu to complete setup.
+
+For detailed instructions, refer to the [wootc Getting Started Guide](https://github.com/tuna-os/wootc/blob/main/docs/getting-started.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ _Generated from the latest conclusive main-branch build for each variant (cancel
 ## Get started
 
 - **Install from an ISO:** [📦 tunaos.org/download](https://tunaos.org/download)
+- **Install from Windows (no USB drive needed):** [🪟 wootc installer](https://github.com/tuna-os/wootc) (download from [releases](https://github.com/tuna-os/wootc/releases) / read the [Migration Guide](MIGRATION.md#from-windows-wootc))
 - **Build your own ISO in the browser:** [🛠️ tunaos.org/iso-builder](https://tunaos.org/iso-builder)
 - **Switch an existing bootc system:**
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -11,6 +11,14 @@ Browse the currently published installation media on the download page:
 
 **[📦 tunaos.org/download](https://tunaos.org/download)**
 
+## Install from Windows (wootc)
+
+If you are coming from Windows, you can install TunaOS directly using **[wootc](https://github.com/tuna-os/wootc)** without writing an ISO to a USB flash drive or repartitioning your disk.
+
+- Download the installer from the [wootc releases](https://github.com/tuna-os/wootc/releases)
+- Run `tunaos-installer.exe` as Administrator, select your desktop and variant, and reboot into TunaOS
+- See the [Migration Guide (From Windows)](../MIGRATION.md#from-windows-wootc) and [wootc documentation](https://github.com/tuna-os/wootc) for full details
+
 ## Build your own ISO or VM image
 
 **In your browser — no tools, no root, nothing uploaded:**

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -136,6 +136,10 @@ just qcow2 ghcr.io/tuna-os/bonito:kde     # produces bonito.qcow2
 just run-qcow2 bonito kde                  # boots it under QEMU
 ```
 
+### Option D — from Windows (wootc)
+
+Moving from Windows 10/11? You can install TunaOS directly without flashing a USB drive using **[wootc](https://github.com/tuna-os/wootc)** (the Windows bootc installer). Download `tunaos-installer.exe` from [wootc releases](https://github.com/tuna-os/wootc/releases), select your desktop, and reboot. See [MIGRATION.md](../MIGRATION.md#from-windows-wootc) for full details.
+
 ## 4. Day-2 administration
 
 This section mirrors Bluefin's


### PR DESCRIPTION
This PR documents **[wootc](https://github.com/tuna-os/wootc)** across the repository documentation as a direct method for Windows users to move to TunaOS without needing to flash a USB drive or repartition beforehand.

### Summary of Changes
- **[MIGRATION.md](file:///home/dev/workspace/tuna-os/tunaos/MIGRATION.md)**: Updated intro to include Windows and added a dedicated `## From Windows (wootc)` section explaining what wootc offers and step-by-step instructions.
- **[README.md](file:///home/dev/workspace/tuna-os/tunaos/README.md)**: Added entry in the `## Get started` section for installing directly from Windows via wootc.
- **[docs/INSTALL.md](file:///home/dev/workspace/tuna-os/tunaos/docs/INSTALL.md)**: Added `## Install from Windows (wootc)` section linking to releases and documentation.
- **[docs/USER-GUIDE.md](file:///home/dev/workspace/tuna-os/tunaos/docs/USER-GUIDE.md)**: Added `### Option D — from Windows (wootc)` in the Installation options list.

Closes #1958

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `d9fee0c6`