### PR TITLE
niri: install dms on every EL10 variant, not just Kitten and CentOS

### DIFF
--- a/build_scripts/desktop/niri.sh
+++ b/build_scripts/desktop/niri.sh
@@ -311,9 +311,32 @@ EOF
 		wl-mirror
 
 	# Install DankMaterialShell suite (quickshell + dms shell + theming/tools)
-	# Only enabled for AlmaLinux Kitten and CentOS Stream 10 (Qt 6.10+)
+	# Every EL10 variant: the gate is Qt 6.10+, and all three have it.
 	# Needs ligenix repo enabled for dms-greeter -> greetd dependency
-	if [[ $IS_ALMALINUXKITTEN == true || $IS_CENTOS == true ]]; then
+	#
+	# albacore (plain AlmaLinux 10) used to be excluded here, which broke its
+	# build outright rather than merely shipping a lesser desktop:
+	# install-zirconium.sh writes /etc/greetd/config.toml pointing at
+	# `dms-greeter` for EVERY niri image, and manifests/desktops/niri.yaml's
+	# el10 list carries no wallpaper daemon because -- per
+	# tests/bats/test_niri_wallpaper_daemon.bats -- "el10 legitimately ships
+	# no wallpaper daemon and passes through the dms branch". albacore passed
+	# through neither, so verify-branding-niri.sh failed twice and the image
+	# build died after three attempts (nightly 33848074014, job 101019603707):
+	#
+	#   FAIL: greetd launches dms-greeter but /usr/share/quickshell/
+	#         dms-greeter/DMSGreeter.qml is missing
+	#   FAIL: no wallpaper daemon (swaybg/swww/wpaperd) and no dms
+	#   TUNAOS_BRANDING_NIRI_FAIL variant=albacore failures=2
+	#
+	# No image published, so both ISO legs then refused to build from a stale
+	# tag -- which is why iso:niri was red on amd64 AND arm64 while every
+	# other desktop was red on arm64 only.
+	#
+	# The exclusion cited Qt 6.10+, and plain AlmaLinux 10 meets it:
+	# repo.almalinux.org/almalinux/10/AppStream/x86_64 ships qt6-qtbase-6.10.1
+	# (checked 2026-09-05). So the condition was narrower than its own reason.
+	if [[ $IS_ALMALINUX == true || $IS_ALMALINUXKITTEN == true || $IS_CENTOS == true ]]; then
 		dnf -y copr enable avengemedia/danklinux
 		dnf -y copr enable avengemedia/dms-git
 		dnf -y --enablerepo copr:copr.fedorainfracloud.org:avengemedia:dms-git \
@@ -331,8 +354,10 @@ EOF
 		dnf -y copr disable avengemedia/dms-git
 	fi
 
-	# Restore brightnessctl and playerctl for compatible EL10 variants (Kitten/CentOS)
-	if [[ $IS_ALMALINUXKITTEN == true || $IS_CENTOS == true ]]; then
+	# Restore brightnessctl and playerctl for every EL10 variant. Same
+	# reasoning as the dms block above: these come from ligenix, which
+	# albacore can reach as readily as Kitten and CentOS.
+	if [[ $IS_ALMALINUX == true || $IS_ALMALINUXKITTEN == true || $IS_CENTOS == true ]]; then
 		install_available --copr ligenix/enterprise-cosmic \
 			brightnessctl \
 			playerctl

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -322,6 +322,32 @@ What is measured today:
 | xfce | xfwl4 (Smithay) | ❌ | — | aborts: `err=NoRenderNode` |
 | niri | niri (Smithay) | ? | ? | never measured with these diagnostics |
 
+niri's row is unmeasured for a blunt reason: on **albacore** the image never
+built, so there was nothing to measure. `install-zirconium.sh` points greetd at
+`dms-greeter` for every niri image, and `niri.sh` installed the DMS suite only
+for AlmaLinux Kitten and CentOS Stream 10. albacore is plain AlmaLinux 10 — so
+it got the greeter config without the greeter, and `niri.yaml`'s el10 list ships
+no wallpaper daemon because (per `test_niri_wallpaper_daemon.bats`) el10 is
+expected to "pass through the dms branch". albacore passed through neither:
+
+```
+FAIL: greetd launches dms-greeter but /usr/share/quickshell/dms-greeter/DMSGreeter.qml is missing
+FAIL: no wallpaper daemon (swaybg/swww/wpaperd) and no dms — background will be blank
+TUNAOS_BRANDING_NIRI_FAIL variant=albacore failures=2
+```
+
+The build then died after three attempts, published no image, and both ISO legs
+refused to build from a tag still holding a previous one — which is why niri was
+the only desktop red on BOTH architectures while the rest were red on arm64
+alone. The arm64 half was the missing installer Flatpak; this was the amd64 half.
+
+The exclusion cited "Qt 6.10+" and plain AlmaLinux 10 ships qt6-qtbase-6.10.1,
+so the condition was narrower than its own reason; every EL10 variant now takes
+the DMS branch. Note this makes reality match a contract that was already
+written down: `verify-desktop-experience.sh` says "Fedora and EL10 use DMS
+(quickshell) while openSUSE uses the wlroots stack". albacore was the EL10
+variant for which that was not true.
+
 **Three of the four measured desktops come up and render on a GPU-less
 runner.** Only xfwl4 aborts.
 


### PR DESCRIPTION
## What was actually wrong

`albacore:niri` did not fail to boot and did not fail a gate — **it failed to build**, on all three platforms. Everything downstream followed from that.

Three pieces have to line up for a niri image, and albacore had none of the working combinations:

1. `install-zirconium.sh` writes `/etc/greetd/config.toml` pointing at `dms-greeter` for **every** niri image, unconditionally.
2. `niri.sh` installed the dms suite only `if [[ $IS_ALMALINUXKITTEN || $IS_CENTOS ]]`.
3. `manifests/desktops/niri.yaml`'s el10 list carries **no wallpaper daemon** — deliberately. Per `test_niri_wallpaper_daemon.bats`: *"el10 legitimately ships no wallpaper daemon and passes through the dms branch"*, and asserting swaybg everywhere *"would be wrong, not merely strict."*

**albacore is plain AlmaLinux 10** — not Kitten, not CentOS. It passed through *neither* branch.

So `verify-branding-niri.sh` failed twice and the build died after three attempts ([nightly 33848074014, job 101019603707](https://github.com/tuna-os/tunaOS/actions/runs/33848074014/job/101019603707)):

```
ok:   greeter command dms-greeter present
FAIL: greetd launches dms-greeter but /usr/share/quickshell/dms-greeter/DMSGreeter.qml is missing
FAIL: no wallpaper daemon (swaybg/swww/wpaperd) and no dms — background will be blank
TUNAOS_BRANDING_NIRI_FAIL variant=albacore failures=2
```

No image published, so both ISO legs refused to build from a tag still holding a previous image — correctly, and loudly:

```
albacore:niri published no image in this run (no artifact 'albacore-niri-linux-amd64-33848074014').
The tag this ISO would build from still holds a PREVIOUS image, so building it would emit media
that looks fresh and is not. Refusing.
```

## This explains an anomaly from the arm64 ISO work

niri was the only desktop red on **both** architectures while every other desktop was red on arm64 alone. That was never one bug: the arm64 half was the missing installer Flatpak (fixed in tuna-installer-niri#67), and this is the amd64 half.

## Why the fix is one condition

The exclusion was narrower than its own stated reason. The comment gave the gate as **"Qt 6.10+"** — and plain AlmaLinux 10 meets it:

```
repo.almalinux.org/almalinux/10/AppStream/x86_64/os/Packages/ → qt6-qtbase-6.10.1
```

checked 2026-09-05. So `IS_ALMALINUX` joins the condition, and the `brightnessctl`/`playerctl` block directly below gets the same treatment for the same reason — both draw from ligenix, which albacore reaches as readily as its siblings.

## What this does NOT claim

**Not that `albacore:niri` goes green.** It should let the image build and publish, which is the precondition for the desktop contract, the boot gate and the ISO ever running at all. What those then report is unmeasured, and `boots` for niri is currently out of scope anyway (#2342, g4dn quota).

## Verification

Full bats suite against a `main` baseline captured in a separate worktree:

```
main:        39 failures
this branch: 38 failures
NEW failures vs baseline: (none)
```

The 38 are pre-existing and environmental to my container (several assert non-root behaviour while it runs as root); CI's bats step on `main` is green. Plus `bash -n`, `shellcheck -S error` clean, and the niri-specific suites — `test_niri_dms_payload.bats`, `test_niri_wallpaper_daemon.bats`, `test_build_scripts.bats` — all pass, including `niri.sh: exists and passes shellcheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_