### PR TITLE
fix(live): present GNOME installer above startup overview

### DIFF
--- a/live-iso/common/src/desktop-gnome.sh
+++ b/live-iso/common/src/desktop-gnome.sh
@@ -42,6 +42,52 @@ EOF
 # matrix (added in #1039), and that is the workflow whose whole job is to
 # assert the installer process is running.
 #
+# GNOME deliberately starts a normal user session in Activities. An XDG
+# autostart application does not dismiss that overview, so the installer maps
+# behind Shell chrome and receives neither focus nor keyboard input. Install a
+# live-session-only extension which closes the overview once Shell's startup
+# animation completes. The launcher enables it in liveuser's volatile dconf
+# before starting the installer; using `gnome-extensions enable` appends to the
+# user's extension set instead of replacing the image's enabled extensions.
+_gnome_live_extension="tunaos-live-installer@tunaos.org"
+_gnome_live_extension_dir="/usr/share/gnome-shell/extensions/${_gnome_live_extension}"
+mkdir -p "${_gnome_live_extension_dir}"
+tee "${_gnome_live_extension_dir}/metadata.json" <<'METADATAEOF'
+{
+  "uuid": "tunaos-live-installer@tunaos.org",
+  "name": "TunaOS Live Installer",
+  "description": "Present the installer instead of the startup overview in the live session",
+  "shell-version": ["45", "46", "47", "48", "49", "50", "51"]
+}
+METADATAEOF
+tee "${_gnome_live_extension_dir}/extension.js" <<'EXTENSIONEOF'
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+export default class TunaOSLiveInstallerExtension {
+    enable() {
+        // Hide now when the extension is enabled after startup, and again at
+        // startup-complete when it is enabled while Shell is still animating.
+        Main.layoutManager.connectObject(
+            'startup-complete', () => Main.overview.hide(), this);
+        Main.overview.hide();
+    }
+
+    disable() {
+        Main.layoutManager.disconnectObject(this);
+    }
+}
+EXTENSIONEOF
+
+install -d /usr/libexec
+tee /usr/libexec/tunaos-live-installer-gnome <<'LAUNCHEREOF'
+#!/usr/bin/env bash
+# Failure to load the convenience extension must not prevent installation.
+gnome-extensions enable tunaos-live-installer@tunaos.org ||
+    echo "tunaos-live-installer: could not suppress GNOME's startup overview" >&2
+exec flatpak run org.bootcinstaller.Installer
+LAUNCHEREOF
+chmod 0755 /usr/libexec/tunaos-live-installer-gnome
+
 # Deliberately no OnlyShowIn=, for the reason spelled out in desktop-cosmic.sh:
 # systemd-xdg-autostart-generator gates on systemd-xdg-autostart-condition
 # against XDG_CURRENT_DESKTOP, and a mismatch silently skips the unit.
@@ -50,7 +96,7 @@ tee /etc/xdg/autostart/org.tunaos.installer-live.desktop <<'DESKEOF'
 [Desktop Entry]
 Type=Application
 Name=Install TunaOS
-Exec=flatpak run org.bootcinstaller.Installer
+Exec=/usr/libexec/tunaos-live-installer-gnome
 Icon=org.bootcinstaller.Installer
 DESKEOF
 

--- a/tests/bats/test_live_installer_launch.bats
+++ b/tests/bats/test_live_installer_launch.bats
@@ -80,6 +80,23 @@ launcher_app() {
   fi
 }
 
+@test "gnome dismisses its startup overview before launching the installer" {
+  local adapter="${SRC}/desktop-gnome.sh"
+  local enable_line launch_line
+
+  grep -Fq "'startup-complete', () => Main.overview.hide()" "$adapter"
+  grep -Fq 'Main.overview.hide();' "$adapter"
+  grep -Fq 'Exec=/usr/libexec/tunaos-live-installer-gnome' "$adapter"
+
+  enable_line="$(grep -n '^gnome-extensions enable tunaos-live-installer@tunaos.org' \
+    "$adapter" | cut -d: -f1)"
+  launch_line="$(grep -n '^exec flatpak run org.bootcinstaller.Installer' \
+    "$adapter" | cut -d: -f1)"
+  [ -n "$enable_line" ]
+  [ -n "$launch_line" ]
+  [ "$enable_line" -lt "$launch_line" ]
+}
+
 @test "installer smoke selects a compositor per flavor" {
   [ -f "$WORKFLOW" ]
   grep -q 'kde)    COMPS="kwin_wayland"' "$WORKFLOW"


### PR DESCRIPTION
## Summary

- add a live-session GNOME Shell extension that closes Activities after the startup animation
- enable the extension before launching the installer without replacing the image's existing extension set
- keep installer startup working if the convenience extension cannot be enabled
- cover the extension behavior and launcher ordering in the live-installer Bats checks

Fixes #1941.

## Testing

- `npx --yes bats tests/bats/test_live_installer_launch.bats`
- `bash -n live-iso/common/src/desktop-gnome.sh`
- `git diff --check`

— hive: backend=pi model=openai-codex/gpt-5.6-sol