### PR TITLE
fix(test): anchor the #2326 slice on the dispatch, not the first case header

### DIFF
--- a/tests/regressions/test_issue_2326_disk_gate_collects_the_failed_systemd_journal.py
+++ b/tests/regressions/test_issue_2326_disk_gate_collects_the_failed_systemd_journal.py
@@ -27,7 +27,14 @@ def test_disk_qemu_attaches_the_prepared_vsock_credentials():
 
 
 def test_missing_contract_collects_diagnostics_before_evidence_capture():
-    disk_mode = SCRIPT.split("case \"$MODE\" in", 1)[1].split("\nready)", 1)[0]
+    # Slice the DISPATCH arm, not "everything after the first case header".
+    # iso-e2e.sh contains three `case "$MODE" in` statements; splitting on the
+    # first one grabbed a region starting ~1600 lines above the dispatch, so
+    # the .index() calls below matched helper definitions instead of the arm
+    # and the test failed whenever anything shifted around them. Anchor on the
+    # `disk)` arm of the last one, which is what this test is about.
+    dispatch = SCRIPT.rsplit('case "$MODE" in', 1)[1]
+    disk_mode = dispatch.split("\ndisk)", 1)[1].split("\n\t;;", 1)[0]
     collect = disk_mode.index("collect_disk_boot_diagnostics")
     paint = disk_mode.index('wait_for_paint "10-ready"')
     assert collect < paint


### PR DESCRIPTION
## main is red

`test_missing_contract_collects_diagnostics_before_evidence_capture` fails on a clean checkout of `main`. I hit it as a "failure" on two of my own PRs before checking whether it was mine — it isn't.

## Cause

It sliced `iso-e2e.sh` as:

```python
SCRIPT.split('case "$MODE" in', 1)[1].split("\nready)", 1)[0]
```

That file contains **three** `case "$MODE" in` statements. Splitting on the first starts the region ~1600 lines above the dispatch, so the `.index()` calls below matched helper definitions instead of the `disk)` arm — and the test failed whenever anything shifted around them.

Both #2369 (`collect_disk_boot_diagnostics()`) and #2411 (the `published)` arm) did shift things, and **neither touched the ordering this test is about**.

## Fix

Anchor on the `disk)` arm of the **last** case statement — the dispatch, which is what the test means.

Verified it still fails for its real regression: moving `collect_disk_boot_diagnostics` after the paint capture trips `assert collect < paint`.

## Why this matters beyond the one test

A test whose subject is an ordering should fail when the ordering changes **and at no other time**. This one had drifted into failing on unrelated edits, which is the same shape as a check that always fails — it stops carrying information, and the next person reads the red as noise. That's the dead-gate pattern recorded in AGENTS.md, arriving from the other direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rprz14ZYS9uCdd51ayuKD