### PR TITLE
ci: codify PR and scheduled workflow lanes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ on:
       # exists and runs; it has to re-run when the gates themselves move.
       - '.github/workflows/**'
       - '.github/green-criteria.yml'
+      - 'docs/CI_SPEC.md'
       - 'Justfile'
+      - 'just/**'
   push:
     branches: [main]
   workflow_dispatch:

--- a/docs/CI_SPEC.md
+++ b/docs/CI_SPEC.md
@@ -8,6 +8,87 @@
 > - **Artifact jobs**: Per-stage \`build_artifacts_s{2,3,4}\` (not single \`build_artifacts\`)
 > - **Composite actions**: Single \`build-artifacts\` action (not three separate actions)
 
+<!-- BEGIN GENERATED CI LANES — scripts/gen-ci-lanes.py -->
+
+## Executing workflow lanes
+
+This inventory is generated from workflow triggers and `.github/green-criteria.yml`; run `scripts/gen-ci-lanes.py` after changing either. **PR-deterministic** is fast contributor feedback. **Post-merge** publishes or reacts to trusted repository events. **Scheduled** independently revalidates state and freshness.
+
+| Workflow | Lane | Assertion | Cadence | Freshness SLA |
+|---|---|---|---|---|
+| `arm64-ulimit-probe.yml` | PR-deterministic + post-merge | arm64 ulimit probe (diagnostic) | each PR, manual | — |
+| `asahi-hw-nightly-one.yml` | post-merge + scheduled | Asahi hardware smoke (one) | caller cadence | — |
+| `asahi-hw-nightly.yml` | post-merge + scheduled | Asahi hardware smoke (Tier 2 rental) | `0 6 * * *`, manual | — |
+| `audit-nvidia-release-assets.yml` | post-merge + scheduled | Audit NVIDIA release assets | `30 0 * * *`, manual | — |
+| `bootc-lifecycle.yml` | post-merge + scheduled | `lifecycle` | `0 5 * * 4`, manual | `lifecycle`: 8d |
+| `build-albacore.yml` | post-merge + scheduled | Build Albacore | `20 2 * * *`, manual | — |
+| `build-archlinuxarm-base.yml` | post-merge + scheduled | Build Arch Linux ARM base | push, `40 2 * * 1`, manual | — |
+| `build-bonito-rawhide.yml` | post-merge + scheduled | Build Bonito-rawhide | `20 15 * * *`, manual | — |
+| `build-bonito.yml` | post-merge + scheduled | Build Bonito | `20 11 * * *`, manual | — |
+| `build-flavor.yml` | post-merge | Build Flavor | manual | — |
+| `build-flounder-sid.yml` | post-merge + scheduled | Build Flounder-sid | `20 23 * * *`, manual | — |
+| `build-flounder.yml` | post-merge + scheduled | Build Flounder | `20 21 * * *`, manual | — |
+| `build-grouper.yml` | post-merge + scheduled | Build Grouper | `20 17 * * *`, manual | — |
+| `build-guppy.yml` | post-merge + scheduled | Build Guppy | `20 6 * * *`, manual | — |
+| `build-gurnard.yml` | post-merge + scheduled | Build Gurnard | `20 4 * * *`, manual | — |
+| `build-hummingbird.yml` | post-merge + scheduled | Build Hummingbird | `20 22 * * *`, manual | — |
+| `build-marlin.yml` | post-merge + scheduled | Build Marlin | `20 13 * * *`, manual | — |
+| `build-sailfin.yml` | post-merge + scheduled | Build Sailfin | `20 19 * * *`, manual | — |
+| `build-skipjack.yml` | post-merge + scheduled | Build Skipjack | `20 9 * * *`, manual | — |
+| `build-toolchain.yml` | post-merge | build-toolchain | push, manual | — |
+| `build-variant.yml` | post-merge + scheduled | Unified Build | caller cadence | — |
+| `build-wahoo.yml` | post-merge | Build Wahoo [experimental] | manual | — |
+| `build-yellowfin.yml` | post-merge + scheduled | Build Yellowfin | `20 0 * * *`, manual | — |
+| `catalog-facts.yml` | post-merge + scheduled | Catalog Facts | `0 6 * * *`, manual | — |
+| `check-base-image-pins.yml` | post-merge + scheduled | `rebuildable`, `arch_honesty` | `20 22 * * *`, manual | `rebuildable`: 2d, `arch_honesty`: 2d |
+| `check-download-checksums.yml` | PR-deterministic + post-merge + scheduled | Check download checksums | each PR, `35 22 * * *`, manual | — |
+| `content-filter.yaml` | post-merge | Check for Spammy Issue Comments | issue_comment | — |
+| `daily-verify.yml` | post-merge + scheduled | Daily Image Verification | `0 4 * * *`, manual | — |
+| `desktop-contract-sweep.yml` | post-merge + scheduled | `desktop`, `no_silent_omissions` | `0 8 * * *`, manual | `desktop`: 2d, `no_silent_omissions`: 2d |
+| `drop-bot-review-requests.yml` | PR-deterministic | Drop bot review requests | each PR | — |
+| `frontend-parity.yml` | post-merge + scheduled | frontend parity | `30 6 * * *`, manual | — |
+| `gdm-paint-benchmark.yml` | post-merge | GDM Paint Benchmark | manual | — |
+| `generate-changelog-release.yml` | post-merge + scheduled | Generate Release | `05 11 * * *`, manual | — |
+| `ghcr-partial-pull-check.yml` | post-merge + scheduled | GHCR Partial-Pull Compatibility Canary | `30 8 * * 1`, manual | — |
+| `graduation-check.yml` | post-merge + scheduled | Graduation Check | `0 7 * * 1`, manual | — |
+| `installer-screenshots.yml` | post-merge + scheduled | Installer Walkthrough Screenshots | `0 5 * * 1`, manual | — |
+| `installer-smoke.yml` | post-merge | Installer Smoke | manual | — |
+| `iso-builder-parity.yml` | post-merge | ISO Builder Parity | caller cadence | — |
+| `iso-e2e.yml` | PR-deterministic + post-merge + scheduled | `iso` | each PR, `0 6 * * 1`, manual | `iso`: 8d |
+| `just-fix.yml` | PR-deterministic + post-merge | Just Fix | each PR, push | — |
+| `lint.yml` | PR-deterministic + post-merge | Lint and Check | each PR, push | — |
+| `live-initramfs.yml` | post-merge | Live Initramfs Artifacts | manual | — |
+| `live-iso-bootc.yml` | PR-deterministic + post-merge | Live ISOs (Tacklebox) | each PR, manual | — |
+| `live-overlay.yml` | post-merge + scheduled | Live Overlay Artifacts | `30 9 * * 3`, manual | — |
+| `luks-e2e.yml` | post-merge + scheduled | `install` | `0 7 1 * *`, `0 7 1 */3 *`, manual | `install`: 35d |
+| `matrix-status.yml` | PR-deterministic + post-merge + scheduled | Matrix Status | each PR, `0 6 * * *`, manual | — |
+| `package-parity.yml` | post-merge + scheduled | `parity` | `40 8 * * *`, manual | `parity`: 2d |
+| `pr-nudges.yml` | PR-deterministic | PR Reminders | each PR | — |
+| `prune-r2.yml` | post-merge + scheduled | Prune R2 retention | `30 12 * * *`, manual | — |
+| `publish-iso-groups.yml` | post-merge + scheduled | Publish Grouped Dedup ISOs to R2 | `0 23 * * 0`, manual | — |
+| `publish-isos.yml` | post-merge | Publish Live ISOs to R2 | manual | — |
+| `randomized-tests.yml` | post-merge + scheduled | Randomized Tests | `30 3 * * *`, manual | — |
+| `rerun-infra-failures.yml` | post-merge | Re-run infra failures | workflow completion, manual | — |
+| `rerun-startup-failures.yml` | post-merge + scheduled | Re-run startup failures | `0 */3 * * *`, manual | — |
+| `reusable-build-artifacts.yml` | post-merge + scheduled | Artifacts | caller cadence | — |
+| `reusable-build-image.yml` | post-merge + scheduled | `builds`, `desktop`, `boots`, `no_silent_omissions` | caller cadence | `builds`: 2d, `desktop`: 2d, `boots`: 2d, `no_silent_omissions`: 2d |
+| `scorecard.yml` | post-merge + scheduled | Scorecard supply-chain security | push, `38 0 * * 4`, branch_protection_rule | — |
+| `snapshot-upstreams.yml` | post-merge + scheduled | Snapshot upstreams | `0 9 * * 1`, manual | — |
+| `test.yml` | PR-deterministic + post-merge | Test | each PR, push, manual | — |
+| `update-build-status.yml` | post-merge + scheduled | Update README build status | `30 13 * * *`, manual | — |
+| `validate-renovate.yaml` | PR-deterministic + post-merge | Validate Renovate Config | each PR, push | — |
+| `verify-asahi-one.yml` | post-merge + scheduled | Verify Asahi image (one) | caller cadence | — |
+| `verify-asahi.yml` | post-merge + scheduled | Verify Asahi image | `40 5 * * *`, manual | — |
+| `watch-aurora.yml` | post-merge + scheduled | Watch Aurora Upstream | `0 8 * * 1`, manual | — |
+| `watch-bluefin-lts.yml` | post-merge + scheduled | Watch bluefin-lts Upstream | `0 8 * * 1`, manual | — |
+| `watch-upstream.yml` | post-merge + scheduled | Watch upstream (reusable) | caller cadence | — |
+| `watch-zirconium.yml` | post-merge + scheduled | Watch Zirconium Upstream | `0 8 * * 1`, manual | — |
+| `weekly-boot-report.yml` | post-merge + scheduled | Weekly Boot Screenshot Report | `0 10 * * 1`, manual | — |
+| `weekly-desktop-screenshots.yml` | post-merge + scheduled | Weekly Desktop Screenshots | `0 2 * * 1`, manual | — |
+| `weekly-qcow2-screenshots.yml` | post-merge + scheduled | Weekly QCOW2 Boot Screenshots | `0 20 * * 0`, manual | — |
+
+<!-- END GENERATED CI LANES -->
+
 ## Overview
 This specification defines the target design for the matrix-driven CI/CD pipeline
 for TunaOS, consolidating redundant workflows and optimizing the build process.

--- a/just/utilities.just
+++ b/just/utilities.just
@@ -36,6 +36,7 @@ check: _ensure_check_deps
     just --unstable --fmt --check -f Justfile
     echo "Checking workflow drift..."
     python3 {{ justfile_directory() }}/scripts/generate-workflows.py
+    python3 {{ justfile_directory() }}/scripts/gen-ci-lanes.py --check
     if ! git diff --exit-code .github/workflows/build-*.yml; then
         echo "::error::Generated workflow files are stale. Run 'just generate-workflows' and commit the changes."
         exit 1

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,6 +17,7 @@ Invoked by:
 | `resolve-flavor.sh` | Routes a variant/flavor to its Containerfile, target, parent, and build flags |
 | `resolve-image.sh` | Resolves image references (base, common, brew, akmods) |
 | `build-image-inner.sh` | The build engine (env-var driven) |
+| `gen-ci-lanes.py` | Generates the PR/post-merge/scheduled workflow inventory in `docs/CI_SPEC.md` |
 | `sync-upstream-snapshots.sh` | Syncs and drift-checks the `_upstream-snapshots/` tree |
 | `check-upstream-snapshot-size.sh` | Fails refreshes that exceed the snapshot size or change budget |
 

--- a/scripts/gen-ci-lanes.py
+++ b/scripts/gen-ci-lanes.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Generate the two-speed workflow inventory in docs/CI_SPEC.md.
+
+The inventory is derived from workflow triggers and green-criteria gates. It is
+not a hand-maintained status table: adding a workflow or moving a gate between
+lanes changes generated output and the PR contract test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github/workflows"
+CRITERIA = ROOT / ".github/green-criteria.yml"
+DOC = ROOT / "docs/CI_SPEC.md"
+BEGIN = "<!-- BEGIN GENERATED CI LANES — scripts/gen-ci-lanes.py -->"
+END = "<!-- END GENERATED CI LANES -->"
+
+PR_TRIGGERS = {"pull_request", "pull_request_target", "merge_group"}
+POST_MERGE_TRIGGERS = {
+    "push",
+    "workflow_run",
+    "release",
+    "repository_dispatch",
+    "workflow_dispatch",
+}
+
+
+def triggers(document: dict) -> dict:
+    """Return `on:` despite PyYAML's YAML-1.1 boolean parsing of that key."""
+    value = document.get("on", document.get(True, {}))
+    if isinstance(value, str):
+        return {value: None}
+    if isinstance(value, list):
+        return {item: None for item in value}
+    return value or {}
+
+
+def load_workflows(directory: Path = WORKFLOWS) -> dict[str, dict]:
+    return {
+        f".github/workflows/{path.name}": yaml.safe_load(path.read_text()) or {}
+        for path in sorted(directory.glob("*.y*ml"))
+    }
+
+
+def callers(workflows: dict[str, dict]) -> dict[str, set[str]]:
+    result: dict[str, set[str]] = defaultdict(set)
+    for caller, document in workflows.items():
+        for job in (document.get("jobs") or {}).values():
+            uses = (job or {}).get("uses", "")
+            if isinstance(uses, str) and uses.startswith("./.github/workflows/"):
+                result[uses[2:]].add(caller)
+    return result
+
+
+def workflow_lanes(name: str, workflows: dict[str, dict], seen=None) -> set[str]:
+    """Classify direct triggers; reusable workflows inherit caller lanes."""
+    seen = set(seen or ())
+    if name in seen:
+        return set()
+    seen.add(name)
+    on = set(triggers(workflows[name]))
+    lanes = set()
+    if on & PR_TRIGGERS:
+        lanes.add("PR-deterministic")
+    if "schedule" in on:
+        lanes.add("scheduled")
+    if on & POST_MERGE_TRIGGERS:
+        lanes.add("post-merge")
+    # Issue/discussion/status events are trusted-repository automation too.
+    # Keep newly introduced event types visible without maintaining a second
+    # exhaustive copy of GitHub's webhook catalogue here.
+    if on - PR_TRIGGERS - {"schedule", "workflow_call"}:
+        lanes.add("post-merge")
+    for caller in callers(workflows).get(name, ()):
+        lanes.update(workflow_lanes(caller, workflows, seen))
+    # A workflow_call-only helper with no current caller is still inventory,
+    # but it cannot claim to be a gate. Keep it visible in the post-merge lane.
+    return lanes or {"post-merge"}
+
+
+def trigger_cadence(document: dict) -> str:
+    on = triggers(document)
+    values = []
+    if "pull_request" in on or "pull_request_target" in on:
+        values.append("each PR")
+    if "merge_group" in on:
+        values.append("merge queue")
+    if "push" in on:
+        values.append("push")
+    values.extend(f"`{entry['cron']}`" for entry in (on.get("schedule") or []))
+    if "workflow_run" in on:
+        values.append("workflow completion")
+    if "release" in on:
+        values.append("release")
+    if "repository_dispatch" in on:
+        values.append("repository dispatch")
+    if "workflow_dispatch" in on:
+        values.append("manual")
+    if "workflow_call" in on:
+        values.append("caller cadence")
+    handled = PR_TRIGGERS | POST_MERGE_TRIGGERS | {"schedule", "workflow_call"}
+    values.extend(sorted(set(on) - handled))
+    return ", ".join(values) or "no active trigger"
+
+
+def criterion_index(criteria_path: Path = CRITERIA):
+    criteria = yaml.safe_load(criteria_path.read_text())["criteria"]
+    asserted: dict[str, list[dict]] = defaultdict(list)
+    for criterion in criteria:
+        for gate in criterion.get("gates") or []:
+            asserted[gate["workflow"]].append(criterion)
+    return asserted
+
+
+def escape(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def render(workflows=None, asserted=None) -> str:
+    workflows = workflows or load_workflows()
+    asserted = asserted or criterion_index()
+    rows = [
+        BEGIN,
+        "",
+        "## Executing workflow lanes",
+        "",
+        (
+            "This inventory is generated from workflow triggers and "
+            "`.github/green-criteria.yml`; run `scripts/gen-ci-lanes.py` after "
+            "changing either. **PR-deterministic** is fast contributor feedback. "
+            "**Post-merge** publishes or reacts to trusted repository events. "
+            "**Scheduled** independently revalidates state and freshness."
+        ),
+        "",
+        "| Workflow | Lane | Assertion | Cadence | Freshness SLA |",
+        "|---|---|---|---|---|",
+    ]
+    order = {"PR-deterministic": 0, "post-merge": 1, "scheduled": 2}
+    for name, document in workflows.items():
+        criteria = asserted.get(name, [])
+        lanes = sorted(workflow_lanes(name, workflows), key=order.get)
+        assertion = ", ".join(f"`{item['id']}`" for item in criteria)
+        if not assertion:
+            assertion = escape(str(document.get("name") or "workflow automation"))
+        slas = (
+            ", ".join(f"`{item['id']}`: {item['freshness_sla_days']}d" for item in criteria) or "—"
+        )
+        rows.append(
+            f"| `{Path(name).name}` | {' + '.join(lanes)} | {assertion} | "
+            f"{escape(trigger_cadence(document))} | {slas} |"
+        )
+    rows.extend(["", END])
+    return "\n".join(rows)
+
+
+def update(check: bool = False, doc_path: Path = DOC) -> int:
+    text = doc_path.read_text()
+    if BEGIN not in text or END not in text:
+        raise SystemExit(f"{doc_path} is missing the generated CI lane markers")
+    head, rest = text.split(BEGIN, 1)
+    _, tail = rest.split(END, 1)
+    updated = head + render() + tail
+    if updated == text:
+        print("CI lane inventory is current")
+        return 0
+    if check:
+        print("CI lane inventory is out of date; run scripts/gen-ci-lanes.py", file=sys.stderr)
+        return 1
+    doc_path.write_text(updated)
+    print(f"updated {doc_path}")
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args(argv)
+    return update(args.check)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_lanes.py
+++ b/tests/test_ci_lanes.py
@@ -1,0 +1,107 @@
+"""The documented two-speed CI split is generated and executable.
+
+TunaOS#2264: predictable PR feedback and independent scheduled revalidation
+must not drift into an aspirational hand-maintained workflow list.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_DIR = ROOT / ".github/workflows"
+
+spec = importlib.util.spec_from_file_location("gen_ci_lanes", ROOT / "scripts/gen-ci-lanes.py")
+assert spec and spec.loader
+generator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(generator)
+
+WORKFLOWS = generator.load_workflows()
+ASSERTED = generator.criterion_index()
+
+
+def test_generated_inventory_names_every_workflow_once() -> None:
+    rendered = generator.render(WORKFLOWS, ASSERTED)
+    rows = [line for line in rendered.splitlines() if line.startswith("| `")]
+    names = [line.split("`")[1] for line in rows]
+    expected = sorted(path.name for path in WORKFLOW_DIR.glob("*.y*ml"))
+    assert names == expected
+
+
+def test_committed_inventory_is_generated_not_transcribed() -> None:
+    text = (ROOT / "docs/CI_SPEC.md").read_text()
+    committed = text.split(generator.BEGIN, 1)[1].split(generator.END, 1)[0]
+    generated = generator.render(WORKFLOWS, ASSERTED)
+    expected = generated.split(generator.BEGIN, 1)[1].split(generator.END, 1)[0]
+    assert committed == expected
+    assert generator.update(check=True) == 0
+
+
+def test_every_green_gate_has_independent_trusted_revalidation() -> None:
+    """A PR-only check tests contributor code, not the published factory.
+    Every declared criterion must also run after merge or on a schedule."""
+    violations = []
+    for workflow, criteria in ASSERTED.items():
+        lanes = generator.workflow_lanes(workflow, WORKFLOWS)
+        if not lanes & {"post-merge", "scheduled"}:
+            ids = ", ".join(item["id"] for item in criteria)
+            violations.append(f"{workflow} ({ids}) is only {sorted(lanes)}")
+    assert not violations, "\n".join(violations)
+
+
+def test_pr_kvm_checks_have_a_hosted_fallback() -> None:
+    """A PR job may use KVM, but lack of KVM cannot strand fork feedback."""
+    violations = []
+    for name, document in WORKFLOWS.items():
+        if "PR-deterministic" not in generator.workflow_lanes(name, WORKFLOWS):
+            continue
+        run_code = "\n".join(
+            str(step.get("run", ""))
+            for job in (document.get("jobs") or {}).values()
+            for step in (job or {}).get("steps", [])
+        )
+        if "/dev/kvm" in run_code and "--no-kvm" not in run_code:
+            violations.append(f"{name} touches /dev/kvm without a TCG fallback")
+    assert not violations, "\n".join(violations)
+
+
+def test_pr_lane_is_covered_by_the_contributor_ci_contract() -> None:
+    """`just ci` composes the same lint, contract, and unit suites used on PRs."""
+    utilities = (ROOT / "just/utilities.just").read_text()
+    assert "ci: check test-contract test" in utilities
+    assert "scripts/gen-ci-lanes.py --check" in utilities
+
+    test_workflow = yaml.safe_load((WORKFLOW_DIR / "test.yml").read_text())
+    paths = generator.triggers(test_workflow)["pull_request"]["paths"]
+    assert "docs/CI_SPEC.md" in paths
+    assert "just/**" in paths
+
+    pr_names = {
+        Path(name).name
+        for name in WORKFLOWS
+        if "PR-deterministic" in generator.workflow_lanes(name, WORKFLOWS)
+    }
+    assert {"lint.yml", "test.yml"} <= pr_names
+
+
+def test_pr_lane_remains_fork_safe() -> None:
+    """The two-speed classification must retain the existing fork contract."""
+    spec = importlib.util.spec_from_file_location(
+        "fork_safety", ROOT / "tests/test_fork_safe_workflows.py"
+    )
+    assert spec and spec.loader
+    fork_safety = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(fork_safety)
+
+    problems = []
+    for name in fork_safety.PR_WORKFLOWS:
+        problems.extend(fork_safety._unguarded_write_steps(name))
+        document = yaml.safe_load((WORKFLOW_DIR / name).read_text()) or {}
+        assert "permissions" in document or all(
+            "permissions" in (job or {}) or "uses" in (job or {})
+            for job in (document.get("jobs") or {}).values()
+        )
+    assert not problems, "\n".join(problems)


### PR DESCRIPTION
## Summary

- add `scripts/gen-ci-lanes.py`, which derives a complete workflow inventory from all 70 workflow trigger blocks and `.github/green-criteria.yml`
- classify workflows as PR-deterministic, post-merge, and/or scheduled, including inherited lanes for reusable workflows
- generate each workflow's assertion, cadence, and criterion freshness SLA into `docs/CI_SPEC.md`
- enforce that every declared green gate has trusted post-merge or scheduled revalidation
- retain the existing fork-safety contract and require KVM-using PR jobs to provide a hosted-runner fallback
- wire inventory drift into `just check` and ensure the PR test runs when the generated spec or imported Just recipes change

The tests also pin `just ci` to its `check + test-contract + test` composition and confirm the core lint/test workflows remain in the PR lane.

## Validation

- `pytest tests/test_ci_lanes.py tests/test_ci_contract.py tests/test_fork_safe_workflows.py tests/test_workflow_expressions_parse.py -q` — 206 passed
- `scripts/gen-ci-lanes.py --check`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/test.yml`
- `ruff check` and `ruff format --check` on the new generator and tests
- `git diff --check`

Fixes #2264
Refs #2250

— hive: backend=pi model=openai-codex/gpt-5.6-sol