### PR TITLE
renovate: adopt the shared org preset; stop bot PRs paging a code owner

### DIFF
--- a/.github/workflows/drop-bot-review-requests.yml
+++ b/.github/workflows/drop-bot-review-requests.yml
@@ -11,12 +11,16 @@ name: Drop bot review requests
 # genuinely requires a code-owner approval, the PR still waits for one; it just
 # stops sitting in a person's review queue.
 #
-# pull_request_target is used so the token can write on the PR. It is safe here
-# because this workflow never checks out or executes any code from the pull
-# request -- it only calls the API with values GitHub itself supplies.
+# Deliberately `pull_request`, not `pull_request_target`: this needs no code
+# from the PR, and pull_request_target would hand a write token and secrets to
+# a workflow triggered by PR contents for no benefit (tunaOS forbids it
+# outright -- tests/test_fork_safe_workflows.py). The job is additionally
+# limited to same-repo PRs: a fork PR's token is read-only, so the API call
+# would fail rather than do anything useful. Renovate branches live in the
+# repository, so the bots this exists for are always in scope.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, ready_for_review]
 
 permissions:
@@ -28,7 +32,9 @@ concurrency:
 
 jobs:
   drop:
-    if: github.event.pull_request.user.type == 'Bot'
+    if: >-
+      github.event.pull_request.user.type == 'Bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Remove auto-requested reviewers

--- a/.github/workflows/drop-bot-review-requests.yml
+++ b/.github/workflows/drop-bot-review-requests.yml
@@ -1,0 +1,52 @@
+name: Drop bot review requests
+
+# CODEOWNERS (`* @hanthor` in most tuna-os repos) makes GitHub request a review
+# on every pull request, bots included. Those requests are what turn routine
+# dependency bumps into a notification stream: Renovate opens the PR, GitHub
+# asks a human to review it, and the human gets pinged even though the PR is
+# going to merge itself on green CI via platformAutomerge.
+#
+# This drops the auto-requested reviewers from bot-authored PRs only. Human PRs
+# are untouched, and nothing about branch protection changes -- if a repo
+# genuinely requires a code-owner approval, the PR still waits for one; it just
+# stops sitting in a person's review queue.
+#
+# pull_request_target is used so the token can write on the PR. It is safe here
+# because this workflow never checks out or executes any code from the pull
+# request -- it only calls the API with values GitHub itself supplies.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: drop-bot-review-requests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  drop:
+    if: github.event.pull_request.user.type == 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove auto-requested reviewers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          requested=$(gh api "repos/${REPO}/pulls/${PR}" \
+            --jq '{reviewers: [.requested_reviewers[].login], team_reviewers: [.requested_teams[].slug]}')
+          users=$(printf '%s' "$requested" | jq -c '.reviewers')
+          teams=$(printf '%s' "$requested" | jq -c '.team_reviewers')
+          if [ "$users" = "[]" ] && [ "$teams" = "[]" ]; then
+            echo "No review requests on this PR; nothing to drop."
+            exit 0
+          fi
+          echo "Dropping review requests -- users: ${users} teams: ${teams}"
+          printf '%s' "$requested" \
+            | gh api -X DELETE "repos/${REPO}/pulls/${PR}/requested_reviewers" --input - >/dev/null
+          echo "Done."

--- a/renovate.json
+++ b/renovate.json
@@ -1,23 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
-
-  "platformAutomerge": true,
+  "extends": [
+    "local>tuna-os/.github",
+    "local>tuna-os/.github",
+    "config:best-practices"
+  ],
   "automergeType": "pr",
   "automergeStrategy": "squash",
-  "automerge": false,
-
   "rebaseWhen": "conflicted",
-
   "git-submodules": {
     "enabled": true
   },
-
   "customManagers": [
     {
       "customType": "regex",
       "description": "Update image digests in image-versions.yaml",
-      "managerFilePatterns": ["/^image-versions\\.yaml$/"],
+      "managerFilePatterns": [
+        "/^image-versions\\.yaml$/"
+      ],
       "matchStrings": [
         "- name: (?<depName>[\\w-]+)\\n\\s+image: (?<packageName>[^\\n]+)\\n\\s+tag: (?<currentValue>[^\\n]+)\\n\\s+digest: (?<currentDigest>sha256:[a-f0-9]+)"
       ],
@@ -27,7 +27,9 @@
     {
       "customType": "regex",
       "description": "Update pinned downloads in image-versions.yaml (GitHub releases)",
-      "managerFilePatterns": ["/^image-versions\\.yaml$/"],
+      "managerFilePatterns": [
+        "/^image-versions\\.yaml$/"
+      ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)\\n\\s+[\\w-]+:\\s*\"(?<currentValue>[^\"]+)\""
       ]
@@ -35,7 +37,9 @@
     {
       "customType": "regex",
       "description": "Update GitHub Actions pinned SHAs",
-      "managerFilePatterns": ["/\\.github/workflows/.+\\.ya?ml$/"],
+      "managerFilePatterns": [
+        "/\\.github/workflows/.+\\.ya?ml$/"
+      ],
       "matchStrings": [
         "uses:\\s+(?<depName>[\\w-]+/[\\w-]+)@(?<currentDigest>[a-f0-9]{40})\\s*#\\s*(?<currentValue>v?\\d[^\\s]*)"
       ],
@@ -44,7 +48,10 @@
     {
       "customType": "regex",
       "description": "Update font/binary version pins in build scripts",
-      "managerFilePatterns": ["/^build_scripts/.+\\.sh$/", "/^scripts/.+\\.sh$/"],
+      "managerFilePatterns": [
+        "/^build_scripts/.+\\.sh$/",
+        "/^scripts/.+\\.sh$/"
+      ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)\\n.*?(?<currentValue>v?\\d+\\.\\d+[^\\s/\"]*)"
       ]
@@ -52,7 +59,9 @@
     {
       "customType": "regex",
       "description": "Update quay.io image digests in registry-map.yaml. tunaOS#1568: this file carried a digest pin for supply-chain safety that nothing bumped, and the pin was garbage-collected upstream (quay 404) before anyone noticed. Scoped to `registry: quay` entries so registryUrlTemplate is correct by construction; a ghcr entry that gains a digest needs its own block rather than silently resolving against the wrong registry.",
-      "managerFilePatterns": ["/^registry-map\\.yaml$/"],
+      "managerFilePatterns": [
+        "/^registry-map\\.yaml$/"
+      ],
       "matchStrings": [
         "registry: quay\\n\\s+path: (?<packageName>[^\\n]+)\\n(?:\\s+#[^\\n]*\\n)*\\s+digest: (?<currentDigest>sha256:[a-f0-9]+)\\n\\s+tag: (?<currentValue>[^\\n]+)"
       ],
@@ -61,31 +70,34 @@
       "depNameTemplate": "{{{packageName}}}"
     }
   ],
-
   "packageRules": [
     {
-      "description": "Automerge only patch/pin/digest updates (org gate .github#12): major/minor require review",
-      "matchUpdateTypes": ["patch", "pin", "pinDigest", "digest"],
-      "automerge": true
-    },
-    {
       "description": "Never automerge a download whose version is paired with a hand-pinned sha256. Renovate bumps the version and cannot bump the checksum, so the bump alone fails every base build closed at `sha256sum --check` (install-remora.sh). The `checksums` check catches it on the PR, but the main ruleset has no required status checks, so platformAutomerge merged #2308 with that check red and took every variant's nightly base build down on 2026-09-03 (flounder run 33694724467). Hold these for a human to run `scripts/check-download-checksums.py --fix` on the branch first. tests/test_checksum_pinned_downloads_are_not_automerged.py derives this list from the repo.",
-      "matchDepNames": ["tuna-os/remora", "twpayne/chezmoi"],
+      "matchDepNames": [
+        "tuna-os/remora",
+        "twpayne/chezmoi"
+      ],
       "automerge": false
     },
     {
       "description": "Group all GitHub Actions updates into a single PR",
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "groupName": "github-actions"
     },
     {
       "description": "Group git-submodule updates into a single PR",
-      "matchManagers": ["git-submodules"],
+      "matchManagers": [
+        "git-submodules"
+      ],
       "groupName": "submodules"
     },
     {
-      "description": "ghcr.io/projectbluefin/common:latest moves upstream multiple times a day, and digest-tracking PRs get superseded rather than updated in place — three separate PRs (each a full CI run) landed in ~33 hours (tunaOS#753). Debounce: wait for a digest to sit still for a few days before opening a PR, so rapid upstream churn coalesces into one PR instead of several.",
-      "matchPackageNames": ["ghcr.io/projectbluefin/common"],
+      "description": "ghcr.io/projectbluefin/common:latest moves upstream multiple times a day, and digest-tracking PRs get superseded rather than updated in place \u2014 three separate PRs (each a full CI run) landed in ~33 hours (tunaOS#753). Debounce: wait for a digest to sit still for a few days before opening a PR, so rapid upstream churn coalesces into one PR instead of several.",
+      "matchPackageNames": [
+        "ghcr.io/projectbluefin/common"
+      ],
       "minimumReleaseAge": "3 days"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -72,6 +72,17 @@
   ],
   "packageRules": [
     {
+      "description": "Mirrors the low-risk set in the shared preset (local>tuna-os/.github). Redundant at runtime -- the preset already carries it, and preset rules are applied before this file's -- but kept HERE on purpose: tests/test_checksum_pinned_downloads_are_not_automerged.py reads this file alone and cannot resolve the preset, so without a local blanket rule the checksum-pinned hold below has nothing to be ordered against and the invariant from #2293/#2308 stops being verifiable in-repo. Keep it immediately above that hold.",
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest"
+      ],
+      "automerge": true
+    },
+    {
       "description": "Never automerge a download whose version is paired with a hand-pinned sha256. Renovate bumps the version and cannot bump the checksum, so the bump alone fails every base build closed at `sha256sum --check` (install-remora.sh). The `checksums` check catches it on the PR, but the main ruleset has no required status checks, so platformAutomerge merged #2308 with that check red and took every variant's nightly base build down on 2026-09-03 (flounder run 33694724467). Hold these for a human to run `scripts/check-download-checksums.py --fix` on the branch first. tests/test_checksum_pinned_downloads_are_not_automerged.py derives this list from the repo.",
       "matchDepNames": [
         "tuna-os/remora",


### PR DESCRIPTION
## Summary

⚠️ **Depends on tuna-os/.github#70.** Until that preset is on `main`, `local>tuna-os/.github` does not resolve — merge it first.

This repo carried its own copy of a `renovate.json` that 32 repos shared almost verbatim, so the fleet's automerge policy could only be changed 32 times or not at all. It now extends the single org preset, which adds `minor` to the automerged set and keeps `major` gated (tuna-os/.github#12). `platformAutomerge` means GitHub's native auto-merge does the merging, so **branch protection still gates every automerged PR**.

**Preserved verbatim** — this repo has the most repo-specific config in the fleet, and none of it changed: all 5 `customManagers`; the GitHub Actions and git-submodule **grouping** rules; the `minimumReleaseAge` hold on `ghcr.io/projectbluefin/common:latest`; `automergeType: pr`, `automergeStrategy: squash`, `rebaseWhen: conflicted`, `git-submodules.enabled`; and `config:best-practices`, kept after the preset in `extends` so it still wins where the two overlap.

`CODEOWNERS` (`* @hanthor @castrojo @tulilirockz`) makes GitHub request a review on every PR, bots included, so a bump that was going to merge itself on green CI still paged three people. The added workflow drops those auto-requested reviewers from bot-authored PRs only.

## Two things this repo's tests caught, and what changed because of them

Both were real, both are fixed in `0a43cafb`.

### 1. `pull_request_target` — `test_fork_safe_workflows.py`

The workflow took a write token and secrets on an event triggered by a PR's contents, for a job that needs no code from the PR at all. `PULL_REQUEST_TARGET_ALLOWED` here is **empty** — there are no sanctioned uses — so the fix is to stop needing an exception rather than to add one.

It is now `pull_request`, limited to same-repo PRs. That is both what the test looks for and what is actually true: a fork PR's token is read-only, so the call would fail rather than do anything useful, and Renovate's branches live in the repository. **Applied to all 31 copies in the fleet, not just this one** — the reasoning holds everywhere, and one workflow that differs from the other thirty is how a fleet drifts.

### 2. The checksum-pinned hold — `test_checksum_pinned_downloads_are_not_automerged.py`

This is the one worth reading. That test exists because of two measured incidents (#2293, #2308) where Renovate automerged a version+sha256 pinned download and the base build died at `sha256sum --check`.

The hold itself (`tuna-os/remora`, `twpayne/chezmoi` → `automerge: false`) was **never dropped**, and `test_every_checksum_paired_download_ends_up_not_automerged` kept passing throughout. What broke was the *ordering* assertion, which requires a blanket automerge rule and the hold in the same file: moving the blanket rule into the preset left the hold with nothing to be ordered against.

Runtime behaviour was still correct — Renovate applies preset rules before the extending repo's, so the hold still wins under last-match-wins. But the invariant stopped being **verifiable in-repo**, and that test reads `renovate.json` alone and cannot resolve a preset. A guard that can no longer check the thing it exists to check is a regression even when the behaviour is fine.

So the blanket rule is restored locally, immediately above the hold, and its `description` says why it is deliberately redundant with the preset. The alternative — relaxing the test to accommodate the new layout — would have quietly traded away the only lever this repository has over #2308.

## Testing

- `pytest tests/test_checksum_pinned_downloads_are_not_automerged.py tests/test_fork_safe_workflows.py tests/test_ci_contract.py` → **65 passed** (was 2 failed).
- `renovate.json` passes the org automerge policy checker: `OK: does not automerge major updates`.
- Rule order asserted by hand as well as by the test: blanket (index 0) → checksum hold (index 1) → groupings → release-age hold.
- Workflow parses; `bash -n` and `shellcheck -S warning` clean on its `run` block; all 31 fleet copies byte-identical.

## Checklist

- [ ] Commit messages are signed-off (`git commit -s`) — not added; I do not add sign-off trailers on a maintainer's behalf.
- [x] No secrets or machine-specific paths are committed
- [x] Config-only change — no image or build behaviour is affected

## Related

- References: tuna-os/.github#70, tuna-os/.github#12, #1612, #1636, #2293, #2308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx