### PR TITLE
fix(wahoo): align ELN KDE with PlasmaLogin

### DIFF
--- a/manifests/desktops/kde.yaml
+++ b/manifests/desktops/kde.yaml
@@ -65,26 +65,18 @@ packages:
   # flavor. Listing them strictly would fail the build over a fingerprint
   # helper; dropping them silently would be the #1555 shape. Neither.
   #
-  # MEASURED 2026-08-27 (run 33041330231), replacing the prediction that
-  # used to sit here: the group makes `plasma-login-manager` (6.7.4)
-  # mandatory, it claims display-manager.service first, and the build logs
-  #
-  #   display-manager.service already points at plasmalogin.service; leaving it
-  #
-  # so the greeter on wahoo is plasmalogin, NOT the sddm this manifest
-  # declares — sddm is installed but not wired. The Gate PASSED on that, so
-  # it boots and this is an accuracy gap rather than a breakage.
-  #
-  # Deliberately not "fixed" by editing display_manager: that key is
-  # top-level in this file and shared with the el10 and fedora sections,
-  # where sddm IS correct. Overriding it for ELN alone needs per-section
-  # display_manager support on the dnf path (the zypper path already has
-  # it). Left as-is until someone decides that is worth adding.
+  # MEASURED 2026-08-27 (run 33041330231): the group makes
+  # `plasma-login-manager` (6.7.4) mandatory, it claims
+  # display-manager.service, and the Gate passed with plasmalogin as the
+  # greeter. The DNF installer now supports a per-section display_manager,
+  # so record the unit ELN actually ships instead of inheriting the global
+  # sddm declaration. Do not install the unused sddm alongside it: the group
+  # already supplies plasmalogin, which owns the active alias on this base.
   eln:
+    display_manager: plasmalogin
     groups:
       - kde-desktop
     packages:
-      - sddm
       - dolphin
       - konsole
       - kate

--- a/tests/bats/test_kde_display_manager.bats
+++ b/tests/bats/test_kde_display_manager.bats
@@ -121,6 +121,23 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
 
 # ── The manifest-declared DM (the one force-linked into graphical.target) ──
 
+@test "wahoo KDE declares only ELN's measured plasmalogin display manager" {
+  command -v yq &>/dev/null || skip "yq not installed"
+  local manifest="${REPO_ROOT}/manifests/desktops/kde.yaml"
+
+  run yq -r '.packages.eln.display_manager' "$manifest"
+  [ "$status" -eq 0 ]
+  [ "$output" = "plasmalogin" ]
+
+  # The kde-desktop group already installs plasma-login-manager. Do not also
+  # request the unused sddm package when plasmalogin owns the active alias.
+  run yq -r '.packages.eln.packages[]' "$manifest"
+  [ "$status" -eq 0 ]
+  local packages="$output"
+  run grep -qx sddm <<<"$packages"
+  [ "$status" -ne 0 ]
+}
+
 @test "install-desktop.sh: resolves a manifest 'sddm' to plasmalogin when shipped" {
   # Assert the ASSIGNMENT, not merely that the word appears — a comment
   # mentioning plasmalogin satisfied the loose version of this test even


### PR DESCRIPTION
## Summary

- declare `plasmalogin` as Wahoo KDE's ELN-specific display manager
- stop explicitly installing the unused `sddm` package beside ELN's mandatory `plasma-login-manager`
- add a BATS assertion that keeps the manifest aligned with the display manager measured in run 33041330231

This closes the KDE display-manager accuracy gap recorded while expanding Wahoo in #2048. The measured Gate used `plasmalogin.service`; the manifest previously inherited its global `sddm` declaration even though per-OS overrides are supported.

## Validation

- `bats tests/bats/test_kde_display_manager.bats` — 19 passed
- `pytest tests/test_matrix_status.py -q` — 21 passed
- `yamllint -c .yamllint.yml manifests/desktops/kde.yaml`
- `git diff --check`

Refs #2048
Refs #2050

— hive: backend=pi model=openai-codex/gpt-5.6-sol