### PR TITLE
fix(just): `just fix` rewrote 145 files on a clean main

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,9 +10,14 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
+# shfmt reads this file, and `just fix` runs shfmt --write over every shell
+# script in the repo. This said `space` / `2` while 100% of the shell code is
+# written with tabs -- 15 of 15 build_scripts/*.sh, and shfmt's own default --
+# so `just fix`, which AGENTS.md makes mandatory before every commit, rewrote
+# 145 files and 12k lines on a clean checkout of main. Nothing caught it
+# because `just check` never ran shfmt at all.
 [*.{sh,bash}]
-indent_style = space
-indent_size = 2
+indent_style = tab
 
 [*.{yml,yaml}]
 indent_style = space

--- a/.github/scripts/cosign-retry.sh
+++ b/.github/scripts/cosign-retry.sh
@@ -48,7 +48,7 @@ _cosign_transient() {
 cosign_retry() {
 	local attempt=1 backoff=15 rc=0 now remaining out deadline
 	out="$(mktemp)"
-	deadline=$(( $(date +%s) + SIGN_DEADLINE_MINUTES * 60 ))
+	deadline=$(($(date +%s) + SIGN_DEADLINE_MINUTES * 60))
 
 	while :; do
 		rc=0
@@ -68,7 +68,7 @@ cosign_retry() {
 		fi
 
 		now="$(date +%s)"
-		remaining=$(( deadline - now ))
+		remaining=$((deadline - now))
 		if [ "$remaining" -le "$backoff" ]; then
 			# Marker, not prose: rerun-infra-failures.yml greps job logs for
 			# SIGSTORE_OUTAGE to tell "Sigstore was down" apart from "this
@@ -78,10 +78,10 @@ cosign_retry() {
 			return "$rc"
 		fi
 
-		echo "::warning::${2:-$1} failed (attempt ${attempt}, transient Sigstore error); retrying in ${backoff}s ($(( remaining / 60 ))m of budget left)..." >&2
+		echo "::warning::${2:-$1} failed (attempt ${attempt}, transient Sigstore error); retrying in ${backoff}s ($((remaining / 60))m of budget left)..." >&2
 		sleep "$backoff"
-		attempt=$(( attempt + 1 ))
-		backoff=$(( backoff * 2 ))
+		attempt=$((attempt + 1))
+		backoff=$((backoff * 2))
 		if [ "$backoff" -gt "$SIGN_BACKOFF_CAP_SECONDS" ]; then
 			backoff="$SIGN_BACKOFF_CAP_SECONDS"
 		fi

--- a/.github/scripts/update-build-status.sh
+++ b/.github/scripts/update-build-status.sh
@@ -167,7 +167,10 @@ total_failing=$((total_cells - total_green - total_unreached))
 # previous behaviour, and it froze the README block for two weeks after
 # `desktop` and `no_silent_omissions` graduated on 2026-08-19.
 mapfile -t blocking_ids < <(yq -r '.criteria[] | select(.enforcement == "blocking") | .id' .github/green-criteria.yml | sort)
-blocking=$(IFS=,; echo "${blocking_ids[*]}")
+blocking=$(
+	IFS=,
+	echo "${blocking_ids[*]}"
+)
 composite_scope="this table"
 composite_total=$total_cells
 scorable=true

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -609,8 +609,8 @@ jobs:
           # a real exit code, with logs, while the agent is still healthy.
           # The wall-clock bound stays for the orthogonal case of a scan that
           # is slow rather than hungry.
-          syft_cmd=( timeout --kill-after=30s 18m
-                     "$SYFT_CMD" "$IMAGE" --scope squashed -o spdx-json="$OUT" )
+          syft_cmd=(timeout --kill-after=30s 18m
+          	"$SYFT_CMD" "$IMAGE" --scope squashed -o spdx-json="$OUT")
 
           # Size the cap off the box we actually landed on, and say so, so a
           # future exit 137 can be read against a real number instead of an
@@ -618,31 +618,30 @@ jobs:
           # is not what ubuntu-latest ships now, and the arm64 leg is a
           # different image again).
           mem_total_mib="$(free -m | awk '/^Mem:/ {print $2}')"
-          cap_mib=$(( mem_total_mib - SYFT_MEMORY_RESERVE_MIB ))
+          cap_mib=$((mem_total_mib - SYFT_MEMORY_RESERVE_MIB))
           if [ "$cap_mib" -lt "$SYFT_MEMORY_FLOOR_MIB" ]; then
-            cap_mib="$SYFT_MEMORY_FLOOR_MIB"
+          	cap_mib="$SYFT_MEMORY_FLOOR_MIB"
           fi
           echo "runner memory (MiB): total=${mem_total_mib} available=$(free -m | awk '/^Mem:/ {print $7}')"
           echo "syft cgroup cap (MiB): ${cap_mib} (reserving ${SYFT_MEMORY_RESERVE_MIB} for the agent)"
 
           if command -v systemd-run >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-            sudo systemd-run --scope --quiet \
-              --uid="$(id -u)" --gid="$(id -g)" \
-              -p MemoryMax="${cap_mib}M" -p MemorySwapMax=0 \
-              -- "${syft_cmd[@]}"
+          	sudo systemd-run --scope --quiet \
+          		--uid="$(id -u)" --gid="$(id -g)" \
+          		-p MemoryMax="${cap_mib}M" -p MemorySwapMax=0 \
+          		-- "${syft_cmd[@]}"
           else
-            # Never silently drop the guard: without it a hungry scan can
-            # still take the agent, which is the failure this step exists to
-            # stop being invisible.
-            echo "::warning::systemd-run unavailable; syft is time-bounded but NOT memory-bounded"
-            "${syft_cmd[@]}"
+          	# Never silently drop the guard: without it a hungry scan can
+          	# still take the agent, which is the failure this step exists to
+          	# stop being invisible.
+          	echo "::warning::systemd-run unavailable; syft is time-bounded but NOT memory-bounded"
+          	"${syft_cmd[@]}"
           fi
 
           jq -e '
             .spdxVersion | startswith("SPDX-")
           ' "$OUT" >/dev/null
           jq -e '(.packages // []) | length > 0' "$OUT" >/dev/null
-
       - name: Synthesize SBOM from the package manifest
         id: sbom_fallback
         # Runs only when the scan did not produce one. On guppy that is most

--- a/build_scripts/40-services.sh
+++ b/build_scripts/40-services.sh
@@ -556,8 +556,8 @@ if [[ "${PKG_MGR:-}" == "pacman" ]] || command -v zypper &>/dev/null || command 
 	if [[ "${ENABLE_SSHD:-0}" == "1" ]]; then
 		safe_enable sshd.service
 		if ! id liveuser &>/dev/null; then
-			useradd -m -s /bin/bash -G wheel liveuser 2>/dev/null || \
-			useradd -m -s /bin/bash liveuser 2>/dev/null || true
+			useradd -m -s /bin/bash -G wheel liveuser 2>/dev/null ||
+				useradd -m -s /bin/bash liveuser 2>/dev/null || true
 		fi
 		echo 'liveuser:live' | chpasswd
 		tunaos_declare_liveuser_home
@@ -764,6 +764,5 @@ if [[ -f /usr/lib/systemd/system/systemd-resolved.service ]]; then
 	# Investigate if resolved consistently fails across all variants.
 	systemctl enable systemd-resolved.service
 fi
-
 
 printf "::endgroup::\n"

--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -50,17 +50,26 @@ waive() { TUNAOS_CONTRACT_WAIVED=$((TUNAOS_CONTRACT_WAIVED + 1)); }
 
 require_command() { command -v "$1" >/dev/null || {
 	echo "missing required command: $1" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then
+		waive
+		return 0
+	fi
 	exit 1
 }; }
 require_glob() { compgen -G "$1" >/dev/null || {
 	echo "missing required path: $1" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then
+		waive
+		return 0
+	fi
 	exit 1
 }; }
 require_unit() { systemctl list-unit-files "$1.service" --no-legend 2>/dev/null | grep -q "^$1.service" || {
 	echo "missing unit: $1.service" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then
+		waive
+		return 0
+	fi
 	exit 1
 }; }
 # Distro drift: the same DE ships different DM units per variant (gdm vs
@@ -74,7 +83,10 @@ require_any_unit() {
 		fi
 	done
 	echo "missing unit: none of [$*] exist" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then
+		waive
+		return 0
+	fi
 	exit 1
 }
 # Session availability may be wayland or x11 depending on DE/distro.
@@ -84,7 +96,10 @@ require_any_glob() {
 		compgen -G "$g" >/dev/null && return 0
 	done
 	echo "missing required path: none of [$*] exist" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then
+		waive
+		return 0
+	fi
 	exit 1
 }
 
@@ -99,7 +114,10 @@ require_user_unit() {
 		return 0
 	fi
 	echo "missing user unit: ${u}.service" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then
+		waive
+		return 0
+	fi
 	exit 1
 }
 
@@ -114,7 +132,10 @@ require_any_user_unit() {
 		fi
 	done
 	echo "missing user unit: none of [$*] exist" >&2
-	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then
+		waive
+		return 0
+	fi
 	exit 1
 }
 
@@ -136,7 +157,10 @@ xfce_greetd_greeter_contract() {
 	local greetd_conf="${TUNAOS_VERIFY_ROOT:-}/etc/greetd/config.toml"
 	if ! grep -qs 'gtkgreet' "$greetd_conf"; then
 		echo "greetd is the display manager but ${greetd_conf} does not launch gtkgreet — stock agreety boots users to a text prompt, not a login screen" >&2
-		if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
+		if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then
+			waive
+			return 0
+		fi
 		exit 1
 	fi
 }
@@ -196,12 +220,18 @@ require_gnome_at_least() {
 	major="$(gnome_shell_major)"
 	if [[ -z "$major" ]]; then
 		echo "cannot determine the installed GNOME version: gnome-shell --version failed and no package manager knows gnome-shell" >&2
-		if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
+		if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then
+			waive
+			return 0
+		fi
 		exit 1
 	fi
 	if ((major < floor)); then
 		echo "GNOME ${major} is below the floor: nothing below GNOME ${floor} ships (maintainer directive 2026-09-03; the target is 51). This image's gnome-shell reports major version ${major}." >&2
-		if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then waive; return 0; fi
+		if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then
+			waive
+			return 0
+		fi
 		exit 1
 	fi
 	echo "GNOME ${major} meets the floor of ${floor}"

--- a/build_scripts/desktop/install-desktop.sh
+++ b/build_scripts/desktop/install-desktop.sh
@@ -1019,4 +1019,3 @@ fi
 emit_packages_manifest
 
 printf "::endgroup::\n"
-

--- a/build_scripts/desktop/xfce-greeter.sh
+++ b/build_scripts/desktop/xfce-greeter.sh
@@ -18,36 +18,36 @@
 # install. Indentation is carried over verbatim from the original block so
 # the heredocs inside stay intact.
 
-		# Display manager: neither branch pulls one in. Probe lightdm first
-		# (XFCE's usual DM), fall back to greetd; the enable logic below
-		# picks whichever landed.
-		install_available \
-			lightdm \
-			lightdm-gtk-greeter \
-			greetd \
-			greetd-selinux
+# Display manager: neither branch pulls one in. Probe lightdm first
+# (XFCE's usual DM), fall back to greetd; the enable logic below
+# picks whichever landed.
+install_available \
+	lightdm \
+	lightdm-gtk-greeter \
+	greetd \
+	greetd-selinux
 
-		# greetd ships no graphical greeter: its stock config runs
-		# `agreety --cmd /bin/sh`, i.e. a text prompt into a bare shell with
-		# no session picker. cosmic/niri never hit this because
-		# cosmic-greeter/dms-greeter ship their own config.toml — XFCE has no
-		# such package, so without this block an installed XFCE system boots
-		# to a shell. It still reaches graphical.target with
-		# display-manager.service active, so the desktop-contract gate cannot
-		# see the difference; only this config can.
-		#
-		# gtkgreet is GTK3 like the XFCE session, so it inherits the same
-		# GTK/icon/cursor/font theme — greeter and desktop match by
-		# construction. It pulls cage (its kiosk host) via Requires.
-		install_available gtkgreet
+# greetd ships no graphical greeter: its stock config runs
+# `agreety --cmd /bin/sh`, i.e. a text prompt into a bare shell with
+# no session picker. cosmic/niri never hit this because
+# cosmic-greeter/dms-greeter ship their own config.toml — XFCE has no
+# such package, so without this block an installed XFCE system boots
+# to a shell. It still reaches graphical.target with
+# display-manager.service active, so the desktop-contract gate cannot
+# see the difference; only this config can.
+#
+# gtkgreet is GTK3 like the XFCE session, so it inherits the same
+# GTK/icon/cursor/font theme — greeter and desktop match by
+# construction. It pulls cage (its kiosk host) via Requires.
+install_available gtkgreet
 
-		# Session entry: the adapted xfce4-session ships a wayland-sessions
-		# desktop file running `startxfce4 --wayland`. Only write a fallback
-		# if no packaged Wayland session landed (keeps DMs from showing an
-		# empty session list on EL10 if packaging regresses).
-		if [[ $IS_FEDORA != true ]] && ! compgen -G "/usr/share/wayland-sessions/*.desktop" >/dev/null; then
-			mkdir -p /usr/share/wayland-sessions
-			cat >/usr/share/wayland-sessions/xfce-wayland.desktop <<'EOF'
+# Session entry: the adapted xfce4-session ships a wayland-sessions
+# desktop file running `startxfce4 --wayland`. Only write a fallback
+# if no packaged Wayland session landed (keeps DMs from showing an
+# empty session list on EL10 if packaging regresses).
+if [[ $IS_FEDORA != true ]] && ! compgen -G "/usr/share/wayland-sessions/*.desktop" >/dev/null; then
+	mkdir -p /usr/share/wayland-sessions
+	cat >/usr/share/wayland-sessions/xfce-wayland.desktop <<'EOF'
 [Desktop Entry]
 Name=Xfce Session (Wayland)
 Comment=XFCE desktop on Wayland (xfwl4)
@@ -55,18 +55,18 @@ Exec=startxfce4 --wayland
 Type=Application
 DesktopNames=XFCE
 EOF
-		fi
+fi
 
-		# Point greetd at gtkgreet. Only rewrite the config when gtkgreet
-		# actually landed — if packaging regressed, leaving greetd's own
-		# config in place fails loudly at a text prompt rather than silently
-		# launching a greeter that is not installed.
-		if command -v gtkgreet &>/dev/null && command -v cage &>/dev/null; then
-			# gtkgreet is a plain Wayland client and cannot own a VT, so cage
-			# hosts it. -s keeps VT switching available (without it a greeter
-			# crash locks you out of the machine entirely).
-			mkdir -p /etc/greetd
-			cat >/etc/greetd/config.toml <<'EOF'
+# Point greetd at gtkgreet. Only rewrite the config when gtkgreet
+# actually landed — if packaging regressed, leaving greetd's own
+# config in place fails loudly at a text prompt rather than silently
+# launching a greeter that is not installed.
+if command -v gtkgreet &>/dev/null && command -v cage &>/dev/null; then
+	# gtkgreet is a plain Wayland client and cannot own a VT, so cage
+	# hosts it. -s keeps VT switching available (without it a greeter
+	# crash locks you out of the machine entirely).
+	mkdir -p /etc/greetd
+	cat >/etc/greetd/config.toml <<'EOF'
 [terminal]
 vt = 1
 
@@ -75,11 +75,11 @@ command = "cage -s -- gtkgreet -l -s /etc/greetd/gtkgreet.css"
 user = "greetd"
 EOF
 
-			# Greeter styling. Kept deliberately small: gtkgreet is GTK3, so
-			# it already picks up the session's GTK theme, icons, cursor and
-			# font — this only supplies the pieces a theme cannot know about
-			# (the layer-shell background behind the login window).
-			cat >/etc/greetd/gtkgreet.css <<'EOF'
+	# Greeter styling. Kept deliberately small: gtkgreet is GTK3, so
+	# it already picks up the session's GTK theme, icons, cursor and
+	# font — this only supplies the pieces a theme cannot know about
+	# (the layer-shell background behind the login window).
+	cat >/etc/greetd/gtkgreet.css <<'EOF'
 /* TunaOS XFCE greeter.
  *
  * gtkgreet inherits the system GTK3 theme, which is the whole reason it is
@@ -101,14 +101,14 @@ box#window-box {
 	padding: 24px;
 }
 EOF
-			# greetd runs the greeter as its own unprivileged user; it must be
-			# able to read both files.
-			chmod 0644 /etc/greetd/config.toml /etc/greetd/gtkgreet.css
-		fi
+	# greetd runs the greeter as its own unprivileged user; it must be
+	# able to read both files.
+	chmod 0644 /etc/greetd/config.toml /etc/greetd/gtkgreet.css
+fi
 
-		# Enable lightdm or greetd for display management
-		if command -v lightdm &>/dev/null; then
-			systemctl enable lightdm
-		elif command -v greetd &>/dev/null; then
-			systemctl enable greetd
-		fi
+# Enable lightdm or greetd for display management
+if command -v lightdm &>/dev/null; then
+	systemctl enable lightdm
+elif command -v greetd &>/dev/null; then
+	systemctl enable greetd
+fi

--- a/build_scripts/install-zirconium.sh
+++ b/build_scripts/install-zirconium.sh
@@ -58,7 +58,10 @@ shopt -u nullglob
 	exit 1
 }
 SRC="${_roots[0]}mkosi.extra"
-[[ -d "$SRC" ]] || { echo "ERROR: mkosi.extra not found in zirconium@${ZIRCONIUM_REF}" >&2; exit 1; }
+[[ -d "$SRC" ]] || {
+	echo "ERROR: mkosi.extra not found in zirconium@${ZIRCONIUM_REF}" >&2
+	exit 1
+}
 
 # Factory etc -> /etc (greetd, profile.d, kmscon, taidan.toml).
 cp -av "$SRC/usr/share/factory/etc/." /etc/

--- a/build_scripts/lib.sh
+++ b/build_scripts/lib.sh
@@ -783,8 +783,8 @@ install_available() {
 detect_fedora_ver() {
 	local ver
 	ver="$(rpm -E %fedora 2>/dev/null || true)"
-	if [[ -z "$ver" || "$ver" == "%fedora" ]] \
-		|| grep -qi rawhide "${OS_RELEASE:-/etc/os-release}" 2>/dev/null; then
+	if [[ -z "$ver" || "$ver" == "%fedora" ]] ||
+		grep -qi rawhide "${OS_RELEASE:-/etc/os-release}" 2>/dev/null; then
 		echo rawhide
 	else
 		echo "$ver"

--- a/build_scripts/overlay/t2.sh
+++ b/build_scripts/overlay/t2.sh
@@ -7,14 +7,14 @@
 set -xeuo pipefail
 
 if [ "$(uname -m)" != "x86_64" ]; then
-    echo "ERROR: the T2 overlay only applies to x86_64 builds" >&2
-    exit 1
+	echo "ERROR: the T2 overlay only applies to x86_64 builds" >&2
+	exit 1
 fi
 
 . /etc/os-release
 if [ "${ID}" != "fedora" ]; then
-    echo "ERROR: the initial T2 profile is supported only on Fedora (bonito)" >&2
-    exit 1
+	echo "ERROR: the initial T2 profile is supported only on Fedora (bonito)" >&2
+	exit 1
 fi
 
 dnf -y copr enable sharpenedblade/t2linux
@@ -32,8 +32,8 @@ EOF
 # Do not install broadcom-wl: T2 Macs use the in-kernel brcmfmac driver plus
 # firmware extracted locally by Bootsahi Legacy.
 if rpm -q broadcom-wl >/dev/null 2>&1; then
-    echo "ERROR: broadcom-wl must not be present in a T2 image" >&2
-    exit 1
+	echo "ERROR: broadcom-wl must not be present in a T2 image" >&2
+	exit 1
 fi
 
 # Keep the image publishable only when the T2 metapackage and the in-tree Wi-Fi
@@ -41,7 +41,7 @@ fi
 rpm -q t2linux-release
 KVER=$(find /usr/lib/modules -maxdepth 1 -mindepth 1 -type d -printf '%T@ %f\n' | sort -rn | head -1 | cut -d' ' -f2-)
 [ -n "${KVER}" ] && [ -d "/usr/lib/modules/${KVER}" ] || {
-    echo "ERROR: no T2 kernel module directory found" >&2
-    exit 1
+	echo "ERROR: no T2 kernel module directory found" >&2
+	exit 1
 }
 find "/usr/lib/modules/${KVER}" -type f -name 'brcmfmac.ko*' -print -quit | grep -q .

--- a/just/utilities.just
+++ b/just/utilities.just
@@ -28,6 +28,22 @@ check: _ensure_check_deps
     cd {{ justfile_directory() }}
     echo "Checking syntax of shell scripts..."
     find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './.build/*' -iname "*.sh" -type f -exec shellcheck --exclude=SC1091 "{}" ";"
+    # `just fix` WROTE shell formatting and nothing ever CHECKED it, so the
+    # .editorconfig could disagree with every file in the repo indefinitely --
+    # and did. A formatter you do not verify is a formatter that drifts.
+    # shfmt -l LISTS files needing formatting; test its OUTPUT, not an exit
+    # code. `find ... -exec shfmt --diff {} \;` returns 0 even when shfmt
+    # itself exits 1 -- find does not propagate the child's status -- so the
+    # obvious spelling of this check is a gate that can never fail. Measured:
+    # shfmt --diff on a bad file exits 1, the same command under find -exec
+    # exits 0.
+    echo "Checking shell formatting (shfmt)..."
+    unformatted="$(find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './.build/*' -not -path './_upstream-snapshots/*' -iname "*.sh" -type f -print0 | xargs -0 shfmt -l 2>/dev/null || true)"
+    if [[ -n "$unformatted" ]]; then
+        echo "::error::Shell formatting drift. Run 'just fix' and commit the result."
+        echo "$unformatted"
+        exit 1
+    fi
     find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './.build/*' -type f -name "*.yaml" -exec yamllint -c ./.yamllint.yml {} \; -o -name "*.yml" -exec yamllint {} \; 2>/dev/null || true
     find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './.build/*' -type f -name "*.json" -exec sh -c 'jq . "$1" > /dev/null' _ {} \; 2>/dev/null || true
     if command -v actionlint &> /dev/null; then
@@ -142,7 +158,11 @@ generate-workflows:
 fix:
     #!/usr/bin/env bash
     cd {{ justfile_directory() }}
-    find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -iname "*.sh" -type f -exec shfmt --write "{}" ";"
+    # _upstream-snapshots is VENDORED upstream code kept for reference. Its
+    # value is being byte-identical to what upstream ships, so reformatting it
+    # destroys the only reason it exists -- and it was 14 of the files `just
+    # fix` rewrote on a clean main.
+    find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './_upstream-snapshots/*' -iname "*.sh" -type f -exec shfmt --write "{}" ";"
     find . -type f -name "*.just" -exec just --unstable --fmt -f {} \;
     just --unstable --fmt -f Justfile || { exit 1; }
 

--- a/just/utilities.just
+++ b/just/utilities.just
@@ -163,7 +163,12 @@ fix:
     # destroys the only reason it exists -- and it was 14 of the files `just
     # fix` rewrote on a clean main.
     find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './_upstream-snapshots/*' -iname "*.sh" -type f -exec shfmt --write "{}" ";"
-    find . -type f -name "*.just" -exec just --unstable --fmt -f {} \;
+    # Same exclusion as the shell loop above, and for the same reason. Without
+    # it the automation bot reformats vendored .just files and opens a PR for
+    # the change on every run: #2421, #2422 and #2423 were three identical
+    # rewrites of the same _upstream-snapshots/zirconium/.../67-gamerslop.just,
+    # regenerated as fast as they were rejected.
+    find . -not -path './_upstream-snapshots/*' -not -path './packages-repo/*' -type f -name "*.just" -exec just --unstable --fmt -f {} \;
     just --unstable --fmt -f Justfile || { exit 1; }
 
 clean:

--- a/scripts/audit-nvidia-release-assets.sh
+++ b/scripts/audit-nvidia-release-assets.sh
@@ -17,10 +17,10 @@ command -v jq >/dev/null || {
 }
 
 case "$minimum" in
-	''|*[!0-9]*)
-		echo "FAIL: NVIDIA_MIN_ASSETS must be a non-negative integer" >&2
-		exit 1
-		;;
+'' | *[!0-9]*)
+	echo "FAIL: NVIDIA_MIN_ASSETS must be a non-negative integer" >&2
+	exit 1
+	;;
 esac
 
 flavors=(
@@ -35,26 +35,26 @@ flavors=(
 fail=0
 for flavor in "${flavors[@]}"; do
 	release=$(GH_TOKEN="${GH_TOKEN:-}" gh api --paginate --slurp \
-		"repos/$repo/releases?per_page=100" \
-		| jq -c --arg prefix "$flavor-" \
-		'add | map(select(.tag_name | startswith($prefix))) | sort_by(.published_at) | last // empty')
+		"repos/$repo/releases?per_page=100" |
+		jq -c --arg prefix "$flavor-" \
+			'add | map(select(.tag_name | startswith($prefix))) | sort_by(.published_at) | last // empty')
 
 	if [ -z "$release" ]; then
 		echo "MISSING $flavor: no GitHub release found"
-	fail=1
+		fail=1
 		continue
 	fi
 
 	tag=$(jq -r '.tag_name' <<<"$release")
 	assets=$(jq '.assets | length' <<<"$release")
 	echo "$flavor: $tag ($assets asset(s))"
-	if (( assets < minimum )); then
+	if ((assets < minimum)); then
 		echo "FAIL $flavor: latest release has fewer than $minimum asset(s)" >&2
 		fail=1
 	fi
 done
 
-if (( fail )); then
+if ((fail)); then
 	echo "NVIDIA RELEASE ASSET AUDIT FAILED: restore downloadable assets for every NVIDIA edition" >&2
 	exit 1
 fi

--- a/scripts/bench-gdm-paint.sh
+++ b/scripts/bench-gdm-paint.sh
@@ -30,14 +30,38 @@ POLL_INTERVAL=3
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
-	--label) LABEL="$2"; shift 2 ;;
-	--machine) MACHINE="$2"; shift 2 ;;
-	--vga) VGA="$2"; shift 2 ;;
-	--cpus) CPUS="$2"; shift 2 ;;
-	--memory) MEMORY="$2"; shift 2 ;;
-	--timeout) TIMEOUT="$2"; shift 2 ;;
-	--output-dir) OUTPUT_DIR="$2"; shift 2 ;;
-	*) echo "unknown arg: $1" >&2; exit 2 ;;
+	--label)
+		LABEL="$2"
+		shift 2
+		;;
+	--machine)
+		MACHINE="$2"
+		shift 2
+		;;
+	--vga)
+		VGA="$2"
+		shift 2
+		;;
+	--cpus)
+		CPUS="$2"
+		shift 2
+		;;
+	--memory)
+		MEMORY="$2"
+		shift 2
+		;;
+	--timeout)
+		TIMEOUT="$2"
+		shift 2
+		;;
+	--output-dir)
+		OUTPUT_DIR="$2"
+		shift 2
+		;;
+	*)
+		echo "unknown arg: $1" >&2
+		exit 2
+		;;
 	esac
 done
 
@@ -53,19 +77,34 @@ rm -f "$MONITOR_SOCK" "$SERIAL_LOG" "$QEMU_PIDFILE" "$OVMF_VARS"
 
 QEMU=""
 for candidate in /usr/libexec/qemu-kvm /usr/bin/qemu-kvm /usr/bin/qemu-system-x86_64; do
-	[[ -x "$candidate" ]] && { QEMU="$candidate"; break; }
+	[[ -x "$candidate" ]] && {
+		QEMU="$candidate"
+		break
+	}
 done
-[[ -z "$QEMU" ]] && { echo "ERROR: QEMU not found" >&2; exit 77; }
+[[ -z "$QEMU" ]] && {
+	echo "ERROR: QEMU not found" >&2
+	exit 77
+}
 
 OVMF_CODE=""
 for f in /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/OVMF/OVMF_CODE.fd /usr/share/edk2/ovmf/OVMF_CODE.fd /usr/share/edk2-ovmf/x64/OVMF_CODE.fd; do
-	[[ -f "$f" ]] && { OVMF_CODE="$f"; break; }
+	[[ -f "$f" ]] && {
+		OVMF_CODE="$f"
+		break
+	}
 done
 OVMF_VARS_SRC=""
 for f in /usr/share/OVMF/OVMF_VARS_4M.fd /usr/share/OVMF/OVMF_VARS.fd /usr/share/edk2/ovmf/OVMF_VARS.fd /usr/share/edk2-ovmf/x64/OVMF_VARS.fd; do
-	[[ -f "$f" ]] && { OVMF_VARS_SRC="$f"; break; }
+	[[ -f "$f" ]] && {
+		OVMF_VARS_SRC="$f"
+		break
+	}
 done
-[[ -z "$OVMF_CODE" ]] && { echo "ERROR: OVMF not found" >&2; exit 77; }
+[[ -z "$OVMF_CODE" ]] && {
+	echo "ERROR: OVMF not found" >&2
+	exit 77
+}
 if [[ -n "$OVMF_VARS_SRC" ]]; then cp -f "$OVMF_VARS_SRC" "$OVMF_VARS"; else truncate -s 4M "$OVMF_VARS"; fi
 
 ACCEL="tcg"
@@ -77,7 +116,10 @@ case "$VGA" in
 virtio) VGA_ARGS=(-vga virtio -display none) ;;
 std) VGA_ARGS=(-vga std -display none) ;;
 cirrus) VGA_ARGS=(-vga cirrus -display none) ;;
-*) echo "unknown --vga: $VGA (want virtio|std|cirrus)" >&2; exit 2 ;;
+*)
+	echo "unknown --vga: $VGA (want virtio|std|cirrus)" >&2
+	exit 2
+	;;
 esac
 
 QEMU_PID=""

--- a/scripts/check-base-image-pins.sh
+++ b/scripts/check-base-image-pins.sh
@@ -23,13 +23,13 @@ CONFIG="${CONFIG:-$(tunaos_build_config)}"
 YQ="${YQ:-yq}"
 
 if ! command -v "$YQ" >/dev/null 2>&1; then
-  echo "::error::yq executable not found ('$YQ'); cannot parse $CONFIG" >&2
-  exit 1
+	echo "::error::yq executable not found ('$YQ'); cannot parse $CONFIG" >&2
+	exit 1
 fi
 
 if [ ! -f "$CONFIG" ]; then
-  echo "::error::config file not found ($CONFIG)" >&2
-  exit 1
+	echo "::error::config file not found ($CONFIG)" >&2
+	exit 1
 fi
 
 # Registries serve manifest lists, image indexes and plain manifests; ask for
@@ -49,24 +49,24 @@ ACCEPT='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribut
 # would otherwise turn "this registry needs no token" into a silent early
 # exit -- which is exactly the failure mode this script exists to expose.
 api_host() {
-  case "$1" in
-    docker.io) printf 'registry-1.docker.io' ;;
-    *)         printf '%s' "$1" ;;
-  esac
+	case "$1" in
+	docker.io) printf 'registry-1.docker.io' ;;
+	*) printf '%s' "$1" ;;
+	esac
 }
 
 auth_header() {
-  local registry="$1" repo="$2" url="" token=""
-  case "$registry" in
-    docker.io) url="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo}:pull" ;;
-    quay.io)   url="https://quay.io/v2/auth?service=quay.io&scope=repository:${repo}:pull" ;;
-    ghcr.io)   url="https://ghcr.io/token?scope=repository:${repo}:pull" ;;
-    *)         return 0 ;;
-  esac
-  token="$(curl -fsS --max-time 20 "$url" 2>/dev/null \
-    | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))' 2>/dev/null || true)"
-  [ -n "$token" ] && printf 'Authorization: Bearer %s' "$token"
-  return 0
+	local registry="$1" repo="$2" url="" token=""
+	case "$registry" in
+	docker.io) url="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo}:pull" ;;
+	quay.io) url="https://quay.io/v2/auth?service=quay.io&scope=repository:${repo}:pull" ;;
+	ghcr.io) url="https://ghcr.io/token?scope=repository:${repo}:pull" ;;
+	*) return 0 ;;
+	esac
+	token="$(curl -fsS --max-time 20 "$url" 2>/dev/null |
+		python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))' 2>/dev/null || true)"
+	[ -n "$token" ] && printf 'Authorization: Bearer %s' "$token"
+	return 0
 }
 
 failed=0
@@ -74,35 +74,36 @@ checked=0
 seen=0
 
 while IFS= read -r ref; do
-  [ -n "$ref" ] || continue
-  [ "$ref" = "null" ] && continue
-  seen=$((seen + 1))
-  case "$ref" in *@sha256:*) ;; *)
-    # Not digest-pinned. Not this script's problem, but say so rather than
-    # silently passing -- an unpinned base is its own kind of surprise.
-    echo "SKIP  (not digest-pinned)  ${ref}"
-    continue ;;
-  esac
+	[ -n "$ref" ] || continue
+	[ "$ref" = "null" ] && continue
+	seen=$((seen + 1))
+	case "$ref" in *@sha256:*) ;; *)
+		# Not digest-pinned. Not this script's problem, but say so rather than
+		# silently passing -- an unpinned base is its own kind of surprise.
+		echo "SKIP  (not digest-pinned)  ${ref}"
+		continue
+		;;
+	esac
 
-  digest="${ref##*@}"
-  before_at="${ref%@*}"
-  name="${before_at%%:*}"          # strip any :tag
-  registry="${name%%/*}"
-  repo="${name#*/}"
+	digest="${ref##*@}"
+	before_at="${ref%@*}"
+	name="${before_at%%:*}" # strip any :tag
+	registry="${name%%/*}"
+	repo="${name#*/}"
 
-  hdr="$(auth_header "$registry" "$repo")"
-  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
-      -H "Accept: ${ACCEPT}" ${hdr:+-H "$hdr"} \
-      "https://$(api_host "$registry")/v2/${repo}/manifests/${digest}" || echo 000)"
+	hdr="$(auth_header "$registry" "$repo")"
+	code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
+		-H "Accept: ${ACCEPT}" ${hdr:+-H "$hdr"} \
+		"https://$(api_host "$registry")/v2/${repo}/manifests/${digest}" || echo 000)"
 
-  checked=$((checked + 1))
-  if [ "$code" = "200" ]; then
-    echo "ok    ${code}  ${ref}"
-  else
-    echo "FAIL  ${code}  ${ref}"
-    echo "::error::base image pin no longer resolves (HTTP ${code}): ${ref}"
-    failed=$((failed + 1))
-  fi
+	checked=$((checked + 1))
+	if [ "$code" = "200" ]; then
+		echo "ok    ${code}  ${ref}"
+	else
+		echo "FAIL  ${code}  ${ref}"
+		echo "::error::base image pin no longer resolves (HTTP ${code}): ${ref}"
+		failed=$((failed + 1))
+	fi
 done < <("$YQ" -r '.variants[] | .base_image // ""' "$CONFIG" | sort -u)
 
 echo
@@ -119,8 +120,8 @@ echo "checked ${checked} digest-pinned base image(s); ${failed} unresolvable"
 # `manifest unknown` (run 33687500544, 2026-09-02). The absence-of-evidence
 # rule (#1730) applies to the checker itself.
 if [ "$seen" -eq 0 ]; then
-  echo "::error::base image pin check read ZERO base images from ${CONFIG} -- the extraction is broken, not the pins clean"
-  exit 1
+	echo "::error::base image pin check read ZERO base images from ${CONFIG} -- the extraction is broken, not the pins clean"
+	exit 1
 fi
 
 # ── Architecture honesty (green criterion 10, GREEN-MASTER-PLAN W8) ─────────
@@ -138,21 +139,21 @@ arch_failed=0
 arch_checked=0
 echo
 while IFS=$'\t' read -r variant ref platforms; do
-  [ -n "$ref" ] && [ "$ref" != "null" ] || continue
-  case "$ref" in *@sha256:*) ;; *) continue ;; esac
+	[ -n "$ref" ] && [ "$ref" != "null" ] || continue
+	case "$ref" in *@sha256:*) ;; *) continue ;; esac
 
-  digest="${ref##*@}"
-  before_at="${ref%@*}"
-  name="${before_at%%:*}"
-  registry="${name%%/*}"
-  repo="${name#*/}"
+	digest="${ref##*@}"
+	before_at="${ref%@*}"
+	name="${before_at%%:*}"
+	registry="${name%%/*}"
+	repo="${name#*/}"
 
-  hdr="$(auth_header "$registry" "$repo")"
-  body="$(curl -fsS --max-time 30 -H "Accept: ${ACCEPT}" ${hdr:+-H "$hdr"} \
-      "https://$(api_host "$registry")/v2/${repo}/manifests/${digest}" 2>/dev/null || true)"
-  [ -n "$body" ] || continue  # resolution failures already reported above
+	hdr="$(auth_header "$registry" "$repo")"
+	body="$(curl -fsS --max-time 30 -H "Accept: ${ACCEPT}" ${hdr:+-H "$hdr"} \
+		"https://$(api_host "$registry")/v2/${repo}/manifests/${digest}" 2>/dev/null || true)"
+	[ -n "$body" ] || continue # resolution failures already reported above
 
-  archs="$(printf '%s' "$body" | python3 -c '
+	archs="$(printf '%s' "$body" | python3 -c '
 import json, sys
 doc = json.load(sys.stdin)
 entries = doc.get("manifests")
@@ -167,38 +168,38 @@ else:
     print(" ".join(seen))
 ' 2>/dev/null || echo '?')"
 
-  for platform in ${platforms//,/ }; do
-    arch="${platform#linux/}"
-    arch="${arch%%/*}"
-    arch_checked=$((arch_checked + 1))
-    if [ "$archs" = "SINGLE" ]; then
-      # Cannot verify cheaply; only complain when the variant claims more
-      # than the one architecture a single manifest can possibly hold.
-      distinct="$(printf '%s\n' ${platforms//,/ } | sed 's|linux/||; s|/.*||' | sort -u | wc -l)"
-      if [ "$distinct" -gt 1 ]; then
-        echo "ARCH?  ${variant}: ${platform} declared but ${name} pins a single-arch manifest"
-        echo "::warning::${variant} declares ${platform} but its base image pin is a single-architecture manifest — at most one declared architecture can be real"
-      fi
-      continue
-    fi
-    case " $archs " in
-      *" $arch "*) echo "arch   ok  ${variant}: ${platform} (base has: ${archs})" ;;
-      *)
-        echo "ARCH  FAIL ${variant}: ${platform} — base ${name} provides only [${archs}]"
-        echo "::error::${variant} declares ${platform} but its base image provides only [${archs}] — a guaranteed-red cell nightly. Drop the platform or fix the base pin (criterion arch_honesty, W8)."
-        arch_failed=$((arch_failed + 1))
-        ;;
-    esac
-  done
+	for platform in ${platforms//,/ }; do
+		arch="${platform#linux/}"
+		arch="${arch%%/*}"
+		arch_checked=$((arch_checked + 1))
+		if [ "$archs" = "SINGLE" ]; then
+			# Cannot verify cheaply; only complain when the variant claims more
+			# than the one architecture a single manifest can possibly hold.
+			distinct="$(printf '%s\n' ${platforms//,/ } | sed 's|linux/||; s|/.*||' | sort -u | wc -l)"
+			if [ "$distinct" -gt 1 ]; then
+				echo "ARCH?  ${variant}: ${platform} declared but ${name} pins a single-arch manifest"
+				echo "::warning::${variant} declares ${platform} but its base image pin is a single-architecture manifest — at most one declared architecture can be real"
+			fi
+			continue
+		fi
+		case " $archs " in
+		*" $arch "*) echo "arch   ok  ${variant}: ${platform} (base has: ${archs})" ;;
+		*)
+			echo "ARCH  FAIL ${variant}: ${platform} — base ${name} provides only [${archs}]"
+			echo "::error::${variant} declares ${platform} but its base image provides only [${archs}] — a guaranteed-red cell nightly. Drop the platform or fix the base pin (criterion arch_honesty, W8)."
+			arch_failed=$((arch_failed + 1))
+			;;
+		esac
+	done
 done < <("$YQ" -r '.variants[] | [.id, (.base_image // ""), ((.platforms // []) | join(","))] | @tsv' "$CONFIG")
 
 echo
 echo "checked ${arch_checked} declared platform(s); ${arch_failed} unsatisfiable"
 
 if [ "$failed" -gt 0 ]; then
-  echo "::error::${failed} base image pin(s) have been garbage-collected upstream. Re-pin them to the tag's current digest before the next nightly (see #1788)."
-  exit 1
+	echo "::error::${failed} base image pin(s) have been garbage-collected upstream. Re-pin them to the tag's current digest before the next nightly (see #1788)."
+	exit 1
 fi
 if [ "$arch_failed" -gt 0 ]; then
-  exit 1
+	exit 1
 fi

--- a/scripts/check-upstream-snapshot-size.sh
+++ b/scripts/check-upstream-snapshot-size.sh
@@ -29,8 +29,8 @@ changed=$(git status --short --untracked-files=all -- "_upstream-snapshots/" | w
 
 echo "Snapshot budget: files=${files}/${MAX_FILES}, bytes=${bytes}/${MAX_BYTES}, changed_paths=${changed}/${MAX_CHANGED_FILES}"
 
-(( files <= MAX_FILES )) || die "${files} files exceeds the ${MAX_FILES}-file limit"
-(( bytes <= MAX_BYTES )) || die "${bytes} bytes exceeds the ${MAX_BYTES}-byte limit"
-(( changed <= MAX_CHANGED_FILES )) || die "${changed} changed paths exceeds the ${MAX_CHANGED_FILES}-path refresh limit"
+((files <= MAX_FILES)) || die "${files} files exceeds the ${MAX_FILES}-file limit"
+((bytes <= MAX_BYTES)) || die "${bytes} bytes exceeds the ${MAX_BYTES}-byte limit"
+((changed <= MAX_CHANGED_FILES)) || die "${changed} changed paths exceeds the ${MAX_CHANGED_FILES}-path refresh limit"
 
 echo "Upstream snapshot budget: OK"

--- a/scripts/e2e-installer-gui-checks.sh
+++ b/scripts/e2e-installer-gui-checks.sh
@@ -61,15 +61,16 @@ echo "# Installer GUI checks — flavor=${FLAVOR}"
 # A generic check accepts any compositor, so a stale Wayland socket or a
 # cosmic-greeter's cosmic-comp can masquerade as a real desktop.
 case "${FLAVOR}" in
-	kde)    COMPS="kwin_wayland" ;;
-	cosmic) COMPS="cosmic-comp" ;;
-	niri)   COMPS="niri" ;;
-	xfce)   COMPS="xfwl4 labwc wayfire xfwm4" ;;
-	gnome)  COMPS="gnome-shell" ;;
-	*)      echo "not ok - unsupported installer flavor: ${FLAVOR}"
-	        FAIL=$((FAIL + 1))
-	        print_summary
-	        ;;
+kde) COMPS="kwin_wayland" ;;
+cosmic) COMPS="cosmic-comp" ;;
+niri) COMPS="niri" ;;
+xfce) COMPS="xfwl4 labwc wayfire xfwm4" ;;
+gnome) COMPS="gnome-shell" ;;
+*)
+	echo "not ok - unsupported installer flavor: ${FLAVOR}"
+	FAIL=$((FAIL + 1))
+	print_summary
+	;;
 esac
 
 compositor_found=""
@@ -98,11 +99,11 @@ fi
 # fallback — it can self-match its own command line and cannot distinguish
 # the four frontends from each other.
 case "${FLAVOR}" in
-	kde)    APP=org.tunaos.InstallerKde ;;
-	cosmic) APP=org.tunaos.InstallerCosmic ;;
-	niri)   APP=org.tunaos.InstallerNiri ;;
-	xfce)   APP=org.tunaos.InstallerXfce ;;
-	*)      APP=org.bootcinstaller.Installer ;;
+kde) APP=org.tunaos.InstallerKde ;;
+cosmic) APP=org.tunaos.InstallerCosmic ;;
+niri) APP=org.tunaos.InstallerNiri ;;
+xfce) APP=org.tunaos.InstallerXfce ;;
+*) APP=org.bootcinstaller.Installer ;;
 esac
 
 installer_running=""
@@ -174,18 +175,18 @@ if [[ -n "$STAMP" ]]; then
 	# ── 5. The signal is one we understand ─────────────────────────────────
 	STAMP_SIGNAL=$(echo "$STAMP" | sed -n 's/^signal=//p' | head -1)
 	case "${STAMP_SIGNAL}" in
-		frame-swapped|gtk-map)
-			echo "#   signal: ${STAMP_SIGNAL} — window confirmed on screen"
-			;;
-		first-frame)
-			echo "#   signal: ${STAMP_SIGNAL} — app producing frames"
-			echo "#   (libcosmic's strongest claim; does not prove a surface was presented)"
-			;;
-		*)
-			echo "not ok - unrecognised readiness signal '${STAMP_SIGNAL:-<none>}'"
-			echo "#   add it or fix the frontend"
-			FAIL=$((FAIL + 1))
-			;;
+	frame-swapped | gtk-map)
+		echo "#   signal: ${STAMP_SIGNAL} — window confirmed on screen"
+		;;
+	first-frame)
+		echo "#   signal: ${STAMP_SIGNAL} — app producing frames"
+		echo "#   (libcosmic's strongest claim; does not prove a surface was presented)"
+		;;
+	*)
+		echo "not ok - unrecognised readiness signal '${STAMP_SIGNAL:-<none>}'"
+		echo "#   add it or fix the frontend"
+		FAIL=$((FAIL + 1))
+		;;
 	esac
 else
 	echo "#   runtime dirs for debugging:"
@@ -197,16 +198,16 @@ fi
 # it claims. A missing flatpak is a build failure, not a GUI failure, and
 # catching it here distinguishes "image is broken" from "GUI didn't start".
 case "${FLAVOR}" in
-	kde)    check "installer flatpak is installed (${APP})" \
-		flatpak list --app --columns=application 2>/dev/null | grep -qFx "${APP}" ;;
-	cosmic) check "installer flatpak is installed (${APP})" \
-		flatpak list --app --columns=application 2>/dev/null | grep -qFx "${APP}" ;;
-	niri)   check "installer flatpak is installed (${APP})" \
-		flatpak list --app --columns=application 2>/dev/null | grep -qFx "${APP}" ;;
-	xfce)   check "installer flatpak is installed (${APP})" \
-		flatpak list --app --columns=application 2>/dev/null | grep -qFx "${APP}" ;;
-	*)      check "installer flatpak is installed (${APP})" \
-		flatpak list --app --columns=application 2>/dev/null | grep -qFx "${APP}" ;;
+kde) check "installer flatpak is installed (${APP})" \
+	flatpak list --app --columns=application 2>/dev/null | grep -qFx "${APP}" ;;
+cosmic) check "installer flatpak is installed (${APP})" \
+	flatpak list --app --columns=application 2>/dev/null | grep -qFx "${APP}" ;;
+niri) check "installer flatpak is installed (${APP})" \
+	flatpak list --app --columns=application 2>/dev/null | grep -qFx "${APP}" ;;
+xfce) check "installer flatpak is installed (${APP})" \
+	flatpak list --app --columns=application 2>/dev/null | grep -qFx "${APP}" ;;
+*) check "installer flatpak is installed (${APP})" \
+	flatpak list --app --columns=application 2>/dev/null | grep -qFx "${APP}" ;;
 esac
 
 print_summary

--- a/scripts/evidence-bundle.sh
+++ b/scripts/evidence-bundle.sh
@@ -4,43 +4,43 @@
 set -euo pipefail
 
 if [[ $# -ne 3 ]]; then
-  echo "usage: $0 <variant:flavor> <criterion[,criterion...]> <run-dir>" >&2
-  exit 2
+	echo "usage: $0 <variant:flavor> <criterion[,criterion...]> <run-dir>" >&2
+	exit 2
 fi
 
 cell=$1
 criteria=$2
 run_dir=$3
 if [[ ! "$cell" =~ ^[a-z0-9-]+:[a-z0-9-]+$ ]]; then
-  echo "invalid cell '$cell' (expected variant:flavor)" >&2
-  exit 2
+	echo "invalid cell '$cell' (expected variant:flavor)" >&2
+	exit 2
 fi
 if [[ ! "$criteria" =~ ^[a-z0-9_-]+(,[a-z0-9_-]+)*$ ]]; then
-  echo "invalid criterion list '$criteria'" >&2
-  exit 2
+	echo "invalid criterion list '$criteria'" >&2
+	exit 2
 fi
 if [[ ! -d "$run_dir" ]]; then
-  echo "run directory does not exist: $run_dir" >&2
-  exit 2
+	echo "run directory does not exist: $run_dir" >&2
+	exit 2
 fi
 command -v jq >/dev/null || {
-  echo "jq is required" >&2
-  exit 2
+	echo "jq is required" >&2
+	exit 2
 }
 
 variant=${cell%%:*}
 flavor=${cell#*:}
 arch=${EVIDENCE_ARCH:-}
 if [[ -z "$arch" ]]; then
-  case "$(uname -m)" in
-  x86_64) arch=amd64 ;;
-  aarch64 | arm64) arch=arm64 ;;
-  *) arch=$(uname -m) ;;
-  esac
+	case "$(uname -m)" in
+	x86_64) arch=amd64 ;;
+	aarch64 | arm64) arch=arm64 ;;
+	*) arch=$(uname -m) ;;
+	esac
 fi
 if [[ ! "$arch" =~ ^[a-zA-Z0-9_.-]+$ ]]; then
-  echo "invalid evidence architecture '$arch'" >&2
-  exit 2
+	echo "invalid evidence architecture '$arch'" >&2
+	exit 2
 fi
 
 root=${EVIDENCE_ROOT:-evidence}
@@ -49,31 +49,31 @@ mkdir -p "$out"
 
 status=${EVIDENCE_STATUS:-unknown}
 if [[ -f "$run_dir/result.json" ]]; then
-  status=$(jq -r '.status // "unknown"' "$run_dir/result.json")
+	status=$(jq -r '.status // "unknown"' "$run_dir/result.json")
 fi
 
 jq -n \
-  --arg cell "$cell" --arg variant "$variant" --arg flavor "$flavor" \
-  --arg arch "$arch" --arg criteria "$criteria" --arg status "$status" \
-  --arg run_id "${GITHUB_RUN_ID:-}" --arg run_attempt "${GITHUB_RUN_ATTEMPT:-}" \
-  --arg repository "${GITHUB_REPOSITORY:-}" --arg sha "${GITHUB_SHA:-}" \
-  --arg timestamp "$(date -u +%FT%TZ)" \
-  '{schema_version:1, cell:$cell, variant:$variant, flavor:$flavor,
+	--arg cell "$cell" --arg variant "$variant" --arg flavor "$flavor" \
+	--arg arch "$arch" --arg criteria "$criteria" --arg status "$status" \
+	--arg run_id "${GITHUB_RUN_ID:-}" --arg run_attempt "${GITHUB_RUN_ATTEMPT:-}" \
+	--arg repository "${GITHUB_REPOSITORY:-}" --arg sha "${GITHUB_SHA:-}" \
+	--arg timestamp "$(date -u +%FT%TZ)" \
+	'{schema_version:1, cell:$cell, variant:$variant, flavor:$flavor,
 	  architecture:$arch, criteria:($criteria|split(",")), status:$status,
 	  run:{id:$run_id, attempt:$run_attempt, repository:$repository},
 	  git_sha:$sha, timestamp:$timestamp}' >"$out/metadata.json"
 
 copy_if_present() {
-  local source=$1 destination=$2
-  if [[ -f "$run_dir/$source" ]]; then
-    cp "$run_dir/$source" "$out/$destination"
-  fi
+	local source=$1 destination=$2
+	if [[ -f "$run_dir/$source" ]]; then
+		cp "$run_dir/$source" "$out/$destination"
+	fi
 }
 
 # Preserve common machine-readable inputs under their schema names.
 for file in image.json packages.txt omissions.json desktop-contract.json \
-  lifecycle.json sbom.spdx.json provenance.json signature.json; do
-  copy_if_present "$file" "$file"
+	lifecycle.json sbom.spdx.json provenance.json signature.json; do
+	copy_if_present "$file" "$file"
 done
 
 # Normalize the ad-hoc names emitted by the existing boot/install gates.
@@ -83,20 +83,20 @@ copy_if_present luks-evidence.log installer.log
 copy_if_present result.json result.json
 
 if [[ -f "$run_dir/result.json" ]]; then
-  jq '{cell,variant,desktop,status,reason,exit}' "$run_dir/result.json" \
-    >"$out/desktop-contract.json"
-  jq '{cell,status:.omissions_status,reason:.omissions_reason}' \
-    "$run_dir/result.json" >"$out/omissions.json"
+	jq '{cell,variant,desktop,status,reason,exit}' "$run_dir/result.json" \
+		>"$out/desktop-contract.json"
+	jq '{cell,status:.omissions_status,reason:.omissions_reason}' \
+		"$run_dir/result.json" >"$out/omissions.json"
 fi
 if [[ "$criteria" == *install* ]]; then
-  jq -n --arg status "$status" \
-    --arg log "$([[ -f "$out/installer.log" ]] && echo installer.log || true)" \
-    '{status:$status, installer_log:$log}' >"$out/install-result.json"
+	jq -n --arg status "$status" \
+		--arg log "$([[ -f "$out/installer.log" ]] && echo installer.log || true)" \
+		'{status:$status, installer_log:$log}' >"$out/install-result.json"
 fi
 
 # Screenshots and other diagnostic logs retain their names; consumers can use
 # metadata.json to identify the cell without encoding identity into filenames.
 find "$run_dir" -maxdepth 1 -type f \( -name '*.png' -o -name '*.webm' \) \
-  -exec cp -t "$out" {} + 2>/dev/null || true
+	-exec cp -t "$out" {} + 2>/dev/null || true
 
 printf '%s\n' "$out"

--- a/scripts/generate-sbom.sh
+++ b/scripts/generate-sbom.sh
@@ -47,8 +47,8 @@ OUT="sbom-${IMAGE_NAME}-${DEFAULT_TAG}-${SAFE_PLATFORM}.spdx.json"
 # a real exit code, with logs, while the agent is still healthy.
 # The wall-clock bound stays for the orthogonal case of a scan that
 # is slow rather than hungry.
-syft_cmd=( timeout --kill-after=30s 18m
-           "$SYFT_CMD" "$IMAGE" --scope squashed -o spdx-json="$OUT" )
+syft_cmd=(timeout --kill-after=30s 18m
+	"$SYFT_CMD" "$IMAGE" --scope squashed -o spdx-json="$OUT")
 
 # Size the cap off the box we actually landed on, and say so, so a
 # future exit 137 can be read against a real number instead of an
@@ -56,24 +56,24 @@ syft_cmd=( timeout --kill-after=30s 18m
 # is not what ubuntu-latest ships now, and the arm64 leg is a
 # different image again).
 mem_total_mib="$(free -m | awk '/^Mem:/ {print $2}')"
-cap_mib=$(( mem_total_mib - SYFT_MEMORY_RESERVE_MIB ))
+cap_mib=$((mem_total_mib - SYFT_MEMORY_RESERVE_MIB))
 if [ "$cap_mib" -lt "$SYFT_MEMORY_FLOOR_MIB" ]; then
-  cap_mib="$SYFT_MEMORY_FLOOR_MIB"
+	cap_mib="$SYFT_MEMORY_FLOOR_MIB"
 fi
 echo "runner memory (MiB): total=${mem_total_mib} available=$(free -m | awk '/^Mem:/ {print $7}')"
 echo "syft cgroup cap (MiB): ${cap_mib} (reserving ${SYFT_MEMORY_RESERVE_MIB} for the agent)"
 
 if command -v systemd-run >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-  sudo systemd-run --scope --quiet \
-    --uid="$(id -u)" --gid="$(id -g)" \
-    -p MemoryMax="${cap_mib}M" -p MemorySwapMax=0 \
-    -- "${syft_cmd[@]}"
+	sudo systemd-run --scope --quiet \
+		--uid="$(id -u)" --gid="$(id -g)" \
+		-p MemoryMax="${cap_mib}M" -p MemorySwapMax=0 \
+		-- "${syft_cmd[@]}"
 else
-  # Never silently drop the guard: without it a hungry scan can
-  # still take the agent, which is the failure this step exists to
-  # stop being invisible.
-  echo "::warning::systemd-run unavailable; syft is time-bounded but NOT memory-bounded"
-  "${syft_cmd[@]}"
+	# Never silently drop the guard: without it a hungry scan can
+	# still take the agent, which is the failure this step exists to
+	# stop being invisible.
+	echo "::warning::systemd-run unavailable; syft is time-bounded but NOT memory-bounded"
+	"${syft_cmd[@]}"
 fi
 
 jq -e '

--- a/scripts/gfi-pool-report.sh
+++ b/scripts/gfi-pool-report.sh
@@ -30,8 +30,14 @@ THRESHOLD="${1:-8}"
 ORG="tuna-os"
 LABEL="good first issue"
 
-[[ "$THRESHOLD" =~ ^[0-9]+$ ]] || { echo "ERROR: threshold must be a number" >&2; exit 2; }
-command -v gh >/dev/null 2>&1 || { echo "ERROR: gh not found" >&2; exit 2; }
+[[ "$THRESHOLD" =~ ^[0-9]+$ ]] || {
+	echo "ERROR: threshold must be a number" >&2
+	exit 2
+}
+command -v gh >/dev/null 2>&1 || {
+	echo "ERROR: gh not found" >&2
+	exit 2
+}
 
 # archived:false is the whole point — see the header.
 query="is:issue is:open org:${ORG} label:\"${LABEL}\" archived:false"

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -408,18 +408,18 @@ HOST_ARCH="$(uname -m)"
 QEMU="${QEMU:-}"
 QEMU_MACHINE=""
 case "$HOST_ARCH" in
-	aarch64 | arm64)
-		QEMU_MACHINE="virt"
-		QEMU_CANDIDATES=(/usr/bin/qemu-system-aarch64 /usr/local/bin/qemu-system-aarch64)
-		;;
-	x86_64 | amd64)
-		QEMU_MACHINE="pc"
-		QEMU_CANDIDATES=(/usr/libexec/qemu-kvm /usr/bin/qemu-kvm /usr/bin/qemu-system-x86_64 /home/linuxbrew/.linuxbrew/bin/qemu-system-x86_64)
-		;;
-	*)
-		echo "ERROR: unsupported host architecture: $HOST_ARCH" >&2
-		exit 77
-		;;
+aarch64 | arm64)
+	QEMU_MACHINE="virt"
+	QEMU_CANDIDATES=(/usr/bin/qemu-system-aarch64 /usr/local/bin/qemu-system-aarch64)
+	;;
+x86_64 | amd64)
+	QEMU_MACHINE="pc"
+	QEMU_CANDIDATES=(/usr/libexec/qemu-kvm /usr/bin/qemu-kvm /usr/bin/qemu-system-x86_64 /home/linuxbrew/.linuxbrew/bin/qemu-system-x86_64)
+	;;
+*)
+	echo "ERROR: unsupported host architecture: $HOST_ARCH" >&2
+	exit 77
+	;;
 esac
 if [[ -z "${QEMU:-}" ]]; then
 	for candidate in "${QEMU_CANDIDATES[@]}"; do

--- a/scripts/lib/tacklebox.sh
+++ b/scripts/lib/tacklebox.sh
@@ -82,10 +82,10 @@ tunaos_run_tacklebox() {
 			"$tacklebox_image")
 	fi
 
-	local -a build_cmd=("${tb[@]}" build "$(realpath "$recipe_file")" \
-		--iso "$(realpath "$iso_out")" \
-		--output-base "$(realpath "$out_dir")" \
-		--yes)
+	local -a build_cmd=("${tb[@]}" build "$(realpath "$recipe_file")"
+	--iso "$(realpath "$iso_out")"
+	--output-base "$(realpath "$out_dir")"
+	--yes)
 
 	echo "==> Running tacklebox with a ${timeout_seconds}s deadline" >&2
 	if timeout --foreground --kill-after=120 "$timeout_seconds" "${build_cmd[@]}"; then

--- a/scripts/verify-manifest-packages.sh
+++ b/scripts/verify-manifest-packages.sh
@@ -35,9 +35,18 @@ MANIFEST="${1:?usage: verify-manifest-packages.sh <manifest.yaml> [series] [arch
 SERIES="${2:-noble}"
 ARCH="${3:-amd64}"
 
-[[ -r "$MANIFEST" ]] || { echo "ERROR: cannot read ${MANIFEST}" >&2; exit 2; }
-command -v curl >/dev/null 2>&1 || { echo "ERROR: curl not found" >&2; exit 2; }
-command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 not found" >&2; exit 2; }
+[[ -r "$MANIFEST" ]] || {
+	echo "ERROR: cannot read ${MANIFEST}" >&2
+	exit 2
+}
+command -v curl >/dev/null 2>&1 || {
+	echo "ERROR: curl not found" >&2
+	exit 2
+}
+command -v python3 >/dev/null 2>&1 || {
+	echo "ERROR: python3 not found" >&2
+	exit 2
+}
 
 DAS="https://api.launchpad.net/1.0/ubuntu/${SERIES}/${ARCH}"
 
@@ -48,7 +57,10 @@ mapfile -t PKGS < <(
 	     f && /^    - /{n=$2; sub(/#.*/,"",n); gsub(/[ \t]/,"",n); if (n != "") print n}
 	     f && /^[a-z_]+:$/{exit}' "$MANIFEST"
 )
-[[ "${#PKGS[@]}" -gt 0 ]] || { echo "ERROR: no apt packages parsed from ${MANIFEST}" >&2; exit 2; }
+[[ "${#PKGS[@]}" -gt 0 ]] || {
+	echo "ERROR: no apt packages parsed from ${MANIFEST}" >&2
+	exit 2
+}
 
 # The PPA it declares, as a Launchpad archive URL. Absent is fine — then every
 # name must come from the primary archive.
@@ -80,12 +92,20 @@ for p in "${PKGS[@]}"; do
 	src=""
 	if [[ -n "$PPA_URL" ]]; then
 		n="$(published_in "$PPA_URL" "$p")"
-		[[ "$n" == "ERR" ]] && { errored=$((errored + 1)); echo "  ?? ${p} (PPA query failed)" >&2; continue; }
+		[[ "$n" == "ERR" ]] && {
+			errored=$((errored + 1))
+			echo "  ?? ${p} (PPA query failed)" >&2
+			continue
+		}
 		[[ "$n" -gt 0 ]] && src="ppa"
 	fi
 	if [[ -z "$src" ]]; then
 		n="$(published_in "https://api.launchpad.net/1.0/ubuntu/+archive/primary" "$p")"
-		[[ "$n" == "ERR" ]] && { errored=$((errored + 1)); echo "  ?? ${p} (archive query failed)" >&2; continue; }
+		[[ "$n" == "ERR" ]] && {
+			errored=$((errored + 1))
+			echo "  ?? ${p} (archive query failed)" >&2
+			continue
+		}
 		[[ "$n" -gt 0 ]] && src="archive"
 	fi
 	if [[ -n "$src" ]]; then

--- a/system_files/usr/local/bin/redfin-image-factory-build.sh
+++ b/system_files/usr/local/bin/redfin-image-factory-build.sh
@@ -24,12 +24,12 @@ REPO="${TUNAOS_REPO:-/etc/bootc-image-factory/tunaos}"
 FLAVORS="${REDFIN_FLAVORS:-gnome kde}"
 
 if [[ ! -d "${REPO}" ]]; then
-    echo "redfin-image-factory: repo missing at ${REPO} — clone tunaos/tunaos there first" >&2
-    exit 1
+	echo "redfin-image-factory: repo missing at ${REPO} — clone tunaos/tunaos there first" >&2
+	exit 1
 fi
 if ! command -v just >/dev/null 2>&1; then
-    echo "redfin-image-factory: 'just' not found (dnf install just)" >&2
-    exit 1
+	echo "redfin-image-factory: 'just' not found (dnf install just)" >&2
+	exit 1
 fi
 
 echo "==> redfin image factory: rebuilding [${FLAVORS}] from ${REPO}"
@@ -37,8 +37,8 @@ cd "${REPO}"
 git pull --ff-only || true
 
 for flavor in ${FLAVORS}; do
-    echo "==> just build redfin ${flavor}"
-    just build redfin "${flavor}"
+	echo "==> just build redfin ${flavor}"
+	just build redfin "${flavor}"
 done
 
 # Switch to the first flavor's fresh build, then update + prune. The remaining

--- a/tests/regressions/test_issue_2326_disk_gate_collects_the_failed_systemd_journal.py
+++ b/tests/regressions/test_issue_2326_disk_gate_collects_the_failed_systemd_journal.py
@@ -27,7 +27,14 @@ def test_disk_qemu_attaches_the_prepared_vsock_credentials():
 
 
 def test_missing_contract_collects_diagnostics_before_evidence_capture():
-    disk_mode = SCRIPT.split("case \"$MODE\" in", 1)[1].split("\nready)", 1)[0]
+    # Slice the DISPATCH arm, not "everything after the first case header".
+    # iso-e2e.sh contains three `case "$MODE" in` statements; splitting on the
+    # first one grabbed a region starting ~1600 lines above the dispatch, so
+    # the .index() calls below matched helper definitions instead of the arm
+    # and the test failed whenever anything shifted around them. Anchor on the
+    # `disk)` arm of the last one, which is what this test is about.
+    dispatch = SCRIPT.rsplit('case "$MODE" in', 1)[1]
+    disk_mode = dispatch.split("\ndisk)", 1)[1].split("\n\t;;", 1)[0]
     collect = disk_mode.index("collect_disk_boot_diagnostics")
     paint = disk_mode.index('wait_for_paint "10-ready"')
     assert collect < paint

--- a/tests/test_a_waived_desktop_contract_does_not_report_pass.py
+++ b/tests/test_a_waived_desktop_contract_does_not_report_pass.py
@@ -25,6 +25,7 @@ code that had already seen the failures.
 
 import subprocess
 import textwrap
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -91,8 +92,18 @@ def test_a_waived_contract_emits_a_greppable_marker(tmp_path):
 def test_every_hummingbird_exemption_counts_what_it_waives():
     """An exemption that doesn't count is invisible again."""
     src = CHECK.read_text()
-    exemptions = src.count('IS_HUMMINGBIRD:-false}" == "true" ]]; then')
-    counted = src.count('== "true" ]]; then waive; return 0; fi')
+    # Count STRUCTURALLY, not by matching one layout. This used to count the
+    # single-line form `... ]]; then waive; return 0; fi`, which meant a
+    # formatter expanding those one-liners into ordinary if-blocks dropped the
+    # count to 0 and failed a test whose subject had not changed at all.
+    # (shfmt does exactly that; see the .editorconfig fix in this PR.)
+    exemption_re = re.compile(
+        r'IS_HUMMINGBIRD:-false\}" == "true" \]\]; then(.*?)\n\s*fi\b',
+        re.S,
+    )
+    blocks = exemption_re.findall(src)
+    exemptions = len(blocks)
+    counted = sum(1 for b in blocks if "waive" in b)
     assert exemptions > 0, "the exemption shape changed; this test is stale"
     assert counted == exemptions, (
         f"{exemptions} require_* exemptions but only {counted} call waive() — "

--- a/tests/test_shell_formatting_contract.py
+++ b/tests/test_shell_formatting_contract.py
@@ -42,8 +42,18 @@ def test_editorconfig_matches_the_code_it_formats() -> None:
 
 
 def test_fix_does_not_reformat_vendored_upstream_code() -> None:
-    """_upstream-snapshots is kept to match upstream byte for byte."""
-    assert "_upstream-snapshots" in _recipe("fix")
+    """_upstream-snapshots is kept to match upstream byte for byte.
+
+    Both loops need the exclusion, not just the shell one. The `.just` loop
+    had none, so the automation bot reformatted a vendored
+    zirconium/...67-gamerslop.just and opened a PR for it on every run --
+    #2421, #2422 and #2423 were three identical rewrites of that same file,
+    regenerated as fast as they were rejected.
+    """
+    fix = _recipe("fix")
+    for loop in ('-iname "*.sh"', '-name "*.just"'):
+        line = next(l for l in fix.splitlines() if loop in l)
+        assert "_upstream-snapshots" in line, f"vendored tree not excluded from {loop}"
 
 
 def test_check_verifies_shell_formatting() -> None:

--- a/tests/test_shell_formatting_contract.py
+++ b/tests/test_shell_formatting_contract.py
@@ -1,0 +1,71 @@
+"""`just fix` must be a no-op on a clean tree, and `just check` must enforce it.
+
+Three separate faults made `just fix` rewrite 145 files and 12,277 lines on a
+clean checkout of main, while AGENTS.md makes `just fix && just check`
+mandatory before every commit:
+
+1. `.editorconfig` declared `indent_style = space` / `indent_size = 2` for
+   shell, while 100% of the shell code is written with tabs (15 of 15
+   build_scripts/*.sh) -- and shfmt reads `.editorconfig`.
+2. `just fix` ran shfmt over `_upstream-snapshots/`, vendored upstream code
+   whose whole value is being byte-identical to what upstream ships.
+3. `just check` never ran shfmt at all, so nothing ever noticed 1 or 2.
+
+These tests pin the shape of the fix, not the formatting itself -- the
+formatting is enforced by `just check`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EDITORCONFIG = ROOT / ".editorconfig"
+UTILITIES = ROOT / "just" / "utilities.just"
+
+
+def _recipe(name: str) -> str:
+    text = UTILITIES.read_text()
+    body = text[text.index(f"\n{name}:"):]
+    nxt = re.search(r"\n[a-z][a-z0-9-]*:", body[1:])
+    return body[: nxt.start() + 1] if nxt else body
+
+
+def test_editorconfig_matches_the_code_it_formats() -> None:
+    """Tabs, because that is what every shell file in the repo uses."""
+    text = EDITORCONFIG.read_text()
+    block = text[text.index("[*.{sh,bash}]"):]
+    block = block[: block.index("\n[", 1)] if "\n[" in block[1:] else block
+    assert "indent_style = tab" in block
+    assert "indent_style = space" not in block
+
+
+def test_fix_does_not_reformat_vendored_upstream_code() -> None:
+    """_upstream-snapshots is kept to match upstream byte for byte."""
+    assert "_upstream-snapshots" in _recipe("fix")
+
+
+def test_check_verifies_shell_formatting() -> None:
+    """A formatter you do not verify is a formatter that drifts."""
+    assert "shfmt" in _recipe("check")
+
+
+def test_the_formatting_gate_can_actually_fail() -> None:
+    """`find -exec shfmt --diff {} \;` returns 0 even when shfmt exits 1.
+
+    find does not propagate the child's status, so the obvious spelling of
+    this check is a gate that can never fail — the same dead-gate shape
+    AGENTS.md warns about. Measured: shfmt --diff on a badly formatted file
+    exits 1; the identical command under `find -exec` exits 0. The check must
+    therefore test shfmt's OUTPUT (`shfmt -l`), not an exit status.
+    """
+    check = _recipe("check")
+    assert "shfmt -l" in check
+    # Check the CODE, not the prose: the recipe's comment deliberately spells
+    # out the broken form so the next reader does not reintroduce it, and a
+    # test that forbids naming the trap forbids documenting it.
+    code = "\n".join(
+        line for line in check.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert not re.search(r"-exec\s+shfmt\s+--diff", code)


### PR DESCRIPTION
## The problem

AGENTS.md makes `just fix && just check` **mandatory before every commit**. On a clean checkout of `origin/main`, `just fix` changed **145 files and 12,277 lines**.

So every contributor either committed an unrelated 12k-line diff, or learned to skip the mandatory step.

## Three independent faults

Each measured in a throwaway worktree off `origin/main`.

**1. `.editorconfig` contradicted the entire codebase.** It declared `indent_style = space` / `indent_size = 2` for `[*.{sh,bash}]`, while **100% of the shell code uses tabs** — 15 of 15 `build_scripts/*.sh`, which is also shfmt's own default. shfmt v3 reads `.editorconfig`, so `just fix` rewrote every shell file tabs→spaces. **110 of the 145 files.** The config and the code disagreed and nothing ever compared them.

**2. `just fix` reformatted vendored upstream code.** It ran shfmt over `_upstream-snapshots/`, whose entire value is matching what upstream ships. **14 more files.**

**3. `just check` never ran shfmt at all.** It runs shellcheck, yamllint, actionlint, jq and workflow-drift checks — but nothing verified shell formatting, which is why 1 and 2 could persist indefinitely. *A formatter you do not verify is a formatter that drifts.*

## The fix

- `.editorconfig` → `indent_style = tab`
- `just fix` skips `_upstream-snapshots/`
- `just check` gains a formatting gate
- the 21 repo files that genuinely weren't shfmt-clean are formatted once

**`just fix` is now idempotent on a clean tree** — verified by running it twice and diffing, and again on this branch (0 files changed).

## The gate nearly shipped dead

The obvious spelling:

```bash
find ... -exec shfmt --diff {} \;
```

returns **0 even when shfmt exits 1**, because `find` doesn't propagate the child's status. Measured: `shfmt --diff` on a bad file exits 1; the identical command under `find -exec` exits 0.

That is exactly the dead-gate shape AGENTS.md warns about — and I wrote it about an hour after writing the warning. The check now tests shfmt's **output** via `shfmt -l`, and was confirmed to fail on injected drift (naming the offending file) and pass on a clean tree.

## Tests

`tests/test_shell_formatting_contract.py` pins all three fixes plus the dead-gate spelling. Confirmed to fail when `.editorconfig` is reverted to `space`.

One of them checks the recipe's **code** rather than its prose, because the comment deliberately spells out the broken form so the next reader doesn't reintroduce it — a test that forbids naming the trap forbids documenting it.

## Out of scope

`just check` still exits 1 on clean `main` for pre-existing actionlint findings in `desktop-contract-sweep.yml` and `installer-smoke.yml`. Not touched here, stated so it isn't mistaken for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rprz14ZYS9uCdd51ayuKD