### PR TITLE
fix(gate): retain dbus crash diagnostics from failed disk boots

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -1532,6 +1532,7 @@ jobs:
           name: boot-gate-${{ inputs.image-name }}-${{ inputs.default-tag }}
           path: |
             verify-out/serial.log
+            verify-out/boot-diagnostics.txt
             verify-out/*.png
             evidence/${{ inputs.image-variant }}/${{ inputs.flavor }}/amd64/
           if-no-files-found: warn

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -3011,6 +3011,44 @@ EOF
 	return 4
 }
 
+# Capture the evidence hidden behind systemd's terse console failure. Disk
+# images normally expose only systemd-ssh-generator's vsock listener, so this
+# depends on boot_disk_image passing the VSOCK_ARGS prepared above. Keep the
+# command broad enough to diagnose the first failed service rather than baking
+# the current dbus hypothesis into the gate, while giving crash-looping core
+# services their status, journal, and coredump metadata (#2326).
+collect_disk_boot_diagnostics() {
+	local out="${OUTPUT_DIR}/boot-diagnostics.txt"
+	# Installed images generally have no liveuser/TCP sshd. Try their native
+	# systemd vsock listener first; retain TCP as a fallback for custom disks.
+	if [[ ${#VSOCK_ARGS[@]} -gt 0 ]] && check_ssh_vsock; then
+		:
+	elif ! check_ssh; then
+		echo "WARNING: guest SSH unavailable; could not collect boot diagnostics" | tee "$out" >&2
+		return 0
+	fi
+
+	echo "==> Collecting failed-unit status, boot journal, and coredump metadata over ${SSH_TRANSPORT} SSH..."
+	"${GUEST_SSH[@]}" 'if [ "$(id -u)" -eq 0 ]; then exec sh -s; else exec sudo -n sh -s; fi' <<-'DIAGEOF' >"$out" 2>&1 || true
+		echo '=== failed units ==='
+		systemctl --failed --no-pager --full || true
+		echo '=== dbus-broker status ==='
+		systemctl status dbus-broker.service dbus.socket --no-pager --full || true
+		echo '=== display manager status ==='
+		systemctl status display-manager.service --no-pager --full || true
+		echo '=== dbus/display-manager journal (this boot) ==='
+		journalctl -b --no-pager -o short-precise \
+			-u dbus-broker.service -u dbus.socket -u display-manager.service || true
+		echo '=== recent coredumps ==='
+		coredumpctl --no-pager --no-legend list 2>&1 | tail -n 30 || true
+		for exe in dbus-broker dbus-broker-launch; do
+			echo "=== coredump info: ${exe} ==="
+			coredumpctl --no-pager info "$exe" 2>&1 | tail -n 160 || true
+		done
+	DIAGEOF
+	cat "$out" >&2
+}
+
 # Boot a disk image (qcow2/raw) directly — used by --disk mode to verify
 # installed/converted images (e.g. the qcow2 produced from a GHCR image
 # before its tags are promoted). Reuses the same firmware/accel plumbing.
@@ -3035,6 +3073,7 @@ boot_disk_image() {
 		-netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22" \
 		-device virtio-net-pci,netdev=net0 \
 		-monitor "unix:${MONITOR_SOCK},server,nowait" \
+		"${VSOCK_ARGS[@]}" \
 		"${E2E_SERIAL_ARGS[@]}" \
 		"${QEMU_GPU_ARGS[@]}" \
 		-pidfile "$QEMU_PIDFILE" \
@@ -3090,6 +3129,11 @@ disk)
 		fi
 		sleep "${DISK_POLL_INTERVAL:-1}"
 	done
+	if [[ "$rc" -eq 2 ]]; then
+		# The serial console reports only "See systemctl status". Preserve the
+		# status and journal it points at while the failed guest is still alive.
+		collect_disk_boot_diagnostics
+	fi
 	# Let the display manager finish drawing before capturing evidence.
 	# Poll for paint instead of a fixed 30s sleep: under plain virtio-vga the
 	# guest renders via llvmpipe and first paint can lag the contract marker

--- a/tests/regressions/test_issue_2326_disk_gate_collects_the_failed_systemd_journal.py
+++ b/tests/regressions/test_issue_2326_disk_gate_collects_the_failed_systemd_journal.py
@@ -1,0 +1,48 @@
+"""tunaOS#2326: a disk Gate failure must preserve the journal it points to.
+
+The yellowfin GNOME Gate serial console only said to run ``systemctl status``.
+The harness had already prepared credentialed root-over-vsock access, but its
+``--disk`` QEMU command never attached the vsock device, so the failed guest's
+journal and dbus-broker coredump metadata disappeared with the VM.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = (ROOT / "scripts" / "iso-e2e.sh").read_text(encoding="utf-8")
+WORKFLOW = (ROOT / ".github" / "workflows" / "reusable-build-image.yml").read_text(
+    encoding="utf-8"
+)
+
+
+def _between(start: str, end: str) -> str:
+    return SCRIPT.split(start, 1)[1].split(end, 1)[0]
+
+
+def test_disk_qemu_attaches_the_prepared_vsock_credentials():
+    disk_boot = _between("boot_disk_image() {", "# ── Main")
+    assert '"${VSOCK_ARGS[@]}"' in disk_boot
+    assert "vhost-vsock-pci" in SCRIPT
+    assert "ssh.ephemeral-authorized_keys-all" in SCRIPT
+
+
+def test_missing_contract_collects_diagnostics_before_evidence_capture():
+    disk_mode = SCRIPT.split("case \"$MODE\" in", 1)[1].split("\nready)", 1)[0]
+    collect = disk_mode.index("collect_disk_boot_diagnostics")
+    paint = disk_mode.index('wait_for_paint "10-ready"')
+    assert collect < paint
+    assert '[[ "$rc" -eq 2 ]]' in disk_mode[:collect]
+
+
+def test_diagnostics_include_the_failed_bus_and_coredump_metadata():
+    diagnostics = _between("collect_disk_boot_diagnostics() {", "boot_disk_image() {")
+    assert "systemctl --failed" in diagnostics
+    assert "systemctl status dbus-broker.service dbus.socket" in diagnostics
+    assert "journalctl -b" in diagnostics
+    assert "coredumpctl" in diagnostics
+    assert '${OUTPUT_DIR}/boot-diagnostics.txt' in diagnostics
+
+
+def test_workflow_uploads_the_diagnostics_even_when_the_gate_fails():
+    assert "- name: Upload boot evidence\n        if: always()" in WORKFLOW
+    assert "verify-out/boot-diagnostics.txt" in WORKFLOW


### PR DESCRIPTION
## Summary

- attach the already-prepared credentialed vsock device to `--disk` Gate VMs
- on a missing contract marker, collect failed units, dbus/display-manager status and journal, and recent coredump metadata while the guest is still alive
- upload `boot-diagnostics.txt` even when the Gate fails
- add a regression test tying the diagnostic path to #2326

This implements the issue's immediate next step. The current serial artifact confirms repeated `dbus-broker` coredumps, but omits the service journal and coredump reason needed to choose a safe image fix; this change makes the next scheduled Yellowfin Gate retain that evidence rather than guessing at SELinux or package changes.

## Tests

- `bash -n scripts/iso-e2e.sh`
- `python3 -m pytest -q tests/regressions/test_issue_2326_disk_gate_collects_the_failed_systemd_journal.py tests/test_regression_convention.py tests/test_workflow_expressions_parse.py` (156 passed)

— hive: backend=pi model=openai-codex/gpt-5.6-sol
