### PR TITLE
build(matrix): exclude guppy gnome below GNOME 50 version floor (#2450)

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -1045,9 +1045,6 @@ variants:
       - id: base
         stage: 1
         build_image: true
-      - id: gnome
-        stage: 2
-        build_image: true
       - id: kde
         stage: 2
         build_image: true
@@ -1059,6 +1056,13 @@ variants:
         stage: 2
         build_image: true
       # NOT declared, and not an oversight:
+      #   gnome   — Gentoo ::gentoo main tree tops out at GNOME 49.9 (tested
+      #             49.7-49.9), while the desktop contract enforces the GNOME 50
+      #             version floor (minimum_version: 50 in manifests/desktops/gnome.yaml,
+      #             GNOME_MINIMUM_MAJOR=50 in verify-desktop-experience.sh).
+      #             Declaring it fails verify-desktop-experience.sh deterministically
+      #             (tunaOS#2450). Re-add once ::gentoo carries GNOME 50/51 or
+      #             an overlay is wired.
       #   niri    — no ebuild in the Gentoo main tree at all. A search returns
       #             only dev-ruby/niceogiri. Declaring it would publish an
       #             installable image with no compositor, exactly as

--- a/.github/workflows/build-variant.yml
+++ b/.github/workflows/build-variant.yml
@@ -10,7 +10,7 @@ name: Unified Build
 # verify-asahi 05:40, matrix-status & catalog-facts 06:00,
 # desktop-contract-sweep 08:00).
 #   00:20 yellowfin(20fl)  02:20 albacore(20)       04:20 gurnard(2)
-#   06:20 guppy(4)         09:20 skipjack(18)       11:20 bonito(16)
+#   06:20 guppy(3)         09:20 skipjack(18)       11:20 bonito(16)
 #   13:20 marlin(16)       15:20 bonito-rawhide(14) 17:20 grouper(7)
 #   19:20 sailfin(7)       21:20 flounder(7)        22:20 hummingbird(3)
 #   23:20 flounder-sid(7)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ TunaOS builds **bootc-based desktop operating systems** with atomic updates and 
 | ☢️ **Flounder Sid** | Debian Sid (Unstable) | `ghcr.io/tuna-os/flounder:*-sid` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64 |
 | 🐉 **Bonito Rawhide** | Fedora Rawhide | `ghcr.io/tuna-os/bonito:*-rawhide` | GNOME, KDE, COSMIC, Niri, XFCE | x86_64, arm64 |
 | 🦈 **Sailfin** | openSUSE Tumbleweed | `ghcr.io/tuna-os/sailfin` | GNOME, KDE, Niri, XFCE | x86_64 |
-| 🌈 **Guppy** | Gentoo Linux | `ghcr.io/tuna-os/guppy` | GNOME, KDE | x86_64 |
+| 🌈 **Guppy** | Gentoo Linux | `ghcr.io/tuna-os/guppy` | KDE, XFCE | x86_64 |
 | 🏔️ **Tromsø** | freedesktop-sdk (BuildStream), built in [tuna-os/tromso](https://github.com/tuna-os/tromso) | `ghcr.io/tuna-os/tromso` | KDE | x86_64 |
 | 🐭 **XFCE Linux** | freedesktop-sdk (BuildStream), built in [tuna-os/xfce-linux](https://github.com/tuna-os/xfce-linux) | `ghcr.io/tuna-os/xfce-linux` | XFCE | x86_64 |
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -54,12 +54,12 @@ flowchart LR
   installs; [INSTALLER-FRONTENDS.md](INSTALLER-FRONTENDS.md) tracks their
   parity matrix.
 
-## 2. The build matrix: 140 cells
+## 2. The build matrix: 139 cells
 
 Everything CI does is driven by **`.github/build-config.yml`**: 14 variants ×
 their flavors (5 desktops + `base` + hardware tiers) × declared platforms
 (amd64 / amd64-v2 / arm64). A **cell** is one `(variant, flavor)` pair —
-`yellowfin:gnome`, `bonito:kde-nvidia` — and there are 140 of them with
+`yellowfin:gnome`, `bonito:kde-nvidia` — and there are 139 of them with
 `build_image: true`. Every scoreboard, gate, and denominator in the project
 derives from this file, on purpose: a flavor that isn't declared here doesn't
 exist, and tests enforce that the workflows regenerate from it rather than
@@ -255,7 +255,7 @@ flowchart LR
     CRIT[".github/green-criteria.yml<br/>enforcement per criterion"]
     GEN["scripts/gen-matrix-status.py<br/>composite scorer"]
     MS["docs/MATRIX-STATUS.md<br/>Composite green — the bar"]
-    RM["README<br/>Built X/140 · composite green Y/140"]
+    RM["README<br/>Built X/139 · composite green Y/139"]
 
     evidence --> GEN
     CRIT --> GEN

--- a/tests/bats/test_guppy_unsupported_desktops.bats
+++ b/tests/bats/test_guppy_unsupported_desktops.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # Gentoo's main tree does not currently provide the packages needed by the
-# Niri or COSMIC manifests. Keep those flavors out of Guppy's published matrix
+# Niri or COSMIC manifests, and its GNOME ebuilds (49.9) sit below the GNOME 50
+# version floor (#2450). Keep those flavors out of Guppy's published matrix
 # until there is a maintained package source and a passing build.
 #
 # This is deliberately a repository-level guard: adding a flavor is otherwise
@@ -18,10 +19,10 @@ root = sys.argv[1]
 cfg = yaml.safe_load(open(os.path.join(root, '.github/build-config.yml')))
 guppy = next(v for v in cfg['variants'] if v['id'] == 'guppy')
 flavors = {f['id'] for f in guppy.get('flavors', [])}
-unsupported = {'niri', 'cosmic'}
+unsupported = {'niri', 'cosmic', 'gnome'}
 found = sorted(flavors & unsupported)
 assert not found, f'guppy declares unsupported Gentoo flavors: {found}'
-assert {'gnome', 'kde', 'xfce'} <= flavors, 'known Gentoo desktop coverage disappeared'
+assert {'kde', 'xfce'} <= flavors, 'known Gentoo desktop coverage disappeared'
 print(','.join(sorted(flavors)))
 EOF
   [ "$status" -eq 0 ]

--- a/tests/regressions/test_issue_2450_guppy_excludes_gnome_below_version_floor.py
+++ b/tests/regressions/test_issue_2450_guppy_excludes_gnome_below_version_floor.py
@@ -1,0 +1,52 @@
+"""#2450: guppy:gnome fails the GNOME 50 version floor (Gentoo ::gentoo tops out at 49.9).
+
+Gentoo's ::gentoo main tree carries GNOME 49.9 (measured 49.7-49.9), while the
+desktop contract (manifests/desktops/gnome.yaml minimum_version: 50,
+verify-desktop-experience.sh GNOME_MINIMUM_MAJOR=50) requires at least GNOME 50.
+Every scheduled Build Guppy run failed deterministically on guppy:gnome since
+the floor was introduced on 2026-09-03 (run 34471218388).
+
+Until Gentoo packages GNOME 50+ or an overlay provides it, guppy must not declare
+the gnome flavor in the build matrix (.github/build-config.yml), avoiding repeated
+CI failure cycles.
+
+Falsification: structural — fails if `gnome` is declared in guppy's flavors in
+.github/build-config.yml or if guppy flavor count in build-variant.yml rots.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG = ROOT / ".github" / "build-config.yml"
+BUILD_VARIANT = ROOT / ".github" / "workflows" / "build-variant.yml"
+
+
+def test_guppy_does_not_declare_gnome_flavor() -> None:
+    config = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+    guppy = next(v for v in config["variants"] if v["id"] == "guppy")
+    flavors = {f["id"] for f in guppy.get("flavors", [])}
+    assert "gnome" not in flavors, (
+        "guppy declares the gnome flavor, but Gentoo ::gentoo tops out at "
+        "GNOME 49.9 and fails the GNOME 50 floor (#2450)"
+    )
+
+
+def test_guppy_exclusion_reason_is_documented() -> None:
+    raw = CONFIG.read_text(encoding="utf-8")
+    assert "2450" in raw, (
+        ".github/build-config.yml should document the guppy:gnome floor "
+        "exclusion referencing #2450"
+    )
+
+
+def test_guppy_flavor_count_matches_nightly_schedule_registry() -> None:
+    config = yaml.safe_load(CONFIG.read_text(encoding="utf-8"))
+    guppy = next(v for v in config["variants"] if v["id"] == "guppy")
+    declared_count = len(guppy.get("flavors", []))
+    assert declared_count == 3, f"expected 3 guppy flavors, got {declared_count}"

--- a/tests/test_matrix_status.py
+++ b/tests/test_matrix_status.py
@@ -332,11 +332,16 @@ class UndeclaredCellsAreNotCountedAgainstUs(unittest.TestCase):
             gms.VOLATILE_LINE,
         )
 
-    def test_the_real_build_config_declares_52_luks_cells(self):
+    def test_the_real_build_config_declares_51_luks_cells(self):
         """Ties the unit tests above to the actual denominator on disk.
 
         If this number moves, the LUKS total moves with it, and that should be
         a deliberate build-config edit rather than a surprise.
+
+        52 -> 51 on 2026-09-10: guppy:gnome is off. Gentoo ::gentoo tops out
+        at GNOME 49.9 against the GNOME 50 floor (manifests/desktops/gnome.yaml
+        minimum_version: 50, verify-desktop-experience.sh GNOME_MINIMUM_MAJOR=50),
+        so the flavor fails verify-desktop-experience.sh deterministically (#2450).
 
         53 -> 52 on 2026-09-05: flounder:gnome is off. Debian 13 trixie
         ships GNOME 48.7 against a floor of 50, and the sid -> trixie
@@ -372,7 +377,7 @@ class UndeclaredCellsAreNotCountedAgainstUs(unittest.TestCase):
         the Niri stack and zero `xfce*`), so they add nothing here.
         """
         matrix = gms.luks_matrix()
-        self.assertEqual(sum(len(v) for v in matrix.values()), 52)
+        self.assertEqual(sum(len(v) for v in matrix.values()), 51)
         # The control that makes the drop specific rather than merely smaller:
         # hummingbird keeps exactly the desktops it has package sets for.
         self.assertEqual(matrix.get("hummingbird"), {"gnome", "cosmic"})
@@ -389,6 +394,9 @@ class UndeclaredCellsAreNotCountedAgainstUs(unittest.TestCase):
         # switched off Debian GNOME entirely would fail here rather than pass
         # as a smaller-but-honest denominator.
         self.assertIn("gnome", matrix.get("flounder-sid", set()))
+        # Guppy excludes gnome until Gentoo carries GNOME 50+ (#2450)
+        self.assertEqual(matrix.get("guppy"), {"kde", "xfce"})
+        self.assertNotIn("gnome", matrix.get("guppy", set()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Gentoo's `::gentoo` main tree currently tops out at GNOME 49.9 (measured 49.7-49.9), while the desktop contract enforces a GNOME 50 version floor (`minimum_version: 50` in `manifests/desktops/gnome.yaml`, `GNOME_MINIMUM_MAJOR=50` in `build_scripts/checks/verify-desktop-experience.sh`).

Every scheduled `Build Guppy` run has failed deterministically on `guppy:gnome` since the floor was set on 2026-09-03. This change excludes `guppy:gnome` from `.github/build-config.yml` until Gentoo upstream or an overlay provides GNOME 50+, matching the pattern used for guppy's absent `niri` and `cosmic` flavors.

## Changes
- `.github/build-config.yml`: Remove `gnome` from guppy's declared flavors and document the exclusion under `# NOT declared, and not an oversight:` referencing #2450.
- `.github/workflows/build-variant.yml`: Update nightly schedule registry flavor count for guppy from 4 to 3.
- `docs/DEVELOPER-GUIDE.md`: Update build matrix cell count from 140 to 139 in heading, text, and diagram.
- `README.md`: Update guppy's desktop list from `GNOME, KDE` to `KDE, XFCE`.
- `tests/bats/test_guppy_unsupported_desktops.bats`: Update test assertions and comments to treat `gnome` as unsupported on guppy.
- `tests/test_matrix_status.py`: Update LUKS cell count test to 51 and assert guppy's active flavors (`kde`, `xfce`).
- `tests/regressions/test_issue_2450_guppy_excludes_gnome_below_version_floor.py`: Add regression test for issue #2450.

Closes #2450

— hive: backend=agy model=gemini-3.7-flash-high effort=low
---
🐝 **Hive Agent**: `contributor` | **SHA:** `075927fd`