### PR TITLE
ci: wrap org-level reusable PR reminders workflow

### DIFF
--- a/.github/workflows/pr-nudges.yml
+++ b/.github/workflows/pr-nudges.yml
@@ -1,12 +1,7 @@
 name: PR Reminders
 
-# Advisory on purpose. The rules live in .github/scripts/pr-nudges.sh with
-# the reasoning; this file only fetches the changed paths and hands them
-# over. It never fails a PR: on a fork the token is read-only and a comment
-# would 403, so the script delivers the reminder as a job summary and a
-# ::notice:: annotation first and treats the comment as a nicety
-# (tests/bats/test_pr_nudges.bats holds the 403 path at exit 0).
-# Epic #2250 item 11; modelled on kubestellar/hive's changelog-reminder.yml.
+# Thin wrapper over org-level reusable workflow in tuna-os/.github.
+# Epic #2250 item 11 (issue #2260).
 
 on:
   pull_request:
@@ -21,30 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  remind:
-    name: reminders
-    # Drafts are not ready for the question; dependency bumps never need it.
-    if: >-
-      github.event.pull_request.draft == false &&
-      github.actor != 'renovate[bot]' &&
-      github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          sparse-checkout: .github/scripts/pr-nudges.sh
-          sparse-checkout-cone-mode: false
-
-      - name: Derive and deliver the reminders
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
-        run: |
-          # Reading the file list needs no write permission, so it works on
-          # forks; --paginate so a large PR cannot hide a path on page two.
-          gh api --paginate "repos/${REPO}/pulls/${PR}/files" --jq '.[].filename' \
-            | bash .github/scripts/pr-nudges.sh --deliver
+  nudges:
+    uses: tuna-os/.github/.github/workflows/reusable-pr-nudges.yml@26a445da7a5b6cfc9de9b3bc239b7a2e0f7daf4a # tuna-os/.github main as of 2026-09-02
+    secrets: inherit


### PR DESCRIPTION
Replaces the in-repo `pr-nudges.yml` job with a thin wrapper calling the org-level `tuna-os/.github/.github/workflows/reusable-pr-nudges.yml` reusable workflow pinned by SHA.

Companion to tuna-os/.github#57.

Closes #2260 (part of #2250).

— hive: backend=agy model=gemini-3.7-flash-high effort=low
---
🐝 **Hive Agent**: `contributor` | **SHA:** `unknown`