### PR TITLE
Drop "Aurora" from the Tromso sibling-image description

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -60,7 +60,7 @@ iso_groups:
 sibling_images:
   - id: tromso
     emoji: "🏔️"
-    description: "Aurora Tromsø: KDE Plasma 6 on freedesktop-sdk (BuildStream)"
+    description: "Tromsø: KDE Plasma 6 on freedesktop-sdk (BuildStream)"
     image: ghcr.io/tuna-os/tromso
     repo: tuna-os/tromso
     workflow: build-tromso-multirunner.yml


### PR DESCRIPTION
Follow-up to tuna-os/tromso#300, which asks that Aurora branding be removed from the project. The artwork removal itself is tuna-os/tromso#301.

## tunaos ships no Aurora artwork

Audited before changing anything:

- No logos, wallpapers, avatars or `dev.getaurora.*` packages reach any image — `find system_files -iname "*aurora*"` is empty, and no `dev.getaurora` string appears outside docs links and comparison comments.
- The KDE images already ship their own branding: `org.tunaos{,.light}.desktop` look-and-feel, the `TunaOS` wallpaper package, `tunaos.svg`, and the fish Plymouth theme.
- `_upstream-snapshots/aurora/` is 108 KB of build scripts and configs with **zero image files**, and is never copied into an image.

## The one change

`.github/build-config.yml` described the Tromso sibling image as `"Aurora Tromsø: ..."`, which `sibling-images-status.sh` renders into the README. That is now `"Tromsø: ..."`.

## Left alone deliberately

`watch-aurora.yml`, `.github/prompts/aurora-port.md`, the `_upstream-snapshots/aurora` tree, and the comparative comments in `verify-branding-kde.sh` — that is upstream-tracking infrastructure and attribution, not branding, and gutting it would break the port workflow without serving the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146mJjAkANNjAnDADsPjVPb