### PR TITLE
boots: stop scoring a gate that cannot launch a runner

### DIFF
--- a/.github/green-criteria.yml
+++ b/.github/green-criteria.yml
@@ -146,6 +146,24 @@ criteria:
       # reusable-build-image.yml the same day. Re-gate `base` here if it
       # ever becomes a supported end-user target.
       excludes_flavors: ["base", "base-hwe", "base-nvidia"]
+      # TEMPORARY, and revert the moment g4dn capacity exists. verify_boot
+      # routes these compositors to a GPU runner for a real DRM render node,
+      # and the account's vCPU limit for that instance bucket is 0, so the
+      # fleet request fails and no runner ever attaches:
+      #   Failed to launch runner: failed to create fleet: VcpuLimitExceeded
+      #   ... vCPU limit of 0 ... AllowedInstanceTypes:["g4dn*"]
+      # Confirmed on two independent runs (#2123): nightly 33848074014 job
+      # 101038352430 on main, and 33948918141 job 101266051600 on a branch.
+      # The job dies before its first step -- no serial log, no screenshot, no
+      # compositor. Nothing was measured, so scoring these cells red asserted
+      # a boot failure nobody observed. Out-of-scope is the honest state until
+      # CI can run the gate; it is NOT a claim that they boot.
+      #
+      # Prefixes, because reusable-build-image.yml routes by prefix too:
+      #   startsWith(inputs.flavor, 'cosmic') || 'niri' || 'xfwl4'
+      # Pinned equal by tests/test_the_boots_scope_matches_the_gpu_routing.py
+      # so the scope and the routing cannot drift apart.
+      excludes_flavor_prefixes: ["cosmic", "niri", "xfwl4"]
     status_2026_08_17: "skippable per cell; silently broke matrix-wide on 2026-08-17 (#1811)"
     status_2026_08_17_pm: >-
       blocking. Gates restored by #1818 (marlin gnome/kde/xfce passed same

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -280,6 +280,32 @@ runners — and tuna-os/tunaOS#848 is a prerequisite, since stage-3 flavors
 currently cannot build a dev ISO at all. Until then the ⬜/stale cells above
 should be read as *not yet covered*, not as a backlog of broken cells.
 
+**The boot gate for cosmic/niri/xfwl4 is out of scope, because it cannot
+start.** This is a different failure from everything else in this section: not
+a compositor that will not render, but a job that never runs. `verify_boot`
+routes those flavors to the GPU runner group for a real DRM render node, and
+the account's vCPU limit for that instance bucket is **0**, so the fleet
+request is rejected and no runner ever attaches:
+
+```
+Failed to launch runner: failed to create fleet: VcpuLimitExceeded
+... vCPU limit of 0 ... AllowedInstanceTypes:["g4dn*"]
+```
+
+Confirmed on two independent runs — 33848074014 job 101038352430 on `main`,
+33948918141 job 101266051600 on a branch — each ending `No files were found
+... verify-out/serial.log`. No serial log, no screenshot, no compositor,
+because no step ran.
+
+Those cells were being scored ❌ on `boots`, which asserted a boot failure
+nobody observed. They are now out of scope for that criterion in
+`green-criteria.yml`, alongside `-asahi`. Read that as **not measured** — ⬜
+means measured and unproven, ❌ means measured and failed, and only the first
+is true here. The exclusion moves no cell to green: every one still fails
+another blocking criterion. It reverts the moment g4dn capacity exists
+(tuna-os/tunaOS#2123), and a test pins the excluded prefixes equal to the
+workflow's routing so the two cannot drift apart.
+
 **Not four of five. Four of five are measured, and three of them START.**
 This section used to say cosmic, niri, xfwl4 **and kde** all need a DRM render
 node, that GitHub runners have none, and that "no configuration change alters

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -582,6 +582,16 @@ def criterion_scope_allows(criterion: dict, flavor: str) -> bool:
     scope = criterion.get("scope") or {}
     if flavor in (scope.get("excludes_flavors") or []):
         return False
+    if any(
+        flavor.startswith(prefix)
+        for prefix in (scope.get("excludes_flavor_prefixes") or [])
+    ):
+        # Prefix rather than exact, because the workflow that routes a cell to
+        # a runner does the same: reusable-build-image.yml selects the GPU
+        # group with startsWith(inputs.flavor, ...). Matching on the same shape
+        # keeps the scope and the routing from disagreeing about which cells a
+        # gate can even reach -- and a test pins the two lists equal.
+        return False
     return not any(
         flavor.endswith(suffix)
         for suffix in (scope.get("excludes_flavor_suffixes") or [])

--- a/tests/test_the_boots_scope_matches_the_gpu_routing.py
+++ b/tests/test_the_boots_scope_matches_the_gpu_routing.py
@@ -1,0 +1,84 @@
+"""The boots scope and the runner routing must name the same compositors.
+
+`boots` is scored by verify_boot, and verify_boot only reaches a cell if a
+runner attaches. reusable-build-image.yml sends cosmic/niri/xfwl4 to the GPU
+group for a real DRM render node; the account's vCPU limit for that instance
+bucket is 0, so the fleet request fails and the job dies before its first step
+(#2123, confirmed on runs 33848074014 and 33948918141). Those cells are
+therefore out of scope for `boots` -- not red, because nothing was measured.
+
+The failure mode this pins is drift between two lists that must agree. If
+someone adds a fourth GPU-gated compositor to the routing and not to the
+scope, its cells silently start being scored red for a gate that cannot run
+-- which is exactly the state this exclusion was added to end. If someone
+removes one from the routing (because capacity arrived) and not from the
+scope, the cell stops being judged on booting at all, which is worse: a
+regression could not fail it.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CRITERIA = ROOT / ".github" / "green-criteria.yml"
+WORKFLOW = ROOT / ".github" / "workflows" / "reusable-build-image.yml"
+
+
+def _boots() -> dict:
+    doc = yaml.safe_load(CRITERIA.read_text())
+    return next(c for c in doc["criteria"] if c["id"] == "boots")
+
+
+def _routed_prefixes() -> set[str]:
+    """The flavors verify_boot sends to the GPU runner group.
+
+    Read out of the runs-on expression rather than hardcoded, so this test
+    fails when the workflow changes rather than when someone edits a copy.
+    """
+    text = WORKFLOW.read_text()
+    start = text.index("  verify_boot:")
+    end = text.index("\n    steps:", start)
+    job = text[start:end]
+    # The runs-on expression ONLY. The job's `if:` also calls startsWith --
+    # `!startsWith(inputs.flavor, 'base')` -- and reading the whole job swept
+    # 'base' in as though it were a GPU-routed compositor. Narrow to the
+    # selector that actually chooses the runner.
+    sel_start = job.index("    runs-on:")
+    sel_end = job.index("\n    timeout-minutes:", sel_start)
+    selector = job[sel_start:sel_end]
+    assert "runner=gpu" in selector, (
+        "verify_boot no longer routes to the GPU runner group; if the gate now "
+        "runs on hosted runners, the boots scope exclusion should be removed"
+    )
+    return set(re.findall(r"startsWith\(inputs\.flavor,\s*'([^']+)'\)", selector))
+
+
+def test_the_scope_excludes_exactly_the_gpu_routed_compositors():
+    scoped = set(_boots()["scope"].get("excludes_flavor_prefixes") or [])
+    routed = _routed_prefixes()
+    assert routed, "no startsWith(...) prefixes found — the routing expression moved"
+    assert scoped == routed, (
+        "green-criteria.yml's boots scope and reusable-build-image.yml's GPU "
+        f"routing disagree.\n  routed to a GPU runner: {sorted(routed)}\n"
+        f"  excluded from boots:    {sorted(scoped)}\n"
+        "Cells routed to a runner CI cannot launch must be out of scope; cells "
+        "that can reach a runner must be judged on booting."
+    )
+
+
+def test_the_exclusion_is_scoped_to_boots_and_nothing_else():
+    """The gate cannot run — that says nothing about the desktop contract,
+    which is measured from the published image with no runner involved."""
+    doc = yaml.safe_load(CRITERIA.read_text())
+    for crit in doc["criteria"]:
+        if crit["id"] == "boots":
+            continue
+        prefixes = (crit.get("scope") or {}).get("excludes_flavor_prefixes") or []
+        assert not set(prefixes) & {"cosmic", "niri", "xfwl4"}, (
+            f"criterion {crit['id']!r} also excludes the GPU-gated compositors; "
+            "the g4dn quota only blocks the boot gate, so widening it to another "
+            "axis stops measuring something CI can actually measure"
+        )


### PR DESCRIPTION
## The problem

The composite board marks cosmic and niri cells **red on `boots`**. Nothing ever booted them — and nothing ever failed to. The gate dies before its first step.

`verify_boot` routes cosmic/niri/xfwl4 to the GPU runner group for a real DRM render node. The account's vCPU limit for that instance bucket is **0**, so the fleet request is rejected and no runner attaches:

```
Failed to launch runner: failed to create fleet: VcpuLimitExceeded
... vCPU limit of 0 ... AllowedInstanceTypes:["g4dn*"]
```

Confirmed on two independent runs, one per branch:

| run | branch | job |
|---|---|---|
| 33848074014 | `main` (nightly) | [101038352430](https://github.com/tuna-os/tunaOS/actions/runs/33848074014/job/101038352430) |
| 33948918141 | branch | [101266051600](https://github.com/tuna-os/tunaOS/actions/runs/33948918141/job/101266051600) |

Both end with `No files were found ... verify-out/serial.log`. No serial log, no screenshot, no compositor — because no step ran.

Scoring that red asserts a boot failure nobody observed. Roughly **11 of the 25 red desktop cells** were in that state: the scoreboard reporting an AWS quota as software defects.

## The fix

`green-criteria.yml` already has the mechanism, and states its meaning plainly — *"a scope entry here is a REVIEWED declaration that CI cannot assert the criterion for that cell"*. That is the `-asahi` precedent (no aarch64 KVM on hosted runners), and it is exactly this situation.

## Three things this deliberately is not

- **Not score inflation.** It moves **zero cells to green**. Every GPU-gated cell still fails another blocking criterion, so the only thing that changes is *why* a cell is not green. Measured, not assumed:
  ```
  green scoring boots on everything : 15
  green with the exclusion applied  : 15
  cells the exclusion moves to green: []
  ```
- **Not a claim that these compositors boot.** Nobody knows. That's the point — out-of-scope reads "not measured", ⬜ reads "measured and unproven", ❌ reads "measured and failed". Only the first is true here.
- **Not permanent.** The comment says revert it the moment g4dn capacity exists, and #2123 now carries the evidence for the quota bump.

## Why a prefix rule

The routing is a prefix — `startsWith(inputs.flavor, 'cosmic')` and friends — so the scope matches on the same shape instead of listing all eight flavours (`cosmic`, `cosmic-cachyos`, `cosmic-hwe`, `cosmic-nvidia`, `niri`, `niri-cachyos`, `niri-hwe`, `niri-nvidia`).

`test_the_boots_scope_matches_the_gpu_routing.py` reads the `runs-on:` expression **out of the workflow** and pins the two lists equal, so they cannot drift:

- add a fourth GPU-gated compositor to the routing but not the scope → its cells silently start being scored red for a gate that can't run, which is the state this ends;
- remove one from the routing when capacity arrives but not from the scope → worse, the cell stops being judged on booting at all and a regression couldn't fail it.

A second test keeps the exclusion on `boots` alone. The quota blocks the boot gate; it says nothing about the desktop contract, which is measured from the published image with no runner involved.

That test caught a bug in itself on first run: reading the whole job swept up `!startsWith(inputs.flavor, 'base')` from the `if:` condition, so it now narrows to the `runs-on:` selector.

## Tests

248 targeted tests (everything touching green-criteria, the scorer, matrix status) pass, including the two new ones. Full suite running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_