### PR TITLE
tests(cosmic): record mesa-vulkan-drivers as a measured apt name

### DIFF
--- a/tests/bats/test_cosmic_apt_package_names.bats
+++ b/tests/bats/test_cosmic_apt_package_names.bats
@@ -88,6 +88,13 @@ setup() { command -v yq >/dev/null || skip "yq not available"; }
 		# Not from the PPA. Ubuntu's own archive ships greetd, which is
 		# why niri.sh installs it straight from there too.
 		greetd
+		# Also not from the PPA: Mesa's software Vulkan driver
+		# (lavapipe), added with the cosmic/niri Vulkan change. Measured
+		# 2026-09-05 against packages.ubuntu.com for grouper's own base
+		# and its neighbours -- resolute, questing and noble all return
+		# 200 for mesa-vulkan-drivers. grouper is the only apt variant
+		# that declares cosmic, and it is ubuntu:resolute.
+		mesa-vulkan-drivers
 	)
 	local p known fail=0
 	while read -r p; do


### PR DESCRIPTION
## Fixes a red `main` that I caused

#2341 added `mesa-vulkan-drivers` to `cosmic.yaml`'s apt list. `test_cosmic_apt_package_names.bats` pins that list against the set measured on 2026-08-07, and the new name wasn't in it:

```
not ok 5 every apt package is one the PPA publishes, or greetd
FAIL: cosmic.yaml's apt list names 'mesa-vulkan-drivers', which neither
      ppa:hepp3n/cosmic-epoch nor the Ubuntu archive was measured to publish.
      apt fails the WHOLE install on an unknown name, not just that package.
```

**My miss, and the gap was in how I checked.** I ran five bats files by hand before #2341 and this wasn't one of them — including `test_declared_flavors_installable.bats`, whose *"COSMIC on apt … names packages that exist there"* passed and gave me false confidence that the apt side was covered. pytest was never the problem: 1338 passed on this same commit, in CI and locally. The red came from the BATS step alone.

## Why update the list rather than relax the check

The test is right to exist and right to be strict — apt fails the **whole** install on an unknown name, so a bad entry here breaks `grouper:cosmic` entirely rather than skipping one package. Its own comment says what to do:

> Update the list when the PPA gains a package — **after checking that it has.**

So this records a measurement instead of weakening an assertion.

## Checked, not assumed

`packages.ubuntu.com` returns HTTP 200 for `mesa-vulkan-drivers` on:

| suite | result |
|---|---|
| **resolute** (grouper's base) | 200 |
| questing | 200 |
| noble | 200 |

`grouper` is the only apt variant that declares `cosmic`, and its `base_image` is `ubuntu:resolute` — so the name resolves for the one image that actually installs it.

It's annotated like `greetd` immediately above it, which is in the list for exactly the same reason: present in Ubuntu's own archive rather than the PPA.

## Verification

`test_cosmic_apt_package_names.bats` 6/6, plus `test_declared_flavors_installable.bats` and `test_desktop_script_apt_branch.bats` — 12/12 together.

Kept deliberately minimal: one entry and its justification, nothing else, so it can land quickly and unblock `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_