### PR TITLE
chore: add ACMM L0/L2/L3 prerequisite files

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -1,0 +1,6 @@
+# Cursor rules
+
+This project's agent instructions live in [`AGENTS.md`](../AGENTS.md) and
+the authoritative guide it points to, [`docs/AGENT_GUIDE.md`](../docs/AGENT_GUIDE.md).
+Read those before making changes — this file just points Cursor at them so
+the instructions aren't duplicated (and can't drift) across tools.

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{sh,bash}]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[Containerfile*]
+indent_style = space
+indent_size = 4

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Testing
+
+<!-- `just fix && just check` and `just test` are run in CI, but note here
+     what you ran locally, and any manual build/boot verification. -->
+
+## Related issues
+
+<!-- Closes #... -->

--- a/.memory/README.md
+++ b/.memory/README.md
@@ -1,0 +1,9 @@
+# Correction capture
+
+If a human corrects something an agent got wrong on this repo — a wrong
+assumption about a variant's behavior, a build convention, a gotcha — write
+it down here as a short, dated entry rather than letting it evaporate at the
+end of the session. `AGENTS.md` already collects the durable, high-value
+lessons (see its "Know your base before reasoning about its packages"
+section for the model); this directory is for the smaller, in-progress
+corrections that haven't been promoted there yet.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# CLAUDE.md
+
+This file exists so Claude Code picks up project instructions automatically.
+The actual agent instructions live in [`AGENTS.md`](AGENTS.md) — read that
+file (and the authoritative guide it points to,
+[`docs/AGENT_GUIDE.md`](docs/AGENT_GUIDE.md)) before making changes here.
+
+Keeping one instruction set instead of two avoids the files drifting apart.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 45%
+        threshold: 2%
+    patch:
+      default:
+        target: 70%
+        informational: true
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,22 @@
+# PR / build metrics
+
+**Status: not yet implemented.** This file exists so the intent is written
+down honestly rather than fabricated — there is no metrics pipeline here
+today.
+
+## What already exists
+
+- [`.github/green-criteria.yml`](../.github/green-criteria.yml) tracks
+  per-criterion status snapshots over time (`status_<date>` fields), which
+  is the closest thing to a trend line TunaOS has right now — see
+  `docs/quality.md`.
+- `.github/workflows/matrix-status.yml` and `weekly-boot-report.yml`
+  produce point-in-time build/boot reports.
+
+## What's missing
+
+A real PR-acceptance metric (time-to-merge, revert rate, CI-failure rate by
+category) would need a script that reads the GitHub API on a schedule and
+writes a report — none of that exists yet. If this becomes worth building,
+model it on `scripts/gen-matrix-status.py`, which already does the
+equivalent aggregation for build status.

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -1,0 +1,23 @@
+# Quality dashboard
+
+TunaOS doesn't have a separate quality dashboard app — the quality signal
+lives in [`.github/green-criteria.yml`](../.github/green-criteria.yml)
+(prose companion: [`docs/GREEN-CRITERIA.md`](GREEN-CRITERIA.md)), which is
+the source of truth for what "green" means for a given (variant, flavor)
+cell, kept honest by `tests/test_green_criteria.py`.
+
+Each criterion in that file records:
+
+- `enforcement` — `blocking` (a cell cannot be green without it), `advisory`
+  (measured and reported, not yet blocking), or `unimplemented` (no
+  automated assertion exists yet).
+- a `status_<date>` history, so progress since the bar was raised
+  (`raised_on: 2026-08-17`) is measurable rather than remembered.
+- which workflow actually asserts it (`asserted_by`), so a criterion always
+  traces back to a real, runnable check rather than an aspiration.
+
+The composite rule that makes the list mean something: a cell is green only
+if every blocking criterion has an affirmative, *current* result — never
+tested, skipped, or stale evidence does not count as satisfied. See
+`.claude/skills/check-green-criteria/SKILL.md` for how to read it when
+investigating a specific cell.

--- a/docs/review-rubric.md
+++ b/docs/review-rubric.md
@@ -1,0 +1,24 @@
+# PR review rubric
+
+What a reviewer (human or agent) checks before approving a PR here, beyond
+"CI is green":
+
+1. **Checks actually ran, and ran on the real change.** `just fix && just
+   check` and `just test` are mandatory per `CONTRIBUTING.md` — verify the
+   PR's CI ran them on the current head, not a stale commit.
+2. **Green-criteria impact.** If the change touches build, desktop, or boot
+   behavior, check whether it moves any cell's status in
+   `.github/green-criteria.yml` — a PR that silently regresses a
+   `blocking` criterion (see `docs/quality.md`) needs that called out
+   explicitly, not discovered later in a nightly sweep.
+3. **Scope matches the issue.** The smallest change that satisfies the
+   linked issue's acceptance criteria, per `CONTRIBUTING.md`'s fork→PR loop
+   — flag unrelated changes bundled into the same PR.
+4. **Known landmines.** Check the PR against `AGENTS.md`'s documented
+   gotchas (e.g. "know your base before reasoning about its packages") —
+   a fix that looks right in isolation can still repeat a mistake that's
+   already been made and recorded once.
+5. **CI failures are diagnosed, not silenced.** A failing check should come
+   with either a fix or a clear explanation of why it's unrelated
+   (pre-existing, infra) — never a skip, disable, or retry-until-green with
+   no root cause.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,2 @@
+target-version = "py311"
+line-length = 100

--- a/skills/check-green-criteria/SKILL.md
+++ b/skills/check-green-criteria/SKILL.md
@@ -1,0 +1,28 @@
+# Check green criteria
+
+Use this when asked whether a (variant, flavor) cell is actually green, or
+why it isn't — "green" here means something specific, defined in
+[`.github/green-criteria.yml`](../../.github/green-criteria.yml) (prose
+companion: [`docs/GREEN-CRITERIA.md`](../../docs/GREEN-CRITERIA.md)).
+
+## Steps
+
+1. Read `.github/green-criteria.yml` — each criterion records its
+   `enforcement` (`blocking`, `advisory`, or `unimplemented`) and a
+   `status_<date>` history. A criterion whose result is skipped, never
+   tested, or stale does **not** count as satisfied (`rule.never_tested_is_not_green`
+   etc.) — don't treat silence as a pass.
+2. Check `scope` blocks under criteria like `boots` and `parity` — a cell
+   outside a criterion's scope isn't judged on it at all; that's a reviewed
+   exclusion, not a gap.
+3. Cross-reference against `tests/test_green_criteria.py`, which is what
+   actually keeps this file honest — if the two disagree, the test is
+   usually right and the YAML needs updating, not the other way round.
+4. For a specific cell's live status, check the workflow named in that
+   criterion's `asserted_by` field (e.g. `desktop-contract-sweep.yml` for
+   `desktop`, `reusable-build-image.yml`'s Gate job for `boots`).
+
+Never report a cell "green" from a "builds and promotes" result alone —
+that's the weakest claim the pipeline can make (see the file's own header
+comment for why: `tunaOS#858`, an image that shipped with no desktop at
+all).

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,16 @@
+# End-to-end tests
+
+This directory is a pointer, not a new test suite — tunaOS already has
+substantial E2E coverage, just not under this path:
+
+- [`.github/workflows/iso-e2e.yml`](../../.github/workflows/iso-e2e.yml) +
+  [`scripts/iso-e2e.sh`](../../scripts/iso-e2e.sh) — boots the live ISO under
+  QEMU and asserts the installer frontend actually appears.
+- [`.github/workflows/luks-e2e.yml`](../../.github/workflows/luks-e2e.yml) —
+  drives fisherman over SSH through a full disk install (including the
+  encrypted path) and asserts the resulting system boots.
+- [`.github/workflows/bootc-lifecycle.yml`](../../.github/workflows/bootc-lifecycle.yml) —
+  update/rebase/rollback against a deployed system.
+
+See [`.github/green-criteria.yml`](../../.github/green-criteria.yml) for how
+these feed into what "green" means for a given (variant, flavor) cell.


### PR DESCRIPTION
## Summary

Adds the ACMM file-existence prerequisites that are genuinely missing and don't conflict with this repo's own conventions.

- **`ruff.toml`** (#2198, Code style config) — this repo's real Python surface is substantial (93 files under `scripts/`, `tests/`, `.github/scripts/`). Verified with `ruff check` — loads and runs cleanly (229 pre-existing findings surfaced, none of which this PR touches).
- **`codecov.yml`** (#2200, Coverage gate) — same pattern already used at `tuna-os/bootc-installer`; patch coverage `informational: true` so it can't fail CI on its own.
- **`.github/pull_request_template.md`** (#2196, PR template).
- **`CLAUDE.md`** (#2201) and **`.cursor/rules`** (#2204) — both are short pointers at `AGENTS.md`/`docs/AGENT_GUIDE.md` rather than duplicated content, so the instructions can't drift into three different versions of the truth.
- **`.editorconfig`** (#2206, EditorConfig) — indent conventions read from the actual codebase (4-space Python, 2-space shell/YAML).
- **`tests/e2e/README.md`** (#2194, E2E tests) — this repo already has real E2E coverage (`iso-e2e.yml`, `luks-e2e.yml`, `bootc-lifecycle.yml`) under different paths; this points at it rather than adding a redundant/fake Playwright config.
- **`docs/quality.md`** (#2211, Quality dashboard) and **`docs/review-rubric.md`** (#2210, PR review rubric) — both ground the criterion in infrastructure that already exists (`.github/green-criteria.yml` + `docs/GREEN-CRITERIA.md`, and `CONTRIBUTING.md`'s fork→PR loop) rather than inventing a parallel system.
- **`docs/metrics.md`** (#2209, PR acceptance metric) — states honestly that no metrics pipeline exists yet, rather than fabricating one.

### Worth flagging: `.claude/` is gitignored here

This repo's `.gitignore` explicitly excludes `.claude/` with the comment *"Local tooling / agent state (not project content)"* — a deliberate policy. Several ACMM criteria only accept paths under `.claude/`:

- **#2207 (Simple skills)** — used the criterion's non-`.claude/` alternative instead: `skills/check-green-criteria/SKILL.md`.
- **#2208 (Correction capture)** — used `.memory/README.md` instead of `.claude/memory/`.
- **#2215 (Session summary artifact)** and **#2213/#2214/#2216 (`.claude/settings.json`-based criteria)** — **left open, not touched here.** Their accepted-path lists are `.claude/`-only with no alternative, so satisfying them means fighting this repo's own gitignore policy. `.claude/settings.json` also has real operational meaning for Claude Code (permissions/hooks) — not something to fabricate just to satisfy a file-existence check. This is a genuine conflict between the ACMM criteria and this repo's conventions, worth a maintainer decision rather than an automated one.

Closes #2194
Closes #2196
Closes #2198
Closes #2200
Closes #2201
Closes #2204
Closes #2206
Closes #2207
Closes #2208
Closes #2209
Closes #2210
Closes #2211

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx)_