### PR TITLE
flounder: stop declaring GNOME on trixie until a backport is real

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -1466,8 +1466,27 @@ variants:
       - id: gnome
         stage: 2
         platforms: ["linux/amd64", "linux/arm64"]
-        build_image: true
-        build_iso: true
+        # Off: Debian 13 trixie ships GNOME 48.7 and the floor is 50
+        # (manifests/desktops/gnome.yaml minimum_version), so this flavor
+        # cannot ship a conforming desktop from its own base.
+        #
+        # Backporting was measured, not assumed. The sid -> trixie closure
+        # for GNOME 50 is 165 source packages, 122 of them Rust crates, and
+        # it pulls rustc 1.85 -> 1.95, debhelper 13 -> 14, systemd 257 ->
+        # 262 and three LLVM toolchains trixie does not have; the build
+        # order cannot even be computed, because gdk-pixbuf, glycin, mutter,
+        # nautilus and the rust-gdk4 crates form a build-dependency cycle.
+        # With only gnome-shell and mutter as roots it is still 151. For
+        # scale, the same engine says Ubuntu resolute needs 18 and Debian
+        # sid needs 1, and trixie-backports carries no GNOME stack at all.
+        # That is a partial distribution rebuild, not a desktop backport
+        # (tuna-os/tunaos-packages#687).
+        #
+        # Debian GNOME ships from flounder-sid, which has 50.4 natively and
+        # takes 51 within weeks of release. Turn this back on only after
+        # re-measuring: while trixie is frozen the number only grows.
+        build_image: false
+        build_iso: false
       # gnome-asahi: NOT declared, and not an oversight.
       #
       # build_scripts/overlay/asahi.sh's debian branch resolves a real
@@ -1542,8 +1561,10 @@ variants:
       - id: gnome-nvidia
         platforms: ["linux/amd64"]
         stage: 3
-        build_image: true
-        build_iso: true
+        # Off with its parent: a stage-3 overlay on gnome, which cannot
+        # meet the GNOME 50 floor from trixie (see above).
+        build_image: false
+        build_iso: false
         build_qcow2: false
       - id: kde-nvidia
         platforms: ["linux/amd64"]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ TunaOS builds **bootc-based desktop operating systems** with atomic updates and 
 | 🐟 **Grouper** | Ubuntu 26.04 | `ghcr.io/tuna-os/grouper` | GNOME, KDE, Niri, XFCE | x86_64 |
 | 🐟 **Gurnard** | Ubuntu 24.04 (Noble Numbat, experimental) | `ghcr.io/tuna-os/gurnard` | Base, Pantheon | x86_64, arm64 |
 | 🚀 **Marlin** | Arch Linux (Rolling) | `ghcr.io/tuna-os/marlin` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
-| 🐡 **Flounder** | Debian 13 (Trixie) | `ghcr.io/tuna-os/flounder` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
+| 🐡 **Flounder** | Debian 13 (Trixie) | `ghcr.io/tuna-os/flounder` | KDE, COSMIC, Niri, XFCE | x86_64 |
 | ☢️ **Flounder Sid** | Debian Sid (Unstable) | `ghcr.io/tuna-os/flounder:*-sid` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
 | 🐉 **Bonito Rawhide** | Fedora Rawhide | `ghcr.io/tuna-os/bonito:*-rawhide` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64, arm64 |
 | 🦈 **Sailfin** | openSUSE Tumbleweed | `ghcr.io/tuna-os/sailfin` | GNOME, KDE, Niri, XFCE | x86_64 |

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -54,12 +54,12 @@ flowchart LR
   installs; [INSTALLER-FRONTENDS.md](INSTALLER-FRONTENDS.md) tracks their
   parity matrix.
 
-## 2. The build matrix: 142 cells
+## 2. The build matrix: 140 cells
 
 Everything CI does is driven by **`.github/build-config.yml`**: 14 variants ×
 their flavors (5 desktops + `base` + hardware tiers) × declared platforms
 (amd64 / amd64-v2 / arm64). A **cell** is one `(variant, flavor)` pair —
-`yellowfin:gnome`, `bonito:kde-nvidia` — and there are 142 of them with
+`yellowfin:gnome`, `bonito:kde-nvidia` — and there are 140 of them with
 `build_image: true`. Every scoreboard, gate, and denominator in the project
 derives from this file, on purpose: a flavor that isn't declared here doesn't
 exist, and tests enforce that the workflows regenerate from it rather than
@@ -255,7 +255,7 @@ flowchart LR
     CRIT[".github/green-criteria.yml<br/>enforcement per criterion"]
     GEN["scripts/gen-matrix-status.py<br/>composite scorer"]
     MS["docs/MATRIX-STATUS.md<br/>Composite green — the bar"]
-    RM["README<br/>Built X/142 · composite green Y/142"]
+    RM["README<br/>Built X/140 · composite green Y/140"]
 
     evidence --> GEN
     CRIT --> GEN

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -75,7 +75,7 @@ Scored against `.github/green-criteria.yml`: a cell is green only when every **b
 | **albacore** | ✅ | ✅ | ❌ | ❌ | ✅ |
 | **bonito** | ⬜ | ⬜ | ⬜ | ⬜ | ⬜ |
 | **bonito-rawhide** | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **flounder** | ✅ | ✅ | — | — | ❌ |
+| **flounder** | — | ✅ | — | — | ❌ |
 | **flounder-sid** | ❌ | ❌ | — | — | ❌ |
 | **grouper** | ✅ | ✅ | ❌ | — | ✅ |
 | **guppy** | ❌ | ⬜ | — | — | ⬜ |

--- a/tests/test_matrix_status.py
+++ b/tests/test_matrix_status.py
@@ -332,11 +332,19 @@ class UndeclaredCellsAreNotCountedAgainstUs(unittest.TestCase):
             gms.VOLATILE_LINE,
         )
 
-    def test_the_real_build_config_declares_53_luks_cells(self):
+    def test_the_real_build_config_declares_52_luks_cells(self):
         """Ties the unit tests above to the actual denominator on disk.
 
         If this number moves, the LUKS total moves with it, and that should be
         a deliberate build-config edit rather than a surprise.
+
+        53 -> 52 on 2026-09-05: flounder:gnome is off. Debian 13 trixie
+        ships GNOME 48.7 against a floor of 50, and the sid -> trixie
+        backport measures at 165 sources including rustc, debhelper 14 and
+        three LLVM toolchains, so the flavor cannot ship a conforming
+        desktop (tuna-os/tunaos-packages#687). Debian GNOME comes from
+        flounder-sid instead. gnome-nvidia is a stage-3 overlay on it and
+        goes with it, but only gnome carries LUKS, hence one cell not two.
 
         52 -> 53 on 2026-08-25: wahoo (Fedora ELN) declares one desktop
         flavor, gnome, with build_image: true. luks-e2e.yml builds its matrix
@@ -364,7 +372,7 @@ class UndeclaredCellsAreNotCountedAgainstUs(unittest.TestCase):
         the Niri stack and zero `xfce*`), so they add nothing here.
         """
         matrix = gms.luks_matrix()
-        self.assertEqual(sum(len(v) for v in matrix.values()), 53)
+        self.assertEqual(sum(len(v) for v in matrix.values()), 52)
         # The control that makes the drop specific rather than merely smaller:
         # hummingbird keeps exactly the desktops it has package sets for.
         self.assertEqual(matrix.get("hummingbird"), {"gnome", "cosmic"})
@@ -375,7 +383,12 @@ class UndeclaredCellsAreNotCountedAgainstUs(unittest.TestCase):
         self.assertNotIn("cosmic", matrix.get("flounder-sid", set()))
         # A control: the flavours flounder DOES declare are still there, so
         # this is not passing because the matrix came back empty.
-        self.assertEqual(matrix.get("flounder"), {"gnome", "kde", "xfce"})
+        self.assertEqual(matrix.get("flounder"), {"kde", "xfce"})
+        # And the paired control on the descope: Debian GNOME did not go away,
+        # it moved. flounder-sid still owes a gnome cell, so a change that
+        # switched off Debian GNOME entirely would fail here rather than pass
+        # as a smaller-but-honest denominator.
+        self.assertIn("gnome", matrix.get("flounder-sid", set()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Turns off `flounder:gnome` and `flounder:gnome-nvidia` (`build_image: false` / `build_iso: false`), with the reasoning kept next to the switch in `.github/build-config.yml`.

## Why

Debian 13 trixie ships **GNOME 48.7**. `manifests/desktops/gnome.yaml` sets `minimum_version: 50`, so `verify-desktop-experience.sh` fails this cell by construction — it is a box in the denominator that cannot be paid from its own base.

The backport was **measured, not assumed**. Closing over `Build-Depends` from sid to trixie and keeping only what trixie cannot already satisfy:

| roots | sources to backport |
|---|---|
| full GNOME 50 desktop | **165** (122 of them Rust crates) |
| `gnome-shell` + `mutter` only | **151** |
| Ubuntu resolute (same engine) | 18 |
| Debian sid (same engine) | 1 |

The 165 drags `rustc` 1.85 → 1.95, `debhelper` 13 → 14, `systemd` 257 → 262, and three LLVM toolchains trixie does not carry. The build order cannot even be computed: `gdk-pixbuf`, `glycin`, `mutter`, `nautilus` and the `rust-gdk4` crates form a build-dependency cycle. `trixie-backports` carries no GNOME stack at all, so there is nothing to lean on.

That is a partial distribution rebuild, not a desktop backport. Tracked for real work in tuna-os/tunaos-packages#687.

**Debian GNOME still ships.** `flounder-sid` has 50.4 natively and takes 51 within weeks of release. That is now a test control rather than a comment: `test_the_real_build_config_declares_52_luks_cells` asserts `flounder-sid` still owes a `gnome` cell, so a change that switched Debian GNOME off *entirely* fails there instead of passing as a smaller-but-honest denominator.

`gnome-nvidia` is a stage-3 overlay on `gnome` and goes with it. Only `gnome` carries LUKS, hence one LUKS cell dropped, not two.

## Numbers that move

- image cells with `build_image: true`: **142 → 140** (`docs/DEVELOPER-GUIDE.md` heading, prose, and the README box in the diagram — all four occurrences are asserted by `test_the_documented_cell_count_is_the_configured_one.py`)
- LUKS cells: **53 → 52** (`tests/test_matrix_status.py`)
- `README.md` flounder row drops GNOME

## Test plan

- `python3 -m pytest tests/test_matrix_status.py tests/test_the_documented_cell_count_is_the_configured_one.py -q` → 23 passed
- every Python test touching `flounder` / `build-config` / `build_image` (188 tests) → passed
- `bats` for declared-flavour installability, build-config adapter, press-claims/ROADMAP parity, guppy desktops, apt desktop branch → 16/16 ok

## Turning it back on

Re-measure first. While trixie is frozen the number only grows; the switch flips back when the closure is small enough to be a backport rather than a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_