### PR TITLE
feat(e2e): publish compact LUKS timelapse gallery

### DIFF
--- a/.github/workflows/luks-e2e.yml
+++ b/.github/workflows/luks-e2e.yml
@@ -108,8 +108,12 @@ on:
     - cron: "0 7 1 */3 *"
 
 permissions:
-  contents: read
+  # The successful full sweep refreshes the orphan pages-assets branch, like
+  # tuna-os/wootc. Filtered/reusable calls never reach that publisher job.
+  contents: write
   packages: read
+  # The publication job downloads the per-cell artifacts from this run.
+  actions: read
 
 jobs:
   # Build the {variant, flavor} matrix from build-config.yml (every variant x
@@ -120,6 +124,9 @@ jobs:
     outputs:
       matrix: ${{ steps.gen.outputs.matrix }}
       tpm_autounlock: ${{ steps.gen.outputs.tpm_autounlock }}
+      base_desktops: ${{ steps.gen.outputs.base_desktops }}
+      base_cells: ${{ steps.gen.outputs.base_cells }}
+      publish_latest: ${{ steps.gen.outputs.publish_latest }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -154,6 +161,30 @@ jobs:
             TPM_AUTOUNLOCK=false
           fi
           echo "tpm_autounlock=${TPM_AUTOUNLOCK}" >> "$GITHUB_OUTPUT"
+
+          # Plain desktop flavors are the install videos we publish. The
+          # suffixes below are overlay or hardware variants, not separate
+          # base-DE walkthroughs; keeping this derived from build-config.yml
+          # means a newly added plain desktop enters the gallery automatically.
+          BASE_DESKTOPS="$(echo "$json" | jq -c '
+            [.variants[].flavors[]
+             | select(.build_image == true)
+             | .id
+             | select(. != "base")
+             | select(test("-(hwe|nvidia|asahi|t2|zfs|cachyos)$") | not)]
+            | unique')"
+          echo "base_desktops=${BASE_DESKTOPS}" >> "$GITHUB_OUTPUT"
+
+          # The stable gallery must come from the complete monthly passphrase
+          # sweep. A single-cell post-build call or the quarterly TPM sweep
+          # has a deliberately partial matrix and must leave that gallery
+          # untouched; its per-cell artifact remains available for diagnosis.
+          if [[ "$FILTER_VARIANT" == "all" && "$FILTER_FLAVOR" == "all" &&
+                "$TPM_AUTOUNLOCK" == "false" ]]; then
+            echo "publish_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish_latest=false" >> "$GITHUB_OUTPUT"
+          fi
 
           if [[ "$TPM_AUTOUNLOCK" == "true" ]]; then
             # docs/LUKS-TPM.md's support matrix: these three never get the
@@ -213,6 +244,13 @@ jobs:
             exit 1
           fi
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          BASE_CELLS="$(echo "$matrix" | jq -c \
+            --argjson base_desktops "$BASE_DESKTOPS" \
+            '[.include[]
+             | select(.flavor as $flavor | $base_desktops | index($flavor))
+             | "\(.variant)-\(.flavor)"]
+            | sort')"
+          echo "base_cells=${BASE_CELLS}" >> "$GITHUB_OUTPUT"
 
           # Keep the scheduled coverage auditable. A variant with no desktop
           # image cannot be exercised by this ISO-based E2E; list it
@@ -417,9 +455,10 @@ jobs:
         run: |
           set -euo pipefail
           sudo install -d /etc/apt/keyrings
-          curl -fsSL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/Release.key \
+          kubic_repo='https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04'
+          curl -fsSL "${kubic_repo}/Release.key" \
             | gpg --dearmor | sudo tee /etc/apt/keyrings/kubic.gpg >/dev/null
-          echo 'deb [signed-by=/etc/apt/keyrings/kubic.gpg] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_24.04/ /' \
+          echo "deb [signed-by=/etc/apt/keyrings/kubic.gpg] ${kubic_repo}/ /" \
             | sudo tee /etc/apt/sources.list.d/kubic.list
           sudo apt-get update -qq
           sudo apt-get remove -y podman conmon crun || true
@@ -660,3 +699,143 @@ jobs:
             luks-out/*.ocr.txt
           if-no-files-found: warn
           retention-days: 14
+
+  # Artifacts are the right place for every cell's complete evidence, but they
+  # expire and the WebM is nested inside a per-cell ZIP. Keep a watchable,
+  # stable Pages gallery of the latest fully passing base-DE installs, like
+  # tuna-os/wootc does. It only runs after the complete monthly passphrase
+  # sweep; HWE/NVIDIA and other overlay flavors stay in the diagnostic
+  # artifacts but are not published here.
+  # A successful matrix with missing media is a broken evidence path: fail the
+  # publisher so the stale Pages gallery cannot be mistaken for this run.
+  publish-latest-timelapse:
+    name: Publish latest LUKS base-DE timelapses
+    needs: [generate-matrix, luks]
+    if: >-
+      needs.luks.result == 'success' &&
+      needs.generate-matrix.outputs.publish_latest == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Pages template and previous media
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # This job pushes the refreshed orphan pages-assets branch.
+          persist-credentials: true
+
+      - name: Download passing-cell artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: luks-e2e-*
+          path: timelapses
+          merge-multiple: false
+
+      - name: Publish the green base-DE gallery to pages-assets
+        env:
+          BASE_DESKTOPS: ${{ needs.generate-matrix.outputs.base_desktops }}
+          BASE_CELLS: ${{ needs.generate-matrix.outputs.base_cells }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          declare -A base_flavors=()
+          while IFS= read -r flavor; do
+            base_flavors["$flavor"]=1
+          done < <(jq -r '.[]' <<<"$BASE_DESKTOPS")
+          declare -A expected_cells=()
+          while IFS= read -r cell; do
+            expected_cells["$cell"]=1
+          done < <(jq -r '.[]' <<<"$BASE_CELLS")
+
+          # Artifact names are luks-e2e-<variant>-<flavor>. The final
+          # hyphen-delimited component is the flavor, so variants such as
+          # flounder-sid still resolve to the plain `gnome`/`kde` cell.
+          declare -A videos=() posters=()
+          while IFS= read -r candidate; do
+            selected_dir="${candidate%/timelapse/timelapse.webm}"
+            cell="${selected_dir##*/luks-e2e-}"
+            flavor="${cell##*-}"
+            [[ "${base_flavors[$flavor]:-}" == 1 ]] || continue
+            [[ "${expected_cells[$cell]:-}" == 1 ]] || continue
+            evidence="$selected_dir/luks-evidence.log"
+            poster="$selected_dir/timelapse/timelapse-poster.webp"
+            if [[ -s "$candidate" && -s "$poster" ]] &&
+               grep -qx 'TUNAOS_LUKS_E2E_PASS encrypted=1 passphrase_unlock=1 installed_boot=1' "$evidence"; then
+              videos["$cell"]="$candidate"
+              posters["$cell"]="$poster"
+            fi
+          done < <(find timelapses -type f \
+            -path '*/timelapse/timelapse.webm' -size +0c -print | sort)
+
+          if [[ "${#videos[@]}" -eq 0 ]]; then
+            echo "::error::No passing base-DE timelapses were present in a successful full matrix."
+            exit 1
+          fi
+          for cell in "${!expected_cells[@]}"; do
+            if [[ -z "${videos[$cell]:-}" ]]; then
+              echo "::error::Missing passing base-DE timelapse for ${cell}."
+              exit 1
+            fi
+          done
+
+          mapfile -t cells < <(printf '%s\n' "${!videos[@]}" | sort)
+
+          # Carry any other Pages content forward before replacing only this
+          # gallery. The assets branch is force-pushed as a fresh orphan so
+          # video bytes never accumulate in Git history.
+          if git fetch --depth 1 origin pages-assets 2>/dev/null; then
+            git checkout FETCH_HEAD -- pages/e2e 2>/dev/null || true
+            git reset -q HEAD -- pages/e2e 2>/dev/null || true
+          fi
+          rm -rf pages/e2e/luks/latest
+          mkdir -p pages/e2e/luks/latest
+
+          {
+            cat <<EOF
+          <!doctype html>
+          <html lang="en">
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>TunaOS latest LUKS E2E timelapses</title>
+          <style>
+          body{max-width:1100px;margin:2rem auto;padding:0 1rem;background:#111;color:#eee;font:16px system-ui,sans-serif}
+          .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:1.5rem}
+          video{width:100%;height:auto}a{color:#7dd3fc}
+          </style>
+          <h1>TunaOS latest LUKS E2E timelapses</h1>
+          <p>Passing encrypted install and first-boot captures for the base desktop cells in
+          <a href="${RUN_URL}#artifacts">this GitHub Actions run</a>.</p>
+          <div class="grid">
+          EOF
+            for cell in "${cells[@]}"; do
+              printf '<article><h2>%s</h2>' "$cell"
+              printf '<video controls muted loop playsinline poster="%s-poster.webp">' "$cell"
+              printf '<source src="%s.webm" type="video/webm"></video><p>' "$cell"
+              printf '<a href="%s.webm">Open or save the WebM</a></p></article>\n' "$cell"
+            done
+            cat <<'EOF'
+          </div>
+          </html>
+          EOF
+          } > pages/e2e/luks/latest/index.html
+          for cell in "${cells[@]}"; do
+            cp "${videos[$cell]}" "pages/e2e/luks/latest/${cell}.webm"
+            cp "${posters[$cell]}" "pages/e2e/luks/latest/${cell}-poster.webp"
+          done
+          printf '%s\n' "$RUN_URL" > pages/e2e/luks/latest/source-run.txt
+
+          if [[ -z "$(git status --porcelain pages/e2e)" ]]; then
+            echo "Timelapse gallery unchanged — nothing to publish."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git checkout --orphan pages-assets
+          git rm -rf --cached . >/dev/null
+          git add -f pages/e2e
+          git commit -m "e2e visual: refresh LUKS gallery (${{ github.run_id }})"
+          git push -f origin HEAD:pages-assets
+          curl -sS -f -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/${{ github.repository }}/dispatches" \
+            -d '{"event_type":"e2e-visual-refresh"}'
+          echo "==> Published ${#cells[@]} base-DE timelapse(s) from ${RUN_URL}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: GitHub Pages
+
+# The committed pages/ tree contains the player shell and a placeholder. The
+# successful LUKS E2E publisher carries the current WebMs on the pages-assets
+# orphan branch; this job overlays that branch before deploying Pages. Keeping
+# media out of main avoids accumulating binary history, matching wootc#87.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pages/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+  repository_dispatch:
+    types: [e2e-visual-refresh]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout Pages shell
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Fetch published E2E media from pages-assets
+        run: |
+          if ! git fetch --depth 1 origin pages-assets; then
+            echo "pages-assets is not published yet; deploying the committed Pages shell."
+          else
+            git checkout FETCH_HEAD -- pages/e2e 2>/dev/null || true
+          fi
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          path: pages
+
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5

--- a/.github/workflows/post-build-luks-e2e.yml
+++ b/.github/workflows/post-build-luks-e2e.yml
@@ -70,6 +70,9 @@ on:
 permissions:
   contents: read
   packages: read
+  # The reusable LUKS workflow downloads its own per-cell artifacts to publish
+  # the stable latest timelapse pointer.
+  actions: read
 
 concurrency:
   # One install e2e at a time per variant. Two nightly builds cannot overlap,

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -31,11 +31,11 @@ captures for every variant × DE to `docs/images/desktops/`, and
 captures to `docs/images/installer/` (then boot-verifies the disk the
 walkthrough installed).
 
-The LUKS E2E workflow also records each base variant/desktop install framebuffer
-as a WebM. The [latest fully passing LUKS install timelapses](https://tuna-os.github.io/tunaOS/e2e/luks/latest/)
-are published as a stable GitHub Pages gallery; HWE/NVIDIA overlays remain in
-the per-cell diagnostic artifacts, which are linked from the player’s source
-Actions run.
+Each base-DE pair has a LUKS E2E WebM.
+
+See the [latest LUKS install timelapses](https://tuna-os.github.io/tunaOS/e2e/luks/latest/).
+HWE and NVIDIA overlays stay in the per-cell artifacts. The source run links
+them.
 
 ## ISO End-to-End Tests
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -31,6 +31,12 @@ captures for every variant × DE to `docs/images/desktops/`, and
 captures to `docs/images/installer/` (then boot-verifies the disk the
 walkthrough installed).
 
+The LUKS E2E workflow also records each base variant/desktop install framebuffer
+as a WebM. The [latest fully passing LUKS install timelapses](https://tuna-os.github.io/tunaOS/e2e/luks/latest/)
+are published as a stable GitHub Pages gallery; HWE/NVIDIA overlays remain in
+the per-cell diagnostic artifacts, which are linked from the player’s source
+Actions run.
+
 ## ISO End-to-End Tests
 
 The `scripts/iso-e2e.sh` script boots a TunaOS live ISO in QEMU with OVMF (UEFI), waits for the live environment to be ready, captures screenshots, and collects serial logs.

--- a/pages/e2e/luks/latest/index.html
+++ b/pages/e2e/luks/latest/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>TunaOS latest LUKS E2E timelapses</title>
+<style>
+  :root { color-scheme: dark; }
+  body { max-width: 1100px; margin: 2rem auto; padding: 0 1rem;
+         background: #111; color: #eee; font: 16px/1.6 system-ui, sans-serif; }
+  h1 { font-size: 1.5rem; }
+  .sub { color: #aaa; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1.5rem; }
+  video { width: 100%; height: auto; border-radius: 8px; background: #000; }
+  a { color: #7dd3fc; }
+</style>
+
+<h1>TunaOS latest LUKS E2E timelapses</h1>
+<p class="sub">No complete green base-DE matrix has been published yet. The next
+successful full passphrase run will populate this gallery.</p>
+</html>

--- a/scripts/lib/pixel-gate.sh
+++ b/scripts/lib/pixel-gate.sh
@@ -8,10 +8,11 @@
 # "display-manager.service is active", and the repo's own history shows that
 # passing over a black console (run 29645108966). The evidence to contradict
 # it has been captured all along — the timelapse recorder screendumps real
-# frames on every GPU-less runner (151-210 frames on passing cells) and the
-# installed-desktop screenshot is stddev-measured — but both were recorded
-# fatal=0 and gated nothing. This turns the measurable cases into a gate and
-# names the unmeasurable ones instead of silently passing them.
+# frames on every GPU-less runner (151-210 frames on passing cells under the
+# prior two-second capture profile) and the installed-desktop screenshot is
+# stddev-measured — but both were recorded fatal=0 and gated nothing. This
+# turns the measurable cases into a gate and names the unmeasurable ones
+# instead of silently passing them.
 #
 # pixel_gate <shot> <stddev> <frames> <virgl> [contract]
 #   shot    drawn | blank | unmeasured | absent — screenshot_sane's verdict

--- a/scripts/record-timelapse.sh
+++ b/scripts/record-timelapse.sh
@@ -23,8 +23,9 @@
 # monitor answers "no surface" and screendump yields nothing (see the long
 # comment at iso-e2e.sh:831). screenshot() handles that by bridging VNC per
 # capture — a fresh socat listener and up to 5s of readiness polling EACH
-# TIME, which is right for a handful of stills and wrong for the ~300 frames
-# a ten-minute install produces. The LUKS matrix runs on GPU-less hosted
+# TIME, which is right for a handful of stills and wrong for the roughly
+# 200 frames a ten-minute install produces at the compact default interval.
+# The LUKS matrix runs on GPU-less hosted
 # runners, where QEMU_GPU_ARGS is the plain `-vga virtio -display none` path
 # and screendump works. On a virgl host this records nothing and says so,
 # rather than pretending.
@@ -36,7 +37,12 @@ set -Eeuo pipefail
 
 command="${1:?usage: record-timelapse.sh start|stop ...}"
 
-FPS="${TUNAOS_TIMELAPSE_FPS:-10}"
+# This is evidence, not a frame-by-frame recording. Six playback frames/sec
+# plus one capture every three seconds keeps a ten-minute install around 200
+# source frames before encoding. Both knobs stay overridable for local
+# debugging when a maintainer needs denser footage.
+FPS="${TUNAOS_TIMELAPSE_FPS:-6}"
+CRF="${TUNAOS_TIMELAPSE_CRF:-38}"
 
 snap_loop() {
 	local sock="$1" outdir="$2" interval="$3"
@@ -50,7 +56,11 @@ snap_loop() {
 		# Only advance the counter when a frame actually landed. ffmpeg's
 		# image2 demuxer needs a gapless sequence; a hole makes it stop at the
 		# gap and silently produce a truncated video.
-		[[ -s "$frame" ]] && n=$((n + 1)) || rm -f "$frame"
+		if [[ -s "$frame" ]]; then
+			n=$((n + 1))
+		else
+			rm -f "$frame"
+		fi
 		sleep "$interval"
 	done
 }
@@ -87,19 +97,24 @@ assemble() {
 	# first filename and has been known to pick the wrong demuxer for .ppm.
 	ffmpeg -y -loglevel warning -framerate "$FPS" \
 		-f image2 -i "$fdir/f%06d.ppm" \
-		-c:v libvpx-vp9 -b:v 1M -pix_fmt yuv420p \
+		-vf 'scale=960:-2:flags=lanczos' \
+		-c:v libvpx-vp9 -crf "$CRF" -b:v 0 -deadline good -cpu-used 4 -row-mt 1 \
+		-pix_fmt yuv420p \
 		"$outdir/timelapse.webm" </dev/null || {
 		echo "==> ffmpeg could not assemble the timelapse; frames kept" >&2
 		return 0
 	}
 
-	# A still poster so a gallery can show something before anyone presses
-	# play, and so GitHub can render it inline. Half the capture rate and a
-	# fixed width keeps it small enough to commit if we ever want to.
-	ffmpeg -y -loglevel warning -framerate "$FPS" \
-		-f image2 -i "$fdir/f%06d.ppm" \
-		-vf 'fps=5,scale=640:-2:flags=lanczos' -loop 0 \
-		-c:v libwebp -quality 60 -compression_level 6 \
+	# A single still poster so a gallery can show something before anyone
+	# presses play, and so GitHub can render it inline. Use the last captured
+	# frame (usually the installed desktop) rather than making an animated WebP;
+	# the latter can be larger than the timelapse it previews.
+	local poster_frame
+	poster_frame="$(find "$fdir" -maxdepth 1 -type f -name 'f*.ppm' -print | sort | tail -n 1)"
+	ffmpeg -y -loglevel warning \
+		-i "$poster_frame" \
+		-vf 'scale=480:-2:flags=lanczos' -frames:v 1 \
+		-c:v libwebp -quality 45 -compression_level 6 \
 		"$outdir/timelapse-poster.webp" </dev/null || true
 
 	echo "==> Timelapse: $outdir/timelapse.webm (${nframes} frames @ ${FPS}fps)"
@@ -109,7 +124,7 @@ case "$command" in
 start)
 	sock="${2:?start needs the QEMU monitor socket}"
 	outdir="${3:?start needs an output directory}"
-	interval="${4:-${TUNAOS_TIMELAPSE_INTERVAL:-2}}"
+	interval="${4:-${TUNAOS_TIMELAPSE_INTERVAL:-3}}"
 	mkdir -p "$outdir"
 	# Recording is best-effort: if the monitor socket never appears the loop
 	# simply captures nothing, and assemble() reports that. It must not wedge

--- a/tests/bats/test_record_timelapse.bats
+++ b/tests/bats/test_record_timelapse.bats
@@ -25,7 +25,7 @@ setup() {
 	# left /usr/bin on PATH, so its negative cases asserted nothing on hosts
 	# that ship the tool.)
 	local u bin
-	for u in bash sh find wc rm cat printf sleep kill mkdir sed; do
+	for u in bash sh find wc rm cat printf sleep kill mkdir sed sort tail; do
 		bin="$(command -v "$u" 2>/dev/null)" || continue
 		ln -sf "$bin" "$BIN/$u"
 	done
@@ -117,6 +117,16 @@ make_frames() {
 # that failed to capture must not consume an index — otherwise the video is
 # silently truncated at the hole rather than being short by one frame.
 @test "the frame counter only advances on a frame that actually landed" {
-	run grep -n 'n=\$((n + 1)) || rm -f' "$SCRIPT"
-	[ "$status" -eq 0 ]
+	grep -q 'if \[\[ -s "\$frame" \]\]; then' "$SCRIPT"
+	grep -q 'n=\$((n + 1))' "$SCRIPT"
+	grep -q 'rm -f "\$frame"' "$SCRIPT"
+}
+
+@test "the default recording profile is compact but overridable" {
+	grep -q 'FPS="\${TUNAOS_TIMELAPSE_FPS:-6}"' "$SCRIPT"
+	grep -q 'CRF="\${TUNAOS_TIMELAPSE_CRF:-38}"' "$SCRIPT"
+	grep -q 'TUNAOS_TIMELAPSE_INTERVAL:-3' "$SCRIPT"
+	grep -q "scale=960:-2:flags=lanczos" "$SCRIPT"
+	grep -q -- '-c:v libvpx-vp9 -crf "\$CRF" -b:v 0' "$SCRIPT"
+	grep -q -- "-frames:v 1" "$SCRIPT"
 }

--- a/tests/test_luks_e2e_matrix.py
+++ b/tests/test_luks_e2e_matrix.py
@@ -11,6 +11,8 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "luks-e2e.yml"
+
+
 def generator_script() -> str:
     workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     return next(
@@ -64,6 +66,14 @@ def matrix_from(output: Path) -> list[dict[str, str]]:
     return json.loads(line.removeprefix("matrix="))["include"]
 
 
+def output_values(output: Path) -> dict[str, str]:
+    return {
+        line.split("=", 1)[0]: line.split("=", 1)[1]
+        for line in output.read_text(encoding="utf-8").splitlines()
+        if "=" in line
+    }
+
+
 def test_default_matrix_never_schedules_headless_base_derivatives(tmp_path):
     """base-hwe/base-nvidia cannot satisfy this workflow's login gate.
 
@@ -91,3 +101,36 @@ def test_headless_base_dispatch_fails_before_runner_fanout(tmp_path):
     proc, _ = run_generator(tmp_path, variant="yellowfin", flavor="base-hwe")
     assert proc.returncode != 0
     assert "No matching variant/flavor cells" in proc.stdout + proc.stderr
+
+
+def test_timelapse_outputs_cover_plain_desktops_only(tmp_path):
+    proc, output = run_generator(tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    values = output_values(output)
+    desktops = set(json.loads(values["base_desktops"]))
+    assert {"gnome", "kde", "cosmic", "niri", "xfce", "pantheon"} <= desktops
+    assert not any(
+        desktop.endswith(("-hwe", "-nvidia", "-asahi", "-t2", "-zfs", "-cachyos"))
+        for desktop in desktops
+    )
+
+    cells = json.loads(values["base_cells"])
+    assert cells
+    assert all(
+        not cell.endswith(
+            ("-hwe", "-nvidia", "-asahi", "-t2", "-zfs", "-cachyos")
+        )
+        for cell in cells
+    )
+
+
+def test_timelapse_publication_is_only_enabled_for_the_full_matrix(tmp_path):
+    proc, output = run_generator(tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert output_values(output)["publish_latest"] == "true"
+
+    filtered = tmp_path / "filtered"
+    filtered.mkdir()
+    proc, output = run_generator(filtered, variant="yellowfin")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert output_values(output)["publish_latest"] == "false"

--- a/tests/test_luks_timelapse_publication.py
+++ b/tests/test_luks_timelapse_publication.py
@@ -1,0 +1,71 @@
+"""Keep the public LUKS timelapse publication wired to the E2E artifacts."""
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "luks-e2e.yml"
+PAGES_WORKFLOW = ROOT / ".github" / "workflows" / "pages.yml"
+DOCS = ROOT / "docs" / "TESTING.md"
+PAGES_INDEX = ROOT / "pages" / "e2e" / "luks" / "latest" / "index.html"
+
+
+def _publication_job() -> dict:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["publish-latest-timelapse"]
+
+
+def _run_steps() -> str:
+    return "\n".join(
+        step.get("run", "")
+        for step in _publication_job()["steps"]
+        if "run" in step
+    )
+
+
+def test_publication_waits_for_a_fully_passing_luks_matrix():
+    job = _publication_job()
+    assert job["needs"] == ["generate-matrix", "luks"]
+    assert job["if"] == (
+        "needs.luks.result == 'success' && "
+        "needs.generate-matrix.outputs.publish_latest == 'true'"
+    )
+
+
+def test_publication_selects_the_uploaded_webm_and_publishes_a_player():
+    text = _run_steps()
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    assert "pattern: luks-e2e-*" in workflow_text
+    assert workflow_text.index("Checkout Pages template") < workflow_text.index(
+        "Download passing-cell artifacts"
+    )
+    assert "base_desktops" in workflow_text
+    assert "base_cells" in WORKFLOW.read_text(encoding="utf-8")
+    assert "base_flavors" in text
+    assert "expected_cells" in text
+    assert "timelapse/timelapse.webm" in text
+    assert "luks-evidence.log" in text
+    assert "pages/e2e/luks/latest" in text
+    assert '"${videos[$cell]}"' in text
+    assert 'git push -f origin HEAD:pages-assets' in text
+    assert "source-run.txt" in text
+
+
+def test_publication_excludes_overlay_flavors_from_the_base_desktop_set():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert 'test("-(hwe|nvidia|asahi|t2|zfs|cachyos)$")' in text
+    assert 'select(. != "base")' in text
+    assert 'echo "publish_latest=true"' in text
+    assert 'echo "publish_latest=false"' in text
+
+
+def test_docs_link_to_the_same_stable_latest_pointer():
+    docs = DOCS.read_text(encoding="utf-8")
+    pages = PAGES_WORKFLOW.read_text(encoding="utf-8")
+    assert "https://tuna-os.github.io/tunaOS/e2e/luks/latest/" in docs
+    assert "repository_dispatch" in pages
+    assert "pages-assets" in pages
+    assert "actions/deploy-pages@" in pages
+    assert PAGES_INDEX.is_file()


### PR DESCRIPTION
## Summary

- Record compact framebuffer WebM timelapses and still posters during LUKS E2E runs.
- Publish one video per plain base-DE matrix cell; HWE and NVIDIA overlays remain diagnostic artifacts only.
- Deploy the stable gallery through workflow-based GitHub Pages, using an orphan pages-assets branch and a repository dispatch refresh.
- Link the gallery from docs/TESTING.md.

## Verification

- `just fix` — passed.
- `pytest -q tests/test_luks_timelapse_publication.py tests/test_luks_e2e_matrix.py tests/test_ci_contract.py tests/test_the_action_pin_gate_rejects_mutable_refs.py tests/test_fork_safe_workflows.py` — 88 passed.
- `bats tests/bats/test_record_timelapse.bats` — 9 passed.
- `shellcheck -x scripts/record-timelapse.sh` — passed.
- Targeted actionlint for the three affected workflows — passed.
- `just test-contract` — passed.
- `git diff --check` — passed.

The repository-wide `just check` was attempted, but its all-workflow actionlint subprocess stalled after reporting existing unrelated lint findings; the affected workflows pass targeted actionlint.

## Deployment evidence

Workflow-based Pages is enabled for the repository (`build_type=workflow`). After merge, the Pages workflow will deploy the placeholder, and the next fully green full LUKS passphrase run will publish the gallery at https://tuna-os.github.io/tunaOS/e2e/luks/latest/.