### PR TITLE
fix(bonito): repin garbage-collected Fedora 44 bootc base digest

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -681,7 +681,7 @@ variants:
   - id: bonito
     emoji: "🎣"
     description: "Based on Fedora 44"
-    base_image: "quay.io/fedora/fedora-bootc:44@sha256:f51e9dca468f0c9d4b2f534d576818d2c4be8bfe225e1eb887ff10101082ecf3"
+    base_image: "quay.io/fedora/fedora-bootc:44@sha256:e91da1afe4026c2c830241557fd5bd40c165bad45cb6f9a89fc0db00ec749d6e"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [fedora]
     akmods: "ublue-os"


### PR DESCRIPTION
Part of #272
Fixes #2112

## Problem
Bonito base builds fail because the previous Fedora 44 bootc digest pinned in `.github/build-config.yml` (`sha256:f51e9dca468f0c9d4b2f534d576818d2c4be8bfe225e1eb887ff10101082ecf3`) was garbage-collected upstream and no longer resolves on `quay.io`.

## Solution
Repinned Bonito's `base_image` to the current multi-architecture manifest list digest:
`quay.io/fedora/fedora-bootc:44@sha256:e91da1afe4026c2c830241557fd5bd40c165bad45cb6f9a89fc0db00ec749d6e`

## Registry Evidence
Multi-arch index:
- Index digest: `sha256:e91da1afe4026c2c830241557fd5bd40c165bad45cb6f9a89fc0db00ec749d6e` (HTTP 200)

Declared platforms:
- `linux/amd64`: `sha256:5d535a64ea7c444c0f0a2549245c8813c1c5aa41e90a6b8fdac2003c41224054` (HTTP 200)
- `linux/arm64`: `sha256:091a6b04c7a2a1666bd2d0105df7759e3e7bd8117ae12de2f156106f114ef9ba` (HTTP 200)

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `93160771`