### PR TITLE
feat(hummingbird): restore COSMIC on arm64

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -930,18 +930,10 @@ variants:
         stage: 1
         build_image: true
         build_iso: true
-      # Desktops are amd64-only until the aarch64 rebuild repo converges
-      # (#1755 option A, W8 architecture honesty). Measured 2026-08-18:
-      # hummingbird/20251124-aarch64 now EXISTS (it 404'd when #1755 was
-      # filed) but is a 1358-package seed against x86_64's 8100 — cosmic
-      # 8/22 manifest packages present, gnome 5/52, no gnome-shell/gdm and
-      # no COSMIC compositor. An arm64 desktop leg today would either 404
-      # nothing and install almost nothing (--skip-unavailable), publishing
-      # the #858 shape: an image with no desktop. Same treatment as
-      # grouper:cosmic's amd64 pin. Re-add "linux/arm64" per flavor when
-      # the aarch64 index carries that desktop's manifest set — re-measure
-      # with the method in manifests/desktops/cosmic.yaml's hummingbird
-      # section comment.
+      # GNOME remains amd64-only until its aarch64 source (utah-packages)
+      # publishes there. The Hummingbird package factory's aarch64 repository
+      # has since converged for COSMIC: all 25 manifest packages resolve as of
+      # 2026-09-06, so that flavor inherits both variant platforms below.
       - id: gnome
         stage: 2
         platforms: ["linux/amd64"]
@@ -979,7 +971,6 @@ variants:
       # do not exist yet and should not be advertised as though they do.
       - id: cosmic
         stage: 2
-        platforms: ["linux/amd64"]
         build_image: true
         build_iso: true
 

--- a/docs/HUMMINGBIRD.md
+++ b/docs/HUMMINGBIRD.md
@@ -42,8 +42,9 @@ it leads directly to expecting Fedora 43's package set to be present. It is not.
 ## What this means for tunaOS
 
 tunaOS builds `hummingbird:{base,gnome,cosmic}` (see
-`.github/build-config.yml`). Desktop flavors are currently amd64-only; the base
-image also builds for arm64. Everything except `base` asks a distribution that
+`.github/build-config.yml`). Base and COSMIC build for amd64 and arm64; GNOME
+remains amd64-only because its utah-packages source is not multi-arch. Everything
+except `base` asks a distribution that
 **deliberately ships no desktop environment** to host a full desktop, layered
 from tunaOS's own package snapshot.
 

--- a/manifests/desktops/cosmic.yaml
+++ b/manifests/desktops/cosmic.yaml
@@ -143,7 +143,7 @@ packages:
       - mesa-vulkan-drivers
 
   fedora:
-    packages:
+    packages: &fedora_cosmic_packages
       # dconf is explicit, not assumed: the TunaOS branding keyfiles in
       # /etc/dconf/db/distro.d need `dconf update` at build time, and
       # verify-branding fails the build if the compiled db is missing. Full
@@ -182,63 +182,22 @@ packages:
       - mesa-vulkan-drivers
 
   # ── Hummingbird (Fedora rebuild) ───────────────────────────────────
-  # The cheapest real win in the matrix (#1755 §4): the rebuild repo carries
-  # 22 of cosmic's 23 Fedora packages, and the cell was red purely because no
-  # section named them. Re-measured 2026-08-18 against the live primary.xml
-  # (8100 packages): everything below resolves.
-  #
-  # NOT an alias of the fedora list (unlike gnome.yaml's section, which IS
-  # `*fedora_gnome_packages`): the repo has no `cosmic-settings-daemon` — the
-  # single gap — and hummingbird installs run --skip-unavailable, so listing
-  # it would record a permanent, known omission every night instead of a
-  # decision. Same treatment as the zypper section's cosmic-settings note
-  # above: do not list what the repository cannot supply. Re-add it (or
-  # restore the alias outright) when tunaos-packages rebuilds it —
-  # tests/bats/test_hummingbird_desktop_wiring.bats pins that the difference
-  # between this list and fedora's is exactly that one package, so the two
-  # cannot drift silently.
+  # The package factory has now closed the last COSMIC gap from #1755:
+  # cosmic-settings-daemon and every other name in the Fedora list resolve
+  # from both the x86_64 and aarch64 20251124 indexes (measured 2026-09-06;
+  # 8,811 and 3,905 unique package names respectively). Reuse Fedora's package
+  # list so the two Fedora-derived targets cannot drift apart again.
   #
   # Snapshot pin, not `current/$basearch/`: same status as gnome.yaml's
   # section — the floating alias does not exist on repo.tunaos.org yet
-  # (tuna-os/tunaos-packages#365), and the x86_64-only path is the only one
-  # published (#1755 §3), which is fine because this section is only read on
-  # the amd64 leg's dnf path.
+  # (tuna-os/tunaos-packages#365). `$basearch` selects the independently
+  # published x86_64 or aarch64 repository.
   hummingbird:
     repos:
       - name: tunaos-hummingbird
         baseurl: https://repo.tunaos.org/hummingbird/20251124-$basearch/
         priority: 5
-    packages:
-      # See the fedora list's dconf note — needed here for real (the rebuild
-      # never pulls it transitively), mirrored there to keep the lists' diff
-      # pinned to exactly cosmic-settings-daemon.
-      - dconf
-      - cosmic-session
-      - cosmic-comp
-      - cosmic-panel
-      - cosmic-app-library
-      - cosmic-applets
-      - cosmic-bg
-      - cosmic-files
-      - cosmic-idle
-      - cosmic-launcher
-      - cosmic-notifications
-      - cosmic-osd
-      - cosmic-randr
-      - cosmic-screenshot
-      - cosmic-settings
-      # cosmic-settings-daemon deliberately absent — see the section comment.
-      - cosmic-term
-      - cosmic-wallpapers
-      - cosmic-workspaces
-      - cosmic-greeter
-      - cosmic-icon-theme
-      - greetd
-      - xdg-desktop-portal-cosmic
-      - pop-icon-theme
-      # Software Vulkan (lavapipe) -- see the apt list's note above for why
-      # this must be named rather than pulled in transitively.
-      - mesa-vulkan-drivers
+    packages: *fedora_cosmic_packages
 
   # ── Wahoo (Fedora ELN) ─────────────────────────────────────────────────
   # ELN carries COSMIC natively, in eln-extras, at 1.6.0 — and that is the

--- a/tests/bats/test_hummingbird_desktop_wiring.bats
+++ b/tests/bats/test_hummingbird_desktop_wiring.bats
@@ -91,25 +91,24 @@ yq_bin() { command -v yq; }
 	done
 }
 
-# cosmic joined gnome on 2026-08-18 (#1755 option B): 22 of its 23 Fedora
-# packages resolve against the live repo (re-measured, 8100-package
-# primary.xml), the gap being exactly cosmic-settings-daemon. Its section is
-# a literal list, NOT the fedora alias gnome uses — listing the missing
-# daemon under --skip-unavailable would turn a decision into a nightly
-# omission. This test IS the drift guard the alias would have been: the
-# difference between the two lists must be exactly that one package, in that
-# direction, so either list changing alone fails loudly here.
-@test "cosmic's hummingbird list is fedora's minus exactly cosmic-settings-daemon" {
+# cosmic joined gnome on 2026-08-18 (#1755 option B). The package factory
+# subsequently published cosmic-settings-daemon, closing its final direct
+# package gap on both architectures. Reuse the Fedora list by YAML alias so
+# the two Fedora-derived targets cannot drift apart again.
+@test "cosmic's hummingbird list matches fedora's package set" {
 	[ -n "$(yq_bin)" ] || skip "yq not available"
 	local cosmic_yaml="${REPO_ROOT}/manifests/desktops/cosmic.yaml"
 	run yq -r '.packages.hummingbird.repos[0].baseurl' "$cosmic_yaml"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *'hummingbird/20251124-$basearch'* ]]
-	local fedora hummingbird diff
+	local fedora hummingbird
 	fedora="$(yq -r '.packages.fedora.packages[]' "$cosmic_yaml" | sort)"
 	hummingbird="$(yq -r '.packages.hummingbird.packages[]' "$cosmic_yaml" | sort)"
 	[ -n "$fedora" ]
 	[ -n "$hummingbird" ]
-	diff="$(comm -3 <(echo "$fedora") <(echo "$hummingbird") | tr -d '\t')"
-	[ "$diff" = "cosmic-settings-daemon" ]
+	[ "$fedora" = "$hummingbird" ]
+
+	run grep -c 'packages: \*fedora_cosmic_packages' "$cosmic_yaml"
+	[ "$status" -eq 0 ]
+	[ "$output" -eq 1 ]
 }

--- a/tests/test_hummingbird_arm64_honesty.py
+++ b/tests/test_hummingbird_arm64_honesty.py
@@ -1,18 +1,9 @@
 """W8 architecture honesty, hummingbird arm64 (#1755 option A).
 
-The aarch64 rebuild repo began publishing on 2026-08-18
-(hummingbird/20251124-aarch64 — it 404'd when #1755 was filed), but it is a
-1358-package seed against x86_64's 8100: measured against its live
-primary.xml, cosmic has 8 of its 22 manifest packages, gnome 5 of 52, with
-no gnome-shell, no gdm, and no COSMIC compositor. An arm64 desktop leg
-would install almost nothing under --skip-unavailable and publish the #858
-shape — an image with no desktop — so the desktop flavors are pinned
-amd64-only until per-desktop coverage exists, exactly like grouper:cosmic.
-
-This test keeps the pin deliberate: whoever re-adds linux/arm64 to a
-desktop flavor deletes that flavor from the pinned set below IN THE SAME
-CHANGE, which is the reviewable claim that the aarch64 index now carries
-that desktop's manifest set.
+Desktop flavors stay amd64-only until their complete package source exists
+on aarch64. The Hummingbird package factory has now converged for COSMIC, but
+GNOME still comes from the amd64-only utah-packages OCI repository. Keep that
+remaining pin explicit so adding arm64 is a reviewable availability claim.
 """
 from __future__ import annotations
 
@@ -22,7 +13,7 @@ import yaml
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
-PINNED_AMD64_ONLY = {"gnome", "kde", "niri", "cosmic"}
+PINNED_AMD64_ONLY = {"gnome"}
 
 
 def _hummingbird() -> dict:
@@ -31,7 +22,7 @@ def _hummingbird() -> dict:
     return next(v for v in cfg["variants"] if v["id"] == "hummingbird")
 
 
-def test_desktop_flavors_are_amd64_only_until_the_aarch64_repo_converges():
+def test_desktop_flavors_without_aarch64_package_sources_are_amd64_only():
     hb = _hummingbird()
     for flavor in hb["flavors"]:
         if flavor["id"] in PINNED_AMD64_ONLY:
@@ -41,6 +32,13 @@ def test_desktop_flavors_are_amd64_only_until_the_aarch64_repo_converges():
                 f"arm64 requires measuring the desktop's manifest set "
                 f"against the live aarch64 index and removing the flavor "
                 f"from PINNED_AMD64_ONLY in the same change")
+
+
+def test_cosmic_uses_both_converged_package_repositories():
+    hb = _hummingbird()
+    cosmic = next(f for f in hb["flavors"] if f["id"] == "cosmic")
+    assert cosmic.get("platforms", hb["platforms"]) == [
+        "linux/amd64", "linux/arm64"]
 
 
 def test_base_keeps_both_arches():


### PR DESCRIPTION
## Summary

- add the now-published `cosmic-settings-daemon` to Hummingbird's COSMIC package set
- reuse the Fedora COSMIC package list via YAML alias so the two Fedora-derived manifests cannot drift
- restore Hummingbird COSMIC's arm64 image and ISO legs now that both architecture repositories carry the complete direct package set
- update architecture-honesty tests and Hummingbird documentation

The live `20251124-x86_64` and `20251124-aarch64` primary indexes now contain every one of the 25 packages requested by the Fedora COSMIC manifest (8,811 and 3,905 unique package names respectively). GNOME remains amd64-only because its separate `utah-packages` source is still single-architecture; KDE and Niri remain undeclared.

Closes #1755

## Tests

- `python3 -m pytest -q tests/test_hummingbird_arm64_honesty.py tests/test_hummingbird_gnome_consumes_utah_packages.py` (13 passed)
- `npx --yes bats tests/bats/test_hummingbird_desktop_wiring.bats` with yq 4.47.2 (7 passed)
- parsed both live Hummingbird `primary.xml` indexes and compared their package names with both COSMIC manifest lists (no missing names)
- `git diff --check`

---
🐝 **Hive Agent**: `contributor` | **SHA:** `5e9c89f2`

— hive: backend=pi model=openai-codex/gpt-5.6-sol