### PR TITLE
chore(dev): run STE in local checks

### DIFF
--- a/docs/CI_SPEC.md
+++ b/docs/CI_SPEC.md
@@ -65,6 +65,7 @@ This inventory is generated from workflow triggers and `.github/green-criteria.y
 | `luks-e2e.yml` | post-merge + scheduled | `install` | `0 7 1 * *`, `0 7 1 */3 *`, manual, caller cadence | `install`: 35d |
 | `matrix-status.yml` | PR-deterministic + post-merge + scheduled | Matrix Status | each PR, `0 6 * * *`, manual | — |
 | `package-parity.yml` | post-merge + scheduled | `parity` | `40 8 * * *`, manual | `parity`: 2d |
+| `pages.yml` | post-merge | GitHub Pages | push, repository dispatch, manual | — |
 | `post-build-luks-e2e.yml` | post-merge + scheduled | Post-Build LUKS E2E | `0 6 * * 4`, workflow completion, manual | — |
 | `pr-nudges.yml` | PR-deterministic | PR Reminders | each PR | — |
 | `prune-r2.yml` | post-merge + scheduled | Prune R2 retention | `30 12 * * *`, manual | — |

--- a/just/utilities.just
+++ b/just/utilities.just
@@ -48,13 +48,22 @@ _ensure_check_deps: _check_shfmt_version
     if ! command -v yamllint &> /dev/null; then brew install yamllint; fi
     if ! command -v jq &> /dev/null; then brew install jq; fi
     if ! command -v actionlint &> /dev/null; then brew install actionlint; fi
+    if ! command -v node &> /dev/null; then brew install node; fi
+
+# Check prose with the same pinned shared linter and budget as CI. This is a
+# check, not a formatter: STE findings need a human wording change, so `just
+# fix` deliberately does not alter Markdown.
+ste: _ensure_check_deps
+    #!/usr/bin/env bash
+    cd {{ justfile_directory() }}
+    ./scripts/run-ste-lint.sh
 
 # Check Just Syntax
-check: _ensure_check_deps
+check: _ensure_check_deps ste
     #!/usr/bin/env bash
     cd {{ justfile_directory() }}
     echo "Checking syntax of shell scripts..."
-    find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './.build/*' -iname "*.sh" -type f -exec shellcheck --exclude=SC1091 "{}" ";"
+    find . -not -path './.git/*' -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './.build/*' -iname "*.sh" -type f -exec shellcheck --exclude=SC1091 "{}" ";"
     # `just fix` WROTE shell formatting and nothing ever CHECKED it, so the
     # .editorconfig could disagree with every file in the repo indefinitely --
     # and did. A formatter you do not verify is a formatter that drifts.
@@ -65,14 +74,19 @@ check: _ensure_check_deps
     # shfmt --diff on a bad file exits 1, the same command under find -exec
     # exits 0.
     echo "Checking shell formatting (shfmt)..."
-    unformatted="$(find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './.build/*' -not -path './_upstream-snapshots/*' -iname "*.sh" -type f -print0 | xargs -0 shfmt -l 2>/dev/null || true)"
+    unformatted="$(find . -not -path './.git/*' -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './.build/*' -not -path './_upstream-snapshots/*' -iname "*.sh" -type f -print0 | xargs -0 shfmt -l 2>/dev/null || true)"
     if [[ -n "$unformatted" ]]; then
         echo "::error::Shell formatting drift. Run 'just fix' and commit the result."
         echo "$unformatted"
         exit 1
     fi
-    find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './.build/*' -type f -name "*.yaml" -exec yamllint -c ./.yamllint.yml {} \; -o -name "*.yml" -exec yamllint {} \; 2>/dev/null || true
-    find . -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './.build/*' -type f -name "*.json" -exec sh -c 'jq . "$1" > /dev/null' _ {} \; 2>/dev/null || true
+    find . -path './.git' -prune -o \
+        -not -path './system_files/usr/share/gnome-shell/extensions/*' \
+        -not -path './packages-repo/*' -not -path './.build/*' -type f \( \
+        -name "*.yaml" -exec yamllint -c ./.yamllint.yml {} \; -o \
+        -name "*.yml" -exec yamllint {} \; \
+        \) 2>/dev/null || true
+    find . -not -path './.git/*' -not -path './system_files/usr/share/gnome-shell/extensions/*' -not -path './packages-repo/*' -not -path './.build/*' -type f -name "*.json" -exec sh -c 'jq . "$1" > /dev/null' _ {} \; 2>/dev/null || true
     if command -v actionlint &> /dev/null; then
         actionlint -ignore "permission \"id-token\" is unknown" -ignore "SC2086" -ignore "SC2129" -ignore "SC2001" -ignore "SC2034" -ignore "SC2015" -ignore "SC1001" -ignore "SC2295" -ignore "SC2016" -ignore "save-always" -ignore "cannot be filtered" .github/workflows/*.yml .github/workflows/*.yaml || { exit 1; }
     fi
@@ -122,7 +136,7 @@ test-pytest: _ensure_test_deps
 setup: _ensure_test_deps
     #!/usr/bin/env bash
     cd {{ justfile_directory() }}
-    for t in shellcheck shfmt yamllint jq actionlint bats yq; do
+    for t in shellcheck shfmt yamllint jq actionlint bats yq node; do
         printf '%-11s %s\n' "$t" "$(command -v "$t" >/dev/null && $t --version 2>&1 | head -1 || echo MISSING)"
     done
     python3 -c 'import pytest, yaml; print("pytest", pytest.__version__, "pyyaml", yaml.__version__)'

--- a/scripts/run-ste-lint.sh
+++ b/scripts/run-ste-lint.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Run the same pinned Simplified Technical English linter as CI.
+#
+# The linter lives in tuna-os/.github, not in this repository. Cache that
+# shared source at the exact workflow pin so local checks use the CI rules
+# without copying a second implementation into TunaOS. The cache is outside
+# the worktree and never becomes source content.
+
+set -Eeuo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+ste_workflow="${repo_root}/.github/workflows/ste.yml"
+ste_ref="$(sed -nE \
+	's|^[[:space:]]*uses: tuna-os/\.github/\.github/workflows/ste-lint\.yml@([0-9a-f]{40}).*$|\1|p' \
+	"$ste_workflow" | head -n 1)"
+
+if [[ ! "$ste_ref" =~ ^[0-9a-f]{40}$ ]]; then
+	echo "ERROR: could not read the pinned STE workflow revision from ${ste_workflow}" >&2
+	exit 1
+fi
+
+budget="$(tr -d '[:space:]' <"${repo_root}/.ste-budget")"
+if [[ ! "$budget" =~ ^[0-9]+$ ]]; then
+	echo "ERROR: .ste-budget must contain one non-negative integer" >&2
+	exit 1
+fi
+
+if [[ -n "${TUNAOS_STE_CACHE_DIR:-}" ]]; then
+	cache_root="$TUNAOS_STE_CACHE_DIR"
+elif [[ -n "${XDG_CACHE_HOME:-}" ]]; then
+	cache_root="${XDG_CACHE_HOME}/tunaos/ste-lint"
+else
+	cache_root="${TMPDIR:-/tmp}/tunaos-ste-lint-$(id -u)"
+fi
+cache_dir="${cache_root}/${ste_ref}"
+linter="${cache_dir}/.github/actions/ste-lint/ste-lint.mjs"
+
+if [[ ! -f "$linter" ]]; then
+	if [[ -e "$cache_dir" ]]; then
+		echo "ERROR: STE cache exists but is incomplete: ${cache_dir}" >&2
+		echo "Remove that cache directory and run 'just ste' again." >&2
+		exit 1
+	fi
+	mkdir -p "$cache_root"
+	echo "Fetching shared STE linter at ${ste_ref} into the local cache..." >&2
+	git clone --quiet --filter=blob:none --no-checkout \
+		https://github.com/tuna-os/.github.git "$cache_dir"
+	git -C "$cache_dir" fetch --quiet --filter=blob:none origin "$ste_ref"
+	git -C "$cache_dir" checkout --quiet --detach "$ste_ref"
+fi
+
+if [[ ! -f "$linter" ]]; then
+	echo "ERROR: shared STE linter is missing from ${cache_dir}" >&2
+	exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+	echo "ERROR: node is required for the STE linter; run 'just setup'" >&2
+	exit 1
+fi
+
+echo "Checking Simplified Technical English (budget: ${budget})..."
+node "$linter" --summary
+node "$linter" --max "$budget" >/dev/null

--- a/tests/test_ste_local_check.py
+++ b/tests/test_ste_local_check.py
@@ -1,0 +1,76 @@
+"""Keep the local STE gate aligned with the shared CI action."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "run-ste-lint.sh"
+UTILITIES = ROOT / "just" / "utilities.just"
+STE_WORKFLOW = ROOT / ".github" / "workflows" / "ste.yml"
+
+
+def _recipe(name: str) -> str:
+    text = UTILITIES.read_text(encoding="utf-8")
+    body = text[text.index(f"\n{name}:") :]
+    match = re.search(r"\n[a-z][a-z0-9-]*:", body[1:])
+    return body[: match.start() + 1] if match else body
+
+
+def _ste_ref() -> str:
+    match = re.search(
+        r"uses: tuna-os/\.github/\.github/workflows/ste-lint\.yml@([0-9a-f]{40})",
+        STE_WORKFLOW.read_text(encoding="utf-8"),
+    )
+    assert match
+    return match.group(1)
+
+
+def test_check_runs_ste_but_fix_does_not() -> None:
+    check = _recipe("check")
+    fix = _recipe("fix")
+    ste = _recipe("ste")
+    assert re.search(r"^check: .*\bste\b", check, re.M)
+    assert "run-ste-lint.sh" in ste
+    assert "run-ste-lint.sh" not in fix
+    assert "./.git/*" in check
+    assert "-path './.git' -prune" in check
+
+
+def test_local_runner_reads_the_ci_pin_and_budget() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+    assert SCRIPT.stat().st_mode & 0o111
+    assert "ste_workflow=" in text
+    assert "ste_ref=" in text
+    assert "ste-lint.mjs" in text
+    assert "--summary" in text
+    assert "--max" in text
+    assert ".ste-budget" in text
+
+
+def test_local_runner_uses_a_cached_pinned_linter(tmp_path: Path) -> None:
+    cache = tmp_path / "cache" / _ste_ref() / ".github" / "actions" / "ste-lint"
+    cache.mkdir(parents=True)
+    (cache / "ste-lint.mjs").write_text(
+        """
+        const args = process.argv.slice(2);
+        const valid = args.includes('--summary') ||
+          (args.includes('--max') && args[args.indexOf('--max') + 1] === '3050');
+        process.exit(valid ? 0 : 1);
+        """,
+        encoding="utf-8",
+    )
+    env = os.environ | {"TUNAOS_STE_CACHE_DIR": str(tmp_path / "cache")}
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout


### PR DESCRIPTION
## Summary

- Add a public `just ste` recipe that runs the same pinned shared STE linter and `.ste-budget` as CI.
- Make `just check` depend on `ste`, so prose checks run before the other local gates.
- Keep `just fix` content-neutral; STE findings require human wording changes.
- Cache the pinned shared linter outside the worktree and exclude `.git` from repository scans.

## Verification

- `just fix` — passed.
- `just ste` — passed at 3050 findings across 102 files, matching `.ste-budget`.
- `pytest -q tests/test_ste_local_check.py tests/test_shell_formatting_contract.py tests/test_ci_contract.py` — 47 passed.
- `bash -n scripts/run-ste-lint.sh` and ShellCheck — passed.
- Justfile formatting and staged diff checks — passed.
- `just check` visibly runs STE first, then exits on the existing unrelated workflow findings `SC2193` in `desktop-contract-sweep.yml` and `SC2094` in `installer-smoke.yml`; GitHub lint uses its existing ignore policy for those findings.