### PR TITLE
feat(ci): three checks for gates that cannot fail (epic #2250, item 1)

### DIFF
--- a/.github/workflows/dead-gate-report.yml
+++ b/.github/workflows/dead-gate-report.yml
@@ -1,0 +1,53 @@
+name: Dead gate report
+
+# Reports assertions that were red in EVERY recent run of a gate workflow.
+#
+# Epic #2250's CI contract catches a criterion with no executing
+# implementation -- the always-GREEN case. This is the inverse, and on this
+# repo the inverse cost more: three assertions in e2e-runtime-checks.sh sat
+# red on every cell for months, each for a reason unrelated to what it
+# claimed to test, and each was read as a known issue rather than as a gate
+# measuring nothing.
+#
+# Deliberately a REPORT, never a gate. Failing the build on "always red"
+# would block the repo on exactly the assertions this is meant to surface,
+# and naming them in a job summary is enough to make them undeniable.
+
+on:
+  schedule:
+    - cron: '17 6 * * 1' # Mondays, after the weekend's scheduled runs
+  workflow_dispatch:
+    inputs:
+      workflow:
+        description: 'Workflow file to examine'
+        required: false
+        default: 'luks-e2e.yml'
+      runs:
+        description: 'How many recent runs'
+        required: false
+        default: '10'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Report dead-gate candidates
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WF: ${{ github.event.inputs.workflow || 'luks-e2e.yml' }}
+          RUNS: ${{ github.event.inputs.runs || '10' }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Dead gate candidates — \`${WF}\`, last ${RUNS} runs"
+            echo
+            echo '```'
+            python3 scripts/detect-dead-gates.py --workflow "$WF" --runs "$RUNS" 2>&1 || true
+            echo '```'
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/docs/CI_SPEC.md
+++ b/docs/CI_SPEC.md
@@ -44,6 +44,7 @@ This inventory is generated from workflow triggers and `.github/green-criteria.y
 | `check-download-checksums.yml` | PR-deterministic + post-merge + scheduled | Check download checksums | each PR, `35 22 * * *`, manual | — |
 | `content-filter.yaml` | post-merge | Check for Spammy Issue Comments | issue_comment | — |
 | `daily-verify.yml` | post-merge + scheduled | Daily Image Verification | `0 4 * * *`, manual | — |
+| `dead-gate-report.yml` | post-merge + scheduled | Dead gate report | `17 6 * * 1`, manual | — |
 | `desktop-contract-sweep.yml` | post-merge + scheduled | `desktop`, `no_silent_omissions` | `0 8 * * *`, manual | `desktop`: 2d, `no_silent_omissions`: 2d |
 | `drop-bot-review-requests.yml` | PR-deterministic | Drop bot review requests | each PR | — |
 | `frontend-parity.yml` | post-merge + scheduled | frontend parity | `30 6 * * *`, manual | — |

--- a/scripts/detect-dead-gates.py
+++ b/scripts/detect-dead-gates.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Report assertions that have been red on every run for N consecutive runs.
+
+A check that always says the same thing cannot report a regression. The
+always-GREEN case is what epic #2250's CI contract already guards -- a
+criterion with no executing implementation. This is the inverse, and on this
+repo it cost more: three assertions in e2e-runtime-checks.sh were red on every
+cell for months, each for a reason unrelated to what it claimed to test, and
+each had been read as a known issue rather than as a dead gate.
+
+The signal is cheap. TAP lines on the serial console are already collected in
+the workflow logs; an assertion whose verdict has not changed in N runs is
+either broken or measuring nothing, and both are worth a look.
+
+This is deliberately a REPORT, not a gate. Turning "always red" into a hard
+failure would block the repo on the very assertions it is trying to surface,
+and a report that names them is enough to make them undeniable.
+
+Usage:
+    scripts/detect-dead-gates.py --workflow luks-e2e.yml --runs 10
+    scripts/detect-dead-gates.py --from-logs out/*.log   # offline
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Real TAP arrives on a guest serial console, so the line is prefixed with a
+# kernel timestamp and the emitting unit:
+#   [   11.6] e2e-runtime-checks[943]: not ok - graphical.target is active
+# Allow any prefix that ends in ": ", plus bare TAP and "# "-quoted TAP.
+TAP = re.compile(
+    r"^(?:.*?:\s+)?(?:#\s*)?(ok|not ok)(?:\s+\d+)?\s+-\s+(.+?)\s*$", re.M
+)
+
+
+def parse_tap(text: str) -> dict[str, set[str]]:
+    """assertion description -> set of verdicts seen ({'ok'}, {'not ok'}, or both)."""
+    seen: dict[str, set[str]] = collections.defaultdict(set)
+    for verdict, desc in TAP.findall(text):
+        # Strip trailing measured values so "(state=x)" variants group together.
+        key = re.sub(r"\s*\([^)]*\)\s*$", "", desc).strip()
+        if key:
+            seen[key].add(verdict)
+    return seen
+
+
+def gh_run_logs(workflow: str, limit: int) -> list[str]:
+    ids = subprocess.run(
+        ["gh", "run", "list", "--workflow", workflow, "--limit", str(limit),
+         "--json", "databaseId", "-q", ".[].databaseId"],
+        capture_output=True, text=True, check=False,
+    ).stdout.split()
+    out = []
+    for rid in ids:
+        r = subprocess.run(["gh", "run", "view", rid, "--log"],
+                           capture_output=True, text=True, check=False)
+        if r.stdout:
+            out.append(r.stdout)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workflow")
+    ap.add_argument("--runs", type=int, default=10)
+    ap.add_argument("--from-logs", nargs="*", default=[])
+    ap.add_argument("--min-runs", type=int, default=3,
+                    help="don't call anything dead on fewer runs than this")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    texts = [Path(p).read_text(errors="replace") for p in args.from_logs]
+    if args.workflow:
+        texts += gh_run_logs(args.workflow, args.runs)
+    if len(texts) < args.min_runs:
+        print(f"only {len(texts)} run(s); need {args.min_runs} to judge — not enough evidence",
+              file=sys.stderr)
+        return 0
+
+    merged: dict[str, set[str]] = collections.defaultdict(set)
+    for t in texts:
+        for k, v in parse_tap(t).items():
+            merged[k] |= v
+
+    always_red = sorted(k for k, v in merged.items() if v == {"not ok"})
+    always_green = sorted(k for k, v in merged.items() if v == {"ok"})
+
+    if args.json:
+        print(json.dumps({"runs": len(texts), "always_red": always_red,
+                          "always_green_count": len(always_green)}, indent=2))
+    else:
+        print(f"Examined {len(texts)} run(s), {len(merged)} distinct assertions.\n")
+        if always_red:
+            print(f"DEAD GATE CANDIDATES — red in every run ({len(always_red)}):")
+            for k in always_red:
+                print(f"  not ok (always) - {k}")
+            print("\nAn assertion that never passes cannot report a regression.")
+            print("Each of these is ONE of two things, and they need opposite responses:")
+            print("  (a) a DEAD GATE  -- structurally incapable of passing, so it is")
+            print("      measuring nothing and hiding whatever it claims to cover;")
+            print("  (b) a REAL and persistent failure that nobody has acted on.")
+            print("Both are worth a look; neither is a 'known issue'. Verified example")
+            print("of each in this repo: 'graphical.target is active' was (a), asserted")
+            print("from inside that target's own startup transaction; the pantheon")
+            print("'screen is not blank' assertions were (b), a live session that")
+            print("genuinely never painted.")
+        else:
+            print("No assertion was red in every run.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/regressions/README.md
+++ b/tests/regressions/README.md
@@ -14,21 +14,20 @@ can be checked (`tests/test_regression_convention.py`):
 - **Assert the failure mode, not the fix.** The test should fail on the tree
   that shipped the incident and pass on the fix — mutate a real input into
   the broken shape where you can, rather than asserting a string is present.
-- **State how it fails.** The docstring carries a line beginning
-  `Falsification:` saying what makes this test go red on the unfixed tree.
-  Two shapes are acceptable, and the line should make clear which:
-  - *behavioural* — the test drives the real code with the broken input, so
-    it falsifies itself;
-  - *structural* — the test asserts a string, ordering or shape, and someone
-    checked it by reverting the fix. Name what was reverted.
+- **State how it fails.** Add a line that starts with `Falsification:`. The
+  line tells the reader what makes this test fail on the unfixed tree. Use one
+  of two shapes, and make it clear which one you used:
+  - *behavioural* — the test runs the real code with the broken input. The
+    test falsifies itself.
+  - *structural* — the test looks for a string, an order or a shape. Revert
+    the fix, watch the test fail, and name what you reverted.
 
-  A test that cannot fail is indistinguishable from a test that passes, and
-  the difference is invisible in a green run. Measured here: three assertions
-  in `build_scripts/checks/e2e-runtime-checks.sh` ran on every cell for months
-  while being structurally incapable of passing, and a formatting gate written
-  the same week used `find -exec`, which returns 0 even when the command it
-  runs exits 1. The line forces the question to be asked once, by the person
-  best placed to answer it.
+  A test that cannot fail looks exactly like a test that passes. A green run
+  does not show the difference. This repo has examples. Three checks in
+  `build_scripts/checks/e2e-runtime-checks.sh` ran on every cell for months.
+  None of them could pass. A format check written in the same week used
+  `find -exec`, which returns 0 even when the command fails. Write the line
+  once, and you ask the question once.
 
 Tests elsewhere in `tests/` already follow the spirit of this (most carry an
 issue or run number in their docstring); this directory makes the mapping

--- a/tests/regressions/README.md
+++ b/tests/regressions/README.md
@@ -14,6 +14,21 @@ can be checked (`tests/test_regression_convention.py`):
 - **Assert the failure mode, not the fix.** The test should fail on the tree
   that shipped the incident and pass on the fix — mutate a real input into
   the broken shape where you can, rather than asserting a string is present.
+- **State how it fails.** The docstring carries a line beginning
+  `Falsification:` saying what makes this test go red on the unfixed tree.
+  Two shapes are acceptable, and the line should make clear which:
+  - *behavioural* — the test drives the real code with the broken input, so
+    it falsifies itself;
+  - *structural* — the test asserts a string, ordering or shape, and someone
+    checked it by reverting the fix. Name what was reverted.
+
+  A test that cannot fail is indistinguishable from a test that passes, and
+  the difference is invisible in a green run. Measured here: three assertions
+  in `build_scripts/checks/e2e-runtime-checks.sh` ran on every cell for months
+  while being structurally incapable of passing, and a formatting gate written
+  the same week used `find -exec`, which returns 0 even when the command it
+  runs exits 1. The line forces the question to be asked once, by the person
+  best placed to answer it.
 
 Tests elsewhere in `tests/` already follow the spirit of this (most carry an
 issue or run number in their docstring); this directory makes the mapping

--- a/tests/regressions/test_issue_2263_infra_rerun_does_not_stop_at_the_first_already_running.py
+++ b/tests/regressions/test_issue_2263_infra_rerun_does_not_stop_at_the_first_already_running.py
@@ -17,6 +17,10 @@ correctly.
 These tests hold the shape of the fix: the benign refusal is recognised and
 counted, an unexpected refusal still fails the step, and a round that
 recovered nothing at all is not reported as success.
+
+Falsification: structural — confirmed red by removing the
+`refused=$((refused + 1))` counter from rerun-infra-failures.yml, which
+fails test_an_unexpected_refusal_still_fails_the_step.
 """
 from __future__ import annotations
 

--- a/tests/regressions/test_issue_2265_live_customize_starts_its_buses_with_the_real_dbus_daemon.py
+++ b/tests/regressions/test_issue_2265_live_customize_starts_its_buses_with_the_real_dbus_daemon.py
@@ -19,6 +19,10 @@ What this holds: the script's OWN `_start_bus`, run under `set -eu` against
 the REAL dbus-daemon, starts a session bus that answers a method call and
 leaves a pidfile naming a live process. No fake is involved on purpose; the
 fake is what let this ship. Skipped, loudly, where dbus-daemon is absent.
+
+Falsification: behavioural — starts a session bus through the real helper
+and asserts on what it produces, so a helper that stopped using the real
+dbus-daemon fails here without any string matching.
 """
 from __future__ import annotations
 

--- a/tests/regressions/test_issue_2279_agent_issue_bodies_bypass_shell_expansion.py
+++ b/tests/regressions/test_issue_2279_agent_issue_bodies_bypass_shell_expansion.py
@@ -4,6 +4,10 @@ The body recovered from tuna-os/corral#217 measured the failure: an agent put
 Markdown in a double-quoted ``--body`` argument, and its backticks ran ``env``.
 This test holds the actual documented command to literal stdin transport so a
 later simplification cannot silently restore credential exposure.
+
+Falsification: behavioural — executes the documented command under bash
+with a body containing shell metacharacters, so an expansion regression
+shows up as wrong output rather than as an absent quote.
 """
 
 from __future__ import annotations

--- a/tests/regressions/test_issue_2326_disk_gate_collects_the_failed_systemd_journal.py
+++ b/tests/regressions/test_issue_2326_disk_gate_collects_the_failed_systemd_journal.py
@@ -4,6 +4,10 @@ The yellowfin GNOME Gate serial console only said to run ``systemctl status``.
 The harness had already prepared credentialed root-over-vsock access, but its
 ``--disk`` QEMU command never attached the vsock device, so the failed guest's
 journal and dbus-broker coredump metadata disappeared with the VM.
+
+Falsification: structural — confirmed red by moving
+collect_disk_boot_diagnostics after the paint capture in iso-e2e.sh,
+which trips `assert collect < paint`.
 """
 
 from pathlib import Path

--- a/tests/regressions/test_issue_858_a_kde_image_without_a_plasma_session_fails_the_contract.py
+++ b/tests/regressions/test_issue_858_a_kde_image_without_a_plasma_session_fails_the_contract.py
@@ -13,6 +13,10 @@ requires the session glob in its `kde)` branch; these tests run the real
 and hold that it fails, loudly, with the path named — and that the
 hummingbird bootstrap waiver, the one legitimate way through, is not in
 effect for a stable variant.
+
+Falsification: behavioural — runs the real require_glob from
+verify-desktop-experience.sh against a root with no session file, so the
+test drives the incident's own input rather than asserting a string.
 """
 
 from __future__ import annotations

--- a/tests/test_dead_gate_detector.py
+++ b/tests/test_dead_gate_detector.py
@@ -1,0 +1,103 @@
+"""The dead-gate detector must detect, and must not over-claim.
+
+Epic #2250's CI contract catches a criterion with no executing implementation
+-- the always-GREEN case. This detector covers the inverse: an assertion that
+is red in every run. On this repo the inverse cost more, because three
+assertions in e2e-runtime-checks.sh sat red on every cell for months and were
+read as known issues rather than as gates measuring nothing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "detect-dead-gates.py"
+
+sys.path.insert(0, str(ROOT / "scripts"))
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args], capture_output=True, text=True
+    )
+
+
+def _log(tmp_path: Path, name: str, lines: list[str]) -> str:
+    p = tmp_path / name
+    p.write_text("\n".join(lines) + "\n")
+    return str(p)
+
+
+def test_an_always_red_assertion_is_reported(tmp_path: Path) -> None:
+    logs = [
+        _log(tmp_path, f"r{i}.log", [
+            "ok 1 - the good one",
+            "not ok 2 - the always red one",
+        ])
+        for i in range(3)
+    ]
+    out = _run("--from-logs", *logs).stdout
+    assert "the always red one" in out
+    assert "the good one" not in out
+
+
+def test_an_assertion_that_ever_passes_is_not_reported(tmp_path: Path) -> None:
+    """One green run is enough to prove the assertion can pass."""
+    logs = [
+        _log(tmp_path, "r0.log", ["not ok 1 - flaky"]),
+        _log(tmp_path, "r1.log", ["not ok 1 - flaky"]),
+        _log(tmp_path, "r2.log", ["ok 1 - flaky"]),
+    ]
+    out = _run("--from-logs", *logs).stdout
+    assert "No assertion was red in every run" in out
+
+
+def test_it_refuses_to_judge_on_too_little_evidence(tmp_path: Path) -> None:
+    """Two runs is not a pattern; saying so is better than a confident wrong answer."""
+    logs = [_log(tmp_path, "r0.log", ["not ok 1 - only twice"])]
+    r = _run("--from-logs", *logs)
+    assert "not enough evidence" in r.stderr
+    assert r.returncode == 0
+
+
+def test_serial_console_prefixes_are_parsed(tmp_path: Path) -> None:
+    """The real source is a guest serial log, where TAP carries a timestamp."""
+    logs = [
+        _log(tmp_path, f"r{i}.log", [
+            "[   11.6] e2e-runtime-checks[943]: not ok - graphical.target is active",
+        ])
+        for i in range(3)
+    ]
+    out = _run("--from-logs", *logs).stdout
+    assert "graphical.target is active" in out
+
+
+def test_measured_values_do_not_split_one_assertion_into_many(tmp_path: Path) -> None:
+    """`(state=activating)` varies per run; the assertion is still one assertion."""
+    logs = [
+        _log(tmp_path, "r0.log", ["not ok - graphical.target is active (state=inactive)"]),
+        _log(tmp_path, "r1.log", ["not ok - graphical.target is active (state=activating)"]),
+        _log(tmp_path, "r2.log", ["not ok - graphical.target is active (state=inactive)"]),
+    ]
+    out = _run("--from-logs", *logs).stdout
+    # Count the CANDIDATE LINES, not the whole output -- the explanatory text
+    # below the list cites this same assertion by name as its worked example.
+    listed = [l for l in out.splitlines() if l.strip().startswith("not ok (always) -")]
+    assert len(listed) == 1, listed
+
+
+def test_it_names_both_readings_rather_than_prejudging(tmp_path: Path) -> None:
+    """An always-red assertion may be a dead gate OR a real persistent failure.
+
+    Verified example of each here: `graphical.target is active` was a dead
+    gate; the pantheon `screen is not blank` assertions were a live session
+    that genuinely never painted. Reporting only the first would have sent
+    someone to 'fix the test' on a real bug.
+    """
+    logs = [_log(tmp_path, f"r{i}.log", ["not ok - something"]) for i in range(3)]
+    out = _run("--from-logs", *logs).stdout
+    assert "DEAD GATE" in out
+    assert "REAL and persistent failure" in out

--- a/tests/test_gates_can_fail.py
+++ b/tests/test_gates_can_fail.py
@@ -1,0 +1,77 @@
+"""A gate that cannot return non-zero is not a gate.
+
+Epic #2250's premise for the CI contract is that "a test existing in the
+repository is not the same as a test being run". This file guards the step
+after that one: **a test being run is not the same as a test that can fail.**
+
+Measured on this repo, all executing on every run and none able to report a
+regression:
+
+  * three assertions in build_scripts/checks/e2e-runtime-checks.sh were red on
+    every cell for months -- graphical.target asserted from inside its own
+    startup transaction, a unit-graph check failing on upstream units plus a
+    man-page check on an image that strips man pages, and an sshd host-key
+    assertion that fired on images which deliberately disable sshd;
+  * a shell formatting gate used `find ... -exec shfmt --diff {} \;`, which
+    returns 0 even when shfmt exits 1, because find does not propagate the
+    child's status. Measured both ways to be certain.
+
+The shapes below are mechanical and cheap to detect. They are not the only
+ways to write an unfailable gate, and passing this file does not mean a gate
+works -- only that it is not broken in one of the ways that has already
+happened here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Scripts whose whole job is to decide pass/fail. Extending this list is the
+# point: a new gate should be added here when it is written.
+GATE_SCRIPTS = [
+    "scripts/iso-e2e.sh",
+    "scripts/e2e-smoke-checks.sh",
+    "build_scripts/checks/e2e-runtime-checks.sh",
+    "build_scripts/checks/verify-desktop-experience.sh",
+]
+
+# `find ... -exec <cmd> \;` ALWAYS exits 0, whatever <cmd> returns. Used as the
+# condition of an if/||/&& it silently never fires.
+FIND_EXEC_AS_CONDITION = re.compile(
+    r"(?:if\s+!?\s*|\|\|\s*|&&\s*)find\b[^\n]*-exec\b[^\n]*\;", re.M
+)
+
+
+def _text(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("rel", GATE_SCRIPTS)
+def test_no_find_exec_used_as_a_pass_fail_condition(rel: str) -> None:
+    """`find -exec cmd \;` exits 0 regardless of cmd, so it cannot gate.
+
+    Use `find ... -print0 | xargs -0 cmd`, or capture the output and test it
+    -- `shfmt -l` listing files is a gate; `shfmt --diff` under find is not.
+    """
+    hits = FIND_EXEC_AS_CONDITION.findall(_text(rel))
+    assert not hits, (
+        f"{rel}: `find -exec` used as a pass/fail condition; it exits 0 "
+        f"whatever the command returns: {hits[:2]}"
+    )
+
+
+def test_the_detector_recognises_the_shape_it_is_named_for() -> None:
+    """The detector must itself be falsifiable.
+
+    A pattern that matches nothing is the same failure this file exists to
+    catch, one level up.
+    """
+    broken = 'if ! find . -name "*.sh" -exec shfmt --diff "{}" ";"; then\n  exit 1\nfi'
+    assert FIND_EXEC_AS_CONDITION.search(broken), "detector misses the real shape"
+    fixed = 'out=$(find . -name "*.sh" -print0 | xargs -0 shfmt -l)\nif [[ -n "$out" ]]; then\n  exit 1\nfi'
+    assert not FIND_EXEC_AS_CONDITION.search(fixed), "detector flags the correct form"

--- a/tests/test_regression_convention.py
+++ b/tests/test_regression_convention.py
@@ -54,3 +54,35 @@ def test_the_test_asserts_something(path):
     src = path.read_text(encoding="utf-8")
     assert re.search(r"^def test_", src, re.M), f"{path.name}: no test functions"
     assert "assert" in src, f"{path.name}: no assertions"
+
+
+@pytest.mark.parametrize("path", FILES, ids=[p.name for p in FILES])
+def test_the_docstring_says_how_the_test_fails(path):
+    """Every regression test states what makes it go red on the unfixed tree.
+
+    A test that cannot fail is indistinguishable from a test that passes, and
+    the difference is invisible in a green run. Measured on this repo: three
+    assertions in build_scripts/checks/e2e-runtime-checks.sh executed on every
+    cell for months while being structurally incapable of passing, and a shell
+    formatting gate written the same week used `find -exec`, which returns 0
+    even when the command it runs exits 1.
+
+    Two shapes are acceptable -- behavioural (the test drives the real code
+    with the broken input, so it falsifies itself) and structural (someone
+    reverted the fix and watched it go red). The line should make clear which,
+    and a structural claim should name what was reverted.
+    """
+    src = path.read_text(encoding="utf-8")
+    m = re.match(r'\s*"""(.*?)"""', src, re.S)
+    assert m, f"{path.name}: no module docstring"
+    doc = m.group(1)
+    assert "Falsification:" in doc, (
+        f"{path.name}: no `Falsification:` line. State what makes this test "
+        "red on the unfixed tree -- see tests/regressions/README.md."
+    )
+    claim = doc.split("Falsification:", 1)[1].strip()
+    assert len(claim) > 30, (
+        f"{path.name}: the Falsification line is too short to say anything: "
+        f"{claim!r}"
+    )
+


### PR DESCRIPTION
The CI contract from epic #2250 proves every green criterion has an executing implementation — *"a test existing in the repository is not the same as a test being run."*

This covers the step after that one:

> **A test being run is not the same as a test that can fail.**

Measured on this repo, all executing on every run and none able to report a regression:

- **`graphical.target is active`** — asserted from a unit that is `WantedBy=graphical.target`, so it ran inside that target's own startup transaction and structurally always read `activating`
- **`systemd unit graph verifies`** — `--recursive-errors=yes` fails on any transitively reachable upstream unit, *plus* a man-page check on an image that strips man pages
- **`SSH host keys were generated`** — the guard matched a unit that was present but **disabled**, so it asserted against the image's own security posture
- **a shell formatting gate** using `find ... -exec shfmt --diff {} \;`, which returns 0 even when shfmt exits 1 — measured both ways

## 1. Falsification lines on regression tests

`tests/regressions/README.md` now requires a `Falsification:` line saying what makes the test red on the **unfixed** tree, enforced by `test_regression_convention.py`. Two shapes, and the line says which:

- **behavioural** — drives the real code with the broken input, so it falsifies itself
- **structural** — someone reverted the fix and watched it go red; name what was reverted

All five existing tests carry **what I actually checked**, not boilerplate. #858, #2265 and #2279 are behavioural. For the two structural ones I did the reverting: #2263 goes red when its `refused=$((refused + 1))` counter is removed, #2326 when `collect_disk_boot_diagnostics` moves after the paint capture.

## 2. Static detector for unfailable shapes

`tests/test_gates_can_fail.py` flags `find -exec` used as a pass/fail condition in the gate scripts.

It also tests that **the detector itself can fail** — matching the real broken shape and not the correct one. A pattern that matches nothing is this same bug one level up.

## 3. Dead-gate report

`scripts/detect-dead-gates.py` reports assertions red in **every** recent run, with a scheduled workflow writing them to a job summary.

**Report, never a gate.** Failing the build on "always red" would block the repo on exactly the assertions this exists to surface.

It names **both** readings rather than prejudging, because they need opposite responses and this repo has a verified example of each:

| reading | example |
|---|---|
| **dead gate** — measuring nothing | `graphical.target is active` |
| **real persistent failure** | pantheon's `screen is not blank` — a live session that genuinely never painted |

Reporting only the first would send someone to "fix the test" on a real bug.

Validated against this session's actual logs: it identifies the 8 always-red pantheon assertions across three runs, parses the guest serial prefix `[   11.6] e2e-runtime-checks[943]: not ok - ...`, and groups `(state=inactive)` / `(state=activating)` as one assertion rather than three.

## Verification

32 tests pass across the three files. 11 files changed.

Note: `just fix` currently reformats ~150 unrelated files on any branch (#2419 fixes that); I reverted its churn so this PR stays at 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rprz14ZYS9uCdd51ayuKD