### PR TITLE
fix(gate): stop waiting after emergency boot

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -3468,6 +3468,16 @@ disk)
 			fi
 			break
 		fi
+		# An initramfs/emergency-shell signature is already a definitive boot
+		# failure. No contract unit can run from there, so waiting out the full
+		# marker deadline only hides the useful failure behind a 15-minute
+		# timeout. This caught albacore:gnome-nvidia-hwe's /sysroot mount
+		# failure in run 34095284957 roughly ten seconds into the guest boot.
+		if boot_failed_on_serial; then
+			echo "ERROR: ${DISK_CONTRACT} contract cannot run after the guest entered an emergency shell" >&2
+			rc=1
+			break
+		fi
 		sleep "${DISK_POLL_INTERVAL:-1}"
 	done
 	# Let the display manager finish drawing before capturing evidence.

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -1051,6 +1051,18 @@ setup_runtime_check_stubs() {
   grep -qF 'journalctl -b --no-pager -n 120' "$harness"
 }
 
+@test "disk gate fails immediately when serial reports an emergency shell" {
+  # albacore:gnome-nvidia-hwe reached its dracut emergency shell in about ten
+  # seconds, then the Gate waited the remaining 15 minutes for a contract unit
+  # that could never run. Keep the failure detector inside the marker loop and
+  # make it set a hard failure before leaving that loop.
+  local disk_case
+  disk_case=$(awk '/^disk\)/,/^ready\)/' "$SCRIPT")
+  grep -qF 'if boot_failed_on_serial; then' <<<"$disk_case"
+  grep -qF 'rc=1' <<<"$disk_case"
+  grep -qF 'contract cannot run after the guest entered an emergency shell' <<<"$disk_case"
+}
+
 # ── TPM2 auto-unlock verification opt-in (tunaOS#680) ──────────────────────
 #
 # fisherman#48 moved TPM2 enrollment from install time (sealed against the


### PR DESCRIPTION
## Summary

- stop a disk boot Gate as soon as serial reports an unambiguous emergency-shell signature
- preserve the existing screenshot and serial evidence path while avoiding the remainder of the contract-marker deadline
- add a regression assertion that keeps the emergency check inside the disk marker loop

In the latest non-rolling sweep, `albacore:gnome-nvidia-hwe` entered dracut emergency mode after `/sysroot` failed to mount roughly ten seconds into boot, but the Gate still waited the full 900-second contract timeout. A contract service cannot run from the initramfs emergency shell, and `boot_failed_on_serial` already centralizes the signatures used to distinguish that state from a merely missing serial marker.

Refs #1753. Evidence: [run 34095284957, Gate job 101686769686](https://github.com/tuna-os/tunaOS/actions/runs/34095284957/job/101686769686).

## Tests

- `bash -n scripts/iso-e2e.sh`
- `shellcheck scripts/iso-e2e.sh`
- `git diff --check`
- Bats is not installed in the contributor environment; CI runs the added Bats assertion.

---
🐝 **Hive Agent**: `contributor` | **SHA:** `68095c6f`

— hive: backend=pi model=openai-codex/gpt-5.6-sol