### PR TITLE
iso-e2e: pick the display device per machine type, not per x86

### DIFF
--- a/.github/workflows/reusable-build-artifacts.yml
+++ b/.github/workflows/reusable-build-artifacts.yml
@@ -224,15 +224,18 @@ jobs:
           sudo -E bash ./scripts/build-iso-tacklebox.sh \
             "${VARIANT}" "${FLAVOR}" ghcr "${TAG}"
 
-      # KNOWN GAP (#1378): qemu-system-x86 + ovmf are x86_64-specific, and
-      # scripts/iso-e2e.sh itself only looks for qemu-system-x86_64 + OVMF
-      # firmware — it has no qemu-system-aarch64/AAVMF path. This job now
-      # runs on an arm64 runner for arm64 platforms (ISO build + tacklebox
-      # need a native host, no cross-arch emulation), so the ISO build step
-      # above should work — but THIS step and iso-e2e.sh's boot gate will
-      # still fail on arm64 until they're taught the aarch64 QEMU/firmware
-      # equivalents. Filed as a follow-up rather than guessed at here: real
-      # aarch64 KVM boot behavior needs verifying on real CI, not assumed.
+      # #1378 follow-through. This step installs the native QEMU + firmware
+      # for the runner arch, and scripts/iso-e2e.sh picks qemu-system-aarch64,
+      # the `virt` machine and AAVMF on an aarch64 host. The last x86 literal
+      # on that path was the display device: `-vga virtio` is virtio-vga,
+      # which does not exist on the ARM virt machine ("type is NULL", run
+      # 34001369641), so iso-e2e.sh selects virtio-gpu-pci there instead.
+      # Still x86-only: scripts/run-walkthrough.sh (qemu-system-x86_64, OVMF,
+      # -machine pc, -vga virtio), which "Capture installer walkthrough" below
+      # runs advisorily (continue-on-error + `|| true`) — on arm64 that step
+      # yields no installer screenshots rather than a failure. Whether the
+      # arm64 boot gate fits its timeout under TCG (hosted arm64 runners
+      # expose no /dev/kvm) is what the run measures; it is not assumed here.
       - name: Install QEMU for boot verification
         env:
           RUNNER_ARCH: ${{ runner.arch }}

--- a/docs/MATRIX-STATUS.md
+++ b/docs/MATRIX-STATUS.md
@@ -348,7 +348,7 @@ written down: `verify-desktop-experience.sh` says "Fedora and EL10 use DMS
 (quickshell) while openSUSE uses the wlroots stack". albacore was the EL10
 variant for which that was not true.
 
-### The arm64 ISO axis had two blockers stacked, not one
+### The arm64 ISO axis had three blockers stacked, not one
 
 Clearing the missing arm64 installer Flatpak did not turn the arm64 ISO green;
 it revealed a second, independent arm64 bug underneath, and the distinction is
@@ -391,6 +391,38 @@ in `test_installer_recipe_backend.bats` built an x64 tree, so a suite that
 exercised all four branches proved nothing about half the matrix. The fixtures
 now take the EFI arch as a parameter and the aarch64 shapes are asserted
 alongside the x64 ones.
+
+With the probe fixed (run [34001369641](https://github.com/tuna-os/tunaOS/actions/runs/34001369641),
+same cell), `Build Live ISO` passed on arm64 for the first time and produced a
+5.7 GB `albacore-kde-10.2-aarch64.iso`. The boot gate then failed in 36 seconds:
+
+```
+==> Accel: tcg, CPU: max, MEM: 4096M, CPUS: 4
+qemu-system-aarch64: type is NULL
+qemu-system-aarch64: Virtio VGA not available. Perhaps you want to install qemu-system-modules-opengl package?
+ERROR: QEMU failed to daemonize
+```
+
+`iso-e2e.sh` already chose the aarch64 emulator, the `virt` machine and AAVMF
+by host architecture; its display device was still `-vga virtio` — shorthand
+for `virtio-vga`, a virtio-gpu behind a VGA-compatible PCI region that exists
+only on targets with legacy VGA. The `virt` machine has `virtio-gpu-pci`, which
+the script now uses there. QEMU's package hint is wrong: the preceding step had
+just installed `qemu-system-modules-opengl`. The mechanism is visible in the
+packages the runner installed (`qemu-system-common` and
+`qemu-system-modules-opengl` 8.2.2+ds-0ubuntu1.18, arm64): `hw-display-virtio-vga.so`
+is shipped, but the aarch64 binary's built-in modinfo table registers only the
+`virtio-gpu` family — `hw-display-virtio-gpu`, `-gpu-pci`, `-gpu-gl`, `-gpu-pci-gl`
+— so the type lookup for `virtio-vga` returns nothing and the file on disk is
+never loadable, while `virtio-gpu-pci` is.
+
+Two things are recorded as unmeasured rather than assumed. The gate ran under
+TCG (`Accel: tcg`) because hosted `ubuntu-24.04-arm` runners expose no
+`/dev/kvm`, so whether a KDE live ISO reaches its readiness marker within the
+900 s timeout on four emulated vCPUs is what the next run measures. And
+`scripts/run-walkthrough.sh` is still x86-only (`qemu-system-x86_64`, OVMF,
+`-machine pc`, `-vga virtio`); it is advisory in the ISO job, so arm64 cells
+will have no installer screenshots until it learns the same three things.
 
 **Three of the four measured desktops come up and render on a GPU-less
 runner.** Only xfwl4 aborts.

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -361,7 +361,7 @@ fi
 # virtio-vga-gl, use virgl + egl-headless so those compositors get real GL and
 # actually render. Override with TBOX_E2E_GPU=virgl|plain.
 #
-# On a GPU-less runner we fall back to -vga virtio. This comment used to say
+# On a GPU-less runner we fall back to the plain 2D virtio device. This comment used to say
 # that was "fine for cosmic/kde/gnome (software fallbacks)". It is not, and
 # the claim cost weeks of misdirected debugging: cosmic and xfce are Smithay
 # too, so on hosted runners they don't render blank — they never start at
@@ -401,10 +401,38 @@ fi
 # squash runs getty only on tty1 and the serial console (ttyS0), so tty3 has
 # no console to switch to; the Wayland compositor holds tty1. The serial log
 # is the source of truth for "is it up", pixels are only for the gallery.
+#
+# The display device is per machine type, not per taste. `-vga virtio` is
+# shorthand for virtio-vga: a virtio-gpu behind a VGA-compatible PCI region,
+# and the VGA half only exists on targets that have legacy VGA — x86. On
+# qemu-system-aarch64 the type does not exist, and QEMU says so in the least
+# helpful way it can:
+#
+#   qemu-system-aarch64: type is NULL
+#   qemu-system-aarch64: Virtio VGA not available. Perhaps you want to
+#     install qemu-system-modules-opengl package?
+#   ERROR: QEMU failed to daemonize
+#
+# (albacore:kde, iso:kde linux-arm64, run 34001369641 — with
+# qemu-system-modules-opengl installed by the step before, so the hint is
+# wrong. Ubuntu ships hw-display-virtio-vga.so for arm64 too, but the
+# aarch64 binary's modinfo table registers no virtio-vga type, so the module
+# on disk is inert there; it does register virtio-gpu-pci and
+# virtio-gpu-gl-pci.) The `virt` machine's devices are the VGA-less
+# virtio-gpu-pci and, for virgl, virtio-gpu-gl-pci. screendump reads the scanout of either, so
+# nothing downstream changes; only the device name does. QEMU_MACHINE is
+# decided with the emulator above, the same way CPU_ARG keys off it below.
+if [[ "$QEMU_MACHINE" == "virt" ]]; then
+	_gpu_plain_args=(-device virtio-gpu-pci)
+	_gpu_gl_device="virtio-gpu-gl-pci"
+else
+	_gpu_plain_args=(-vga virtio)
+	_gpu_gl_device="virtio-vga-gl"
+fi
 _gpu_mode="${TBOX_E2E_GPU:-auto}"
-QEMU_GPU_ARGS=(-vga virtio -display none)
+QEMU_GPU_ARGS=("${_gpu_plain_args[@]}" -display none)
 if [[ "$_gpu_mode" != "plain" ]] && { [[ "$_gpu_mode" == "virgl" ]] || [[ -e /dev/dri/renderD128 ]]; } &&
-	"$QEMU" -device help 2>/dev/null | grep -q "virtio-vga-gl"; then
+	"$QEMU" -device help 2>/dev/null | grep -qF "$_gpu_gl_device"; then
 	# egl-headless is NOT a display in its own right — it renders GL locally and
 	# expects another UI to present the result. Without one, `screendump` fails:
 	#
@@ -426,11 +454,11 @@ if [[ "$_gpu_mode" != "plain" ]] && { [[ "$_gpu_mode" == "virgl" ]] || [[ -e /de
 	# concurrent runs.
 	# The -vnc argument needs OUTPUT_DIR, which is defined further down, so it
 	# is appended there rather than here.
-	QEMU_GPU_ARGS=(-device virtio-vga-gl -display "egl-headless,rendernode=/dev/dri/renderD128")
+	QEMU_GPU_ARGS=(-device "$_gpu_gl_device" -display "egl-headless,rendernode=/dev/dri/renderD128")
 	QEMU_NEEDS_VNC_SURFACE=1
-	echo "==> GPU: virgl (virtio-vga-gl + egl-headless /dev/dri/renderD128 + vnc surface) — Smithay compositors can render"
+	echo "==> GPU: virgl (${_gpu_gl_device} + egl-headless /dev/dri/renderD128 + vnc surface) — Smithay compositors can render"
 else
-	echo "==> GPU: -vga virtio headless (no render node/virgl) — niri/xfwl4 will not render here"
+	echo "==> GPU: ${_gpu_plain_args[*]} headless (no render node/virgl) — niri/xfwl4 will not render here"
 fi
 
 # Locate architecture-appropriate UEFI firmware. Path varies across distros

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -1108,3 +1108,55 @@ setup_runtime_check_stubs() {
 @test "TPM auto-unlock verification preserves its own serial log rather than clobbering others" {
   grep -qF 'installed-tpm-autounlock-serial.log' "$SCRIPT"
 }
+
+# ── GPU/display device is per machine type ──────────────────────────────────
+#
+# These execute the script's OWN selection block — extracted by its comment
+# marker, not re-typed here — so a change to iso-e2e.sh is what they assert
+# on. `-vga virtio` is virtio-vga, which does not exist on qemu-system-aarch64's
+# `virt` machine: run 34001369641, iso:kde linux-arm64 died before the guest
+# existed with "type is NULL … Virtio VGA not available … QEMU failed to
+# daemonize". The virt machine's devices are virtio-gpu-pci and, for virgl,
+# virtio-gpu-gl-pci. The virgl probe greps `-device help` for the GL device,
+# so it must ask for the aarch64 name too or virgl could never engage there.
+
+gpu_block_file() {
+  local out="${BATS_TEST_TMPDIR}/gpu-block.sh"
+  awk '/^# The display device is per machine type/{p=1} p{print} p && /no render node\/virgl/{q=1} q && /^fi$/{exit}' \
+    "${REPO_ROOT}/scripts/iso-e2e.sh" >"$out"
+  echo "$out"
+}
+
+@test "gpu block: the selection code is found by its marker" {
+  f="$(gpu_block_file)"
+  grep -q 'QEMU_GPU_ARGS=' "$f"
+  grep -q 'QEMU_NEEDS_VNC_SURFACE=1' "$f"
+}
+
+@test "gpu: aarch64 virt machine gets virtio-gpu-pci, never -vga virtio" {
+  f="$(gpu_block_file)"
+  run bash -c "QEMU_MACHINE=virt QEMU=/bin/false TBOX_E2E_GPU=plain; source '$f'; echo \"\${QEMU_GPU_ARGS[*]}\""
+  [ "$status" -eq 0 ]
+  [ "${lines[-1]}" = "-device virtio-gpu-pci -display none" ]
+}
+
+@test "gpu: x86 pc machine keeps -vga virtio" {
+  f="$(gpu_block_file)"
+  run bash -c "QEMU_MACHINE=pc QEMU=/bin/false TBOX_E2E_GPU=plain; source '$f'; echo \"\${QEMU_GPU_ARGS[*]}\""
+  [ "$status" -eq 0 ]
+  [ "${lines[-1]}" = "-vga virtio -display none" ]
+}
+
+@test "gpu: virgl on aarch64 probes for and uses virtio-gpu-gl-pci" {
+  f="$(gpu_block_file)"
+  stub="${BATS_TEST_TMPDIR}/qemu-stub"
+  cat >"$stub" <<'STUB'
+#!/usr/bin/env bash
+# Minimal `qemu -device help` stand-in that lists only the aarch64 GL device.
+[[ "$1" == "-device" && "$2" == "help" ]] && echo 'name "virtio-gpu-gl-pci", bus PCI'
+STUB
+  chmod +x "$stub"
+  run bash -c "QEMU_MACHINE=virt QEMU='$stub' TBOX_E2E_GPU=virgl; source '$f'; echo \"\${QEMU_GPU_ARGS[*]}\""
+  [ "$status" -eq 0 ]
+  [ "${lines[-1]}" = "-device virtio-gpu-gl-pci -display egl-headless,rendernode=/dev/dri/renderD128" ]
+}


### PR DESCRIPTION
## Summary

The ISO boot gate passed `-vga virtio` unconditionally. That is shorthand for the `virtio-vga` device — a virtio-gpu behind a VGA-compatible PCI region — and on `qemu-system-aarch64` the type is not registered, so the ARM `virt` machine refused it before the guest existed:

```
==> Accel: tcg, CPU: max, MEM: 4096M, CPUS: 4
qemu-system-aarch64: type is NULL
qemu-system-aarch64: Virtio VGA not available. Perhaps you want to install qemu-system-modules-opengl package?
ERROR: QEMU failed to daemonize
```

Run [34001369641](https://github.com/tuna-os/tunaOS/actions/runs/34001369641), `iso:kde (linux-arm64)`, albacore. This is the **third** arm64 ISO blocker, stacked behind the missing installer Flatpak and the x86-spelled bootupd probe (#2350): with those cleared, `Build Live ISO` passed on arm64 for the first time and produced a 5.7 GB `albacore-kde-10.2-aarch64.iso` — and the gate then died in 36 seconds. **Control:** the amd64 leg of the same commit passed this exact step (01:06 → 01:21) and went on to sign and upload, so the failure is arm64-specific.

`iso-e2e.sh` already selected the aarch64 emulator, the `virt` machine and AAVMF by host architecture; the display device was the last x86 literal on that path. It is now chosen by `QEMU_MACHINE`, the same way `CPU_ARG` already is: `virtio-gpu-pci` on `virt`, `-vga virtio` on `pc`. The virgl branch probes `-device help` for `virtio-gpu-gl-pci` on `virt` instead of `virtio-vga-gl`, otherwise virgl could never engage on an aarch64 GPU host. `screendump` reads the scanout of either device, so nothing downstream changes.

**QEMU's package hint is wrong, and the mechanism is worth recording.** I fetched the exact packages the runner installed (`qemu-system-common` and `qemu-system-modules-opengl` `8.2.2+ds-0ubuntu1.18`, arm64): they *do* ship `hw-display-virtio-vga.so`, but the aarch64 binary's built-in modinfo table registers only the `virtio-gpu` family — `hw-display-virtio-gpu`, `-gpu-pci`, `-gpu-gl`, `-gpu-pci-gl` — so the `virtio-vga` type lookup returns nothing and the module on disk is inert, while `virtio-gpu-pci` resolves. That is why installing `qemu-system-modules-opengl` (which the log shows happened seconds earlier) changed nothing.

Also in this change:
- The `#1378 KNOWN GAP` comment in `reusable-build-artifacts.yml` claimed `iso-e2e.sh` had no aarch64 QEMU/AAVMF path. It does. Rewritten to say what actually remains (below).
- `docs/MATRIX-STATUS.md`: the arm64 ISO section now records all three stacked blockers with the evidence for each.

**What this does not fix, stated so nobody has to rediscover it:**
- `scripts/run-walkthrough.sh` is still x86-only (`qemu-system-x86_64`, OVMF, `-machine pc`, `-vga virtio`). The `Capture installer walkthrough` step runs it with `continue-on-error: true` and `|| true`, so on arm64 it yields no installer screenshots rather than a red job. Left alone deliberately — it is advisory, not a gate.
- The arm64 gate ran under **TCG** (`Accel: tcg`): hosted `ubuntu-24.04-arm` runners expose no `/dev/kvm`. Whether a KDE live ISO reaches its readiness marker within the 900 s timeout on four emulated vCPUs is what the next run measures. I have not bumped the timeout speculatively; if it times out, that is a fourth item to be diagnosed from its serial log, not guessed at here.

## Testing

- New tests in `tests/bats/test_iso_e2e.bats` **execute the script's own selection block** (extracted by its comment marker, not re-typed), for `QEMU_MACHINE=virt`, `QEMU_MACHINE=pc`, and a virgl case using a stub QEMU whose `-device help` lists only `virtio-gpu-gl-pci`.
- **Before/after control**, run in a `git worktree` of `main` so the working tree was never mutated mid-run: all four new tests **fail** against the previous `iso-e2e.sh` and pass after it. The pre-existing tests in that file are unchanged in both directions.
- `bats tests/bats/test_iso_e2e.bats`: 87 ok / 4 not ok on this branch — the 4 are `e2e-smoke-checks` / `e2e-runtime-checks`, environmental here and identical on `main`.
- Full `bats tests/bats/` on this branch vs. `main` (dd1e9e07): **identical** 38-name failure sets (all environmental — missing `yq`, root checks, network), `ok` count 1482 → 1486, i.e. exactly the four added tests and no regression.
- `shellcheck -S warning scripts/iso-e2e.sh`: clean (CI runs `--severity=error`; zero findings of any severity inside the edited range). `yamllint` on the workflow: exit 0.
- The device-availability claim is **measured, with its scope stated**: by inspecting the runner's exact `.deb` files (shipped modules + the aarch64 binary's modinfo table). This environment cannot execute `qemu-system-aarch64`, so the dispatched run is the final confirmation — I will re-dispatch `build-albacore.yml` kde on `main` after merge and report what it does, including if it fails on the TCG timeout.
- Docs edit is at lines 351/395, outside the `GENERATED` block (63–262).

## Related issues

Follow-through on #1378 (the KNOWN GAP comment it left). Third of three stacked arm64 ISO blockers, after the arm64 installer Flatpak work and #2350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_