### PR TITLE
docs(lifecycle): define rolling availability contract

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -706,6 +706,7 @@ variants:
   # Promotion to a cron lane needs the capacity note the gate asks for.
   - id: wahoo
     emoji: "🎏"
+    upstream_track: experimental
     description: "Based on Fedora ELN (EL11 preview, rolling)"
     experimental: true
     base_image: "registry.fedoraproject.org/eln-bootc:latest@sha256:1909ffb6ae0c51c0ac831878f0778d7127f38e8bbfddf90d4a14afb281a05748"
@@ -917,6 +918,7 @@ variants:
   # (Konflux hermetic build model, CKI ARK kernel).
   - id: hummingbird
     emoji: "🐦"
+    upstream_track: experimental
     # Rolling, security-hardened fork tracking Fedora RAWHIDE -- not Fedora 43,
     # whatever the .fc43 dist tags suggest -- and shipping NO desktop upstream.
     # The desktop flavors below are therefore a PORT onto a desktop-less base,
@@ -987,6 +989,7 @@ variants:
   # Sailfin Tumbleweed: rolling-release, zypper-based.
   - id: sailfin
     emoji: "🦈"
+    upstream_track: rolling
     description: "Based on openSUSE Tumbleweed (rolling)"
     base_image: "registry.opensuse.org/opensuse/tumbleweed:latest@sha256:1691585b5daf973c032d1f94d3b8b85393d259ac0348c1c5b91abceeeb3334a9"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
@@ -1034,6 +1037,7 @@ variants:
   # Guppy: source-based, emerge/portage. Compiles everything from source.
   - id: guppy
     emoji: "🌈"
+    upstream_track: rolling
     description: "Based on Gentoo Linux (source-based)"
     # Digest-pinned to match Containerfile.gentoo's FROM exactly. This value
     # is not decorative: reusable-build-image.yml pre-pulls it to warm local
@@ -1085,6 +1089,7 @@ variants:
     publish_name: bonito
     tag_suffix: rawhide
     emoji: "🐉"
+    upstream_track: rolling
     description: "Based on Fedora Rawhide (rolling)"
     base_image: "quay.io/fedora/fedora-bootc:rawhide@sha256:6c04d2602182c7f8ae465be9ecf9987695e26895a35f7226dbe8b63be912d5c3"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
@@ -1336,6 +1341,7 @@ variants:
   # up the ostree/composefs filesystem layout.
   - id: marlin
     emoji: "🚀"
+    upstream_track: rolling
     description: "Based on Arch Linux (rolling)"
     base_image: "docker.io/archlinux/archlinux:latest@sha256:71810bb6f8bece3e2172e458dd8c0793fec139a6b6a7e5da2c832f96d1b9a0a6"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
@@ -1584,6 +1590,7 @@ variants:
     publish_name: flounder
     tag_suffix: sid
     emoji: "☢️"
+    upstream_track: rolling
     description: "Based on Debian Sid (unstable, rolling)"
     base_image: "docker.io/library/debian:sid@sha256:24c766c06ebdbda66a026e92361ede7d9212819701b2fca82e347ef0c240cb2c"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>

--- a/VARIANT-LIFECYCLE.md
+++ b/VARIANT-LIFECYCLE.md
@@ -25,6 +25,35 @@ shipped. The mkosi build-backend investigation (#999, #1227) is explicitly in
 scope: adopting a new output architecture is a portfolio commitment and passes
 the Proposal admission gate below, even though it reuses existing roots.
 
+## Upstream update tracks and availability
+
+A lifecycle stage describes product maturity; an **upstream track** describes
+how predictable its inputs are. These are separate dimensions. A Beta can
+consume either a fixed release or a rolling repository, but they cannot carry
+the same availability promise.
+
+`.github/build-config.yml` is the machine-readable source for non-release
+tracks. A variant without `upstream_track` consumes a fixed release or stream.
+The current exceptions are:
+
+| Upstream track | Variants | Availability promise |
+|---|---|---|
+| **Rolling** | `bonito-rawhide`, `marlin`, `sailfin`, `guppy`, `flounder-sid` | Best effort. A newly resolved upstream snapshot may fail until TunaOS catches up; no next-night promotion or uninterrupted-green promise is made. |
+| **Experimental** | `hummingbird`, `wahoo` | Evaluation only. No uptime, flavor-completeness, or continued-publication promise; cells can be narrowed or withdrawn when their upstream is incomplete. |
+| **Release/stream** (the default) | Every variant not marked above | CI targets continuous promotion. A red scheduled build is treated as a regression rather than expected upstream churn. |
+
+Promotion is fail-closed on every track. A failed rolling build does not replace
+the last promoted image with an unverified one. “Best effort” changes how a red
+cell is interpreted; it does not waive build, boot, desktop, signing, or other
+applicable gates.
+
+Operationally, rolling and experimental failures must still become
+**explained failures**: automation should identify upstream dependency or
+snapshot movement where possible, and an unexplained red remains a triage item.
+Expected churn is not counted as a release-track availability regression and
+does not create an obligation to restore promotion by the next nightly. See
+#1754 for that queue; fixed-release recovery is tracked separately in #1753.
+
 ## Lifecycle stages
 
 | Stage | Meaning | Entry criteria | Exit criteria |

--- a/tests/test_variant_upstream_tracks.py
+++ b/tests/test_variant_upstream_tracks.py
@@ -1,0 +1,48 @@
+"""Keep the rolling/experimental availability contract machine-readable.
+
+The distinction is operational, not cosmetic: a red release-track build is a
+regression, while a moving upstream can temporarily be incompatible without
+violating an uninterrupted-green promise.  Issue #1754 originally carried the
+only complete list, which let the policy and matrix drift independently.
+"""
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / ".github" / "build-config.yml"
+POLICY = ROOT / "VARIANT-LIFECYCLE.md"
+
+NON_RELEASE_TRACKS = {
+    "bonito-rawhide": "rolling",
+    "flounder-sid": "rolling",
+    "guppy": "rolling",
+    "hummingbird": "experimental",
+    "marlin": "rolling",
+    "sailfin": "rolling",
+    "wahoo": "experimental",
+}
+
+
+def test_non_release_upstream_tracks_are_explicit_and_complete():
+    config = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+    actual = {
+        variant["id"]: variant["upstream_track"]
+        for variant in config["variants"]
+        if "upstream_track" in variant
+    }
+
+    assert actual == NON_RELEASE_TRACKS
+    assert set(actual.values()) <= {"rolling", "experimental"}
+
+
+def test_every_non_release_track_has_a_documented_availability_contract():
+    policy = POLICY.read_text(encoding="utf-8")
+
+    for variant in NON_RELEASE_TRACKS:
+        assert f"`{variant}`" in policy
+    assert "no next-night promotion or uninterrupted-green promise" in policy
+    assert "No uptime, flavor-completeness, or continued-publication promise" in policy
+    assert "Promotion is fail-closed on every track" in policy


### PR DESCRIPTION
## Summary

- define the different availability promises for release, rolling, and experimental upstream tracks
- mark the five rolling variants and two experimental variants in the machine-readable build config
- test the complete non-release classification and its documented fail-closed contract

This implements the lifecycle-policy part of #1754's definition of done. Rolling red is now explicitly best-effort upstream compatibility rather than an uninterrupted-green regression, while unexplained failures still require triage and every promotion gate remains mandatory. Experimental Hummingbird and Wahoo make no uptime or flavor-completeness promise.

The distinction is separate from product maturity and scheduling: `upstream_track` describes input predictability, while the existing `experimental` field continues to control Wahoo's dispatch-only behavior.

Refs #1754 and #1753.

## Tests

- `python3 -m pytest -q tests/test_variant_upstream_tracks.py tests/test_declared_flavors_are_implemented.py tests/test_generate_workflows.py` (21 passed)
- parsed `.github/build-config.yml` with PyYAML
- `git diff --check`

---
🐝 **Hive Agent**: `contributor` | **SHA:** `94a0080c`

— hive: backend=pi model=openai-codex/gpt-5.6-sol