### PR TITLE
docs: add git history rewrite runbook

### DIFF
--- a/docs/GIT-HISTORY-REWRITE.md
+++ b/docs/GIT-HISTORY-REWRITE.md
@@ -1,0 +1,171 @@
+# Git history rewrite runbook
+
+**Status:** proposed; no history has been rewritten
+
+**Tracks:** [#2290](https://github.com/tuna-os/tunaos/issues/2290)
+
+This runbook turns the large-blob inventory into a repeatable, auditable
+rewrite procedure. A rewrite changes commit and tag IDs, invalidates open pull
+request bases, and requires existing contributors to re-clone. It must be run
+by a maintainer with permission to coordinate a freeze and temporarily change
+branch protection; it is not routine repository maintenance.
+
+## Measure the same thing everywhere
+
+`scripts/audit-git-blobs.py` reports each unique reachable blob once. The
+threshold is strictly greater than 5 MiB by default.
+
+```bash
+# What a normal clone of the default branch inherits
+python3 scripts/audit-git-blobs.py HEAD
+
+# Forensics across every ref available in an existing clone
+python3 scripts/audit-git-blobs.py --all --format json >large-blobs.json
+
+# Fail a policy job if a branch introduces an oversized blob anywhere in its
+# new history. Use a range: HEAD alone also reports inherited, approved blobs.
+git fetch origin main
+python3 scripts/audit-git-blobs.py --fail-if-found origin/main..HEAD
+```
+
+Do not use an old working clone for the final inventory: its fork remotes and
+locally retained refs change what `--all` means. Make a fresh mirror and record
+its object database size before doing anything else:
+
+```bash
+git clone --mirror https://github.com/tuna-os/tunaos.git tunaos-before.git
+git -C tunaos-before.git count-objects -vH
+(cd tunaos-before.git && python3 /path/to/audit-git-blobs.py --all \
+  --format json) >tunaos-before.json
+```
+
+GitHub pull-request refs can retain objects even after every branch and tag is
+rewritten. Report these separately from the refs maintainers can update:
+
+```bash
+cd tunaos-before.git
+mapfile -t PUBLISHED_REFS < <(
+  git for-each-ref --format='%(refname)' refs/heads refs/tags
+)
+python3 /path/to/audit-git-blobs.py "${PUBLISHED_REFS[@]}"
+python3 /path/to/audit-git-blobs.py --all
+```
+
+The first result is the rewrite target. The second is a forensic upper bound,
+not a promise about immediate server-side garbage collection.
+
+## TunaOS decision record
+
+The 2026-09-02 mirror scan in #2290 found 16 blobs totaling 244.94 MiB:
+
+| Paths | Blobs | Size | Disposition |
+|---|---:|---:|---|
+| `prototype/iso-builder/app/public/initramfs-sailfin-tbox.img` | 1 | 68.69 MiB | remove; generated initramfs |
+| `prototype/iso-builder/app/public/tbox.wasm`, `prototype/iso-builder/app/tbox.wasm` | 9 | 109.77 MiB | remove; compiled output now owned by `iso-builder` |
+| `system_files/usr/share/backgrounds/bluefin/12-bluefin-{day,night}.{png,jxl}` | 6 | 66.48 MiB | policy gate; retired but deliberate artwork |
+
+The first two rows are the unambiguous rewrite set (178.46 MiB). Do not add
+the wallpaper paths unless maintainers explicitly decide that their historical
+source value is lower than the additional reclaim. Generate the object-level
+list with the audit script rather than copying IDs from this dated summary.
+
+## Rewrite window
+
+### 1. Prepare and announce
+
+1. Assign one rewrite owner and a second maintainer to verify the result.
+2. Resolve the path policy for every repository. Keep runtime media and
+   deliberately vendored source unless its owner approves removal.
+3. Drain or close open pull requests. Record any commit that must be recreated.
+4. Announce the UTC freeze and require a fresh clone after the all-clear.
+5. Pause bots and scheduled writers. Disable automatic merges.
+6. Export branch protection/ruleset settings and identify signed release tags.
+   Rewriting a signed tag invalidates its signature; issue a replacement tag
+   only under the release policy.
+7. Make two fresh mirrors. Mark one read-only and retain `*-before.json` plus
+   `git count-objects -vH` output as the rollback evidence.
+
+Do not start while an active branch, tag, submodule pointer, deployment, or
+release consumer is unaccounted for. Repositories that pin another affected
+repository must be updated after that dependency is rewritten.
+
+### 2. Rehearse offline
+
+Use `git-filter-repo` from the distribution package or a version-pinned tool.
+The TunaOS generated-artifact rehearsal is:
+
+```bash
+cp -a tunaos-before.git tunaos-rehearsal.git
+cd tunaos-rehearsal.git
+git filter-repo --force --invert-paths \
+  --path prototype/iso-builder/app/public/initramfs-sailfin-tbox.img \
+  --path prototype/iso-builder/app/public/tbox.wasm \
+  --path prototype/iso-builder/app/tbox.wasm
+```
+
+`git filter-repo` writes commit and ref maps; retain them with the maintenance
+record. Before publishing, the second maintainer must verify:
+
+```bash
+# Removed paths must not occur in any rewritten published ref.
+git log --all --name-only --format= -- \
+  prototype/iso-builder/app/public/initramfs-sailfin-tbox.img \
+  prototype/iso-builder/app/public/tbox.wasm \
+  prototype/iso-builder/app/tbox.wasm
+
+python3 /path/to/audit-git-blobs.py --all
+
+git fsck --full
+git count-objects -vH
+```
+
+Also check out the default branch, run the repository's normal test suite, and
+compare all expected branch and tag names with the backup. A smaller pack file
+alone is not proof of a correct rewrite.
+
+### 3. Publish or roll back
+
+1. Reconfirm the writer freeze and backup readability.
+2. Temporarily allow the rewrite owner to force-update the approved branches
+   and tags. Delete stale branches instead of preserving their old objects.
+3. Push the exact reviewed ref set from the rehearsal mirror. Avoid a blind
+   `--mirror` push: it includes provider-managed pull-request refs and can
+   delete refs that were not part of the approved plan.
+4. Fetch a brand-new mirror from GitHub and repeat ref, `fsck`, checkout, and
+   test verification against that server-fetched copy. Run the path and blob
+   audits against its published branch/tag ref list; audit `--all` separately
+   because provider-managed pull refs may retain the pre-rewrite objects.
+5. If any required ref or content is wrong, keep the freeze in place and
+   restore the reviewed refs from the read-only mirror. Otherwise restore
+   rulesets and bots, then announce the new commit IDs and re-clone command.
+6. Update downstream submodule pins and automation that stores commit IDs.
+   Re-open work by recreating branches on the new history, not by merging an
+   old local branch.
+
+Git hosting garbage collection is asynchronous. Acceptance is that the
+published refs no longer reach the removed objects and a fresh ordinary clone
+is correct; the hosting UI or storage total may lag.
+
+## Contributor recovery
+
+The supported recovery is a fresh clone:
+
+```bash
+mv tunaos tunaos.pre-rewrite
+git clone https://github.com/tuna-os/tunaos.git tunaos
+```
+
+Copy uncommitted files selectively. Do not pull, merge, or push an old branch
+into the rewritten repository: doing so reconnects the removed history. A
+maintainer can help recreate a small change by applying its patch to a branch
+created from the new default branch.
+
+## Org sequencing
+
+Run one repository at a time: `corral`, `tacklebox`, `iso-builder`, and
+`bluefin-cli` are the low-ambiguity pilots; then `tromso` and `xfce-linux`;
+TunaOS and `tunaos-packages` come last because they have the widest blast
+radius and packaging policy questions. For `bootc-installer`, retain the
+runtime installer video and remove only approved generated objects. Each
+repository gets its own before/after reports, freeze, ref map, verification,
+and all-clear; never use one org-wide force-push window.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,6 +21,7 @@ Invoked by:
 | `gen-ci-lanes.py` | Generates the PR/post-merge/scheduled workflow inventory in `docs/CI_SPEC.md` |
 | `sync-upstream-snapshots.sh` | Syncs and drift-checks the `_upstream-snapshots/` tree |
 | `check-upstream-snapshot-size.sh` | Fails refreshes that exceed the snapshot size or change budget |
+| `audit-git-blobs.py` | Inventories oversized blobs reachable from selected Git refs; see the [rewrite runbook](../docs/GIT-HISTORY-REWRITE.md) |
 
 See `docs/AGENT_GUIDE.md`'s Key Files table for the fuller list and how
 these fit into the overall build pipeline (`docs/PIPELINE.md`,

--- a/scripts/audit-git-blobs.py
+++ b/scripts/audit-git-blobs.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Inventory large blobs reachable from one or more Git revisions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+DEFAULT_THRESHOLD = 5 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class Blob:
+    oid: str
+    size_bytes: int
+    path: str
+
+
+def git(*args: str, stdin: str | None = None) -> str:
+    try:
+        return subprocess.run(
+            ["git", *args],
+            input=stdin,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        ).stdout
+    except FileNotFoundError:
+        raise SystemExit("error: git is not installed") from None
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() or "git command failed"
+        raise SystemExit(f"error: {detail}") from None
+
+
+def inventory(revisions: list[str], threshold: int) -> list[Blob]:
+    object_paths: dict[str, str] = {}
+    for line in git("rev-list", "--objects", *revisions).splitlines():
+        oid, separator, path = line.partition(" ")
+        object_paths.setdefault(oid, path if separator else "")
+
+    if not object_paths:
+        return []
+
+    request = "".join(f"{oid}\n" for oid in object_paths)
+    blobs: list[Blob] = []
+    for line in git(
+        "cat-file",
+        "--batch-check=%(objectname) %(objecttype) %(objectsize)",
+        stdin=request,
+    ).splitlines():
+        fields = line.split()
+        if len(fields) != 3 or fields[1] != "blob":
+            continue
+        oid, _, raw_size = fields
+        size = int(raw_size)
+        if size > threshold:
+            blobs.append(Blob(oid=oid, size_bytes=size, path=object_paths[oid]))
+
+    return sorted(blobs, key=lambda blob: (-blob.size_bytes, blob.path, blob.oid))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="List unique Git blobs larger than a threshold."
+    )
+    parser.add_argument(
+        "revisions",
+        nargs="*",
+        help="revisions to scan (default: HEAD); use --all for every local ref",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="scan every ref visible in this clone",
+    )
+    parser.add_argument(
+        "--threshold-bytes",
+        type=int,
+        default=DEFAULT_THRESHOLD,
+        metavar="BYTES",
+        help=f"report blobs larger than BYTES (default: {DEFAULT_THRESHOLD})",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("table", "json"),
+        default="table",
+        help="output format (default: table)",
+    )
+    parser.add_argument(
+        "--fail-if-found",
+        action="store_true",
+        help="exit 1 when at least one blob exceeds the threshold",
+    )
+    args = parser.parse_args()
+    if args.all and args.revisions:
+        parser.error("--all cannot be combined with revisions")
+    if args.threshold_bytes < 0:
+        parser.error("--threshold-bytes must be non-negative")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    revisions = ["--all"] if args.all else (args.revisions or ["HEAD"])
+    blobs = inventory(revisions, args.threshold_bytes)
+    total = sum(blob.size_bytes for blob in blobs)
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "repository": str(Path.cwd()),
+                    "revisions": revisions,
+                    "threshold_bytes": args.threshold_bytes,
+                    "count": len(blobs),
+                    "total_bytes": total,
+                    "blobs": [asdict(blob) for blob in blobs],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print("size_bytes\tsize_mib\toid\tpath")
+        for blob in blobs:
+            print(
+                f"{blob.size_bytes}\t{blob.size_bytes / 1024 / 1024:.2f}"
+                f"\t{blob.oid}\t{blob.path}"
+            )
+        print(
+            f"# {len(blobs)} unique blobs; {total} bytes "
+            f"({total / 1024 / 1024:.2f} MiB)",
+            file=sys.stderr,
+        )
+
+    return 1 if args.fail_if_found and blobs else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_git_blobs.py
+++ b/tests/test_audit_git_blobs.py
@@ -1,0 +1,131 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "audit-git-blobs.py"
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+
+
+def make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git(repo, "init", "--initial-branch=main")
+    git(repo, "config", "user.name", "Blob Test")
+    git(repo, "config", "user.email", "blob@example.com")
+    (repo / "small.txt").write_text("ok")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def run_audit(repo: Path, *args: str, check: bool = True):
+    return subprocess.run(
+        ["python3", str(SCRIPT), *args],
+        cwd=repo,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_json_inventory_is_deduplicated_and_sorted(tmp_path):
+    repo = make_repo(tmp_path)
+    (repo / "large file.bin").write_bytes(b"a" * 20)
+    (repo / "medium.bin").write_bytes(b"b" * 10)
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "add blobs")
+    git(repo, "commit", "--allow-empty", "-m", "same blobs remain reachable")
+
+    result = run_audit(repo, "--threshold-bytes", "3", "--format", "json")
+    report = json.loads(result.stdout)
+
+    assert report["count"] == 2
+    assert report["total_bytes"] == 30
+    assert [blob["path"] for blob in report["blobs"]] == [
+        "large file.bin",
+        "medium.bin",
+    ]
+    assert [blob["size_bytes"] for blob in report["blobs"]] == [20, 10]
+
+
+def test_all_includes_blob_reachable_only_from_another_ref(tmp_path):
+    repo = make_repo(tmp_path)
+    git(repo, "switch", "--orphan", "old-artifact")
+    (repo / "retired.bin").write_bytes(b"x" * 20)
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "retired artifact")
+    git(repo, "switch", "main")
+
+    head = json.loads(
+        run_audit(repo, "--threshold-bytes", "3", "--format", "json").stdout
+    )
+    all_refs = json.loads(
+        run_audit(repo, "--all", "--threshold-bytes", "3", "--format", "json").stdout
+    )
+
+    assert head["count"] == 0
+    assert [blob["path"] for blob in all_refs["blobs"]] == ["retired.bin"]
+
+
+def test_fail_if_found_is_suitable_for_a_policy_gate(tmp_path):
+    repo = make_repo(tmp_path)
+    base = git(repo, "rev-parse", "HEAD")
+    (repo / "large.bin").write_bytes(b"x" * 20)
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "large blob")
+
+    failed = run_audit(
+        repo,
+        "--threshold-bytes",
+        "3",
+        "--fail-if-found",
+        f"{base}..HEAD",
+        check=False,
+    )
+    passed = run_audit(
+        repo, "--threshold-bytes", "30", "--fail-if-found", check=False
+    )
+
+    assert failed.returncode == 1
+    assert passed.returncode == 0
+
+
+def test_revision_range_does_not_reject_inherited_large_blobs(tmp_path):
+    repo = make_repo(tmp_path)
+    (repo / "approved.bin").write_bytes(b"x" * 20)
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "approved baseline blob")
+    base = git(repo, "rev-parse", "HEAD")
+    (repo / "small.txt").write_text("changed")
+    git(repo, "commit", "-am", "change a small file")
+
+    result = run_audit(
+        repo,
+        "--threshold-bytes",
+        "10",
+        "--fail-if-found",
+        f"{base}..HEAD",
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "# 0 unique blobs" in result.stderr
+
+
+def test_rejects_ambiguous_revision_selection(tmp_path):
+    repo = make_repo(tmp_path)
+
+    result = run_audit(repo, "--all", "HEAD", check=False)
+
+    assert result.returncode == 2
+    assert "--all cannot be combined with revisions" in result.stderr


### PR DESCRIPTION
## Summary

- add a maintainer runbook for inventorying, rehearsing, publishing, verifying, and recovering from coordinated history rewrites
- record TunaOS's generated-artifact rewrite set separately from deliberate artwork that still needs a policy decision
- add a reusable blob auditor with ref/range selection, JSON output, and a policy-gate exit mode
- document org sequencing and the fresh-clone recovery contract

Closes #2290.

## Verification

- `python3 -m pytest -q tests/test_audit_git_blobs.py` — 5 passed
- `python3 scripts/audit-git-blobs.py <upstream remote refs>` — reproduced 16 unique blobs / 244.94 MiB from the issue inventory
- `git diff --check`

— hive: backend=pi model=openai-codex/gpt-5.6-sol
