### PR TITLE
fix(live): detect virgl-less render nodes

### DIFF
--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -706,6 +706,11 @@ safe_disable mcelog.service
 safe_enable tailscaled.service
 safe_enable uupd.timer
 
+# Resolve the software-rendering policy as root before greeters and user
+# environment generators start. The preset preserves this enablement when
+# systemd reapplies distro policy on first boot.
+systemctl enable tunaos-software-gl-detect.service
+
 # Base boot contract (green criterion 3, GREEN-MASTER-PLAN W3). Every image
 # gets the unit — on desktop images it is the multi-user complement to
 # tunaos-desktop-contract.service, on base images it is the only boot proof

--- a/build_scripts/desktop/greetd-gtkgreet.sh
+++ b/build_scripts/desktop/greetd-gtkgreet.sh
@@ -57,18 +57,16 @@ if command -v gtkgreet &>/dev/null && command -v cage &>/dev/null; then
 	# it. -s keeps VT switching available (without it a greeter crash locks
 	# you out of the machine entirely).
 	# cage is wlroots-based and needs a renderer. A VM without virgl has a DRM
-	# card (virtio-gpu) but NO render node, so GL initialisation fails, cage
-	# exits, greetd restarts it forever and never reaches active — a black
+	# card (virtio-gpu) and may still have a render node that cannot provide
+	# accelerated GL, so cage exits, greetd restarts it forever — a black
 	# screen with no login. That is not a CI artefact: it is GNOME Boxes,
 	# VirtualBox and every plain `-vga virtio` guest, which is exactly how
-	# most people will first try TunaOS. scripts/iso-e2e.sh:281 says the same
-	# thing about this runner ("no render node/virgl — niri/xfwl4 will not
-	# render here").
+	# most people will first try TunaOS. scripts/iso-e2e.sh identifies this as
+	# the virgl-unavailable path where guest software rendering is required.
 	#
-	# So pick the renderer at boot rather than baking one in: software
-	# (pixman) only when there is no render node, hardware GL everywhere else.
-	# A login screen is cheap to render, so the fallback costs nothing where
-	# it is used, and machines with a GPU are unaffected.
+	# So pick the renderer at boot rather than baking one in. The root detector
+	# records virtio-gpu's `-virgl` capability in /run; the no-render-node check
+	# remains a safe fallback. Hardware with working GL is unaffected.
 	install -Dm0755 /dev/stdin /usr/libexec/tunaos/greetd-session <<'SESSION_EOF'
 #!/usr/bin/env bash
 # Launch gtkgreet under cage on hardware that may have neither 3D nor a GPU
@@ -86,14 +84,15 @@ if command -v gtkgreet &>/dev/null && command -v cage &>/dev/null; then
 #      "[drm] features: -virgl", so GL initialisation cannot succeed even once
 #      the device exists. wlroots' pixman renderer draws fine on dumb buffers.
 #
-# Waiting for card* fixes (1); forcing pixman when no render node exists fixes
-# (2). A render node is the honest test for 3D here — virtio-gpu without virgl
-# exposes card* but no renderD*.
+# Waiting for card* fixes (1). For (2), the root boot detector reads the
+# kernel's `-virgl` report and writes /run/tunaos-software-gl; render-node
+# presence cannot answer this because virtio-gpu can expose one with zero caps.
 for _ in $(seq 1 30); do
 	compgen -G '/dev/dri/card*' >/dev/null 2>&1 && break
 	sleep 0.5
 done
-if ! compgen -G '/dev/dri/renderD*' >/dev/null 2>&1; then
+if [[ -e /run/tunaos-software-gl ]] ||
+	! compgen -G '/dev/dri/renderD*' >/dev/null 2>&1; then
 	export WLR_RENDERER=pixman
 	export LIBGL_ALWAYS_SOFTWARE=1
 fi

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -538,7 +538,7 @@ if [[ "$_gpu_mode" != "plain" ]] && { [[ "$_gpu_mode" == "virgl" ]] || [[ -e /de
 	QEMU_NEEDS_VNC_SURFACE=1
 	echo "==> GPU: virgl (${_gpu_gl_device} + egl-headless /dev/dri/renderD128 + vnc surface) — Smithay compositors can render"
 else
-	echo "==> GPU: ${_gpu_plain_args[*]} headless (no render node/virgl) — niri/xfwl4 will not render here"
+	echo "==> GPU: ${_gpu_plain_args[*]} headless (virgl unavailable) — guest software rendering required"
 	# Tell the screen checkpoints to REPORT rather than enforce the pixel
 	# assertions for the desktops listed under needs_virgl in
 	# tests/install-pipeline-screens.yaml. Without this every such cell fails

--- a/system_files/usr/lib/systemd/system-preset/50-tunaos.preset
+++ b/system_files/usr/lib/systemd/system-preset/50-tunaos.preset
@@ -45,7 +45,8 @@ enable tunaos-base-contract.service
 enable tunaos-desktop-contract.service
 enable tunaos-live-ready.service
 
-# First-boot setup.
+# Boot-time hardware detection and first-boot setup.
+enable tunaos-software-gl-detect.service
 enable tunaos-var-home-restorecon.service
 enable ublue-system-setup.service
 enable flatpak-preinstall.service

--- a/system_files/usr/lib/systemd/system/tunaos-software-gl-detect.service
+++ b/system_files/usr/lib/systemd/system/tunaos-software-gl-detect.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Detect whether TunaOS sessions need software rendering
+# The virtio-gpu driver reports virgl support while udev processes the GPU.
+# Wait for that report before deciding, and finish before a greeter or login can
+# start a user manager and run the environment generator.
+Wants=systemd-udev-settle.service
+After=systemd-udev-settle.service
+Before=display-manager.service systemd-user-sessions.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/tunaos/detect-software-gl
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/usr/lib/systemd/user-environment-generators/60-tunaos-software-gl
+++ b/system_files/usr/lib/systemd/user-environment-generators/60-tunaos-software-gl
@@ -19,11 +19,14 @@
 # the login screen renders on machines where the session does not. This is
 # that same fix, moved to where every Wayland session picks it up.
 #
-# A render node is the honest test for 3D: virtio-gpu without virgl exposes
-# card* but no renderD*. Where a render node exists this generator prints
-# nothing at all, so hardware with working GL is untouched.
+# Render-node presence is not a sufficient 3D test: current virtio-gpu creates
+# renderD128 even when its kernel capability report says `-virgl` and zero cap
+# sets. tunaos-software-gl-detect.service reads that privileged report at boot
+# and leaves a flag for unprivileged generators. Keep the no-node check here as
+# a safe fallback if the detector did not run.
 
-if compgen -G '/dev/dri/renderD*' >/dev/null 2>&1; then
+if compgen -G '/dev/dri/renderD*' >/dev/null 2>&1 &&
+	[[ ! -e /run/tunaos-software-gl ]]; then
 	exit 0
 fi
 

--- a/system_files/usr/libexec/tunaos/detect-software-gl
+++ b/system_files/usr/libexec/tunaos/detect-software-gl
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Record whether user sessions need software rendering. This runs as root so it
+# can read the kernel's virtio-gpu capability report; render-node presence alone
+# is not sufficient because modern virtio-gpu exposes one even without virgl.
+set -euo pipefail
+
+_dri_dir="${TUNAOS_DRI_DIR:-/dev/dri}"
+_flag="${TUNAOS_SOFTWARE_GL_FLAG:-/run/tunaos-software-gl}"
+_kernel_log="${TUNAOS_KERNEL_LOG:-}"
+
+rm -f "${_flag}"
+
+# Preserve the existing fallback for machines with no render node at all.
+if ! compgen -G "${_dri_dir}/renderD*" >/dev/null 2>&1; then
+	install -Dm0644 /dev/null "${_flag}"
+	exit 0
+fi
+
+# virtio_gpu reports the negotiated 3D capability explicitly. In particular,
+# `-virgl` means that the render node above cannot provide accelerated GL.
+# A failed kernel-log read is deliberately treated as unknown: forcing software
+# globally on a real GPU is worse than retaining the previous behaviour.
+read_kernel_log() {
+	if [[ -n "${_kernel_log}" ]]; then
+		cat -- "${_kernel_log}"
+	else
+		dmesg
+	fi
+}
+if read_kernel_log 2>/dev/null |
+	grep -Eq '\[drm\] features:.*-virgl([[:space:]]|$)'; then
+	install -Dm0644 /dev/null "${_flag}"
+fi

--- a/tests/bats/test_build_scripts_remaining.bats
+++ b/tests/bats/test_build_scripts_remaining.bats
@@ -317,11 +317,10 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
   [ "$fail" -eq 0 ]
 }
 
-@test "greetd greeter degrades to software rendering without a render node" {
-  # cage is wlroots-based: on a VM with virtio-gpu but no virgl there is a DRM
-  # card and NO render node, GL init fails, cage exits and greetd restart-loops
-  # on a black screen. Boot-time detection is required — a baked-in renderer
-  # either breaks virgl-less VMs or needlessly softens every GPU machine.
+@test "greetd greeter degrades to software rendering when boot detection requests it" {
+  # cage is wlroots-based. Modern virtio-gpu may create a render node despite
+  # negotiating no virgl capabilities, so the root boot detector must be able
+  # to override node-based detection without softening real GPU machines.
   local script="${REPO_ROOT}/build_scripts/desktop/greetd-gtkgreet.sh"
   grep -qF '/dev/dri/renderD*' "$script"
   grep -qF 'WLR_RENDERER=pixman' "$script"
@@ -334,10 +333,12 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
   # is redirected into the test tmpdir so the result does not depend on whether
   # the machine running the tests happens to have a GPU.
   local base="${BATS_TEST_TMPDIR}/dri"
+  local flag="${BATS_TEST_TMPDIR}/software-gl"
   local w="${BATS_TEST_TMPDIR}/greetd-session"
   awk '/<<.SESSION_EOF.$/{f=1;next} /^SESSION_EOF$/{f=0} f' "$script" \
     | sed -e "s|/dev/dri/renderD\*|${base}/renderD*|" \
       -e "s|/dev/dri/card\*|${base}/card*|" \
+      -e "s|/run/tunaos-software-gl|${flag}|" \
       -e 's|^\tsleep 0.5|\t:|' \
       -e 's|^exec cage.*|echo "R=${WLR_RENDERER:-hw}"|' > "$w"
 
@@ -349,11 +350,18 @@ REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
   [ "$status" -eq 0 ]
   [[ "$output" == *"R=pixman"* ]]
 
-  # Render node present (real GPU) -> left on hardware GL.
+  # Render node present with no detector flag (real GPU) -> hardware GL.
   touch "${base}/renderD128"
   run bash "$w"
   [ "$status" -eq 0 ]
   [[ "$output" == *"R=hw"* ]]
+
+  # Render node present but virtio reported -virgl -> detector forces pixman.
+  touch "$flag"
+  run bash "$w"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"R=pixman"* ]]
+  rm -f "$flag"
 
   # The wait loop must be bounded: with no DRM device at all it still has to
   # exec the greeter rather than hang greetd forever.

--- a/tests/bats/test_iso_e2e.bats
+++ b/tests/bats/test_iso_e2e.bats
@@ -1222,7 +1222,14 @@ setup_runtime_check_stubs() {
 
 gpu_block_file() {
   local out="${BATS_TEST_TMPDIR}/gpu-block.sh"
-  awk '/^# The display device is per machine type/{p=1} p{print} p && /no render node\/virgl/{q=1} q && /^fi$/{exit}' \
+  # Terminate on TUNAOS_CHECKPOINT_NO_GPU=, not on the diagnostic TEXT. The
+  # marker used to be the string "no render node/virgl"; rewording that
+  # message stopped the terminator matching, so this extracted 3,396 lines
+  # instead of ~70, ran on into the UEFI-firmware check, and failed with
+  # "UEFI firmware not found" -- three GPU tests red for a reason with
+  # nothing to do with GPU selection. An extractor keyed on prose breaks
+  # when the prose is improved.
+  awk '/^# The display device is per machine type/{p=1} p{print} p && /TUNAOS_CHECKPOINT_NO_GPU=/{q=1} q && /^fi$/{exit}' \
     "${REPO_ROOT}/scripts/iso-e2e.sh" >"$out"
   echo "$out"
 }

--- a/tests/bats/test_software_gl_detection.bats
+++ b/tests/bats/test_software_gl_detection.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+DETECTOR="${REPO_ROOT}/system_files/usr/libexec/tunaos/detect-software-gl"
+GENERATOR="${REPO_ROOT}/system_files/usr/lib/systemd/user-environment-generators/60-tunaos-software-gl"
+UNIT="${REPO_ROOT}/system_files/usr/lib/systemd/system/tunaos-software-gl-detect.service"
+PRESET="${REPO_ROOT}/system_files/usr/lib/systemd/system-preset/50-tunaos.preset"
+SERVICES="${REPO_ROOT}/build_scripts/40-services.sh"
+
+setup() {
+  export TUNAOS_DRI_DIR="${BATS_TEST_TMPDIR}/dri"
+  export TUNAOS_SOFTWARE_GL_FLAG="${BATS_TEST_TMPDIR}/software-gl"
+  export TUNAOS_KERNEL_LOG="${BATS_TEST_TMPDIR}/kernel.log"
+  mkdir -p "$TUNAOS_DRI_DIR"
+  : > "$TUNAOS_KERNEL_LOG"
+}
+
+@test "detector requests software GL when no render node exists" {
+  run "$DETECTOR"
+  [ "$status" -eq 0 ]
+  [ -f "$TUNAOS_SOFTWARE_GL_FLAG" ]
+}
+
+@test "detector leaves working render nodes on hardware GL" {
+  touch "${TUNAOS_DRI_DIR}/renderD128"
+  printf '%s\n' '[drm] features: +virgl +edid +resource_blob +host_visible' > "$TUNAOS_KERNEL_LOG"
+
+  run "$DETECTOR"
+  [ "$status" -eq 0 ]
+  [ ! -e "$TUNAOS_SOFTWARE_GL_FLAG" ]
+}
+
+@test "detector catches virtio-gpu without virgl despite its render node" {
+  touch "${TUNAOS_DRI_DIR}/renderD128"
+  cat > "$TUNAOS_KERNEL_LOG" <<'EOF'
+[drm] pci: virtio-vga detected at 0000:00:02.0
+[drm] features: -virgl +edid -resource_blob -host_visible
+[drm] number of cap sets: 0
+EOF
+
+  run "$DETECTOR"
+  [ "$status" -eq 0 ]
+  [ -f "$TUNAOS_SOFTWARE_GL_FLAG" ]
+}
+
+@test "detector does not force software when the privileged evidence is unavailable" {
+  touch "${TUNAOS_DRI_DIR}/renderD128"
+  export TUNAOS_KERNEL_LOG="${BATS_TEST_TMPDIR}/missing"
+  run "$DETECTOR"
+  [ "$status" -eq 0 ]
+  [ ! -e "$TUNAOS_SOFTWARE_GL_FLAG" ]
+}
+
+@test "boot detector runs before greeters and survives first-boot presets" {
+  grep -qF 'Before=display-manager.service systemd-user-sessions.service' "$UNIT"
+  grep -qF 'WantedBy=multi-user.target' "$UNIT"
+  grep -qF 'systemctl enable tunaos-software-gl-detect.service' "$SERVICES"
+  grep -qF 'enable tunaos-software-gl-detect.service' "$PRESET"
+}
+
+@test "session generator consumes the detector flag and retains no-node fallback" {
+  grep -qF '[[ ! -e /run/tunaos-software-gl ]]' "$GENERATOR"
+  grep -qF "compgen -G '/dev/dri/renderD*'" "$GENERATOR"
+  grep -qF 'WLR_RENDERER=pixman' "$GENERATOR"
+}


### PR DESCRIPTION
## Summary
- detect virtio-gpu's kernel-reported `-virgl` capability as root at boot instead of treating every render node as working 3D
- share the resulting runtime flag with both the user environment generator and the greetd/cage wrapper while retaining the no-render-node fallback
- correct the plain-QEMU diagnostic and add behavioral coverage for no-node, working-virgl, and render-node-without-virgl cases

Closes #1945

## Testing
- `git diff --check`
- `bash -n build_scripts/40-services.sh build_scripts/desktop/greetd-gtkgreet.sh scripts/iso-e2e.sh system_files/usr/libexec/tunaos/detect-software-gl system_files/usr/lib/systemd/user-environment-generators/60-tunaos-software-gl`
- manually exercised detector fixtures for absent render node, `+virgl`, `-virgl`, and unavailable kernel log
- manually exercised extracted greetd wrapper with no render node, a render node, and a render node plus detector flag

— hive: backend=pi model=openai-codex/gpt-5.6-sol
