### PR TITLE
fix(luks-e2e): exclude headless base overlays

### DIFF
--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -176,7 +176,9 @@ jobs:
                    | select($skiplist | index($v) | not)
                    | ([$variant.flavors[]
                        | select(.build_image == true)
-                       | select(.id != "base")
+                       # Headless base derivatives (base-hwe/base-nvidia) have
+                       # no login target, just like base itself.
+                       | select(.id | test("^base(?:-|$)") | not)
                        | select((.platforms // $variant.platforms // []) | index("linux/amd64"))
                      ] | sort_by(.id)) as $eligible
                    | (($eligible | map(select(.id == "gnome")) | .[0]) // $eligible[0]) as $pick
@@ -189,14 +191,15 @@ jobs:
             # from any image, so image-only variants (sailfin, guppy,
             # flounder-sid) need boot+install coverage too. Cover every amd64
             # graphical image: standard desktops, overlays (NVIDIA/CachyOS),
-            # and any future desktop tag. `base` has no login target to gate;
+            # and any future desktop tag. `base` and its headless derivatives
+            # (`base-hwe`, `base-nvidia`) have no login target to gate;
             # arm64-only flavors require an arm64 QEMU runner and are reported
             # separately in the job summary.
             matrix="$(echo "$json" | jq -c \
               --arg fv "$FILTER_VARIANT" --arg ff "$FILTER_FLAVOR" \
               '{include: [ .variants[] | . as $variant | .id as $v | .flavors[]
                  | select(.build_image == true)
-                 | select(.id != "base")
+                 | select(.id | test("^base(?:-|$)") | not)
                  | select((.platforms // $variant.platforms // []) | index("linux/amd64"))
                  | {variant: $v, flavor: .id}
                  | select($fv == "all" or .variant == $fv)
@@ -225,7 +228,7 @@ jobs:
               .variants[] | . as $variant
               | [.id, ([.flavors[]
                  | select(.build_image == true)
-                 | select(.id != "base")
+                 | select(.id | test("^base(?:-|$)") | not)
                  | select((.platforms // $variant.platforms // []) | index("linux/amd64"))
                  | .id] | join(", "))]
               | select(.[1] != "")
@@ -237,7 +240,7 @@ jobs:
               [.variants[] | . as $variant
                | select([.flavors[]
                  | select(.build_image == true)
-                 | select(.id != "base")
+                 | select(.id | test("^base(?:-|$)") | not)
                  | select((.platforms // $variant.platforms // []) | index("linux/amd64"))] | length == 0)
                | "- `\(.id)`: no amd64 graphical image (`build_image: true`)"]
               | if length == 0 then "- None" else .[] end'

--- a/tests/test_luks_e2e_matrix.py
+++ b/tests/test_luks_e2e_matrix.py
@@ -1,0 +1,93 @@
+"""Regression tests for the matrix emitted by luks-e2e.yml."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "luks-e2e.yml"
+def generator_script() -> str:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return next(
+        step["run"]
+        for step in workflow["jobs"]["generate-matrix"]["steps"]
+        if step.get("id") == "gen"
+    )
+
+
+def install_yq_shim(directory: Path) -> None:
+    """The workflow only needs ``yq -o=json . FILE``; provide that in tests."""
+    shim = directory / "yq"
+    shim.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys, yaml\n"
+        "with open(sys.argv[-1], encoding='utf-8') as stream:\n"
+        "    print(json.dumps(yaml.safe_load(stream)))\n",
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IXUSR)
+
+
+def run_generator(tmp_path: Path, variant: str = "all", flavor: str = "all"):
+    install_yq_shim(tmp_path)
+    output = tmp_path / "github-output"
+    summary = tmp_path / "summary"
+    proc = subprocess.run(
+        ["bash", "-c", generator_script()],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        env=dict(
+            os.environ,
+            PATH=f"{tmp_path}:{os.environ['PATH']}",
+            FILTER_VARIANT=variant,
+            FILTER_FLAVOR=flavor,
+            TPM_DISPATCH="false",
+            TPM_SCHEDULE="false",
+            GITHUB_OUTPUT=str(output),
+            GITHUB_STEP_SUMMARY=str(summary),
+        ),
+    )
+    return proc, output
+
+
+def matrix_from(output: Path) -> list[dict[str, str]]:
+    line = next(
+        line for line in output.read_text(encoding="utf-8").splitlines()
+        if line.startswith("matrix=")
+    )
+    return json.loads(line.removeprefix("matrix="))["include"]
+
+
+def test_default_matrix_never_schedules_headless_base_derivatives(tmp_path):
+    """base-hwe/base-nvidia cannot satisfy this workflow's login gate.
+
+    Run 33506738063 spent two jobs on each applicable variant even though those
+    images deliberately have no graphical login target. They are base kernel
+    and driver overlays, not desktop cells.
+    """
+    proc, output = run_generator(tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    cells = matrix_from(output)
+    flavors = {cell["flavor"] for cell in cells}
+
+    headless = {
+        flavor for flavor in flavors
+        if flavor == "base" or flavor.startswith("base-")
+    }
+    assert not headless
+    # Control: graphical derivatives remain covered; this is not an accidental
+    # return to the five unqualified desktop names only.
+    assert "gnome-hwe" in flavors
+    assert "gnome-nvidia" in flavors
+
+
+def test_headless_base_dispatch_fails_before_runner_fanout(tmp_path):
+    proc, _ = run_generator(tmp_path, variant="yellowfin", flavor="base-hwe")
+    assert proc.returncode != 0
+    assert "No matching variant/flavor cells" in proc.stdout + proc.stderr


### PR DESCRIPTION
## Summary

- exclude `base-hwe` and `base-nvidia` from both normal and TPM LUKS matrices
- keep the generated coverage summary aligned with the jobs actually scheduled
- execute the real workflow matrix shell in regression tests

## Why

The monthly sweep in run 33506738063 scheduled these headless base overlays as LUKS desktop cells. They deliberately have no graphical login target, so they cannot satisfy this workflow's desktop boot contract. This removes 11 guaranteed-red, multi-hour jobs while retaining all 113 graphical cells, including HWE and NVIDIA desktop overlays.

Fixes one source of false failures blocking progress on #979.

## Tests

- `python3 -m pytest -q tests/test_matrix_status.py tests/test_matrix_status_config.py tests/test_luks_e2e_matrix.py` (57 passed)
- workflow YAML parsed with PyYAML
- `git diff --check`

— hive: backend=pi model=openai-codex/gpt-5.6-sol
