### PR TITLE
fix(desktop): decouple Debian XFCE from sid GNOME

### DIFF
--- a/manifests/desktops/gnome-debian.yaml
+++ b/manifests/desktops/gnome-debian.yaml
@@ -13,7 +13,8 @@ packages:
     - gnome-core
     - gnome-disk-utility
     - gnome-system-monitor
-    - gnome-shell-extension-manager
+    # Optional during sid's GNOME 50→51 transition: libgjs0 can advance
+    # before gnome-shell, making this extension manager unsatisfiable.
     - nautilus
     - xdg-desktop-portal-gnome
     - xdg-desktop-portal-gtk

--- a/manifests/desktops/xfce-debian.yaml
+++ b/manifests/desktops/xfce-debian.yaml
@@ -1,0 +1,18 @@
+# XFCE Desktop Manifest — Debian override.
+#
+# Debian sid's gdm3 pulls the GNOME stack. During the GNOME 50→51
+# transition, sid's libgjs0 explicitly Breaks the available gnome-shell,
+# which makes an otherwise independent XFCE build impossible to resolve.
+# XFCE does not require GNOME or gdm3, so use LightDM on Debian bases.
+
+display_manager: lightdm
+
+packages:
+  apt:
+    - xfce4
+    - xfce4-goodies
+    - lightdm
+    - lightdm-gtk-greeter
+    - xdg-desktop-portal-gtk
+    - thunar
+    - mousepad

--- a/tests/bats/test_flounder_sid_desktops.bats
+++ b/tests/bats/test_flounder_sid_desktops.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+
+@test "Debian XFCE override avoids the sid GNOME dependency" {
+  local manifest="$REPO_ROOT/manifests/desktops/xfce-debian.yaml"
+  [ -f "$manifest" ]
+  grep -q '^display_manager: lightdm$' "$manifest"
+  grep -q '^    - lightdm$' "$manifest"
+  grep -q '^    - lightdm-gtk-greeter$' "$manifest"
+  ! grep -q 'gdm3\|gnome-shell' "$manifest"
+}
+
+@test "Debian GNOME manifest keeps the extension manager optional to the transition" {
+  local manifest="$REPO_ROOT/manifests/desktops/gnome-debian.yaml"
+  # gnome-core remains the supported GNOME baseline; this assertion documents
+  # that the extension manager is the optional package that must not reintroduce
+  # a second libgjs/gnome-shell transaction during sid's transition.
+  ! grep -q '^    - gnome-shell-extension-manager$' "$manifest"
+}


### PR DESCRIPTION
Closes #1833

Debian sid's GNOME 50→51 transition can leave `libgjs0` ahead of `gnome-shell`. Keep the GNOME extension manager out of the Debian manifest's required transaction while the archive converges, and add a Debian-specific XFCE manifest that uses LightDM instead of pulling `gdm3` and the GNOME stack. This lets XFCE remain buildable independently of the transition while preserving the GNOME baseline.

Added a Bats contract covering the Debian XFCE override and the optional GNOME extension-manager package. Validation: shell syntax, manifest assertions, and `git diff --check`.

— hive: backend=pi model=openai-codex/gpt-5.6-luna
---
🐝 **Hive Agent**: `contributor` | **SHA:** `78798e13`