### PR TITLE
feat(ci): honour freshness SLA in composite green scoring

### DIFF
--- a/.github/scripts/update-build-status.sh
+++ b/.github/scripts/update-build-status.sh
@@ -17,6 +17,7 @@ trap 'rm -f "$tmp_table" "$tmp_readme"' EXIT
 total_green=0
 total_cells=0
 total_unreached=0
+total_stale=0
 composite_green=0
 
 # The boots criterion's scope, read from the criteria file so this script and
@@ -130,6 +131,21 @@ while IFS=$'\t' read -r variant emoji; do
 	composite_green=$((composite_green + cgreen))
 	total_unreached=$((total_unreached + ${#unreached[@]}))
 
+	builds_sla=$(yq -r '.criteria[] | select(.id == "builds") | .freshness_sla_days // 2' .github/green-criteria.yml 2>/dev/null || echo 2)
+	builds_sla="${builds_sla:-2}"
+	today=$(date -u +%F)
+	run_age=0
+	if [[ -n "$run_date" && "$run_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+		run_epoch=$(date -u -d "$run_date" +%s 2>/dev/null || echo 0)
+		today_epoch=$(date -u -d "$today" +%s 2>/dev/null || echo 0)
+		if [[ "$run_epoch" -gt 0 && "$today_epoch" -ge "$run_epoch" ]]; then
+			run_age=$(( (today_epoch - run_epoch) / 86400 ))
+		fi
+	fi
+	if [[ "$run_age" -gt "$builds_sla" ]]; then
+		total_stale=$((total_stale + green))
+	fi
+
 	failing_text=$(join_or_dash "${failing[@]+"${failing[@]}"}")
 	unreached_text=$(join_or_dash "${unreached[@]+"${unreached[@]}"}")
 
@@ -201,7 +217,7 @@ blocking_text=$(sed -E 's/,/`, `/g' <<<"$blocking")
 
 {
 	echo
-	echo "**Built ${total_green}/${total_cells} · composite green ${composite_green}/${composite_total} (${percent}% built)** — The remainder has **${total_failing} ${failure_word}** and **${total_unreached} never reached**; no job asserted the latter. We show the two values separately. A cell with no job has no test, but it can still work."
+	echo "**Built ${total_green}/${total_cells} · composite green ${composite_green}/${composite_total} (${percent}% built)** — The remainder has **${total_failing} ${failure_word}** and **${total_unreached} never reached** (stale: ${total_stale}); no job asserted the latter. We show the two values separately. A cell with no job has no test, but it can still work."
 	echo
 	echo "The score for composite green uses ${composite_scope}. [\`.github/green-criteria.yml\`](.github/green-criteria.yml) provides the score. Today, these criteria prevent publication: \`${blocking_text}\`. A cell must satisfy each criterion."
 	echo

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ _This snapshot uses the latest conclusive build from the main branch for each va
 | 🏔️ `ghcr.io/tuna-os/tromso` | [tromso](https://github.com/tuna-os/tromso) | KDE | [❌ 2026-09-10](https://github.com/tuna-os/tromso/actions/runs/34439484511) |
 | 🐭 `ghcr.io/tuna-os/xfce-linux` | [xfce-linux](https://github.com/tuna-os/xfce-linux) | XFCE | [❌ 2026-09-10](https://github.com/tuna-os/xfce-linux/actions/runs/34424755451) |
 
-**Built 50/140 · composite green 46/140 (35% built)** — The remainder has **4 failures** and **86 never reached**; no job asserted the latter. We show the two values separately. A cell with no job has no test, but it can still work.
+**Built 50/140 · composite green 46/140 (35% built)** — The remainder has **4 failures** and **86 never reached** (stale: 0); no job asserted the latter. We show the two values separately. A cell with no job has no test, but it can still work.
 
 The score for composite green uses published cells, per [docs/MATRIX-STATUS.md](docs/MATRIX-STATUS.md). [`.github/green-criteria.yml`](.github/green-criteria.yml) provides the score. Today, these criteria prevent publication: `boots`, `builds`, `desktop`, `no_silent_omissions`. A cell must satisfy each criterion.
 

--- a/scripts/gen-matrix-status.py
+++ b/scripts/gen-matrix-status.py
@@ -23,6 +23,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import datetime
 import difflib
 import json
 import os
@@ -598,8 +599,34 @@ def criterion_scope_allows(criterion: dict, flavor: str) -> bool:
     )
 
 
+def is_stale(
+    date_str: str,
+    sla_days: int | float | None,
+    today: datetime.date | str | None = None,
+) -> bool:
+    """True if evidence date_str is older than sla_days relative to today."""
+    if not date_str or sla_days is None:
+        return False
+    try:
+        ev_date = datetime.date.fromisoformat(date_str)
+    except (ValueError, TypeError):
+        return False
+    if today is None:
+        ref = datetime.date.today()
+    elif isinstance(today, str):
+        try:
+            ref = datetime.date.fromisoformat(today)
+        except (ValueError, TypeError):
+            ref = datetime.date.today()
+    elif isinstance(today, datetime.date):
+        ref = today
+    else:
+        ref = datetime.date.today()
+    return (ref - ev_date).days > sla_days
+
+
 def composite_section(criteria, stage, contract, luks, smoke, lifecycle,
-                      omissions, parity):
+                      omissions, parity, today: datetime.date | str | None = None):
     """The bar itself: one table scored against the blocking criteria.
 
     Per-criterion applicability follows each axis's own denominator, exactly
@@ -689,19 +716,26 @@ def composite_section(criteria, stage, contract, luks, smoke, lifecycle,
 
     def verdict(variant: str, flavor: str) -> str:
         per_cell = scorers(variant, flavor)
+        entry = provenance.get(f"{variant}:{flavor}", {})
         applicable = []
         for criterion in blocking_criteria:
             if not criterion_scope_allows(criterion, flavor):
                 continue
             cid = criterion["id"]
+            sla = criterion.get("freshness_sla_days")
+            axis_entry = entry.get(cid, {})
+            v = axis_entry.get("verdict", "untested")
+            d = axis_entry.get("date", "")
+            if is_stale(d, sla, today):
+                v = "untested"
             if cid in ("builds", "boots"):
                 # Universal criteria: absence of a verdict is ⬜, it never
                 # silently drops out of the bar (skipped_is_not_green).
-                applicable.append(per_cell.get(cid, "untested"))
+                applicable.append(v)
             elif cid in per_cell:
                 # Axis-scoped criteria (desktop/install/iso/...): judged only
                 # where their own denominator schedules the cell.
-                applicable.append(per_cell[cid])
+                applicable.append(v)
         return composite_verdict(applicable or ["untested"])
 
     green = total = 0
@@ -721,8 +755,10 @@ def composite_section(criteria, stage, contract, luks, smoke, lifecycle,
         entry = provenance[f"{variant}:{flavor}"]
         # Prefer runtime evidence over build metadata when both assert green.
         for axis in ("boots", "desktop", "no_silent_omissions", "builds"):
-            if entry.get(axis, {}).get("verdict") == "pass":
-                url = entry[axis].get("evidence", "")
+            axis_entry = entry.get(axis, {})
+            sla = next((c.get("freshness_sla_days") for c in criteria if c.get("id") == axis), None)
+            if axis_entry.get("verdict") == "pass" and not is_stale(axis_entry.get("date", ""), sla, today):
+                url = axis_entry.get("evidence", "")
                 if url:
                     return f"[{symbol}]({url})"
         return symbol

--- a/tests/bats/test_build_status_classification.bats
+++ b/tests/bats/test_build_status_classification.bats
@@ -92,6 +92,7 @@ run_generator() {
   run_generator
   grep -q '1 failure' "$README"
   grep -q '2 never reached' "$README"
+  grep -q '(stale: 1)' "$README"
 }
 
 @test "a cancelled run is skipped in favour of the newest conclusive one" {

--- a/tests/test_composite_green_scoring.py
+++ b/tests/test_composite_green_scoring.py
@@ -82,6 +82,39 @@ def test_composite_scores_a_promoted_gated_cell_green_iff_blocking_pass() -> Non
         assert green == 0
 
 
+def test_composite_scores_stale_verdict_as_untested() -> None:
+    """A cell whose only desktop verdict is 5 days old (SLA 2) is not composite-green."""
+    today = "2026-09-10"
+    stage = {
+        "albacore": {
+            "jobs": {
+                ("gnome", "Promote"): "success",
+                ("gnome", "Gate"): "success",
+            },
+            "date": "2026-09-10",
+        }
+    }
+    omissions = {"albacore:gnome": ("success", "2026-09-10", "34459513536")}
+    # Desktop verdict is 5 days old (2026-09-05), SLA is 2 days -> stale -> ⬜
+    contract_stale = {"albacore:gnome": ("success", "2026-09-05", "33629919067")}
+
+    lines, green_stale, total, prov = gms.composite_section(
+        CRITERIA, stage, contract_stale, {}, {}, {}, omissions, {}, today=today
+    )
+    assert green_stale == 0, (
+        "a cell whose desktop verdict is 5 days old (SLA 2) must not be composite-green"
+    )
+
+    # When desktop verdict is fresh (e.g. 1 day old, 2026-09-09), it is composite-green
+    contract_fresh = {"albacore:gnome": ("success", "2026-09-09", "33629919067")}
+    lines, green_fresh, total, prov = gms.composite_section(
+        CRITERIA, stage, contract_fresh, {}, {}, {}, omissions, {}, today=today
+    )
+    assert green_fresh == 1, (
+        "a cell with all fresh blocking verdicts must be composite-green"
+    )
+
+
 def test_readme_updater_guards_the_composite_number() -> None:
     body = (ROOT / ".github" / "scripts" / "update-build-status.sh").read_text()
     assert 'select(.enforcement == "blocking")' in body


### PR DESCRIPTION
## Summary

- Honour `freshness_sla_days` in `scripts/gen-matrix-status.py` `composite_section()`: treat evidence older than the criterion's SLA as untested (⬜) in composite green scoring.
- In rendered composite table, only link evidence URLs for passing verdicts that are not stale.
- Add test coverage in `tests/test_composite_green_scoring.py` asserting that a 5-day-old desktop verdict (SLA 2) is not composite-green, while fresh verdicts remain green.
- Report `(stale: N)` next to `never reached` in `.github/scripts/update-build-status.sh` and `README.md`.

Fixes #2259

— hive: backend=agy model=gemini-3.7-flash-high effort=low
---
🐝 **Hive Agent**: `contributor` | **SHA:** `9bee79e2`