### PR TITLE
iso: make the bootc backend probe architecture-neutral

### DIFF
--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -348,6 +348,50 @@ written down: `verify-desktop-experience.sh` says "Fedora and EL10 use DMS
 (quickshell) while openSUSE uses the wlroots stack". albacore was the EL10
 variant for which that was not true.
 
+### The arm64 ISO axis had two blockers stacked, not one
+
+Clearing the missing arm64 installer Flatpak did not turn the arm64 ISO green;
+it revealed a second, independent arm64 bug underneath, and the distinction is
+worth recording because the first fix looked like it had failed.
+
+Run [33997358111](https://github.com/tuna-os/tunaOS/actions/runs/33997358111),
+`albacore:kde`, dispatched precisely because its amd64 ISO already passed and
+only arm64 failed. The Flatpak now installs — `Installing
+app/org.tunaos.InstallerKde/aarch64/master` — where it previously died on
+`error: Nothing matches org.tunaos.InstallerKde in remote tuna-os`. The build
+then got four steps further and stopped somewhere new:
+
+```
+++ bash /run/tbox-customize/1/installer-recipe-backend.sh
+ERROR: cannot determine the bootc backend of this image.
+       No bootupd payload, no composefs pin in prepare-root.conf,
+       and no systemd-boot EFI binary.
+```
+
+The image is not unclassifiable. Reading the published layers of
+`ghcr.io/tuna-os/albacore:kde-linux-arm64` directly out of the registry shows a
+complete legacy bootupd payload:
+
+```
+usr/lib/bootupd/updates/EFI/almalinux/grubaa64.efi
+usr/lib/bootupd/updates/EFI/almalinux/shimaa64.efi
+usr/lib/bootupd/updates/EFI/BOOT/BOOTAA64.EFI
+```
+
+That is branch 1 of the probe — except the probe spelled the filename
+`grubx64.efi`. The EFI binary suffix *is* the EFI architecture (`x64` on
+x86_64, `aa64` on aarch64), so both copies of the probe
+(`live-iso/common/src/installer-recipe-backend.sh` and
+`TUNAOS_BACKEND_PROBE_SH` in `scripts/lib/backend.sh`) missed every branch on
+every arm64 image and took the deliberate "never guess" exit. The names are now
+globbed, which is what the branches always meant to ask.
+
+The reason this reached production is visible in the test file: every fixture
+in `test_installer_recipe_backend.bats` built an x64 tree, so a suite that
+exercised all four branches proved nothing about half the matrix. The fixtures
+now take the EFI arch as a parameter and the aarch64 shapes are asserted
+alongside the x64 ones.
+
 **Three of the four measured desktops come up and render on a GPU-less
 runner.** Only xfwl4 aborts.
 

--- a/live-iso/common/src/installer-recipe-backend.sh
+++ b/live-iso/common/src/installer-recipe-backend.sh
@@ -36,17 +36,30 @@ fi
 # bootupd 0.2.x kept binaries under updates/EFI/<vendor>; current Fedora keeps
 # versioned binaries under /usr/lib/efi with only EFI.json under bootupd/
 # updates — hence the two-form test.
-if ls "${SYSROOT}"/usr/lib/bootupd/updates/EFI/*/grubx64.efi >/dev/null 2>&1 ||
+#
+# THE EFI BINARY NAMES ARE GLOBBED, NOT SPELLED OUT, because the suffix is the
+# EFI architecture: grubx64/shimx64/systemd-bootx64 on x86_64, and
+# grubaa64/shimaa64/systemd-bootaa64 on aarch64. Spelling out the x64 forms
+# made this probe silently unclassifiable on every arm64 image, which is not a
+# theoretical concern — albacore:kde-linux-arm64 ships a complete legacy
+# bootupd payload
+#   /usr/lib/bootupd/updates/EFI/almalinux/{grubaa64,shimaa64}.efi
+# and still fell all the way through to the "cannot determine the bootc
+# backend" exit, failing the arm64 ISO build while the amd64 leg of the same
+# cell passed. The question each branch asks — "is there a GRUB EFI binary in
+# the bootupd payload?", "is there a systemd-boot EFI binary?" — was never
+# architecture-specific; only the spelling was.
+if ls "${SYSROOT}"/usr/lib/bootupd/updates/EFI/*/grub*.efi >/dev/null 2>&1 ||
 	{ [[ -f "${SYSROOT}/usr/lib/bootupd/updates/EFI.json" ]] &&
-		find "${SYSROOT}/usr/lib/efi/grub2" -type f -name grubx64.efi -print -quit 2>/dev/null | grep -q . &&
-		find "${SYSROOT}/usr/lib/efi/shim" -type f -name shimx64.efi -print -quit 2>/dev/null | grep -q .; }; then
+		find "${SYSROOT}/usr/lib/efi/grub2" -type f -name 'grub*.efi' -print -quit 2>/dev/null | grep -q . &&
+		find "${SYSROOT}/usr/lib/efi/shim" -type f -name 'shim*.efi' -print -quit 2>/dev/null | grep -q .; }; then
 	backend="ostree"
 elif [[ "$composefs_enabled" == "1" ]]; then
 	# Reaching here means there is NO bootupd payload, so an ostree install is
 	# impossible: bootc aborts with
 	#   error: Installing to disk: bootupd is required for ostree-based installs
 	backend="composefs-native"
-elif [[ -f "${SYSROOT}/usr/lib/systemd/boot/efi/systemd-bootx64.efi" ]]; then
+elif find "${SYSROOT}/usr/lib/systemd/boot/efi" -type f -name 'systemd-boot*.efi' -print -quit 2>/dev/null | grep -q .; then
 	backend="composefs-native"
 else
 	# Never guessed. A wrong guess in either direction is an unbootable disk,

--- a/scripts/lib/backend.sh
+++ b/scripts/lib/backend.sh
@@ -6,17 +6,25 @@
 # THE ORDER IS LOAD-BEARING: a bootupd payload identifies ostree even when
 # composefs is sealed; otherwise an enabled composefs config or systemd-boot
 # identifies composefs-native. Unknown images are never guessed.
+#
+# The EFI binary names are GLOBBED because their suffix is the EFI
+# architecture — grubx64/shimx64/systemd-bootx64 on x86_64, and
+# grubaa64/shimaa64/systemd-bootaa64 on aarch64. Globbing rather than deriving
+# the suffix from `uname -m` is deliberate: this body is run inside the image
+# under `podman run`, which may be emulating a foreign architecture, so the
+# filenames present are the only trustworthy signal. Keep this in step with
+# live-iso/common/src/installer-recipe-backend.sh, which is a port of it.
 # shellcheck disable=SC2016  # the $-free sh body is intentionally unexpanded
 TUNAOS_BACKEND_PROBE_SH='
-if { ls /usr/lib/bootupd/updates/EFI/*/grubx64.efi >/dev/null 2>&1 ||
+if { ls /usr/lib/bootupd/updates/EFI/*/grub*.efi >/dev/null 2>&1 ||
      { test -f /usr/lib/bootupd/updates/EFI.json &&
-       find /usr/lib/efi/grub2 -type f -name grubx64.efi -print -quit 2>/dev/null | grep -q . &&
-       find /usr/lib/efi/shim -type f -name shimx64.efi -print -quit 2>/dev/null | grep -q .; }; }; then
+       find /usr/lib/efi/grub2 -type f -name "grub*.efi" -print -quit 2>/dev/null | grep -q . &&
+       find /usr/lib/efi/shim -type f -name "shim*.efi" -print -quit 2>/dev/null | grep -q .; }; }; then
     echo BACKEND=ostree
 elif grep -A8 "^\[composefs\]" /usr/lib/ostree/prepare-root.conf 2>/dev/null \
      | grep -qiE "enabled[[:space:]]*=[[:space:]]*(yes|true|1|signed)"; then
     echo BACKEND=composefs-native
-elif test -f /usr/lib/systemd/boot/efi/systemd-bootx64.efi; then
+elif find /usr/lib/systemd/boot/efi -type f -name "systemd-boot*.efi" -print -quit 2>/dev/null | grep -q .; then
     echo BACKEND=composefs-native
 else
     echo BACKEND=unknown

--- a/tests/bats/test_installer_recipe_backend.bats
+++ b/tests/bats/test_installer_recipe_backend.bats
@@ -34,26 +34,31 @@ set_composefs() {
     >"$FIXTURE/usr/lib/ostree/prepare-root.conf"
 }
 
-# bootupd 0.2.x shape: binaries under updates/EFI/<vendor>.
+# bootupd 0.2.x shape: binaries under updates/EFI/<vendor>. The EFI arch suffix
+# is a parameter here (x64 / aa64) because it is a parameter in reality, and
+# every fixture below that hardcoded x64 is why the arm64 blindness shipped.
 add_bootupd_legacy() {
+  local efiarch="${1:-x64}"
   mkdir -p "$FIXTURE/usr/lib/bootupd/updates/EFI/almalinux"
-  touch "$FIXTURE/usr/lib/bootupd/updates/EFI/almalinux/grubx64.efi"
+  touch "$FIXTURE/usr/lib/bootupd/updates/EFI/almalinux/grub${efiarch}.efi"
 }
 
 # Current Fedora shape: only EFI.json under bootupd/updates, versioned binaries
 # under /usr/lib/efi. The probe requires ALL THREE, which is what stops a bare
 # EFI.json from being read as a payload.
 add_bootupd_modern() {
+  local efiarch="${1:-x64}"
   mkdir -p "$FIXTURE/usr/lib/bootupd/updates" \
-    "$FIXTURE/usr/lib/efi/grub2/x64" "$FIXTURE/usr/lib/efi/shim/x64"
+    "$FIXTURE/usr/lib/efi/grub2/${efiarch}" "$FIXTURE/usr/lib/efi/shim/${efiarch}"
   touch "$FIXTURE/usr/lib/bootupd/updates/EFI.json"
-  touch "$FIXTURE/usr/lib/efi/grub2/x64/grubx64.efi"
-  touch "$FIXTURE/usr/lib/efi/shim/x64/shimx64.efi"
+  touch "$FIXTURE/usr/lib/efi/grub2/${efiarch}/grub${efiarch}.efi"
+  touch "$FIXTURE/usr/lib/efi/shim/${efiarch}/shim${efiarch}.efi"
 }
 
 add_systemd_boot() {
+  local efiarch="${1:-x64}"
   mkdir -p "$FIXTURE/usr/lib/systemd/boot/efi"
-  touch "$FIXTURE/usr/lib/systemd/boot/efi/systemd-bootx64.efi"
+  touch "$FIXTURE/usr/lib/systemd/boot/efi/systemd-boot${efiarch}.efi"
 }
 
 probe() {
@@ -149,6 +154,42 @@ probe() {
   [[ "$output" == *"filesystem=xfs"* ]]
 }
 
+# ── aarch64: the same three shapes, spelled the way arm64 spells them ────────
+#
+# REGRESSION COVERAGE. The probe used to name grubx64/shimx64/systemd-bootx64
+# literally, so on aarch64 — where the EFI suffix is aa64 — every branch missed
+# and the script exited with "cannot determine the bootc backend". That failed
+# the arm64 ISO for every desktop while the amd64 leg of the same cell passed,
+# and nothing here noticed because every fixture above was x64. Measured on
+# ghcr.io/tuna-os/albacore:kde-linux-arm64, which carries the legacy payload
+# /usr/lib/bootupd/updates/EFI/almalinux/{grubaa64,shimaa64}.efi.
+
+@test "aarch64 legacy bootupd payload (grubaa64) is recognised as ostree" {
+  add_bootupd_legacy aa64
+  set_composefs no
+  probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bootloader=grub2"* ]]
+  [[ "$output" == *"composeFsBackend=false"* ]]
+  [[ "$output" == *"filesystem=xfs"* ]]
+}
+
+@test "aarch64 modern bootupd payload (grubaa64 + shimaa64) is recognised" {
+  add_bootupd_modern aa64
+  set_composefs no
+  probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bootloader=grub2"* ]]
+}
+
+@test "aarch64 systemd-boot (systemd-bootaa64) is composefs-native" {
+  add_systemd_boot aa64
+  probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bootloader=systemd"* ]]
+  [[ "$output" == *"composeFsBackend=true"* ]]
+}
+
 # ── Never guess ──────────────────────────────────────────────────────────────
 
 @test "an unclassifiable image fails instead of guessing" {
@@ -158,4 +199,17 @@ probe() {
   probe
   [ "$status" -ne 0 ]
   [[ "$output" == *"cannot determine the bootc backend"* ]]
+}
+
+@test "aarch64 EFI.json with grubaa64 but no shim is not a bootupd payload" {
+  # The globbing must not have loosened the two-form test into a one-form test.
+  # This is the arm64 twin of the bare-EFI.json guard above.
+  mkdir -p "$FIXTURE/usr/lib/bootupd/updates" "$FIXTURE/usr/lib/efi/grub2/aa64"
+  touch "$FIXTURE/usr/lib/bootupd/updates/EFI.json"
+  touch "$FIXTURE/usr/lib/efi/grub2/aa64/grubaa64.efi"
+  set_composefs yes
+  probe
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bootloader=systemd"* ]]
+  [[ "$output" == *"composeFsBackend=true"* ]]
 }


### PR DESCRIPTION
## Summary

The probe that decides an image's `bootloader` / `composeFsBackend` / `filesystem` triple named its EFI binaries literally — `grubx64.efi`, `shimx64.efi`, `systemd-bootx64.efi`. That suffix **is** the EFI architecture, so on aarch64 (`grubaa64.efi`, `shimaa64.efi`, `systemd-bootaa64.efi`) every branch missed and the script took its deliberate "never guess" exit:

```
ERROR: cannot determine the bootc backend of this image.
       No bootupd payload, no composefs pin in prepare-root.conf,
       and no systemd-boot EFI binary.
```

That failed the arm64 ISO for **every** desktop while the amd64 leg of the same cell passed.

Seen on run [33997358111](https://github.com/tuna-os/tunaOS/actions/runs/33997358111) (`albacore:kde`), dispatched to verify the arm64 installer Flatpak fix. That fix worked — the log now shows `Installing app/org.tunaos.InstallerKde/aarch64/master` where it previously died on `error: Nothing matches org.tunaos.InstallerKde in remote tuna-os` — and the build got four steps further before hitting this second, independent arm64 bug.

**The image is not unclassifiable.** Reading the published layers of `ghcr.io/tuna-os/albacore:kde-linux-arm64` directly out of the registry shows a complete legacy bootupd payload:

```
usr/lib/bootupd/updates/EFI/almalinux/grubaa64.efi
usr/lib/bootupd/updates/EFI/almalinux/shimaa64.efi
usr/lib/bootupd/updates/EFI/BOOT/BOOTAA64.EFI
```

That is branch 1 of the probe, spelled for arm64.

Both copies of the probe now glob the binary names — the ISO-path script and `TUNAOS_BACKEND_PROBE_SH`, which its own header documents as the same decision. Globbing rather than deriving the suffix from `uname -m` is deliberate: the `sh` body runs inside the image under `podman run`, possibly emulating a foreign architecture, so the filenames actually present are the only trustworthy signal. The questions the branches ask — *is there a GRUB EFI binary in the bootupd payload*, *is there a systemd-boot EFI binary* — were never architecture-specific; only the spelling was.

**Why it shipped:** every fixture in `test_installer_recipe_backend.bats` built an x64 tree, so a suite that exercised all four branches proved nothing about half the matrix. The fixtures now take the EFI arch as a parameter and assert the aarch64 shapes alongside the x64 ones.

## Testing

- `bats tests/bats/test_installer_recipe_backend.bats` — 13/13 pass.
- **Before/after control**, run against a `git worktree` of `main` so the working tree was never mutated mid-run: the three new aarch64 tests **fail** on the pre-fix script (each on `[ "$status" -eq 0 ]`, i.e. the "cannot determine" exit) and pass after it. The eight pre-existing tests are unchanged in both directions.
- A fourth new test guards against the globbing having loosened the two-form bootupd test into a one-form one: an `EFI.json` plus `grubaa64.efi` with no shim must still not count as a payload.
- `shellcheck scripts/lib/backend.sh live-iso/common/src/installer-recipe-backend.sh` — clean.
- Full `bats tests/bats/` on this branch vs. `main`: **identical** 38-failure sets (all environmental here — missing `yq`, root checks, network), `ok` count 1478 → 1482, i.e. exactly the four added tests and no regression.
- The evidence in the Summary is measured, not inferred: the arm64 payload listing comes from pulling and reading the published image's layers, and the amd64 leg of the same cell passing this same step is the paired control.
- `gen-matrix-status.py --check-structure` cannot run here (needs `gh`); the doc edit is at line 351, well outside the `GENERATED` block (lines 63–262).

## Related issues

Follow-up to #2349 and to the arm64 installer Flatpak work across the five installer repos. This is the second of two stacked arm64 ISO blockers; clearing the first is what exposed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_