### PR TITLE
fix: give CODEOWNERS a path pattern so it actually applies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@hanthor @castrojo @tulilirockz
+* @hanthor @castrojo @tulilirockz


### PR DESCRIPTION
## Summary

One-character-class fix. `.github/CODEOWNERS` was a bare list of owners:

```
@hanthor @castrojo @tulilirockz
```

CODEOWNERS lines are `pattern owner...`, so GitHub parses that as **the pattern `@hanthor`, owned by @castrojo and @tulilirockz**. `@hanthor` matches no path in the repo, so the rule never fires:

- no reviewer is auto-requested on any PR,
- if branch protection ever requires code-owner review, the file silently supplies none,
- and it shows as an error in the repository's CODEOWNERS view.

```diff
-@hanthor @castrojo @tulilirockz
+* @hanthor @castrojo @tulilirockz
```

Adding `*` makes the file say what it evidently means: these three own everything.

I found this while writing CODEOWNERS for the rest of the fleet — tunaOS was the only repo that had one, so it was my reference, and it turned out not to work. The other repos got the corrected form.

**Worth knowing before merging:** this actually turns the rule on. From here, @castrojo and @tulilirockz will start receiving automatic review requests on every PR in this repo, which they weren't before. If that's not wanted, the fix is `* @hanthor` instead — say which you prefer and I'll adjust.

## Testing

No code changed. The syntax is verifiable by inspection against GitHub's CODEOWNERS format (`pattern owner...`); GitHub's own CODEOWNERS view on this branch will confirm the rule now resolves instead of erroring.

## Checklist

- [ ] Commit messages are signed-off (`git commit -s`) — DCO required — *not added: I'm not able to attest a DCO sign-off on a maintainer's behalf.*
- [x] `just fix` passes locally (format + lint) — n/a, no code changed
- [x] Tests pass (`just test` / relevant CI workflow) — n/a; CI will confirm
- [x] No secrets or machine-specific paths are committed
- [x] Changelog / docs updated if user-visible behavior changed — n/a

## Related

- References: `aef:structural-gates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx)_