### PR TITLE
feat(e2e): print agent debug instructions when a gate fails

### DIFF
--- a/build_scripts/checks/e2e-runtime-checks.sh
+++ b/build_scripts/checks/e2e-runtime-checks.sh
@@ -304,5 +304,19 @@ check "hostname is set" \
 check "locale is configured" \
 	locale
 
+# Tell an automated reader where to go next. These checks run on the guest's
+# serial console, which is the ONLY channel out of an installed system that
+# ships no sshd -- so whatever this does not print is unknowable after the
+# fact. Naming the artifacts here saves the next agent rediscovering them.
+if [[ "$FAIL" -gt 0 ]]; then
+	emit "# AGENT: ${FAIL} assertion(s) failed on the INSTALLED system."
+	emit "# AGENT: this output is the guest serial console; the host copy is"
+	emit "#        <output-dir>/installed-serial.log (or serial.log for the live boot)."
+	emit "# AGENT: re-read the '# ' info lines above — they carry the measured"
+	emit "#        values (display manager, ActiveState, ip, listeners) that say WHY."
+	emit "# AGENT: symptom-indexed catalogue: docs/ci-troubleshooting.md"
+	emit "# AGENT: a check that fails on EVERY run and every flavor is a dead gate,"
+	emit "#        not a known issue — see the PR quality contract in AGENTS.md."
+fi
 emit "TUNAOS_INSTALL_CHECKS_RESULT pass=${PASS} fail=${FAIL} desktop=${DESKTOP}"
 exit "$FAIL"

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -981,7 +981,73 @@ cleanup_vm() {
 		[[ -n "$tpid" ]] && kill "$tpid" 2>/dev/null || true
 	fi
 }
-trap cleanup_vm EXIT
+# ── Agent debugging instructions ────────────────────────────────────────────
+# Printed on ANY non-zero exit, from the EXIT trap, so every one of this
+# script's 60-odd failure paths gets it without each having to remember.
+#
+# Written because an agent (me) burned real time on this harness working out
+# facts that were never printed anywhere: that the serial console goes to
+# serial.log inside the output dir rather than to stdout; that the SSH-based
+# modes cannot work on published media because production images disable sshd;
+# that the image ref is parsed from the ISO FILENAME, so a renamed download
+# fails for a reason unrelated to the ISO; and that the output directory holds
+# screenshots and a boot-diagnostics dump that nothing mentions. A failing gate
+# that does not say where its evidence lives makes every consumer rediscover
+# the layout.
+#
+# Keep this factual and current. A stale pointer is worse than none, because it
+# sends the reader somewhere confidently wrong.
+_agent_debug_instructions() {
+	local rc="$1"
+	[[ "$rc" -eq 0 ]] && return 0
+	# Only the outermost invocation should print; nested subshells inherit the
+	# trap and would repeat this several times per failure.
+	[[ "${_AGENT_HINT_PRINTED:-0}" -eq 1 ]] && return 0
+	_AGENT_HINT_PRINTED=1
+
+	printf '\n'
+	echo "════════════════════════════════════════════════════════════════════"
+	echo "AGENT DEBUG INSTRUCTIONS — iso-e2e.sh exited ${rc} (mode=${MODE:-?} variant=${VARIANT:-?} flavor=${FLAVOR:-?})"
+	echo "════════════════════════════════════════════════════════════════════"
+	echo "Evidence lives in the output directory, NOT in this log:"
+	echo "  ${OUTPUT_DIR:-<unset>}"
+	echo
+	echo "Read these first, in this order:"
+	echo "  serial.log                     guest kernel + systemd console (the live boot)"
+	echo "  installed-serial.log           the same for the post-install boot (LUKS/install modes)"
+	echo "  current-phase.txt              which phase was in flight when it died"
+	echo "  boot-diagnostics.txt           failed-unit status/journal/coredump, when collected"
+	echo "  *.ppm / *.png                  framebuffer captures (00-boot, 10-ready, 30-installed)"
+	echo "  walkthrough/                   per-step installer frames + TAP (published mode)"
+	echo
+	echo "Useful commands:"
+	echo "  grep -aE 'not ok - |TUNAOS_' \"${OUTPUT_DIR:-.}\"/serial.log"
+	echo "  tesseract <frame>.png stdout --psm 6      # read a screenshot"
+	echo
+	echo "Facts that are not obvious and have cost time before:"
+	echo "  * Exit codes: 2 = never became ready, 3 = install/contract failed."
+	echo "  * The image ref is derived from the ISO FILENAME (<variant>-<flavor>-...)."
+	echo "    Renaming a download makes this probe the wrong image and fail for an"
+	echo "    unrelated reason."
+	echo "  * --luks/--ssh-only/--kickstart/--app-launch need sshd IN THE GUEST."
+	echo "    Production ISOs ship it disabled, so those modes only work on dev"
+	echo "    ISOs. For published media use --published, which drives the GUI"
+	echo "    through the QEMU monitor instead."
+	echo "  * A blank framebuffer (stddev 0) means the compositor never painted;"
+	echo "    check serial.log for the display manager before suspecting the ISO."
+	echo
+	echo "Known-failure catalogue, symptom-indexed:"
+	echo "  docs/ci-troubleshooting.md"
+	echo "════════════════════════════════════════════════════════════════════"
+}
+
+_on_exit() {
+	local rc=$?
+	cleanup_vm
+	_agent_debug_instructions "$rc"
+	return "$rc"
+}
+trap _on_exit EXIT
 # Without this, SIGTERM kills the shell outright and the EXIT trap never runs,
 # so the watchdog below would leave QEMU and swtpm orphaned on the runner.
 trap 'exit 143' TERM

--- a/tests/bats/test_agent_debug_instructions.bats
+++ b/tests/bats/test_agent_debug_instructions.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# Failing gates must say where their evidence lives.
+#
+# WHY: an agent debugging this harness has to rediscover, every time, that the
+# serial console goes to serial.log inside the output dir rather than stdout;
+# that the SSH-based modes cannot work on published media because production
+# images disable sshd; that the image ref is parsed from the ISO FILENAME, so a
+# renamed download fails for an unrelated reason; and that the output dir holds
+# screenshots and a boot-diagnostics dump nothing mentions. All four cost real
+# time in one session. A gate that does not name its own evidence makes every
+# consumer pay that again.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+E2E="${REPO_ROOT}/scripts/iso-e2e.sh"
+RUNTIME="${REPO_ROOT}/build_scripts/checks/e2e-runtime-checks.sh"
+
+@test "iso-e2e prints agent instructions from the EXIT trap" {
+  # From the trap, so all ~60 failure paths get it without each remembering.
+  grep -q '_agent_debug_instructions' "$E2E"
+  grep -q 'trap _on_exit EXIT' "$E2E"
+}
+
+@test "it stays silent on success" {
+  # A gate that shouts on every green run trains people to ignore it.
+  run bash -c "sed -n '/_agent_debug_instructions() {/,/^}/p' '$E2E'"
+  [[ "$output" == *'[[ "$rc" -eq 0 ]] && return 0'* ]]
+}
+
+@test "it prints once, not once per subshell" {
+  run bash -c "sed -n '/_agent_debug_instructions() {/,/^}/p' '$E2E'"
+  [[ "$output" == *"_AGENT_HINT_PRINTED"* ]]
+}
+
+@test "cleanup still runs, and the exit code is preserved" {
+  # The trap was cleanup_vm; wrapping it must not drop either behaviour, or a
+  # failing gate starts reporting success and leaks QEMU on the runner.
+  run bash -c "sed -n '/^_on_exit() {/,/^}/p' '$E2E'"
+  [[ "$output" == *"cleanup_vm"* ]]
+  [[ "$output" == *"local rc=\$?"* ]]
+  [[ "$output" == *"return \"\$rc\""* ]]
+}
+
+@test "it names the artifacts an agent actually needs" {
+  local body
+  body="$(sed -n '/_agent_debug_instructions() {/,/^}/p' "$E2E")"
+  for artifact in serial.log installed-serial.log current-phase.txt \
+    boot-diagnostics.txt walkthrough ci-troubleshooting.md; do
+    echo "$body" | grep -qF "$artifact" || {
+      echo "missing pointer: $artifact"
+      return 1
+    }
+  done
+}
+
+@test "it records the non-obvious facts that cost time" {
+  local body
+  body="$(sed -n '/_agent_debug_instructions() {/,/^}/p' "$E2E")"
+  # sshd is the one that makes a published ISO look broken when it is fine.
+  echo "$body" | grep -q 'disabled'
+  echo "$body" | grep -q -- '--published'
+  # The filename-derived image ref sent me probing ghcr.io/tuna-os/published.
+  echo "$body" | grep -qi 'FILENAME'
+}
+
+@test "the in-guest checks point at their own evidence too" {
+  # Serial is the only channel out of an installed system with no sshd, so
+  # whatever these checks do not print is unknowable afterwards.
+  grep -q 'AGENT:' "$RUNTIME"
+  grep -q 'installed-serial.log' "$RUNTIME"
+  grep -q 'ci-troubleshooting.md' "$RUNTIME"
+}
+
+@test "the guest hint only fires when something failed" {
+  run bash -c "grep -B2 'AGENT: .* assertion(s) failed' '$RUNTIME'"
+  [[ "$output" == *'if [[ "$FAIL" -gt 0 ]]'* ]]
+}


### PR DESCRIPTION
## Why

Automated agents debugging this harness rediscover the same facts every time, because nothing prints them:

- the serial console goes to `serial.log` **inside the output dir**, not to stdout
- `--luks` / `--ssh-only` / `--kickstart` / `--app-launch` need sshd in the guest, which production ISOs disable — so those modes **cannot test published media at all**, and a published ISO looks broken when it's fine
- the image ref is parsed from the **ISO filename**, so a renamed download probes the wrong image and fails for an unrelated reason
- the output dir holds framebuffer captures and a `boot-diagnostics.txt` that nothing mentions

All four cost me real time in a single session. **A gate that doesn't name its own evidence makes every consumer pay that again.**

## What it prints

On any non-zero exit:

```
════════════════════════════════════════════════════════════════════
AGENT DEBUG INSTRUCTIONS — iso-e2e.sh exited 143 (mode=published variant=marlin flavor=kde)
════════════════════════════════════════════════════════════════════
Evidence lives in the output directory, NOT in this log:
  /tmp/agenttest3

Read these first, in this order:
  serial.log                     guest kernel + systemd console (the live boot)
  installed-serial.log           the same for the post-install boot
  current-phase.txt              which phase was in flight when it died
  boot-diagnostics.txt           failed-unit status/journal/coredump
  *.ppm / *.png                  framebuffer captures
  walkthrough/                   per-step installer frames + TAP
...
```

(That's a real run, not a mock-up.)

## Design choices worth noting

**Hooked into the EXIT trap**, so all ~60 failure paths get it without each one remembering to call it.

**Silent on success** — a gate that shouts on every green run trains people to ignore it. **Prints once**, not once per subshell.

**The wrapper preserves both of the trap's existing jobs**: `cleanup_vm` still runs and the original exit code is still returned. Dropping either would turn a failing gate green or leak QEMU on the runner — both are asserted by tests.

## In-guest side

`e2e-runtime-checks.sh` gets the same treatment, where it matters more: serial is the **only** channel out of an installed system that ships no sshd, so whatever those checks don't print is unknowable afterwards. It points at the host-side log, at the `# ` info lines carrying the measured values, at the troubleshooting catalogue, and at the dead-gate rule — because three assertions in that very file had been red on every run for months.

## Tests

8 bats cases covering: fires from the trap, silent on success, prints once, cleanup + exit code preserved, names every artifact, records the non-obvious facts, and the guest hint only fires on failure. 111 adjacent assertions still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rprz14ZYS9uCdd51ayuKD