### PR TITLE
ci: restore promotion (runner 2.337.0 dropped --privileged), fix two nightly checks that were passing while checking nothing, re-pin three GC'd bases, repin remora

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -704,7 +704,7 @@ variants:
   - id: bonito
     emoji: "🎣"
     description: "Based on Fedora 44"
-    base_image: "quay.io/fedora/fedora-bootc:44@sha256:e91da1afe4026c2c830241557fd5bd40c165bad45cb6f9a89fc0db00ec749d6e"
+    base_image: "quay.io/fedora/fedora-bootc:44@sha256:a531996fe58a57155b5c67a8d008f2fff3b750d3dcb9ffe92f704925193e86a4"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [fedora]
     akmods: "ublue-os"
@@ -928,7 +928,7 @@ variants:
   - id: sailfin
     emoji: "🦈"
     description: "Based on openSUSE Tumbleweed (rolling)"
-    base_image: "registry.opensuse.org/opensuse/tumbleweed:latest@sha256:bbe3311a70b9b5fec1f57b44ee86b68fce0490424c5b804e18dd473123216e87"
+    base_image: "registry.opensuse.org/opensuse/tumbleweed:latest@sha256:035ae7a1ad00da1889028f926bceb05e8d93e7add37f0a4a1acfcf646c128ecf"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [opensuse, tumbleweed]
     platforms: ["linux/amd64"]
@@ -1026,7 +1026,7 @@ variants:
     tag_suffix: rawhide
     emoji: "🐉"
     description: "Based on Fedora Rawhide (rolling)"
-    base_image: "quay.io/fedora/fedora-bootc:rawhide@sha256:38682c7550526995bbc8bff3bba02a6fda5f57029a60706f1dc7f9fbefaf71ef"
+    base_image: "quay.io/fedora/fedora-bootc:rawhide@sha256:d44d1ba44990eed8cb2447bcd0151caaf4382ed1c147a4dc19dd5e5a5743a6aa"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [fedora]
     akmods: "ublue-os"

--- a/.github/workflows/check-download-checksums.yml
+++ b/.github/workflows/check-download-checksums.yml
@@ -10,10 +10,16 @@ name: Check download checksums
 # a v2.72.0 .deb and checked it against a v2.71.0 hash. It fails closed, so
 # nothing bad shipped -- but the build died and nothing named the cause.
 #
-# Running on pull requests is the point: `automerge: true` covers patch
-# updates, and platformAutomerge waits on checks, so a Renovate bump that
-# leaves checksums behind cannot merge itself. The schedule catches the other
-# case -- a release re-published under the same tag with different content.
+# Running on pull requests names the stale pair on the Renovate PR itself.
+# It does NOT stop the merge: platformAutomerge waits only on checks the
+# branch ruleset REQUIRES, and main's ruleset requires none
+# (docs/BRANCH-PROTECTION.md), so #2308 merged with this check red and every
+# variant's nightly base build failed closed at install-remora.sh on
+# 2026-09-03. What holds the merge is renovate.json: downloads paired with a
+# hand-pinned sha256 are `automerge: false`, so a human runs `--fix` on the
+# branch first. The schedule catches the other case -- a release re-published
+# under the same tag with different content -- and a bump that slipped past
+# both, which is how the two remora breakages of 09-02/09-03 were found.
 on:
   pull_request:
     paths:

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -785,8 +785,30 @@ jobs:
       image: cgr.dev/chainguard/wolfi-base@sha256:f69faa11b2523b86e9f474316ac17c64d49c3adf4f15425e3266bb85c4fcfba8  # :latest linux/amd64 as of 2026-06-13
       # This job only performs registry/API operations (podman login and
       # manifest create/add/annotate/push). It does not run or build a
-      # container, mount a host filesystem, or need kernel capabilities.
-      # Keep the job at the runner's default container confinement.
+      # container or mount a host filesystem -- but podman itself needs
+      # CAP_SYS_ADMIN to believe it is root. Without it, podman classifies
+      # the process as rootless and re-execs into a user namespace before
+      # doing anything at all, and docker's default seccomp profile denies
+      # clone(CLONE_NEWUSER) to a process without that capability:
+      #
+      #   cannot clone: Operation not permitted
+      #   Error: cannot re-exec process
+      #
+      # Until 2026-09-02 that never surfaced, because the hosted runner
+      # launched every job container with `--privileged --security-opt
+      # seccomp=unconfined` on its own. Runner 2.337.0 stopped doing that.
+      # Measured on the same runner image (ubuntu-24.04 20260823.283.1),
+      # the same 63 apk packages and the same podman 6.0.2-r2: marlin's six
+      # Manifest jobs passed on runner 2.336.0 at 18:26Z (run 33659564363);
+      # every Manifest job on runner 2.337.0 from 23:12Z on died on the two
+      # lines above (sailfin 33687500544, flounder 33694724467, flounder-sid
+      # 33702354589). The two `docker create` commands differ only in those
+      # flags and the runner path. So ask explicitly for the confinement
+      # this job has always actually run under; the next runner change must
+      # not be able to take promotion down matrix-wide again.
+      # tests/test_the_manifest_job_asks_for_the_confinement_podman_needs.py
+      # holds this line in place.
+      options: --privileged
     permissions:
       contents: read
       packages: write

--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -193,7 +193,20 @@ enabled=1
 gpgcheck=0
 priority=5
 REPO
-	dnf -y install --skip-unavailable \
+	# --skip-broken as well as --skip-unavailable: the two are different
+	# misses and only one of them was covered. On 2026-09-03 (run
+	# 33699113444, both arches) tunaos-hummingbird began serving
+	# flatpak-1.17.3-1.bfin1, built against fuse3 3.18 (libfuse3.so.4),
+	# while the pinned base still ships fuse3-libs 3.16.2 (libfuse3.so.3)
+	# and a grub2-tools-minimal that requires the old soname, which neither
+	# repo has rebuilt. flatpak was therefore not unavailable but BROKEN --
+	# and dnf's answer to one broken request is to refuse the whole
+	# transaction, so xfsprogs (present, resolvable, mandatory) was never
+	# installed and the base build died at the guard below with a message
+	# about xfsprogs. --skip-broken drops the request that cannot resolve
+	# and installs the rest; the two rpm -q guards below still decide what
+	# was mandatory, so a skipped xfsprogs cannot slip through either way.
+	dnf -y install --skip-unavailable --skip-broken \
 		buildah \
 		podman \
 		skopeo \

--- a/build_scripts/install-remora.sh
+++ b/build_scripts/install-remora.sh
@@ -36,8 +36,8 @@ set -xeuo pipefail
 REMORA_VERSION="v0.4.2"
 REMORA_ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
 case "${REMORA_ARCH}" in
-amd64) REMORA_SHA256="f04d7baa589482787947bf812a62e76e8d2f185c3c24b89c11f437abccf4a674" ;;
-arm64) REMORA_SHA256="4f1fd7934954d1697e03c5916a3a1864c62cfb3c8defb30d24c5d6f56f5f50e0" ;;
+amd64) REMORA_SHA256="87e2bb91e532da8c6f2fb426ae0fccc6cd3f6c04acd3ff3e421f5e0ed30a2570" ;;
+arm64) REMORA_SHA256="2e248ca3e2ec855113ca8e0e7d4857a1ef6f6f3ad77a023ad037a51052f602f8" ;;
 *)
 	echo "ERROR: unsupported Remora architecture: ${REMORA_ARCH}" >&2
 	exit 1

--- a/renovate.json
+++ b/renovate.json
@@ -69,6 +69,11 @@
       "automerge": true
     },
     {
+      "description": "Never automerge a download whose version is paired with a hand-pinned sha256. Renovate bumps the version and cannot bump the checksum, so the bump alone fails every base build closed at `sha256sum --check` (install-remora.sh). The `checksums` check catches it on the PR, but the main ruleset has no required status checks, so platformAutomerge merged #2308 with that check red and took every variant's nightly base build down on 2026-09-03 (flounder run 33694724467). Hold these for a human to run `scripts/check-download-checksums.py --fix` on the branch first. tests/test_checksum_pinned_downloads_are_not_automerged.py derives this list from the repo.",
+      "matchDepNames": ["tuna-os/remora", "twpayne/chezmoi"],
+      "automerge": false
+    },
+    {
       "description": "Group all GitHub Actions updates into a single PR",
       "matchManagers": ["github-actions"],
       "groupName": "github-actions"

--- a/scripts/check-base-image-pins.sh
+++ b/scripts/check-base-image-pins.sh
@@ -71,10 +71,12 @@ auth_header() {
 
 failed=0
 checked=0
+seen=0
 
 while IFS= read -r ref; do
   [ -n "$ref" ] || continue
   [ "$ref" = "null" ] && continue
+  seen=$((seen + 1))
   case "$ref" in *@sha256:*) ;; *)
     # Not digest-pinned. Not this script's problem, but say so rather than
     # silently passing -- an unpinned base is its own kind of surprise.
@@ -101,10 +103,25 @@ while IFS= read -r ref; do
     echo "::error::base image pin no longer resolves (HTTP ${code}): ${ref}"
     failed=$((failed + 1))
   fi
-done < <("$YQ" -r '.variants[].base_image // empty' "$CONFIG" | sort -u)
+done < <("$YQ" -r '.variants[] | .base_image // ""' "$CONFIG" | sort -u)
 
 echo
 echo "checked ${checked} digest-pinned base image(s); ${failed} unresolvable"
+
+# Zero base images read is the check being broken, not the config being
+# clean. This is not hypothetical: the extraction above used to fall back
+# with jq's `empty` keyword, which mikefarah yq v4.53.3 rejects ("lexer:
+# invalid input text"). The error happened inside a process substitution,
+# where `set -e` cannot see it, so from the night that shipped the job
+# printed "checked 0 digest-pinned base image(s); 0 unresolvable" and
+# exited 0 -- while sailfin's tumbleweed digest and both fedora-bootc
+# digests had been garbage-collected and every sailfin build died on
+# `manifest unknown` (run 33687500544, 2026-09-02). The absence-of-evidence
+# rule (#1730) applies to the checker itself.
+if [ "$seen" -eq 0 ]; then
+  echo "::error::base image pin check read ZERO base images from ${CONFIG} -- the extraction is broken, not the pins clean"
+  exit 1
+fi
 
 # ── Architecture honesty (green criterion 10, GREEN-MASTER-PLAN W8) ─────────
 # A variant may not declare a platform its base image cannot provide: the

--- a/scripts/check-package-repo-pins.py
+++ b/scripts/check-package-repo-pins.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import datetime
 import glob
+import json
 import re
 import sys
 import urllib.error
@@ -37,6 +38,7 @@ import urllib.request
 import yaml
 
 MANIFEST_GLOB = "manifests/desktops/*.yaml"
+IMAGE_VERSIONS = "image-versions.yaml"
 TIMEOUT = 25
 UA = {"User-Agent": "tunaos-repo-pin-check (+https://github.com/tuna-os/tunaOS)"}
 
@@ -99,11 +101,44 @@ def snapshot_age_days(url: str, today: datetime.date | None = None) -> int | Non
     return ((today or datetime.date.today()) - taken).days
 
 
-def collect(doc) -> list[tuple[str, str]]:
+def oci_pins(path: str = IMAGE_VERSIONS) -> dict[str, str]:
+    """name -> image@digest for every digest-pinned entry in image-versions.yaml."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            doc = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        return {}
+    out: dict[str, str] = {}
+    for entry in doc.get("images") or []:
+        if not isinstance(entry, dict):
+            continue
+        name, image, digest = entry.get("name"), entry.get("image"), entry.get("digest")
+        if isinstance(name, str) and isinstance(image, str) and isinstance(digest, str):
+            out[name] = f"{image}@{digest}"
+    return out
+
+
+FILE_REPO_RE = re.compile(r"^file:///run/([^/]+)/?$")
+
+
+def collect(doc, pins_by_name: dict[str, str] | None = None) -> list[tuple[str, str]]:
     """Walk a parsed manifest and return (kind, probe_url) pairs.
 
     Shapes handled — one per declaration style that exists in the manifests:
       dnf:   {..., "baseurl": URL}            -> URL/repodata/repomd.xml
+      oci:   {..., "baseurl": "file:///run/NAME"}
+                                              -> the image@digest that
+                                                 image-versions.yaml pins
+                                                 under NAME (Containerfile.el10
+                                                 bind-mounts its /repository
+                                                 at /run/NAME). Probed as a
+                                                 registry manifest, since a
+                                                 file:// URL is only ever
+                                                 reachable inside the build.
+                                                 A file:// baseurl with no pin
+                                                 behind it is reported as
+                                                 `oci-unpinned` and FAILS: it
+                                                 names a repo nothing provides.
       apt:   {..., "uri": URL, "suite": S}    -> flat (S == "./") URL/Packages
                                                  else URL/dists/S/InRelease
              {..., "keyring_url": URL}        -> URL itself
@@ -121,8 +156,19 @@ def collect(doc) -> list[tuple[str, str]]:
     def walk(node):
         if isinstance(node, dict):
             if isinstance(node.get("baseurl"), str):
-                pins.append(("dnf", _sub_vars(node["baseurl"]).rstrip("/")
-                             + "/repodata/repomd.xml"))
+                baseurl = node["baseurl"]
+                file_hit = FILE_REPO_RE.match(baseurl)
+                if file_hit:
+                    ref = (pins_by_name or {}).get(file_hit.group(1))
+                    if ref:
+                        pins.append(("oci", ref))
+                    else:
+                        pins.append(("oci-unpinned", baseurl))
+                elif baseurl.startswith("file://"):
+                    pins.append(("oci-unpinned", baseurl))
+                else:
+                    pins.append(("dnf", _sub_vars(baseurl).rstrip("/")
+                                 + "/repodata/repomd.xml"))
             if isinstance(node.get("uri"), str) and "suite" in node:
                 uri = node["uri"].rstrip("/")
                 suite = str(node.get("suite", "./"))
@@ -151,6 +197,56 @@ def collect(doc) -> list[tuple[str, str]]:
 
     walk(doc)
     return pins
+
+
+# Registry quirks mirror scripts/check-base-image-pins.sh: docker.io is a
+# name whose API host is registry-1.docker.io; quay/ghcr/docker hand out
+# anonymous pull tokens from different endpoints; anything else is tried
+# unauthenticated.
+OCI_ACCEPT = ",".join((
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+    "application/vnd.oci.image.manifest.v1+json",
+))
+
+
+def oci_manifest_request(ref: str) -> tuple[str, str | None]:
+    """(manifest_url, token_url_or_None) for an image@digest reference."""
+    name, _, digest = ref.partition("@")
+    name = name.split(":", 1)[0] if "/" not in name.split(":", 1)[-1] else name
+    registry, _, repo = name.partition("/")
+    host = "registry-1.docker.io" if registry == "docker.io" else registry
+    token = {
+        "docker.io": f"https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repo}:pull",
+        "quay.io": f"https://quay.io/v2/auth?service=quay.io&scope=repository:{repo}:pull",
+        "ghcr.io": f"https://ghcr.io/token?scope=repository:{repo}:pull",
+    }.get(registry)
+    return f"https://{host}/v2/{repo}/manifests/{digest}", token
+
+
+def probe_oci(ref: str) -> tuple[int, bytes]:
+    """HTTP status of the registry manifest behind image@digest."""
+    manifest_url, token_url = oci_manifest_request(ref)
+    headers = {**UA, "Accept": OCI_ACCEPT}
+    if token_url:
+        try:
+            with urllib.request.urlopen(
+                    urllib.request.Request(token_url, headers=UA),
+                    timeout=TIMEOUT) as resp:
+                token = json.loads(resp.read().decode()).get("token", "")
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+        except (urllib.error.URLError, OSError, ValueError):
+            pass  # an unauthenticated probe still answers 401/404 honestly
+    req = urllib.request.Request(manifest_url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, b""
+    except (urllib.error.URLError, OSError):
+        return 0, b""
 
 
 def probe(url: str) -> tuple[int, bytes]:
@@ -186,7 +282,7 @@ def repomd_content_age_days(body: bytes,
         return None
     ts = int(m.group(1))
     try:
-        taken = datetime.datetime.utcfromtimestamp(ts).date()
+        taken = datetime.datetime.fromtimestamp(ts, datetime.timezone.utc).date()
     except (OverflowError, OSError, ValueError):
         return None
     return ((today or datetime.date.today()) - taken).days
@@ -194,10 +290,11 @@ def repomd_content_age_days(body: bytes,
 
 def main() -> int:
     pins: dict[str, str] = {}
+    by_name = oci_pins()
     for path in sorted(glob.glob(MANIFEST_GLOB)):
         with open(path, encoding="utf-8") as f:
             doc = yaml.safe_load(f)
-        for kind, url in collect(doc):
+        for kind, url in collect(doc, by_name):
             pins.setdefault(url, kind)
 
     if not pins:
@@ -212,13 +309,28 @@ def main() -> int:
     stale = 0
     for url in sorted(pins):
         kind = pins[url]
+        if kind == "oci-unpinned":
+            # A file:// repo is a bind mount of something; if image-versions.yaml
+            # pins nothing under that name, the build has no bytes to mount and
+            # dnf will read an empty directory. Loud, not skipped.
+            print(f"FAIL  {kind:5s} ---  {url}")
+            print(f"::error::file:// package repo has no digest pin behind it "
+                  f"in {IMAGE_VERSIONS}: {url} — nothing provides the "
+                  f"repository the manifest mounts (rebuildable criterion, W7)")
+            failed += 1
+            continue
         if "$" in url:
             print(f"SKIP  {kind:5s} (unresolved repo variable)  {url}")
             skipped += 1
             continue
-        code, body = probe(url)
-        if code != 200:
-            code, body = probe(url)  # one retry on transport failure
+        if kind == "oci":
+            code, body = probe_oci(url)
+            if code != 200:
+                code, body = probe_oci(url)
+        else:
+            code, body = probe(url)
+            if code != 200:
+                code, body = probe(url)  # one retry on transport failure
         if code == 200:
             age = snapshot_age_days(url)
             basis = "name"
@@ -250,9 +362,11 @@ def main() -> int:
                 print(f"ok    {kind:5s} {code}  {url}  ({age}d old, by {basis})")
         else:
             print(f"FAIL  {kind:5s} {code}  {url}")
-            print(f"::error::package-repo pin no longer resolves "
-                  f"(HTTP {code}): {url} — an image that references it "
-                  f"cannot be rebuilt (rebuildable criterion, W7)")
+            what = ("OCI package-repo pin (the digest behind a file:// "
+                    "baseurl) no longer resolves" if kind == "oci"
+                    else "package-repo pin no longer resolves")
+            print(f"::error::{what} (HTTP {code}): {url} — an image that "
+                  f"references it cannot be rebuilt (rebuildable criterion, W7)")
             failed += 1
 
     print(f"\nchecked {len(pins) - skipped} package-repo pin(s), "

--- a/tests/injection/test_declared_arch_missing.py
+++ b/tests/injection/test_declared_arch_missing.py
@@ -40,13 +40,18 @@ def _run_arch_check(tmp_path: Path, variant: str, platforms: list[str], availabl
     platforms_str = ",".join(platforms)
 
     # Mock yq to return:
-    # 1. Base image list
-    # 2. Tab-separated [id, base_image, platforms]
+    # 1. Tab-separated [id, base_image, platforms] (the arch-honesty loop)
+    # 2. Base image list (the resolution loop) for any other .base_image query
+    #
+    # Matched on `.base_image`, not on the exact expression: an earlier
+    # version keyed on the literal `// empty` fallback, which was the jq-only
+    # syntax the pinned mikefarah yq rejected, so the stub was faithfully
+    # reproducing the broken query rather than the config.
     yq_script = f"""#!/usr/bin/env bash
-if [[ "$*" == *".base_image // empty"* ]]; then
-  echo "{base_ref}"
-elif [[ "$*" == *"@tsv"* ]]; then
+if [[ "$*" == *"@tsv"* ]]; then
   printf "%s\\t%s\\t%s\\n" "{variant}" "{base_ref}" "{platforms_str}"
+elif [[ "$*" == *".base_image"* ]]; then
+  echo "{base_ref}"
 else
   echo ""
 fi

--- a/tests/test_a_broken_optional_package_cannot_sink_the_hummingbird_base.py
+++ b/tests/test_a_broken_optional_package_cannot_sink_the_hummingbird_base.py
@@ -1,0 +1,71 @@
+"""One broken optional package must not take the hummingbird base down with it.
+
+10-base-packages.sh installs the hummingbird base set in one dnf transaction
+and then asserts, by `rpm -q`, that xfsprogs (mandatory: bootc install execs
+mkfs.xfs from inside the image) arrived, while flatpak (not yet publishable,
+tunaOS#1397) is only warned about.
+
+`--skip-unavailable` covers a package no repo carries. It does not cover a
+package a repo carries but cannot resolve, and dnf's answer to one such
+request is to refuse the WHOLE transaction. Measured 2026-09-03, run
+33699113444, both arches: tunaos-hummingbird began serving
+flatpak-1.17.3-1.bfin1 built against fuse3 3.18 (libfuse3.so.4), the pinned
+base ships fuse3-libs 3.16.2 (libfuse3.so.3) and a grub2-tools-minimal that
+still requires the old soname (measured against both repodata on 2026-09-03:
+public-hummingbird carries fuse3-libs 3.18.2 and no grub2-tools-minimal;
+tunaos-hummingbird carries flatpak and xfsprogs and no fuse3). dnf reported
+flatpak as the problem, installed nothing, and the build died at the xfsprogs
+guard with a message about xfsprogs.
+
+The transaction must carry `--skip-broken` alongside `--skip-unavailable`,
+so the optional request is dropped and the mandatory one lands; the rpm -q
+guards remain the arbiter of what was mandatory.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "build_scripts/10-base-packages.sh"
+
+
+def _hummingbird_install_command() -> str:
+    """The single `dnf ... install` inside the IS_HUMMINGBIRD branch, with its
+    line continuations joined."""
+    body = SCRIPT.read_text()
+    start = body.index("if [[ $IS_HUMMINGBIRD == true ]]; then")
+    end = body.index("elif [[ ${IS_ELN:-false} == true ]]; then", start)
+    branch = body[start:end]
+    joined = re.sub(r"\\\n\s*", " ", branch)
+    cmds = [line.strip() for line in joined.splitlines()
+            if re.match(r"\s*dnf\s+-y\s+install\b", line)]
+    assert len(cmds) == 1, f"expected exactly one dnf install in the hummingbird branch, found {cmds}"
+    return cmds[0]
+
+
+def test_the_hummingbird_transaction_skips_broken_as_well_as_unavailable():
+    cmd = _hummingbird_install_command()
+    assert "--skip-unavailable" in cmd.split()
+    assert "--skip-broken" in cmd.split(), (
+        "without --skip-broken one unresolvable optional package (flatpak, "
+        "run 33699113444) refuses the whole transaction, xfsprogs included"
+    )
+
+
+def test_flatpak_and_xfsprogs_share_that_transaction():
+    """The failure mode needs both in one request: the optional one breaks,
+    the mandatory one is collateral. If they are ever split into separate
+    transactions this test should be rewritten, not deleted."""
+    cmd = _hummingbird_install_command()
+    words = cmd.split()
+    assert "flatpak" in words and "xfsprogs" in words
+
+
+def test_the_mandatory_guard_still_decides():
+    """--skip-broken must not turn a skipped xfsprogs into a silent pass; the
+    rpm -q guard is what makes the miss fatal, and it has to stay."""
+    body = SCRIPT.read_text()
+    assert re.search(r"if ! rpm -q xfsprogs >/dev/null 2>&1; then\s*\n\s*echo \"ERROR: xfsprogs did not install", body)
+    assert re.search(r"if ! rpm -q flatpak >/dev/null 2>&1; then\s*\n\s*echo \"WARNING: flatpak did not install", body)

--- a/tests/test_base_image_pins_are_checked.py
+++ b/tests/test_base_image_pins_are_checked.py
@@ -269,3 +269,40 @@ def test_arch_honesty_criterion_is_advisory_and_asserted():
     c = next(c for c in criteria if c["id"] == "arch_honesty")
     assert c["enforcement"] == "advisory"
     assert "check-base-image-pins" in c["asserted_by"]
+
+
+# ── the checker itself can be the thing that is broken ─────────────────────
+
+
+def test_zero_pins_checked_is_a_failure_not_a_pass(tmp_path):
+    """A yq expression the pinned yq rejects (`// empty` is jq, and mikefarah
+    yq v4.53.3 answers "lexer: invalid input text \"empty\"") fails inside a
+    process substitution where `set -e` cannot see it. From the night that
+    shipped, the nightly printed "checked 0 digest-pinned base image(s);
+    0 unresolvable" and exited 0 while sailfin's garbage-collected pin took
+    every sailfin build down on `manifest unknown` (run 33687500544). The
+    absence-of-evidence rule applies to the checker: zero checked is red."""
+    proc, _ = run_check(tmp_path, [])
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "checked 0 digest-pinned base image(s)" in proc.stdout
+    assert "::error::" in proc.stdout
+    assert "ZERO" in proc.stdout
+
+
+def test_an_all_unpinned_config_is_still_read_not_broken(tmp_path):
+    """The guard is about the extraction reading nothing, not about the pins
+    it read being digest-less: an unpinned base is SKIP (its own test above),
+    and one SKIP proves the expression works."""
+    proc, _ = run_check(tmp_path, ["docker.io/library/alpine:latest"])
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_the_pin_extraction_uses_no_jq_only_syntax():
+    """`empty` is jq. mikefarah yq -- the binary the workflow installs -- has
+    no such operator, and the arch-honesty loop in the same script already
+    uses the `// ""` form that both accept. Keep the two consistent."""
+    body = SCRIPT.read_text()
+    assert "// " + "empty" not in body, (
+        "the jq `empty` fallback is rejected by the pinned mikefarah yq "
+        "(v4.53.3: 'lexer: invalid input text'); use `.base_image // \"\"`"
+    )

--- a/tests/test_checksum_pinned_downloads_are_not_automerged.py
+++ b/tests/test_checksum_pinned_downloads_are_not_automerged.py
@@ -1,0 +1,125 @@
+"""A download pinned twice (version + sha256) must not be automerged by Renovate.
+
+Renovate maintains the version half of such a pin and cannot maintain the
+checksum half, so its bump alone fails every base build closed at
+`sha256sum --check`. `check-download-checksums.yml` names the stale pair on
+the PR, but the main ruleset requires no status checks
+(docs/BRANCH-PROTECTION.md), so platformAutomerge merges through a red
+check. Measured twice in two days:
+
+- #2293 (remora v0.4.0 -> v0.4.1) merged 2026-09-02 21:58Z with v0.4.0's
+  hashes; #2305 repinned them.
+- #2308 (v0.4.1 -> v0.4.2) merged 2026-09-03 01:11Z with the `checksums`
+  check FAILED on the PR, and flounder's base build died at
+  install-remora.sh an hour later (run 33694724467, job 100479165741:
+  "sha256sum: WARNING: 1 computed checksum did NOT match").
+
+The only lever inside this repository is renovate.json: every dependency
+whose version is paired with a hand-pinned checksum must end up with
+`automerge: false` after Renovate's last-rule-wins evaluation. The list of
+such dependencies is DERIVED from the files that carry the pairs, so adding
+a new checksummed download without excluding it fails here first.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+RENOVATE = ROOT / "renovate.json"
+IMAGE_VERSIONS = ROOT / "image-versions.yaml"
+REMORA = ROOT / "build_scripts/install-remora.sh"
+
+RENOVATE_MARKER = re.compile(r"#\s*renovate:\s*datasource=\S+\s+depName=(\S+)")
+
+
+def checksum_paired_dep_names() -> set[str]:
+    """Every depName whose version sits next to a sha256 map or literal."""
+    names: set[str] = set()
+
+    # image-versions.yaml: a `<key>_sha256:` map next to `<key>: "vX"` whose
+    # preceding comment carries the renovate marker.
+    text = IMAGE_VERSIONS.read_text()
+    downloads = yaml.safe_load(text).get("downloads") or {}
+    for key in downloads:
+        if key.endswith("_sha256") and key[: -len("_sha256")] in downloads:
+            base = key[: -len("_sha256")]
+            m = re.search(rf"{RENOVATE_MARKER.pattern}\n\s*{re.escape(base)}:", text)
+            assert m, f"{base} has a sha256 map but no renovate marker to name it"
+            names.add(m.group(1))
+
+    # install-remora.sh: a renovate marker over REMORA_VERSION and a
+    # REMORA_SHA256 case table below it.
+    remora = REMORA.read_text()
+    if "REMORA_SHA256=" in remora:
+        m = RENOVATE_MARKER.search(remora)
+        assert m, "install-remora.sh pins a sha256 but carries no renovate marker"
+        names.add(m.group(1))
+
+    return names
+
+
+def effective_automerge(dep_name: str) -> bool | None:
+    """Renovate semantics: later packageRules override earlier ones."""
+    cfg = json.loads(RENOVATE.read_text())
+    result = cfg.get("automerge")
+    for rule in cfg.get("packageRules", []):
+        matched = False
+        if dep_name in (rule.get("matchDepNames") or []):
+            matched = True
+        if dep_name in (rule.get("matchPackageNames") or []):
+            matched = True
+        # Rules keyed only on update type apply to every dependency.
+        if "matchUpdateTypes" in rule and not any(
+            k.startswith("match") and k != "matchUpdateTypes" for k in rule
+        ):
+            matched = True
+        if matched and "automerge" in rule:
+            result = rule["automerge"]
+    return result
+
+
+def test_the_derived_list_names_the_known_pairs():
+    names = checksum_paired_dep_names()
+    assert "tuna-os/remora" in names
+    assert "twpayne/chezmoi" in names
+
+
+def test_every_checksum_paired_download_ends_up_not_automerged():
+    for dep in sorted(checksum_paired_dep_names()):
+        assert effective_automerge(dep) is False, (
+            f"{dep} is version+sha256 pinned but Renovate would automerge its "
+            "bump; add it to the `automerge: false` rule in renovate.json "
+            "(#2308 shipped a red `checksums` check into main this way)"
+        )
+
+
+def test_the_exclusion_comes_after_the_patch_automerge_rule():
+    """Renovate applies packageRules in order and the last match wins. An
+    exclusion placed BEFORE the blanket patch/pin/digest automerge rule is
+    overridden by it and protects nothing."""
+    rules = json.loads(RENOVATE.read_text())["packageRules"]
+    blanket = [i for i, r in enumerate(rules) if r.get("automerge") is True
+               and "matchUpdateTypes" in r]
+    holds = [i for i, r in enumerate(rules) if r.get("automerge") is False
+             and "tuna-os/remora" in (r.get("matchDepNames") or [])]
+    assert blanket and holds, "expected both the blanket automerge rule and the remora hold"
+    assert max(blanket) < min(holds), (
+        "the checksum-pinned hold must come AFTER the blanket patch automerge "
+        "rule, or the blanket rule overrides it"
+    )
+
+
+def test_the_pr_check_does_not_claim_to_block_the_merge():
+    """The workflow's header used to say a stale bump 'cannot merge itself'.
+    It demonstrably can (#2308). The comment must not make that claim again
+    until a required-status-check rule exists on main."""
+    body = (ROOT / ".github/workflows/check-download-checksums.yml").read_text()
+    assert "cannot merge itself" not in body, (
+        "check-download-checksums.yml claims to block merges; the main "
+        "ruleset has no required checks, so it does not (#2308)"
+    )

--- a/tests/test_package_repo_pins_are_checked.py
+++ b/tests/test_package_repo_pins_are_checked.py
@@ -93,3 +93,70 @@ def test_the_nightly_workflow_runs_it() -> None:
         "package-repo pins get their own job so a base-pin failure cannot "
         "stop them from reporting (and vice versa)"
     )
+
+
+# ── file:// repos are OCI pins in disguise ─────────────────────────────────
+#
+# hummingbird:gnome takes GNOME 51 from projectbluefin/utah-packages: an OCI
+# image carrying a createrepo_c repository, pinned by digest in
+# image-versions.yaml and bind-mounted at /run/utah-packages by
+# Containerfile.el10. The manifest declares it as `baseurl:
+# file:///run/utah-packages`. Probing that as an HTTP URL answers 0 and the
+# nightly went red on it from the day the pin landed (run 33699188451,
+# 2026-09-03: "FAIL dnf 0 file:///run/utah-packages/repodata/repomd.xml").
+# The pin behind it is what can rot, so that is what gets probed.
+
+
+def test_a_file_repo_resolves_to_the_oci_pin_that_provides_it():
+    doc = {"hummingbird": {"repos": [{"name": "utah-packages",
+                                      "baseurl": "file:///run/utah-packages",
+                                      "priority": 4}]}}
+    pins = {"utah-packages": "ghcr.io/projectbluefin/utah-packages@sha256:" + "a" * 64}
+    assert crpp.collect(doc, pins) == [
+        ("oci", "ghcr.io/projectbluefin/utah-packages@sha256:" + "a" * 64)
+    ]
+
+
+def test_a_file_repo_with_no_pin_behind_it_is_a_failure_not_a_skip():
+    """Nothing provides the bytes the manifest mounts: that is a repo that
+    cannot be rebuilt, and it must be named, not skipped."""
+    doc = {"repos": [{"baseurl": "file:///run/nothing-pins-this"}]}
+    assert crpp.collect(doc, {}) == [("oci-unpinned", "file:///run/nothing-pins-this")]
+    assert crpp.collect(doc, None) == [("oci-unpinned", "file:///run/nothing-pins-this")]
+
+
+def test_the_real_manifests_route_the_utah_repo_through_image_versions():
+    pins = crpp.oci_pins(str(ROOT / "image-versions.yaml"))
+    assert "utah-packages" in pins, "image-versions.yaml no longer pins utah-packages"
+    assert pins["utah-packages"].startswith("ghcr.io/projectbluefin/utah-packages@sha256:")
+    collected: list[tuple[str, str]] = []
+    for path in sorted((ROOT / "manifests" / "desktops").glob("*.yaml")):
+        collected.extend(crpp.collect(yaml.safe_load(path.read_text()), pins))
+    kinds = {k for k, _ in collected}
+    assert "oci-unpinned" not in kinds, [u for k, u in collected if k == "oci-unpinned"]
+    assert ("oci", pins["utah-packages"]) in collected
+    assert not any(u.startswith("file://") for _, u in collected), (
+        "a file:// URL survived to the probe list; it can never resolve over HTTP"
+    )
+
+
+def test_the_oci_probe_asks_the_registry_for_the_digest_with_a_token():
+    """Same quirks as check-base-image-pins.sh: ghcr/quay/docker.io hand out
+    anonymous pull tokens from different places, docker.io is not an API
+    host, and the manifest must be requested by digest, not by tag."""
+    ref = "ghcr.io/projectbluefin/utah-packages@sha256:" + "b" * 64
+    url, token = crpp.oci_manifest_request(ref)
+    assert url == "https://ghcr.io/v2/projectbluefin/utah-packages/manifests/sha256:" + "b" * 64
+    assert token == "https://ghcr.io/token?scope=repository:projectbluefin/utah-packages:pull"
+
+    url, token = crpp.oci_manifest_request("docker.io/library/debian:trixie@sha256:" + "c" * 64)
+    assert url.startswith("https://registry-1.docker.io/v2/library/debian/manifests/sha256:")
+    assert "auth.docker.io" in token
+
+    url, token = crpp.oci_manifest_request("quay.io/fedora/fedora-bootc:44@sha256:" + "d" * 64)
+    assert url == "https://quay.io/v2/fedora/fedora-bootc/manifests/sha256:" + "d" * 64
+    assert token == "https://quay.io/v2/auth?service=quay.io&scope=repository:fedora/fedora-bootc:pull"
+
+    url, token = crpp.oci_manifest_request("registry.opensuse.org/opensuse/tumbleweed@sha256:" + "e" * 64)
+    assert url == "https://registry.opensuse.org/v2/opensuse/tumbleweed/manifests/sha256:" + "e" * 64
+    assert token is None

--- a/tests/test_the_manifest_job_asks_for_the_confinement_podman_needs.py
+++ b/tests/test_the_manifest_job_asks_for_the_confinement_podman_needs.py
@@ -1,0 +1,75 @@
+"""The Manifest job must ask for the container confinement podman needs.
+
+`podman manifest create` inside a job container decides whether it is root
+by asking for CAP_SYS_ADMIN, not by asking for uid 0. Without the capability
+it re-execs into a user namespace first, and docker's default seccomp profile
+denies clone(CLONE_NEWUSER) to a process that lacks it:
+
+    cannot clone: Operation not permitted
+    Error: cannot re-exec process
+
+That never surfaced because the hosted runner used to launch every job
+container with `--privileged --security-opt seccomp=unconfined` of its own
+accord. Runner 2.337.0 stopped. Measured on 2026-09-02 with the runner image,
+the apk package set and podman (6.0.2-r2) all identical: marlin's six Manifest
+jobs passed on runner 2.336.0 (run 33659564363, 18:26Z); every Manifest job
+on runner 2.337.0 from 23:12Z on died on the two lines above (sailfin
+33687500544, flounder 33694724467, flounder-sid 33702354589). Not one image
+was promoted matrix-wide.
+
+The workflow now states the confinement it has always run under instead of
+inheriting it. This test holds that in place: the failure mode is a
+`container:` block on the manifest job with no `options:` granting it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/reusable-build-image.yml"
+
+
+def _manifest_job():
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    jobs = doc["jobs"]
+    assert "manifest" in jobs, "the Manifest job moved; update this test and the CI contract"
+    return jobs["manifest"]
+
+
+def test_the_manifest_job_runs_in_a_job_container():
+    """If someone moves it onto the runner directly, the option below is moot
+    and the test should be revisited rather than silently pass."""
+    job = _manifest_job()
+    assert isinstance(job.get("container"), dict), (
+        "the Manifest job no longer runs in a job container; if that is "
+        "deliberate, delete this test with the reason in the commit message"
+    )
+
+
+def test_the_manifest_container_is_privileged():
+    """The one flag the runner silently supplied until 2.337.0."""
+    container = _manifest_job()["container"]
+    options = str(container.get("options") or "")
+    assert "--privileged" in options.split(), (
+        "manifest.container.options must carry --privileged: podman without "
+        "CAP_SYS_ADMIN re-execs into a user namespace and docker's default "
+        "seccomp denies the clone (runs 33687500544, 33694724467, 33702354589)"
+    )
+
+
+def test_no_other_job_container_is_left_to_inherit_its_confinement():
+    """The same class applies to any future `container:` job that runs podman
+    or buildah. Every job container in this workflow must state options
+    explicitly, so a runner default change is a diff here and not a mystery
+    red night."""
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    for name, job in doc["jobs"].items():
+        container = job.get("container")
+        if isinstance(container, dict):
+            assert container.get("options"), (
+                f"job {name!r} runs in a container with no explicit options; "
+                "state the confinement it needs (see the manifest job)"
+            )


### PR DESCRIPTION
## Summary

Main has been unable to publish a single image since 2026-09-02 23:12Z, and two of the nightly checks that exist to catch exactly that have been reporting green while checking nothing. Five independent fixes, each with the measurement that found it and a test that holds it.

### 1. Every Manifest job dies at `podman manifest create` — runner 2.337.0, not the wolfi bump

Since 23:12Z on 09-02 every Manifest job fails with `cannot clone: Operation not permitted / Error: cannot re-exec process` (sailfin 33687500544, flounder 33694724467, flounder-sid 33702354589), so nothing has been promoted since. The wolfi-base digest bump (#2284) merged the same evening and is not the cause. Comparing marlin's last passing Manifest job (run 33659564363, 18:26Z) with the first failing one:

| | passing (18:26Z) | failing (23:12Z) |
|---|---|---|
| runner image | ubuntu-24.04 20260823.283.1 | same |
| apk set | 63 packages, podman-6.0 6.0.2-r2, crun 1.29.1-r1 | same |
| wolfi-base layer diff | — | libssl3/libcrypto3 3.6.4-r1→r2, `/etc/ssl/openssl.cnf` added |
| `docker create` | `--privileged --security-opt seccomp=unconfined` | **absent** |
| runner | `actions-runner/cached/2.336.0` | `actions-runner/cached/2.337.0` |

podman decides it is root by asking for CAP_SYS_ADMIN, not uid 0; without it, it re-execs into a user namespace and docker's default seccomp denies the clone. The job's comment said "keep the runner's default container confinement" — the default had been privileged all along. `options: --privileged` now states what the job has always actually run under; the new test also requires every job container in the workflow to declare its options.

### 2. The nightly base-pin check has been checking zero pins and passing

`check-base-image-pins.yml`'s `check` job prints `Error: 1:27: lexer: invalid input text "empty"` then `checked 0 digest-pinned base image(s); 0 unresolvable` and exits 0 (job 100474565543 last night). `.variants[].base_image // empty` is jq; mikefarah yq v4.53.3, the binary the workflow installs, rejects it, and the error is inside a process substitution where `set -e` cannot see it. Reproduced with the pinned binary; the `// ""` form (already used by the arch loop in the same script) returns all 14 refs.

Fixed, run against main's config with that binary:

```
FAIL  404  quay.io/fedora/fedora-bootc:44@sha256:e91da1af…
FAIL  404  quay.io/fedora/fedora-bootc:rawhide@sha256:38682c75…
FAIL  404  registry.opensuse.org/opensuse/tumbleweed:latest@sha256:bbe3311a…
checked 14 digest-pinned base image(s); 3 unresolvable
```

Three garbage-collected pins (bonito, bonito-rawhide, sailfin). sailfin base died on exactly this last night (`manifest unknown`, run 33687500544). All three are re-pinned to their tag's current digest (GET 200 by digest, amd64+arm64 present on all three). After the re-pins: `checked 14 digest-pinned base image(s); 0 unresolvable` / `checked 21 declared platform(s); 0 unsatisfiable`. The script now refuses to pass when it read zero base images — the absence-of-evidence rule applied to the checker itself.

### 3. Every base build fails closed at install-remora.sh — Renovate bumps the version it cannot checksum

`sha256sum: WARNING: 1 computed checksum did NOT match` (flounder base, run 33694724467). #2293 (v0.4.1) and #2308 (v0.4.2) each left the previous release's hashes behind; #2305 repinned one and #2308 undid it within three hours. The `checksums` check **failed on #2308 and it merged anyway**: platformAutomerge waits on required checks and main's ruleset has none (docs/BRANCH-PROTECTION.md). The workflow header claimed a stale bump "cannot merge itself"; it can.

- `install-remora.sh` repinned via `--fix` (`87e2bb91e532…` / `2e248ca3e2ec…`; re-run without `--fix`: `all checksum pins match their pinned release`).
- `renovate.json`: `automerge: false` for `tuna-os/remora` and `twpayne/chezmoi`, after the blanket patch rule so it wins.
- A test derives the version+sha256-paired dependency list from the files that carry the pairs and evaluates renovate.json last-rule-wins.

### 4. The nightly package-repo check has been red since the utah-packages pin landed

`FAIL dnf 0 file:///run/utah-packages/repodata/repomd.xml` (job 100474565414). A file:// baseurl is a bind mount of the digest pinned in image-versions.yaml; probing it over HTTP can only ever answer 0. It now resolves through image-versions.yaml and is probed as a registry manifest by digest (`ok oci 200 ghcr.io/projectbluefin/utah-packages@sha256:9cb66729…`; 15/15 pins ok). A file:// baseurl with no pin behind it FAILS as `oci-unpinned`.

### 5. hummingbird base: one broken optional package sank the mandatory ones

Run 33699113444, both arches: tunaos-hummingbird now serves `flatpak-1.17.3-1.bfin1` built against fuse3 3.18 (libfuse3.so.4); the pinned base ships fuse3-libs 3.16.2 and a grub2-tools-minimal requiring libfuse3.so.3; public-hummingbird has fuse3-libs 3.18.2 but no grub2-tools-minimal (all measured against live repodata on 09-03). flatpak is BROKEN, not unavailable; dnf refused the whole transaction, xfsprogs (present in tunaos-hummingbird, 7.1.1-1.1.fc43) never installed, and the build died at a guard naming xfsprogs. `--skip-broken` alongside `--skip-unavailable`; the rpm -q guards still decide what was mandatory. The soname split itself is a tunaos-packages matter (flatpak rebuilt against a fuse3 the base cannot take) and is not papered over.

### Also verified

The README matrix refresh that #2281 fixed was dispatched on main (run 33711898304): first success since 08-19; its PR #2313 merged and the README block now reads 2026-09-02/09-03.

## Testing

```
python3 -m pytest -q tests/                 1189 passed in 1171.72s
bats tests/bats                               1425 ok, 38 not ok -- the identical 38 fail on origin/main in this sandbox (ISO/e2e tests needing podman/QEMU); none touch the changed files
python3 scripts/check-ci-contract.py     CI contract: 10 criteria, every gate exists, is reachable, and meets its freshness SLA
python3 scripts/check-download-checksums.py     all checksum pins match their pinned release
python3 scripts/check-package-repo-pins.py      checked 15 package-repo pin(s), 0 skipped; 0 unresolvable or stale
YQ=<yq v4.53.3> scripts/check-base-image-pins.sh   checked 14 digest-pinned base image(s); 0 unresolvable
shellcheck / ruff / yamllint -d relaxed .github/   clean (pre-existing line-length warnings only)
```

New tests: `test_the_manifest_job_asks_for_the_confinement_podman_needs.py` (3), `test_checksum_pinned_downloads_are_not_automerged.py` (4), `test_a_broken_optional_package_cannot_sink_the_hummingbird_base.py` (3), plus 2 in `test_base_image_pins_are_checked.py` and 4 in `test_package_repo_pins_are_checked.py`.

Not run here: an actual image build. The first real evidence for 1, 3 and 5 is tonight's nightlies; for 2 and 4 the 22:20Z pin check.

## Related issues

Supersedes the failure mode of #2308 (merged with a red check). Relates to #1788 (GC'd pins), #1397 (hummingbird flatpak), #2263/#2281 (README matrix freeze, now verified fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_