### PR TITLE
cosmic, niri: install the software Vulkan driver these manifests never had

### DIFF
--- a/manifests/desktops/cosmic-arch.yaml
+++ b/manifests/desktops/cosmic-arch.yaml
@@ -53,6 +53,12 @@ packages:
     - power-profiles-daemon
     - fwupd
     - plymouth
+    # Software Vulkan (lavapipe) plus the ICD loader. Arch splits these out
+    # of `mesa`, so neither arrives transitively. Without a Vulkan ICD, Mesa's
+    # zink path cannot choose a device on the GPU-less CI guest and cosmic-comp
+    # comes up with no surface -- see the note in cosmic.yaml.
+    - vulkan-icd-loader
+    - vulkan-swrast
 
   # CachyOS adds its own repos on top of Arch — same pacman packages
   # but with performance-optimized builds.

--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -120,18 +120,26 @@ packages:
       - greetd
       - xdg-desktop-portal-cosmic
       # Software Vulkan (lavapipe). Not a dependency of anything, so it is
-      # only present if asked for by name -- which is why every cosmic cell
-      # that has been booted fails on GPU-less CI while gnome starts on the
-      # identical guest. The guest HAS a render node (run 32681262659 read
+      # only present if asked for by name.
+      #
+      # This is for the INSTALLER SMOKE path, which runs on hosted runners
+      # with no GPU. There the guest has a render node (run 32681262659 read
       # /dev/dri and found renderD128) but the kernel reports `-virgl`, so
-      # Mesa routes GL through zink, and zink with no Vulkan ICD installed
+      # Mesa routes GL through zink -- and zink with no Vulkan ICD installed
       # cannot pick a device:
       #   MESA: error: ZINK: failed to choose pdev
       #   libEGL warning: egl: failed to create dri2 screen
-      # cosmic-comp then holds a Wayland connection with no surface, which
-      # is the 'process running, nothing on screen' state the smoke gate
-      # reports. On real hardware it survived by falling back to Vulkan
-      # llvmpipe -- this is that fallback, packaged.
+      # cosmic-comp then holds a Wayland connection with no surface. On real
+      # hardware it survived by falling back to Vulkan llvmpipe; this is that
+      # fallback, packaged. Also the right thing for anyone running cosmic in
+      # a plain VM.
+      #
+      # It is NOT why the `boots` gate is red for cosmic. That gate asks for
+      # a g4dn GPU runner and the account's vCPU limit for that instance
+      # bucket is 0, so the runner never launches and QEMU never starts:
+      #   Failed to launch runner: failed to create fleet:
+      #   VcpuLimitExceeded ... AllowedInstanceTypes:["g4dn*"]
+      # No package fixes a quota of zero (tuna-os/tunaOS#2123).
       - mesa-vulkan-drivers
 
   fedora:

--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -119,6 +119,20 @@ packages:
       - cosmic-greeter
       - greetd
       - xdg-desktop-portal-cosmic
+      # Software Vulkan (lavapipe). Not a dependency of anything, so it is
+      # only present if asked for by name -- which is why every cosmic cell
+      # that has been booted fails on GPU-less CI while gnome starts on the
+      # identical guest. The guest HAS a render node (run 32681262659 read
+      # /dev/dri and found renderD128) but the kernel reports `-virgl`, so
+      # Mesa routes GL through zink, and zink with no Vulkan ICD installed
+      # cannot pick a device:
+      #   MESA: error: ZINK: failed to choose pdev
+      #   libEGL warning: egl: failed to create dri2 screen
+      # cosmic-comp then holds a Wayland connection with no surface, which
+      # is the 'process running, nothing on screen' state the smoke gate
+      # reports. On real hardware it survived by falling back to Vulkan
+      # llvmpipe -- this is that fallback, packaged.
+      - mesa-vulkan-drivers
 
   fedora:
     packages:
@@ -155,6 +169,9 @@ packages:
       - greetd
       - xdg-desktop-portal-cosmic
       - pop-icon-theme
+      # Software Vulkan (lavapipe) -- see the apt list's note above for why
+      # this must be named rather than pulled in transitively.
+      - mesa-vulkan-drivers
 
   # ── Hummingbird (Fedora rebuild) ───────────────────────────────────
   # The cheapest real win in the matrix (#1755 §4): the rebuild repo carries
@@ -211,6 +228,9 @@ packages:
       - greetd
       - xdg-desktop-portal-cosmic
       - pop-icon-theme
+      # Software Vulkan (lavapipe) -- see the apt list's note above for why
+      # this must be named rather than pulled in transitively.
+      - mesa-vulkan-drivers
 
   # ── Wahoo (Fedora ELN) ─────────────────────────────────────────────────
   # ELN carries COSMIC natively, in eln-extras, at 1.6.0 — and that is the
@@ -255,6 +275,9 @@ packages:
       - greetd
       - xdg-desktop-portal-cosmic
       - pop-icon-theme
+      # Software Vulkan (lavapipe) -- see the apt list's note above for why
+      # this must be named rather than pulled in transitively.
+      - mesa-vulkan-drivers
     # Absent from ELN on 2026-08-26 (cosmic-icons likewise, and it is not
     # in the fedora list either). Best-effort so it lands by itself when
     # the compose grows it — tracked in tunaos-packages.
@@ -314,6 +337,9 @@ packages:
       # the login flow. Both are in EL10 appstream, so require (not best-effort).
       - gnome-keyring
       - gnome-keyring-pam
+      # Software Vulkan (lavapipe) -- see the apt list's note above for why
+      # this must be named rather than pulled in transitively.
+      - mesa-vulkan-drivers
     optional:
       - brightnessctl
       - playerctl
@@ -386,6 +412,11 @@ packages:
     - wl-clipboard
     - Mesa-dri
     - Mesa-libEGL1
+    # Software Vulkan (lavapipe). Not a dependency of anything, so it is
+    # only present if asked for by name -- which is why every cosmic cell
+    # that has been booted fails on GPU-less CI while gnome starts on the
+    # See the RPM lists above for the full zink/lavapipe note.
+    - libvulkan_lvp
 
   # ── Emerge (Gentoo) ────────────────────────────────────────────────
   # DELIBERATELY ABSENT — no emerge section at all, same treatment as

--- a/manifests/desktops/niri-arch.yaml
+++ b/manifests/desktops/niri-arch.yaml
@@ -79,6 +79,10 @@ packages:
     - flatpak
     - adw-gtk-theme
     - papirus-icon-theme
+    # Software Vulkan (lavapipe) + ICD loader; Arch splits both out of `mesa`.
+    # See niri.yaml for why this is the test rather than the fix.
+    - vulkan-icd-loader
+    - vulkan-swrast
 
   cachyos:
     repos:

--- a/manifests/desktops/niri.yaml
+++ b/manifests/desktops/niri.yaml
@@ -61,6 +61,14 @@ packages:
       - nautilus
       - adw-gtk3-theme
       - papirus-icon-theme
+      # Software Vulkan (lavapipe). Smithay needs EGL/GLES on the GBM device,
+      # and on the GPU-less CI guest the render node reports `-virgl`, so Mesa
+      # falls back to zink -- which needs a Vulkan ICD to choose a device at
+      # all. Not a dependency of anything, so it must be named. Whether niri
+      # then accepts a software GLES is the open question this tests: unlike
+      # wlroots it ships no Pixman/CPU renderer, so it may still decline. If
+      # it does, the honest answer is a boots-scope exclusion, not a package.
+      - mesa-vulkan-drivers
     optional:
       - polkit-gnome
 
@@ -121,6 +129,8 @@ packages:
       - gnome-keyring
       - gnome-keyring-pam
       - papirus-icon-theme
+      # Software Vulkan (lavapipe) -- see the fedora list's note above.
+      - mesa-vulkan-drivers
       # NOTE: blueman (Bluetooth applet) has no EL10/EPEL 10 build, so it is
       # intentionally absent here (present in the Fedora section). No packaged
       # standalone Bluetooth GUI exists for EL10 niri yet.
@@ -218,6 +228,8 @@ packages:
     - adwaita-icon-theme
     - Mesa-dri
     - Mesa-libEGL1
+    # See the RPM lists above: software Vulkan for the zink path.
+    - libvulkan_lvp
 
   # ── Emerge (Gentoo) ────────────────────────────────────────────────
   # DELIBERATELY ABSENT. niri is not packaged in the Gentoo main tree at all —

--- a/manifests/desktops/niri.yaml
+++ b/manifests/desktops/niri.yaml
@@ -61,13 +61,17 @@ packages:
       - nautilus
       - adw-gtk3-theme
       - papirus-icon-theme
-      # Software Vulkan (lavapipe). Smithay needs EGL/GLES on the GBM device,
-      # and on the GPU-less CI guest the render node reports `-virgl`, so Mesa
-      # falls back to zink -- which needs a Vulkan ICD to choose a device at
-      # all. Not a dependency of anything, so it must be named. Whether niri
-      # then accepts a software GLES is the open question this tests: unlike
-      # wlroots it ships no Pixman/CPU renderer, so it may still decline. If
-      # it does, the honest answer is a boots-scope exclusion, not a package.
+      # Software Vulkan (lavapipe), for the hosted-runner installer smoke
+      # path: Smithay needs EGL/GLES on the GBM device, and there the render
+      # node reports `-virgl`, so Mesa falls back to zink -- which needs a
+      # Vulkan ICD to choose a device at all. Not a dependency of anything,
+      # so it must be named. Whether niri then accepts a software GLES is
+      # untested; unlike wlroots it ships no Pixman/CPU renderer, so it may
+      # still decline.
+      #
+      # This does not touch the `boots` gate, which for niri (as for cosmic)
+      # asks for a g4dn runner the account has a vCPU limit of 0 for -- the
+      # runner never launches. See cosmic.yaml and tuna-os/tunaOS#2123.
       - mesa-vulkan-drivers
     optional:
       - polkit-gnome


### PR DESCRIPTION
## What this is

Adds the software Vulkan driver (lavapipe) to the cosmic and niri manifests across every distro section.

**Read the correction below before reviewing this as a fix for the red cosmic cells — it is not one.**

## Correction: this does not fix the `boots` gate

I opened this claiming it addressed the seven failing `boots` cells. That was wrong, and the evidence was from the wrong harness.

The actual failing gate — `albacore:cosmic`, job [101038352430](https://github.com/tuna-os/tunaOS/actions/runs/33848074014) in nightly run 33848074014 — never ran a compositor. It never ran QEMU:

```
Failed to launch runner: failed to create fleet:
[{"ErrorCode":"VcpuLimitExceeded",
  "ErrorMessage":"You have requested more vCPU capacity than your current vCPU limit
   of 0 allows for the instance bucket that the specified instance type belongs to.",
  "InstanceRequirements":{"AllowedInstanceTypes":["g4dn*"] ...
```

`verify_boot` routes cosmic/niri/xfwl4 to `runs-on=<id>/runner=gpu` for a real DRM render node. The account's vCPU limit for the **g4dn bucket is 0**, so the fleet request fails, no runner ever attaches, and the job dies before its first step. That's why the boot-gate artifact is empty (`No files were found ... verify-out/serial.log`).

That is #2123. **No package fixes a quota of zero.**

## Where the original evidence actually came from

The zink/lavapipe symptoms are real — `MESA: error: ZINK: failed to choose pdev`, and run 32681262659 finding `renderD128` present with `[drm] features: -virgl`. But they come from the **installer smoke** path, which runs on hosted runners with no GPU. That is the `install` criterion (advisory), not `boots` (blocking). Conflating the two axes was the error.

## What the change is still worth

Software Vulkan is genuinely missing from these manifests on every distro, and it's what the hosted-runner smoke path needs to get GL through zink at all — as well as what anyone running cosmic or niri in a plain VM needs. So the packages stay, with an honest justification in the manifest comments.

**Untested.** This does not claim to fix the smoke path either; it has not been measured there. It is a defensible packaging gap being closed, nothing more.

## Package names (verified against live repositories)

| section | package |
|---|---|
| apt, fedora, hummingbird, eln, el10 | `mesa-vulkan-drivers` |
| zypper | `libvulkan_lvp` (openSUSE splits the ICDs; no `Mesa-vulkan-drivers` there) |
| pacman | `vulkan-icd-loader` + `vulkan-swrast` (Arch splits both out of `mesa`) |

Checked against AlmaLinux 10, Fedora, Debian trixie, Ubuntu, Arch and openSUSE Tumbleweed rather than assumed. The bats check *"COSMIC on apt is manifest-driven, and names packages that exist there"* passes.

## Tests

Full suite 1336 passed / 0 failed; bats desktop/manifest checks 8/8; yamllint clean (its two warnings are pre-existing on main).

## The real finding

Seven cosmic cells and the niri cells are counted red for a gate that **cannot run at all** on this account. That is an infrastructure and denominator question — raise the g4dn quota, or scope `boots` out for GPU-gated compositors the way `-asahi` already is — not a code change, and deliberately not decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC