### PR TITLE
docs: prevent shell expansion in agent issue bodies

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -4,18 +4,47 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 
 ## Conventions
 
-- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Create an issue**: pass Markdown on stdin with a quoted heredoc delimiter:
+
+  ```bash
+  gh issue create --title 'Short title' --body-file - <<'EOF'
+  ## What happened
+
+  Markdown such as `env`, $GH_TOKEN, and $(command) stays literal.
+  EOF
+  ```
+
 - **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
-- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Comment on an issue**: use the same stdin pattern:
+
+  ```bash
+  gh issue comment <number> --body-file - <<'EOF'
+  Markdown comment, including `code` and $VARIABLE references.
+  EOF
+  ```
+
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
-- **Close**: `gh issue close <number> --comment "..."`
+- **Close**: add a closing explanation with the safe comment form above, then run `gh issue close <number>`.
+
+### Markdown is never a shell argument
+
+Never put generated or authored Markdown directly in `--body`, `--comment`, or
+a double-quoted shell variable assignment. Backticks, `$(...)`, and `$VARIABLE`
+are shell syntax: the shell evaluates them before `gh` sees the text and can
+splice credentials or command output into a public issue. Escaping backticks
+alone is not sufficient.
+
+Use `--body-file -` and a **single-quoted heredoc delimiter** (`<<'EOF'`) so the
+shell performs no command, parameter, or backslash expansion. A temporary file
+created with a quoted heredoc and passed through `--body-file "$file"` is also
+safe when the body must be reused.
 
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
 
 ## When a skill says "publish to the issue tracker"
 
-Create a GitHub issue.
+Create a GitHub issue using the quoted-heredoc `--body-file -` form above.
 
 ## When a skill says "fetch the relevant ticket"
 

--- a/tests/regressions/test_issue_2279_agent_issue_bodies_bypass_shell_expansion.py
+++ b/tests/regressions/test_issue_2279_agent_issue_bodies_bypass_shell_expansion.py
@@ -1,0 +1,73 @@
+"""tunaOS#2279: an agent-filed issue publicly shipped an environment dump.
+
+The body recovered from tuna-os/corral#217 measured the failure: an agent put
+Markdown in a double-quoted ``--body`` argument, and its backticks ran ``env``.
+This test holds the actual documented command to literal stdin transport so a
+later simplification cannot silently restore credential exposure.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+GUIDE = ROOT / "docs" / "agents" / "issue-tracker.md"
+
+
+def _create_example() -> str:
+    body = GUIDE.read_text(encoding="utf-8")
+    match = re.search(r"```bash\n(\s+gh issue create .*?\n\s+EOF)\n\s+```", body, re.DOTALL)
+    assert match, "the agent guide must include an executable safe creation example"
+    return textwrap.dedent(match.group(1))
+
+
+def test_documented_create_command_preserves_shell_syntax_literally(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$CAPTURE_ARGS\"\ncat > \"$CAPTURE_BODY\"\n"
+    )
+    fake_gh.chmod(0o755)
+    captured_body = tmp_path / "body"
+    captured_args = tmp_path / "args"
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "GH_TOKEN": "credential-that-must-not-be-expanded",
+        "CAPTURE_BODY": str(captured_body),
+        "CAPTURE_ARGS": str(captured_args),
+    }
+
+    subprocess.run(["bash", "-eu", "-c", _create_example()], env=env, check=True)
+
+    body = captured_body.read_text()
+    assert "`env`" in body
+    assert "$GH_TOKEN" in body
+    assert "$(command)" in body
+    assert env["GH_TOKEN"] not in body
+    assert captured_args.read_text().splitlines()[-2:] == ["--body-file", "-"]
+
+
+def test_agent_docs_never_recommend_inline_markdown_arguments() -> None:
+    offenders = []
+    unsafe = re.compile(
+        r"\bgh\s+issue\s+(?:create|comment|edit)\b.*\s--body(?:=|\s)"
+        r"|\bgh\s+issue\s+close\b.*\s--comment(?:=|\s)"
+    )
+    for path in sorted((ROOT / "docs" / "agents").glob("*.md")):
+        for line_number, line in enumerate(path.read_text().splitlines(), 1):
+            if unsafe.search(line):
+                offenders.append(f"{path.relative_to(ROOT)}:{line_number}: {line.strip()}")
+    assert not offenders, "Markdown must use --body-file, never a shell argument:\n" + "\n".join(offenders)
+
+
+def test_safety_rule_names_every_expansion_form() -> None:
+    guide = GUIDE.read_text()
+    assert "<<'EOF'" in guide
+    for dangerous in ("Backticks", "$(...)", "$VARIABLE"):
+        assert dangerous in guide


### PR DESCRIPTION
## Summary
- replace the agent guide's inline `--body`/`--comment` examples with `--body-file -` and single-quoted heredocs
- explain why backticks, command substitutions, and parameter expansions must bypass shell interpolation
- exercise the documented command with hostile Markdown and reject future unsafe issue-body examples

Fixes #2279

## Tests
- `python3 -m pytest tests/regressions/test_issue_2279_agent_issue_bodies_bypass_shell_expansion.py tests/test_regression_convention.py -q` (16 passed)

— hive: backend=pi model=openai-codex/gpt-5.6-sol
