### PR TITLE
fix(niri): wire the EL10 DMS QML fallback into the live install path

### DIFF
--- a/build_scripts/desktop/dms-qml-fallback-el10.sh
+++ b/build_scripts/desktop/dms-qml-fallback-el10.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Overlay the checksum-pinned DMS QML payload on EL10 niri builds.
+#
+# The AvengeMedia EL10 dms-greeter RPM (installed by manifests/desktops/
+# niri.yaml's el10.copr section) only ships a runtime-sync launcher — no QML —
+# so without this, greetd execs dms-greeter into a blank window and
+# /usr/share/quickshell/dms-greeter/DMSGreeter.qml never exists
+# (verify-branding-niri.sh's "dms-greeter shell present" check).
+#
+# build_scripts/install-dms-qml-fallback.sh already does the actual download
+# + checksum + install; this file exists only to call it from the live,
+# manifest-driven install path and to gate it to EL10. It used to be wired
+# into build_scripts/desktop/niri.sh's "base" case instead, which
+# install-desktop.sh (the manifest-driven installer every desktop actually
+# goes through now) never calls — so the fallback has never run in a real
+# build since it was added (tunaOS#2359).
+#
+# This is sourced by install-desktop.sh via a manifest's post_install list, so
+# it must never call `exit` — that would end the whole desktop install
+# (see greetd-gtkgreet.sh for the same contract). The underlying script DOES
+# call exit, which is why it is run as a subprocess here rather than sourced.
+if [[ "${IS_ALMALINUX:-false}" == true || "${IS_ALMALINUXKITTEN:-false}" == true || "${IS_CENTOS:-false}" == true ]]; then
+	if ! "${_TD_CTX}/build_scripts/install-dms-qml-fallback.sh"; then
+		echo "ERROR: DMS QML fallback failed; niri greeter would ship with no shell" >&2
+		return 1
+	fi
+fi

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -111,7 +111,7 @@ downloads:
   # tunaos-packages dms/dms-greeter recipes for the offline-build fallback.
   # renovate: datasource=github-releases depName=AvengeMedia/DankMaterialShell
   dms_qml: "v1.6.1"
-  dms_qml_sha256: "aef0e90ad39bf85f676743da7bbe4c32758059d49342d82741d93ec414b88888"
+  dms_qml_sha256: "904ad2709a2075f10dbb089b42a9f4eb39d8f06cb2634fd4c95fa739ef9c4a2d"
 
   # Zirconium's mkosi.extra payload, fetched as a source tarball by
   # build_scripts/install-zirconium.sh (niri stages only). Pinned to a commit

--- a/manifests/desktops/niri.yaml
+++ b/manifests/desktops/niri.yaml
@@ -286,6 +286,11 @@ post_install:
   # dms-greeter); on openSUSE it is the difference between a login screen and
   # greetd's stock text prompt into a bare shell.
   - greetd-gtkgreet.sh
+  # EL10-only: the dms-greeter RPM installed above ships no QML, so overlay
+  # the checksum-pinned upstream payload or greetd launches dms-greeter into
+  # a blank window (verify-branding-niri.sh's dms-greeter-shell-present and
+  # background checks; tunaOS#2359). No-op on every other base.
+  - dms-qml-fallback-el10.sh
   # Curated Flatpak set (store + browser) + preinstall service — see the
   # script header; asserts live in verify-desktop-experience.sh.
   - flatpak-preinstall.sh

--- a/tests/bats/test_niri_dms_payload.bats
+++ b/tests/bats/test_niri_dms_payload.bats
@@ -43,16 +43,42 @@ _code() { grep -v '^[[:space:]]*#' "$1"; }
 }
 
 @test "EL10 installs a checksum-pinned QML fallback after the COPR transaction" {
-  local installer="${REPO_ROOT}/build_scripts/desktop/niri.sh"
+  # build_scripts/desktop/niri.sh's "base" case is dead code: install-desktop.sh
+  # (what every desktop build actually runs) never calls a per-desktop
+  # <name>.sh, it drives manifests/desktops/<name>.yaml instead. The fallback
+  # used to be wired only into niri.sh, so it never ran in a real build even
+  # though this test passed (tunaOS#2359's build_yellowfin niri leg red every
+  # night since before the "fix" landed) -- assert against the manifest's
+  # post_install list, the path install-desktop.sh actually resolves.
+  local wrapper="${REPO_ROOT}/build_scripts/desktop/dms-qml-fallback-el10.sh"
+  local manifest="${REPO_ROOT}/manifests/desktops/niri.yaml"
   local fallback="${REPO_ROOT}/build_scripts/install-dms-qml-fallback.sh"
   local versions="${REPO_ROOT}/image-versions.yaml"
 
   [ -x "$fallback" ]
-  _code "$installer" | grep -qF '/run/context/build_scripts/install-dms-qml-fallback.sh'
+  [ -x "$wrapper" ]
+  grep -qxF '  - dms-qml-fallback-el10.sh' "$manifest"
+  _code "$wrapper" | grep -qF 'build_scripts/install-dms-qml-fallback.sh'
   _code "$fallback" | grep -qF '/usr/share/quickshell/dms-greeter/DMSGreeter.qml'
   _code "$fallback" | grep -qF 'sha256sum --check --strict'
   grep -qE '^[[:space:]]+dms_qml: "v[0-9]' "$versions"
   grep -qE '^[[:space:]]+dms_qml_sha256: "[0-9a-f]{64}"' "$versions"
+}
+
+@test "dms-qml-fallback-el10.sh is sourced, not exec'd, and never calls exit" {
+  # install-desktop.sh's post_install loop sources every script under
+  # set -e; one that calls exit ends the whole desktop install instead of
+  # just this hook (see greetd-gtkgreet.sh's header comment for the same
+  # contract). install-dms-qml-fallback.sh itself DOES call exit, which is
+  # exactly why this wrapper must run it as a subprocess rather than source it.
+  local wrapper="${REPO_ROOT}/build_scripts/desktop/dms-qml-fallback-el10.sh"
+  ! _code "$wrapper" | grep -qE '(^|[^A-Za-z])exit([^A-Za-z]|$)'
+}
+
+@test "dms-qml-fallback-el10.sh passes shellcheck" {
+  if ! command -v shellcheck &>/dev/null; then skip "shellcheck not installed"; fi
+  run shellcheck --severity=error --exclude=SC1091 "${REPO_ROOT}/build_scripts/desktop/dms-qml-fallback-el10.sh"
+  [ "$status" -eq 0 ]
 }
 
 @test "DMS QML fallback passes shellcheck" {


### PR DESCRIPTION
## Root cause

`build_scripts/desktop/niri.sh`'s "base" case is dead code: `install-desktop.sh` (what every desktop build actually runs since the manifest-driven install system replaced per-desktop scripts) never invokes a per-desktop `<name>.sh` — it drives `manifests/desktops/<name>.yaml` instead. `d8954da0` added `install-dms-qml-fallback.sh` (the AvengeMedia EL10 `dms-greeter` RPM ships no QML) and wired it only into `niri.sh`, plus a bats test that also only checked `niri.sh` — so the fix looked landed and tested, but has never actually run in a real build.

`yellowfin:niri` (and any other EL10 niri build) has failed `verify-branding-niri.sh` on every scheduled `Build Yellowfin` run since at least 2026-09-03/04:
```
FAIL: greetd launches dms-greeter but /usr/share/quickshell/dms-greeter/DMSGreeter.qml is missing
FAIL: no wallpaper daemon (swaybg/swww/wpaperd) and no dms — background will be blank
```

## Fix

- Add `build_scripts/desktop/dms-qml-fallback-el10.sh`, a thin EL10-gated wrapper listed in `niri.yaml`'s `post_install` (the list `install-desktop.sh` actually sources). It runs the existing standalone script as a subprocess rather than sourcing it directly — that script calls `exit`, which this repo's post_install contract forbids (see `greetd-gtkgreet.sh`'s header comment for the same rule).
- Rewrote `tests/bats/test_niri_dms_payload.bats`'s coverage to assert against the manifest's `post_install` list instead of the dead `niri.sh` — the old test's false confidence is exactly how this regression shipped unnoticed.
- Also fixes a second, independently-real bug this surfaced: `image-versions.yaml` pinned `dms_qml`'s sha256 to a value that no longer matches the `v1.6.1` release asset. Measured directly (`curl` + `sha256sum`): the asset now hashes to `904ad2709a2075f10dbb089b42a9f4eb39d8f06cb2634fd4c95fa739ef9c4a2d`, matching `tests/test_pinned_download_checksums.py`, which was already red on `main` for this exact reason. Fixing only the wiring would have traded one failure for another.

## Test plan

- [x] `shellcheck`, `shfmt` clean on the new/changed scripts
- [x] `yamllint` clean on the changed manifest
- [x] `bats tests/bats/test_niri_dms_payload.bats` — 9/9 passing (previously 1 test passed by checking the wrong file)
- [x] Full local `bats` suite — no regressions
- [x] `pytest tests/test_pinned_download_checksums.py -k dms_qml` — now passes
- [x] **Local end-to-end build** (`sudo -E env TMPDIR=... TBOX_CUSTOMIZE_NETWORK=host TACKLEBOX_FROM_SOURCE=1 just iso yellowfin niri ghcr "" 1`), since CI verification is currently blocked by a separate, already-tracked infra regression (a runc/podman bind-mount incompatibility failing every EL10 build at a trivial early `RUN` step — unrelated to this fix, being fixed independently). The local build reached and passed the branding contract cleanly:
  ```
  ==> Installed pinned DMS v1.6.1 QML fallback
  ...
  desktop experience contract passed: niri (zirconium-dev/zirconium)
    ok: dms-greeter shell present
    ok: no wallpaper daemon, but dms/quickshell can draw the background
  TUNAOS_BRANDING_NIRI_OK variant=yellowfin
  ...
  ==> Done! ISO: yellowfin-niri-10-x86_64.iso (4.6G)
  ```
  Both previously-failing assertions now pass, and the full ISO build completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPy3UKQtRXxGzZZG3KXVEk