### PR TITLE
fix(niri): ship pinned DMS QML on EL10

### DIFF
--- a/build_scripts/desktop/niri.sh
+++ b/build_scripts/desktop/niri.sh
@@ -311,31 +311,13 @@ EOF
 		wl-mirror
 
 	# Install DankMaterialShell suite (quickshell + dms shell + theming/tools)
-	# Every EL10 variant: the gate is Qt 6.10+, and all three have it.
-	# Needs ligenix repo enabled for dms-greeter -> greetd dependency
+	# for every EL10 variant. Needs ligenix enabled for the greetd dependency.
 	#
-	# albacore (plain AlmaLinux 10) used to be excluded here, which broke its
-	# build outright rather than merely shipping a lesser desktop:
-	# install-zirconium.sh writes /etc/greetd/config.toml pointing at
-	# `dms-greeter` for EVERY niri image, and manifests/desktops/niri.yaml's
-	# el10 list carries no wallpaper daemon because -- per
-	# tests/bats/test_niri_wallpaper_daemon.bats -- "el10 legitimately ships
-	# no wallpaper daemon and passes through the dms branch". albacore passed
-	# through neither, so verify-branding-niri.sh failed twice and the image
-	# build died after three attempts (nightly 33848074014, job 101019603707):
-	#
-	#   FAIL: greetd launches dms-greeter but /usr/share/quickshell/
-	#         dms-greeter/DMSGreeter.qml is missing
-	#   FAIL: no wallpaper daemon (swaybg/swww/wpaperd) and no dms
-	#   TUNAOS_BRANDING_NIRI_FAIL variant=albacore failures=2
-	#
-	# No image published, so both ISO legs then refused to build from a stale
-	# tag -- which is why iso:niri was red on amd64 AND arm64 while every
-	# other desktop was red on arm64 only.
-	#
-	# The exclusion cited Qt 6.10+, and plain AlmaLinux 10 meets it:
-	# repo.almalinux.org/almalinux/10/AppStream/x86_64 ships qt6-qtbase-6.10.1
-	# (checked 2026-09-05). So the condition was narrower than its own reason.
+	# The AvengeMedia EL10 dms-greeter 1.6 RPM is only a runtime-sync launcher:
+	# it ships no QML. An image build cannot rely on a first-boot download, so
+	# overlay the checksum-pinned upstream payload when the RPM omitted it.
+	# install-dms-qml-fallback.sh becomes a no-op once tunaos-packages publishes
+	# an EL10 RPM that owns DMSGreeter.qml (tunaOS#2359).
 	if [[ $IS_ALMALINUX == true || $IS_ALMALINUXKITTEN == true || $IS_CENTOS == true ]]; then
 		dnf -y copr enable avengemedia/danklinux
 		dnf -y copr enable avengemedia/dms-git
@@ -352,6 +334,7 @@ EOF
 			danksearch
 		dnf -y copr disable avengemedia/danklinux
 		dnf -y copr disable avengemedia/dms-git
+		/run/context/build_scripts/install-dms-qml-fallback.sh
 	fi
 
 	# Restore brightnessctl and playerctl for every EL10 variant. Same

--- a/build_scripts/install-dms-qml-fallback.sh
+++ b/build_scripts/install-dms-qml-fallback.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Install the pinned DMS application payload when an RPM only ships the
+# runtime-sync launcher. AvengeMedia's EL10 dms-greeter 1.6 RPM contains no
+# QML, so an offline image otherwise reaches greetd without a usable greeter.
+#
+# This mirrors the source payload used by tunaos-packages. Once that repository
+# publishes an EL10 dms-greeter containing DMSGreeter.qml, the caller skips this
+# fallback and the RPM remains authoritative.
+set -euo pipefail
+
+[[ -f /usr/share/quickshell/dms-greeter/DMSGreeter.qml ]] && exit 0
+
+VERSIONS="${VERSIONS_FILE:-/run/context/image-versions.yaml}"
+read_version() {
+	local key="$1"
+	sed -n "s/^[[:space:]]*${key}:[[:space:]]*\"\{0,1\}\([^\"]*\)\"\{0,1\}[[:space:]]*$/\1/p" "$VERSIONS" | head -1
+}
+
+DMS_QML_VERSION="${DMS_QML_VERSION:-$(read_version dms_qml)}"
+DMS_QML_SHA256="${DMS_QML_SHA256:-$(read_version dms_qml_sha256)}"
+[[ -n "$DMS_QML_VERSION" && -n "$DMS_QML_SHA256" ]] || {
+	echo "ERROR: downloads.dms_qml and dms_qml_sha256 must be pinned in $VERSIONS" >&2
+	exit 1
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+ARCHIVE="$TMP/dms-qml.tar.gz"
+SRC="$TMP/src"
+mkdir "$SRC"
+
+curl -fsSL --retry 3 \
+	"https://github.com/AvengeMedia/DankMaterialShell/releases/download/${DMS_QML_VERSION}/dms-qml.tar.gz" \
+	-o "$ARCHIVE"
+printf '%s  %s\n' "$DMS_QML_SHA256" "$ARCHIVE" | sha256sum --check --strict
+tar --no-same-owner -xzf "$ARCHIVE" -C "$SRC"
+
+[[ -f "$SRC/DMSGreeter.qml" && -x "$SRC/Modules/Greetd/assets/dms-greeter" ]] || {
+	echo "ERROR: DMS ${DMS_QML_VERSION} archive lacks its greeter payload" >&2
+	exit 1
+}
+
+# Match the tunaos-packages dms and dms-greeter recipes: both packages install
+# the release's complete QML tree, under the paths Quickshell resolves.
+rm -rf /usr/share/dankmaterialshell /usr/share/quickshell/dms-greeter
+install -d /usr/share/dankmaterialshell /usr/share/quickshell/dms-greeter
+cp -a "$SRC/." /usr/share/dankmaterialshell/
+cp -a "$SRC/." /usr/share/quickshell/dms-greeter/
+install -Dm0755 "$SRC/Modules/Greetd/assets/dms-greeter" /usr/bin/dms-greeter
+
+echo "==> Installed pinned DMS ${DMS_QML_VERSION} QML fallback"

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -92,6 +92,13 @@ downloads:
   # (tunaOS#1893): the runner images lack journald for the container,
   # and the customize/initramfs/commit steps otherwise die in conmon.
 
+  # AvengeMedia's EL10 dms-greeter 1.6 RPM is a runtime-sync launcher and
+  # carries no QML. Keep the same source payload and checksum as the pending
+  # tunaos-packages dms/dms-greeter recipes for the offline-build fallback.
+  # renovate: datasource=github-releases depName=AvengeMedia/DankMaterialShell
+  dms_qml: "v1.5.2"
+  dms_qml_sha256: "a504d4684aed1fde07bc3cad3ea1ba417331bfd43cb97420133082ae70da1478"
+
   # Zirconium's mkosi.extra payload, fetched as a source tarball by
   # build_scripts/install-zirconium.sh (niri stages only). Pinned to a commit
   # for the same reason every other download here is: `main` moves, so an

--- a/renovate.json
+++ b/renovate.json
@@ -86,7 +86,8 @@
       "description": "Never automerge a download whose version is paired with a hand-pinned sha256. Renovate bumps the version and cannot bump the checksum, so the bump alone fails every base build closed at `sha256sum --check` (install-remora.sh). The `checksums` check catches it on the PR, but the main ruleset has no required status checks, so platformAutomerge merged #2308 with that check red and took every variant's nightly base build down on 2026-09-03 (flounder run 33694724467). Hold these for a human to run `scripts/check-download-checksums.py --fix` on the branch first. tests/test_checksum_pinned_downloads_are_not_automerged.py derives this list from the repo.",
       "matchDepNames": [
         "tuna-os/remora",
-        "twpayne/chezmoi"
+        "twpayne/chezmoi",
+        "AvengeMedia/DankMaterialShell"
       ],
       "automerge": false
     },

--- a/tests/bats/test_niri_dms_payload.bats
+++ b/tests/bats/test_niri_dms_payload.bats
@@ -42,6 +42,25 @@ _code() { grep -v '^[[:space:]]*#' "$1"; }
   [ "$status" -eq 0 ]
 }
 
+@test "EL10 installs a checksum-pinned QML fallback after the COPR transaction" {
+  local installer="${REPO_ROOT}/build_scripts/desktop/niri.sh"
+  local fallback="${REPO_ROOT}/build_scripts/install-dms-qml-fallback.sh"
+  local versions="${REPO_ROOT}/image-versions.yaml"
+
+  [ -x "$fallback" ]
+  _code "$installer" | grep -qF '/run/context/build_scripts/install-dms-qml-fallback.sh'
+  _code "$fallback" | grep -qF '/usr/share/quickshell/dms-greeter/DMSGreeter.qml'
+  _code "$fallback" | grep -qF 'sha256sum --check --strict'
+  grep -qE '^[[:space:]]+dms_qml: "v[0-9]' "$versions"
+  grep -qE '^[[:space:]]+dms_qml_sha256: "[0-9a-f]{64}"' "$versions"
+}
+
+@test "DMS QML fallback passes shellcheck" {
+  if ! command -v shellcheck &>/dev/null; then skip "shellcheck not installed"; fi
+  run shellcheck --severity=error --exclude=SC1091 "${REPO_ROOT}/build_scripts/install-dms-qml-fallback.sh"
+  [ "$status" -eq 0 ]
+}
+
 @test "every DMS package is asked of a COPR that can resolve it" {
   if ! command -v "$YQ_BIN" &>/dev/null; then skip "yq not installed"; fi
   local manifest="${REPO_ROOT}/manifests/desktops/niri.yaml"


### PR DESCRIPTION
## Summary

- install a checksum-pinned DMS 1.5.2 QML payload when the EL10 COPR RPM only provides its runtime-sync launcher
- mirror the pending `tunaos-packages` `dms`/`dms-greeter` payload paths, while making the fallback a no-op once a complete RPM is published
- hold checksum-paired DMS Renovate updates for manual review and cover the EL10 fallback contract in Bats

This keeps the immutable image self-contained: greetd has `DMSGreeter.qml` before first boot, and the DMS shell can draw the background without requiring runtime provisioning.

Fixes #2359

## Tests

- `bash -n build_scripts/install-dms-qml-fallback.sh build_scripts/desktop/niri.sh`
- ShellCheck 0.10.0 on both changed shell scripts
- `npx --yes bats tests/bats/test_niri_dms_payload.bats` (7 passed/skipped according to optional local tools)
- `python3 -m pytest -q tests/test_checksum_pinned_downloads_are_not_automerged.py` (4 passed)
- downloaded the pinned release asset and verified its SHA-256 and `DMSGreeter.qml`

---
🐝 **Hive Agent**: `contributor` | **SHA:** `d8954da0`

— hive: backend=pi model=openai-codex/gpt-5.6-sol