### PR TITLE
Re-pin three garbage-collected base images, and stop shipping build-only repos

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -704,7 +704,7 @@ variants:
   - id: bonito
     emoji: "🎣"
     description: "Based on Fedora 44"
-    base_image: "quay.io/fedora/fedora-bootc:44@sha256:a531996fe58a57155b5c67a8d008f2fff3b750d3dcb9ffe92f704925193e86a4"
+    base_image: "quay.io/fedora/fedora-bootc:44@sha256:9c8fae9f47e7287d27542a6fe30ec408151655b142a61beea787c94654f1911a"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [fedora]
     akmods: "ublue-os"
@@ -928,7 +928,7 @@ variants:
   - id: sailfin
     emoji: "🦈"
     description: "Based on openSUSE Tumbleweed (rolling)"
-    base_image: "registry.opensuse.org/opensuse/tumbleweed:latest@sha256:035ae7a1ad00da1889028f926bceb05e8d93e7add37f0a4a1acfcf646c128ecf"
+    base_image: "registry.opensuse.org/opensuse/tumbleweed:latest@sha256:1691585b5daf973c032d1f94d3b8b85393d259ac0348c1c5b91abceeeb3334a9"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [opensuse, tumbleweed]
     platforms: ["linux/amd64"]
@@ -1026,7 +1026,7 @@ variants:
     tag_suffix: rawhide
     emoji: "🐉"
     description: "Based on Fedora Rawhide (rolling)"
-    base_image: "quay.io/fedora/fedora-bootc:rawhide@sha256:d44d1ba44990eed8cb2447bcd0151caaf4382ed1c147a4dc19dd5e5a5743a6aa"
+    base_image: "quay.io/fedora/fedora-bootc:rawhide@sha256:6c04d2602182c7f8ae465be9ecf9987695e26895a35f7226dbe8b63be912d5c3"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [fedora]
     akmods: "ublue-os"

--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -717,6 +717,29 @@ if [[ "${_TD_OS}" == "el10" || "${_TD_OS}" == "fedora" || "${_TD_OS}" == "hummin
 		done
 	fi
 
+	# ── Retire the build-only repos ──────────────────────────────────────────────
+	# A file:// repo is a bind mount that exists for the duration of one RUN
+	# (Containerfile.el10 mounts /run/utah-packages and
+	# /run/gnome50-el10-packages out of digest-pinned OCI images). The .repo file
+	# the loop above wrote is NOT scoped to that RUN -- 99-cleanup.sh runs in
+	# base-no-de, before the desktop stages fork from it, so nothing removes it
+	# and it ships. On a booted host the baseurl names a path that does not
+	# exist, and the loop writes skip_if_unavailable=False, so it is not a
+	# harmless stale entry: it fails every dnf transaction the user runs.
+	#
+	# Only the file:// ones go. The https tiers are reachable from a booted host
+	# and some are deliberately left enabled (10-base-packages.sh writes
+	# tunaos-hummingbird.repo the same way).
+	for ((i = 0; i < _TD_REPO_COUNT; i++)); do
+		_TD_RN=$($YQ -r ".packages.${_TD_OS}.repos[$i].name" "${_TD_MANIFEST}")
+		_TD_RB=$($YQ -r ".packages.${_TD_OS}.repos[$i].baseurl" "${_TD_MANIFEST}")
+		[[ -z "${_TD_RN}" || "${_TD_RN}" == "null" ]] && continue
+		if [[ "${_TD_RB}" == file://* ]]; then
+			rm -f "/etc/yum.repos.d/${_TD_RN}.repo"
+			echo "Removed build-only repo ${_TD_RN} (${_TD_RB} is a bind mount, not a runtime path)"
+		fi
+	done
+
 fi # end DNF path (el10/fedora)
 
 # ── Display manager (all OSes) ───────────────────────────────────────────────

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -195,6 +195,16 @@ Homebrew → distrobox/toolbox container → build your own image
 custom-image story). That last option is the escape hatch that makes the
 first three acceptable.
 
+You can still run `dnf` inside a toolbox, and some images do ship a
+repository definition under `/etc/yum.repos.d` — hummingbird carries the
+tunaOS package repository, for instance. What they do **not** ship is the
+repositories that existed only while the image was being built: those are
+bind-mounted directories that are gone by the time you boot, and a
+definition left pointing at one would fail every `dnf` transaction rather
+than sit there harmlessly. The build removes them at the end of the desktop
+install, so every repository an image ships is one a running system can
+actually reach.
+
 ## 5. Rollback
 
 One command, or pick the previous entry in the boot menu:

--- a/tests/test_a_build_only_repo_does_not_ship.py
+++ b/tests/test_a_build_only_repo_does_not_ship.py
@@ -1,0 +1,121 @@
+"""A repo that only exists during the build must not ship in the image.
+
+install-desktop.sh writes /etc/yum.repos.d/<name>.repo for every repo the
+manifest's OS section declares. For an https tier that is fine and sometimes
+deliberate -- 10-base-packages.sh writes tunaos-hummingbird.repo the same way,
+and a booted host can reach it.
+
+For a file:// repo it is not. Those baseurls are bind mounts of digest-pinned
+OCI images that Containerfile.el10 provides for the duration of ONE RUN
+(/run/utah-packages for hummingbird:gnome, /run/gnome50-el10-packages for
+el10). The .repo file is not scoped to that RUN: 99-cleanup.sh runs in
+base-no-de, BEFORE the desktop stages fork from it, so nothing removed it and
+it shipped. And the write loop emits skip_if_unavailable=False, so the result
+is not a harmless stale entry -- it fails every dnf transaction the user runs
+on the booted host. hummingbird has shipped utah-packages.repo that way since
+8a31ace9.
+
+These tests run the shipped loops themselves, against a fake yq, rather than a
+paraphrase of them.
+"""
+from __future__ import annotations
+
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "build_scripts" / "desktop" / "install-desktop.sh"
+
+MOUNTED_REPO = "gnome50-el10-packages"
+MOUNTED_URL = f"file:///run/{MOUNTED_REPO}"
+
+
+FAKE_YQ = """#!/usr/bin/env python3
+import re, sys, yaml
+expr, path = sys.argv[2], sys.argv[3]
+doc = yaml.safe_load(open(path))
+m = re.fullmatch(r"\\.packages\\.(\\w+) \\| type", expr)
+if m:
+    v = doc["packages"].get(m.group(1))
+    print("!!map" if isinstance(v, dict) else "!!seq" if isinstance(v, list) else "!!null")
+    sys.exit(0)
+m = re.fullmatch(r"\\.packages\\.(\\w+)\\.repos \\| length // 0", expr)
+if m:
+    print(len(doc["packages"][m.group(1)].get("repos") or []))
+    sys.exit(0)
+m = re.fullmatch(r"\\.packages\\.(\\w+)\\.repos\\[(\\d+)\\]\\.(\\w+)(?: // (.*))?", expr)
+if m:
+    os_, i, field, default = m.groups()
+    v = doc["packages"][os_]["repos"][int(i)].get(field)
+    if v is None:
+        print("" if default == '\"\"' else (default if default is not None else "null"))
+    else:
+        print(str(v).lower() if isinstance(v, bool) else v)
+    sys.exit(0)
+sys.exit(1)
+"""
+
+
+def _block(start_marker: str) -> str:
+    """The literal loop out of install-desktop.sh, so the test runs the shipped
+    code rather than a paraphrase of it."""
+    src = SCRIPT.read_text()
+    start = src.index(start_marker)
+    end = src.index("\tdone\n", start) + len("\tdone\n")
+    return textwrap.dedent(src[start:end])
+
+
+def test_a_file_repo_is_removed_after_the_install_and_an_https_one_is_not(tmp_path):
+    """Containerfile.el10 mounts the repository for exactly one RUN, but the
+    .repo file the write loop leaves behind is not scoped to that RUN --
+    99-cleanup.sh runs in base-no-de, before the desktop stages fork from it.
+    A shipped repo whose baseurl is a path that no longer exists, written with
+    skip_if_unavailable=False, fails every dnf the user runs on the booted
+    host. It has to be retired at the end of the section."""
+    manifest = {"packages": {"el10": {"repos": [
+        {"name": MOUNTED_REPO, "baseurl": MOUNTED_URL, "priority": 1, "unsigned": True},
+        {"name": "keep-me", "baseurl": "https://repo.tunaos.org/xfce/10-stream-x86_64/"},
+    ]}}}
+    (tmp_path / "manifest.yaml").write_text(yaml.safe_dump(manifest))
+    yq = tmp_path / "yq"
+    yq.write_text(FAKE_YQ)
+    yq.chmod(yq.stat().st_mode | stat.S_IEXEC)
+    reposd = tmp_path / "yum.repos.d"
+    reposd.mkdir()
+
+    body = (_block("\t_TD_REPO_COUNT=0\n") + "\n"
+            + _block("\t# ── Retire the build-only repos"))
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        "#!/usr/bin/env bash\nset -euo pipefail\n"
+        f'YQ="{yq}"\n_TD_OS=el10\n_TD_MANIFEST="{tmp_path / "manifest.yaml"}"\n'
+        + body.replace("/etc/yum.repos.d", str(reposd))
+    )
+    proc = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+
+    assert not (reposd / f"{MOUNTED_REPO}.repo").exists(), (
+        f"{MOUNTED_REPO}.repo survives into the image; its baseurl {MOUNTED_URL} is a bind "
+        "mount that does not exist on a booted host"
+    )
+    kept = (reposd / "keep-me.repo").read_text()
+    assert "https://repo.tunaos.org" in kept, (
+        "an https tier is reachable from a booted host; only file:// repos are "
+        "build-only"
+    )
+
+
+def test_the_removal_loop_runs_after_the_packages_are_installed():
+    src = SCRIPT.read_text()
+    assert src.index("\t# Install packages\n") < src.index(
+        "\t# ── Retire the build-only repos"
+    ), "the repo cannot be retired before the transaction that needs it"
+    assert src.index("\t# ── Retire the build-only repos") < src.index(
+        "\nfi # end DNF path (el10/fedora)"
+    )


### PR DESCRIPTION
## Summary

Split out of #2324 so the time-critical half does not wait on the GNOME 50 factory index. Two independent changes, neither touching `manifests/desktops/gnome.yaml`.

### 1. Three base image pins have been garbage-collected upstream

`Check base image pins` has failed on `main` for two nights running ([33699188451](https://github.com/tuna-os/tunaOS/actions/runs/33699188451), [33820669203](https://github.com/tuna-os/tunaOS/actions/runs/33820669203)):

```
FAIL  404  quay.io/fedora/fedora-bootc:44@sha256:a531996f...
FAIL  404  quay.io/fedora/fedora-bootc:rawhide@sha256:d44d1ba4...
FAIL  404  registry.opensuse.org/opensuse/tumbleweed:latest@sha256:035ae7a1...
checked 14 digest-pinned base image(s); 3 unresolvable
```

Re-pinned to each tag's current digest:

| variant base | new digest |
|---|---|
| `quay.io/fedora/fedora-bootc:44` | `sha256:9c8fae9f47e7287d27542a6fe30ec408151655b142a61beea787c94654f1911a` |
| `quay.io/fedora/fedora-bootc:rawhide` | `sha256:6c04d2602182c7f8ae465be9ecf9987695e26895a35f7226dbe8b63be912d5c3` |
| `registry.opensuse.org/opensuse/tumbleweed:latest` | `sha256:1691585b5daf973c032d1f94d3b8b85393d259ac0348c1c5b91abceeeb3334a9` |

This is why it is urgent: bonito's nightly fires at 11:20Z and dies at `FROM` without these.

### 2. A build-only `file://` repo ships in the image and breaks `dnf` on the host

`install-desktop.sh` writes `/etc/yum.repos.d/<name>.repo` for every repo the manifest's OS section declares, and nothing removes it — `99-cleanup.sh` runs in `base-no-de`, **before** the desktop stages fork from it.

For an https tier that is fine and sometimes deliberate (`10-base-packages.sh` writes `tunaos-hummingbird.repo` the same way). For a `file://` repo it is not: those baseurls are bind mounts `Containerfile.el10` provides for the duration of one `RUN`. On a booted host the path does not exist, and the write loop emits `skip_if_unavailable=False` — so it is not a stale entry, it fails every `dnf` transaction the user runs.

hummingbird has shipped `utah-packages.repo` pointing at `/run/utah-packages` since `8a31ace9`. Nothing asserted the repo set an image ships, so nothing caught it.

The end of the dnf section now removes the repo files it wrote whose baseurl is `file://`, and only those.

## Testing

```
python3 -m pytest tests/test_a_build_only_repo_does_not_ship.py \
    tests/test_base_image_pins_are_checked.py \
    tests/test_package_repo_pins_are_checked.py -q          26 passed

bats tests/bats/test_build_scripts_remaining.bats           75 ok, 2 not ok
```

The two bats failures (`every zypper desktop installs the display manager it enables`, `40-services.sh declares the privsep directory sshd cannot start without`) are pre-existing — they fail identically on `main` with these changes stashed.

The new tests run the shipped write and removal loops against a fake `yq`; both were verified to fail against the unfixed script and pass against the fixed one, so they are not vacuous.

## Related issues

Split from #2324, which retains the GNOME 50 tier switch and floor enforcement. Base-pin GC is the recurring failure from #1788.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_