### PR TITLE
feat(e2e): --published — the only mode that can test media users actually download

### DIFF
--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -35,6 +35,11 @@
 #       Used to gate GHCR tag promotion on images actually booting.
 #
 #   scripts/iso-e2e.sh <iso_path> --luks
+#   scripts/iso-e2e.sh <iso_path> --published
+#
+# --published is the one mode that works on media a USER can download.
+# Production ISOs ship sshd disabled, so every other mode here is
+# dev-ISO-only; this one drives the GUI through the QEMU monitor.
 #       Full LUKS e2e: boot the live ISO (needs ENABLE_SSHD=1), install via
 #       fisherman (the same backend every TunaOS installer frontend uses)
 #       with encryption.type=tpm2-luks-passphrase against an emulated TPM
@@ -207,7 +212,7 @@ fi
 ISO_PATH=""
 KICKSTART=""
 APP_CMD=""
-MODE="ready" # ready | install | kickstart | ssh | app-launch
+MODE="ready" # ready | install | kickstart | ssh | app-launch | published
 TIMEOUT=300
 LIVE_MARKER="${LIVE_MARKER:-TUNAOS_LIVE_READY|TBOX_LIVE_READY}"
 OUTPUT_DIR="./iso-e2e-out"
@@ -250,6 +255,16 @@ while [[ $# -gt 0 ]]; do
 		MODE="app-launch"
 		APP_CMD="$2"
 		shift 2
+		;;
+	--published)
+		# Test an ISO the way a USER gets it. Production media ships sshd
+		# disabled on purpose, so every SSH-based mode below is unavailable
+		# against the artifacts people actually download -- which means the
+		# gate has only ever exercised dev ISOs. This mode drives the GUI
+		# through the QEMU monitor instead: no guest agent, no sshd, nothing
+		# the image has to opt into.
+		MODE="published"
+		shift
 		;;
 	--ssh-only)
 		MODE="ssh"
@@ -318,7 +333,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$ISO_PATH" ]]; then
-	echo "Usage: $0 <iso_path> [--kickstart KS | --luks | --ssh-only] [options]" >&2
+	echo "Usage: $0 <iso_path> [--kickstart KS | --luks | --ssh-only | --published] [options]" >&2
 	exit 1
 fi
 
@@ -3557,6 +3572,57 @@ ready)
 		run_checkpoint_asserts || rc=$?
 	else
 		run_checkpoint_asserts || true
+	fi
+	exit "$rc"
+	;;
+published)
+	# ── Published/production media: no sshd, so drive the GUI ───────────────
+	#
+	# Everything else in this script reaches into the guest over SSH, which
+	# production ISOs deliberately do not offer (40-services.sh disables sshd
+	# unless ENABLE_SSHD=1). The practical consequence is that the LUKS gate,
+	# the smoke checks and the installer GUI checks have only ever run against
+	# DEV ISOs -- never against the artifact a user downloads. A published ISO
+	# could regress in any of the ways this session fixed and no gate here
+	# would notice.
+	#
+	# So: boot it, prove the live session actually painted, assert the
+	# screen contract, then drive the installer with hardware key events
+	# through the QEMU monitor. installer-walkthrough.py already does the
+	# driving compositor-agnostically (sendkey + screendump + OCR); it simply
+	# was never wired into this script.
+	#
+	# Readiness is judged by PIXELS, not the serial marker: production media
+	# need not ship tunaos-live-ready.service, and waiting 900s for a marker
+	# that is not coming is how this looked like a hang the first time.
+	boot_live_iso || exit 1
+	sleep 5
+	screenshot "00-boot"
+	rc=0
+	if ! wait_for_paint "10-ready"; then
+		echo "ERROR: live session never painted — nothing to drive" >&2
+		screenshot_compare "10-ready" || true
+		exit 2
+	fi
+	echo "==> live session painted; asserting the screen contract"
+	run_checkpoint_asserts || rc=$?
+
+	# Drive the installer. Non-fatal by default because a published ISO whose
+	# desktop is fine but whose installer regressed is a different verdict
+	# from one that never booted, and both are worth reporting separately.
+	walkthrough="${SCRIPT_DIR}/installer-walkthrough.py"
+	if [[ -f "$walkthrough" ]] && command -v python3 &>/dev/null; then
+		echo "==> Driving the installer through the QEMU monitor (no SSH)"
+		wt_rc=0
+		python3 "$walkthrough" "$MONITOR_SOCK" "${OUTPUT_DIR}/walkthrough" \
+			"${TUNAOS_PUBLISHED_STEPS:-6}" "${FLAVOR:-de}" |
+			tee -a "${SERIAL_LOG}" || wt_rc=$?
+		if [[ "$wt_rc" -ne 0 ]]; then
+			echo "::warning::installer walkthrough reported ${wt_rc} failure(s) for ${VARIANT:-?}:${FLAVOR:-?}"
+			[[ "${TUNAOS_PUBLISHED_STRICT:-0}" -eq 1 ]] && rc="$wt_rc"
+		fi
+	else
+		echo "::warning::installer-walkthrough.py or python3 unavailable — GUI drive skipped"
 	fi
 	exit "$rc"
 	;;

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -3604,6 +3604,45 @@ published)
 		screenshot_compare "10-ready" || true
 		exit 2
 	fi
+	# "Painted" is not "booted". wait_for_paint only asks whether the frame is
+	# non-blank, and a GRUB menu satisfies that easily — MEASURED on the
+	# published gurnard-pantheon ISO, where 10-ready OCR'd to
+	#
+	#   gurnard-pantheon (live)
+	#   Reboot Into Firmware Interface
+	#   Boot in 1s.
+	#
+	# so the walkthrough then drove sendkey into a machine that was still
+	# booting and reported a blank, unchanging screen. That is a false failure
+	# manufactured by this gate, which is worse than no gate.
+	#
+	# So: keep re-capturing until the frame stops looking like a bootloader.
+	# Bounded, and non-fatal on timeout — a slow boot should still be driven
+	# and judged by the walkthrough, not abandoned here.
+	boot_menu_re='Boot in|Reboot Into Firmware|GNU GRUB|Press .* to edit'
+	settle_deadline=$((SECONDS + ${TUNAOS_PUBLISHED_BOOT_SETTLE:-240}))
+	while ((SECONDS < settle_deadline)); do
+		frame_txt=""
+		if command -v tesseract &>/dev/null && command -v magick &>/dev/null; then
+			magick "${OUTPUT_DIR}/10-ready.ppm" -colorspace Gray /tmp/.pubocr.png 2>/dev/null &&
+				frame_txt="$(tesseract /tmp/.pubocr.png stdout --psm 6 2>/dev/null || true)"
+		fi
+		# Two ways to be "not the bootloader", and only one of them means the
+		# session arrived. A BLANK frame also has no bootloader text, so the
+		# first version of this broke out of the loop the moment the screen
+		# went black between GRUB and the compositor — turning "still booting"
+		# into "ready" and handing the walkthrough a black screen. Require the
+		# frame to be non-blank AS WELL as free of bootloader text.
+		frame_sd="$(magick "${OUTPUT_DIR}/10-ready.ppm" -colorspace Gray \
+			-format "%[fx:standard_deviation]" info: 2>/dev/null || echo 0)"
+		if awk -v v="$frame_sd" 'BEGIN{exit !(v > 0.02)}' 2>/dev/null &&
+			! grep -qiE "$boot_menu_re" <<<"$frame_txt"; then
+			break
+		fi
+		echo "==> still on the bootloader; waiting for the session (${settle_deadline}s cap)"
+		sleep 15
+		wait_for_paint "10-ready" || true
+	done
 	echo "==> live session painted; asserting the screen contract"
 	run_checkpoint_asserts || rc=$?
 

--- a/tests/bats/test_published_iso_mode.bats
+++ b/tests/bats/test_published_iso_mode.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# The one mode that can test media a user actually downloads.
+#
+# WHY: production ISOs ship sshd disabled (40-services.sh disables it unless
+# ENABLE_SSHD=1), and every other mode in iso-e2e.sh reaches into the guest
+# over SSH. MEASURED against the published marlin-kde ISO: `--luks` fails at
+# "SSH not available", and an --ssh-only probe returns NO_SSH after 60 attempts.
+# So the LUKS gate, the smoke checks and the installer GUI checks have only
+# ever run against DEV ISOs — never against the artifact people download.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/iso-e2e.sh"
+
+@test "the published mode exists and is documented in usage" {
+  grep -q '\-\-published)' "$SCRIPT"
+  grep -q 'MODE="published"' "$SCRIPT"
+  grep -q '\-\-published\]' "$SCRIPT"
+}
+
+@test "the published mode never calls SSH" {
+  # Extract the mode body and assert no SSH helper appears in it. A single
+  # check_ssh here would reintroduce exactly the dependency this mode exists
+  # to avoid, and would only be discovered against real published media.
+  local body
+  body="$(sed -n '/^published)$/,/^ssh)$/p' "$SCRIPT")"
+  [ -n "$body" ]
+  ! echo "$body" | grep -qE 'check_ssh|ssh_cmd|GUEST_SSH|sshpass|scp_cmd'
+}
+
+@test "readiness is judged by pixels, not the serial marker" {
+  # Production media need not ship tunaos-live-ready.service. Waiting on the
+  # marker there burns the full --timeout and reads as a hang; the first
+  # attempt at this did exactly that for 900s.
+  local body
+  body="$(sed -n '/^published)$/,/^ssh)$/p' "$SCRIPT")"
+  echo "$body" | grep -q 'wait_for_paint'
+  ! echo "$body" | grep -q 'wait_for_ready'
+}
+
+@test "it drives the installer through the QEMU monitor" {
+  local body
+  body="$(sed -n '/^published)$/,/^ssh)$/p' "$SCRIPT")"
+  echo "$body" | grep -q 'installer-walkthrough.py'
+  echo "$body" | grep -q 'MONITOR_SOCK'
+}
+
+@test "a walkthrough failure is reported separately from a boot failure" {
+  # A published ISO whose desktop is fine but whose installer regressed is a
+  # different verdict from one that never booted. Non-fatal by default,
+  # promotable with TUNAOS_PUBLISHED_STRICT=1.
+  local body
+  body="$(sed -n '/^published)$/,/^ssh)$/p' "$SCRIPT")"
+  echo "$body" | grep -q 'TUNAOS_PUBLISHED_STRICT'
+  echo "$body" | grep -q 'never painted'
+}
+
+@test "the walkthrough driver it depends on exists and takes a monitor socket" {
+  local wt="${REPO_ROOT}/scripts/installer-walkthrough.py"
+  [ -f "$wt" ]
+  grep -q 'mon_path = args\[0\]' "$wt"
+}

--- a/tests/bats/test_published_iso_mode.bats
+++ b/tests/bats/test_published_iso_mode.bats
@@ -59,3 +59,41 @@ SCRIPT="${REPO_ROOT}/scripts/iso-e2e.sh"
   [ -f "$wt" ]
   grep -q 'mon_path = args\[0\]' "$wt"
 }
+
+@test "readiness waits past the bootloader, not just for any paint" {
+  # MEASURED on the published gurnard-pantheon ISO: wait_for_paint accepted the
+  # GRUB menu as "painted" (it is non-blank), so the walkthrough drove sendkey
+  # into a machine that was still booting and reported a blank, unchanging
+  # screen — a false failure manufactured by the gate itself. The 10-ready
+  # frame OCR'd to "gurnard-pantheon (live) / Reboot Into Firmware Interface /
+  # Boot in 1s."
+  local body
+  body="$(sed -n '/^published)$/,/^ssh)$/p' "$SCRIPT")"
+  echo "$body" | grep -q 'boot_menu_re'
+  echo "$body" | grep -q 'Reboot Into Firmware'
+  echo "$body" | grep -q 'GNU GRUB'
+}
+
+@test "a slow boot is still driven, not abandoned" {
+  # The settle loop is bounded and non-fatal: a machine that takes longer than
+  # the cap should still be handed to the walkthrough and judged there, rather
+  # than failing here on a timer.
+  local body
+  body="$(sed -n '/^published)$/,/^ssh)$/p' "$SCRIPT")"
+  echo "$body" | grep -q 'TUNAOS_PUBLISHED_BOOT_SETTLE'
+  # The loop must break out, not exit.
+  echo "$body" | grep -A12 'boot_menu_re' | grep -q 'break'
+}
+
+@test "a black screen is not mistaken for a booted session" {
+  # The first settle loop broke out as soon as the frame had no bootloader
+  # text — but a BLANK frame has no text either, so the moment the screen went
+  # black between GRUB and the compositor it declared ready and handed the
+  # walkthrough a black screen. MEASURED on gurnard-pantheon: 10-ready came
+  # back stddev=0 after the settle "succeeded".
+  local body
+  body="$(sed -n '/^published)$/,/^ssh)$/p' "$SCRIPT")"
+  echo "$body" | grep -q 'standard_deviation'
+  # Must require non-blank AND not-bootloader, not either one alone.
+  echo "$body" | grep -q 'frame_sd'
+}


### PR DESCRIPTION
## The gap

Production ISOs ship sshd **disabled** (`40-services.sh` turns it off unless `ENABLE_SSHD=1`). Every other mode in `iso-e2e.sh` reaches into the guest over SSH.

So the LUKS gate, the smoke checks and the installer GUI checks have only ever run against **dev ISOs** — never against the artifact people download. Measured against the published `marlin-kde`:

- `--luks` → `ERROR: SSH not available`
- `--ssh-only` probe → `NO_SSH` after 60 attempts

A published ISO could regress in any of the ways this session fixed and nothing here would notice.

## The mode

`--published` drives the GUI through the QEMU monitor: boot → prove the live session painted → assert the screen contract → hand the running VM to `installer-walkthrough.py`, which already does `sendkey` + `screendump` + OCR compositor-agnostically. It was simply never wired into this script.

Readiness is judged by **pixels, not the serial marker** — production media need not ship `tunaos-live-ready.service`, and waiting on a marker that isn't coming burns the whole `--timeout` and reads as a hang. (The first attempt did exactly that for 900s.)

A walkthrough failure is reported **separately** from a boot failure, since a published ISO whose desktop is fine but whose installer regressed is a different verdict from one that never booted. Non-fatal by default, promotable with `TUNAOS_PUBLISHED_STRICT=1`.

## Two bugs it had, both found by running it

**It declared "ready" at the GRUB menu.** `wait_for_paint` only asks whether the frame is non-blank, and a bootloader menu satisfies that. On `gurnard-pantheon` the 10-ready frame OCR'd to `Reboot Into Firmware Interface / Boot in 1s.`, so the walkthrough drove sendkey into a still-booting machine and reported a blank screen — **a false failure manufactured by the gate**, which is worse than no gate.

**Then it declared "ready" at a black screen.** The first settle loop broke out as soon as the frame had no bootloader text — but a blank frame has no text either, so it fired the moment the screen went black between GRUB and the compositor. Measured: `10-ready` came back `stddev=0` after the settle "succeeded". It now requires non-blank **as well as** not-bootloader.

Both conditions are pinned by tests. 9 tests total, all passing.

## What it found on real published media

**`bonito` (gnome)** — live session paints, installer is driven with no SSH, screen genuinely advances. But:

```
not ok - gnome: installer is frontmost at session start
ok     - gnome: reached 'welcome' screen
not ok - gnome: reached 'disk' screen
```

OCR of the frames shows the session sitting on GNOME's own **Welcome → Privacy → "Location Services"** pages, not the tunaOS installer, and still there 16 steps in. Related to #2392 (installer behind the startup overview) but a different screen. **Not root-caused** — live customisation is applied at boot rather than baked into `combined.rootfs.sfs`, so inspecting the squashfs can't settle it; the runtime observation is the evidence.

**`gurnard-pantheon`** — black screen after boot (`stddev=0` on every frame, three runs, 420s settle). Whether that's a product bug or Pantheon's compositor needing a render node this headless host lacks is **undetermined**: the host reports "no render node/virgl", but renders GNOME fine, so it isn't a blanket llvmpipe failure. Settling it needs a GPU host or the guest journal — and production media ships no sshd to read it with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rprz14ZYS9uCdd51ayuKD