### PR TITLE
fix(build): unbreak six variants' base builds — dead digests, the niri DMS payload, hummingbird arm64, and the boot gate that cannot launch

### DIFF
--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -1120,7 +1120,40 @@ variants:
     emoji: "🐉"
     upstream_track: rolling
     description: "Based on Fedora Rawhide (rolling)"
-    base_image: "quay.io/fedora/fedora-bootc:rawhide@sha256:0d942e1b637ad5480cbdbdabb790060f894223a55ebedbc1729f97da8b5b1ab1"
+    # NOT digest-pinned, and this is the only base image here that is not.
+    #
+    # A digest pin on this tag is dead before the nightly that would use it.
+    # Measured 2026-09-11: the digest resolved at 12:55 was already 404 by
+    # 13:36 -- 41 minutes -- and `:rawhide` had moved on. It is not that the
+    # digest goes stale; quay garbage-collects the untagged manifest at once,
+    # so the pin does not resolve AT ALL:
+    #
+    #   Error: creating build container: ... reading manifest sha256:0d942e1b…
+    #   in quay.io/fedora/fedora-bootc: manifest unknown
+    #
+    # Compare fedora-bootc:44 in this same file, whose digest was still 200 in
+    # the same measurement. Stable tags are retained; Rawhide's are not.
+    #
+    # That makes repinning a fix with a one-hour half-life, and the repo's own
+    # safety net cannot close the gap either: check-base-image-pins.yml runs at
+    # 22:20 and the variant builds at 01:00, so the digest it verified is
+    # already gone by the time anything builds. scripts/check-base-image-pins.sh
+    # names this exact variant in its own history (#1788, 2026-08-16), because
+    # it keeps happening here and nowhere else for the same reason.
+    #
+    # So the tag is the honest reference. The point of bonito-rawhide is to
+    # track Rawhide, a target that moves several times a day; a digest that
+    # cannot be fetched buys no reproducibility, it only guarantees a red base
+    # every night and takes every downstream flavor with it. The pin checker
+    # already treats this as a declared state rather than an error, and says so
+    # per run:
+    #
+    #   SKIP  (not digest-pinned)  quay.io/fedora/fedora-bootc:rawhide
+    #
+    # Re-pin by digest only if quay starts retaining Rawhide manifests, or if
+    # something resolves the tag at build time and threads one digest through
+    # every stage of that build.
+    base_image: "quay.io/fedora/fedora-bootc:rawhide"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [fedora]
     akmods: "ublue-os"

--- a/.github/build-config.yml
+++ b/.github/build-config.yml
@@ -765,7 +765,7 @@ variants:
   - id: bonito
     emoji: "🎣"
     description: "Based on Fedora 44"
-    base_image: "quay.io/fedora/fedora-bootc:44@sha256:9c8fae9f47e7287d27542a6fe30ec408151655b142a61beea787c94654f1911a"
+    base_image: "quay.io/fedora/fedora-bootc:44@sha256:2c38c5f71a43993e07577629ef8e1695420ed38143482340215abdcea85a31fd"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [fedora]
     akmods: "ublue-os"
@@ -926,16 +926,54 @@ variants:
     # reasoning about what its package set should contain.
     description: "Fedora Hummingbird (hardened rolling Rawhide fork, bootc)"
     base_image: "quay.io/hummingbird-community/bootc-os:latest@sha256:c5539f9ed4d93aab6bd41e4f5aef8ab83055f3f9e855a47b69fadb7420d0d1df"
-    platforms: ["linux/amd64", "linux/arm64"]
+    # amd64 only, because aarch64 has nothing to build FROM yet: the base
+    # stage's mandatory xfsprogs guard (build_scripts/10-base-packages.sh) has
+    # no repository that can satisfy it on arm64, so every hummingbird arm64
+    # leg dies before a desktop is ever considered.
+    #
+    #   ERROR: xfsprogs did not install — no enabled repo carries it;
+    #          bootc install to-disk cannot format the root without it.
+    #
+    # Measured against the live indexes rather than inferred, 2026-09-11
+    # (repo.tunaos.org/hummingbird/20251124-$basearch/repodata):
+    #
+    #   x86_64    13442 packages   xfsprogs: 1   malcontent: 2
+    #   aarch64    7177 packages   xfsprogs: 0   malcontent: 0
+    #
+    # The aarch64 rebuild wave is roughly half-published, and the same gap
+    # explains the flatpak breakage two lines further down that log ("nothing
+    # provides libmalcontent-0.so.0 needed by flatpak-1.17.3-1.bfin1.aarch64"):
+    # malcontent is an x86_64-only build in that snapshot too.
+    #
+    # This is the arch-honesty criterion, not a retreat: advertising an
+    # architecture whose base cannot resolve its mandatory packages scores an
+    # unsatisfiable cell red every night and tells a user the image exists.
+    #
+    # The direction of travel points the same way. As hummingbird takes more of
+    # its package set from projectbluefin/utah-packages, arm64 gets further out
+    # of reach, not closer: that repository is a SINGLE-manifest OCI image
+    # (measured 2026-09-11 — mediaType application/vnd.oci.image.manifest.v1+json,
+    # no manifest list, x86_64 only), which is already why hummingbird:gnome
+    # carries its own amd64 pin. A source that cannot be pulled for aarch64
+    # cannot supply an aarch64 image.
+    #
+    # Restore "linux/arm64" only alongside BOTH: the aarch64 snapshot carrying
+    # xfsprogs (the one-line curl above is the check) and an aarch64 build of
+    # whatever package source the variant is on by then. See
+    # docs/HUMMINGBIRD.md.
+    platforms: ["linux/amd64"]
     flavors:
       - id: base
         stage: 1
         build_image: true
         build_iso: true
       # GNOME remains amd64-only until its aarch64 source (utah-packages)
-      # publishes there. The Hummingbird package factory's aarch64 repository
-      # has since converged for COSMIC: all 25 manifest packages resolve as of
-      # 2026-09-06, so that flavor inherits both variant platforms below.
+      # publishes there. COSMIC's own 25 manifest packages did converge on
+      # aarch64 (2026-09-06) and this flavor inherits the variant platforms
+      # below — which are amd64-only today for a reason one layer down: the
+      # BASE cannot build on arm64 at all (see the platforms note above), so a
+      # desktop whose package set resolves still had nothing to layer onto.
+      # Both notes revert together.
       - id: gnome
         stage: 2
         platforms: ["linux/amd64"]
@@ -982,7 +1020,7 @@ variants:
     emoji: "🦈"
     upstream_track: rolling
     description: "Based on openSUSE Tumbleweed (rolling)"
-    base_image: "registry.opensuse.org/opensuse/tumbleweed:latest@sha256:1691585b5daf973c032d1f94d3b8b85393d259ac0348c1c5b91abceeeb3334a9"
+    base_image: "registry.opensuse.org/opensuse/tumbleweed:latest@sha256:349094bef091c41cf5cb84d5727a1e2ad9aa96de173cdaac4cdb68d5cea09e49"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [opensuse, tumbleweed]
     platforms: ["linux/amd64"]
@@ -1082,7 +1120,7 @@ variants:
     emoji: "🐉"
     upstream_track: rolling
     description: "Based on Fedora Rawhide (rolling)"
-    base_image: "quay.io/fedora/fedora-bootc:rawhide@sha256:6c04d2602182c7f8ae465be9ecf9987695e26895a35f7226dbe8b63be912d5c3"
+    base_image: "quay.io/fedora/fedora-bootc:rawhide@sha256:0d942e1b637ad5480cbdbdabb790060f894223a55ebedbc1729f97da8b5b1ab1"
     # Friendly alias: same digest also published as ghcr.io/tuna-os/<alias>:<flavor>
     aliases: [fedora]
     akmods: "ublue-os"

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -1332,9 +1332,44 @@ jobs:
     # starts. Promote treats a skipped gate as pass; asahi images are
     # verified by the dispatched "Verify Asahi image" 35-point harness
     # instead (no aarch64 KVM on GH runners — TCG boot gate is future work).
+    #
+    # cosmic/niri/xfwl4 are NOT SCHEDULED while the GPU runner group cannot be
+    # launched. TEMPORARY, maintainer decision 2026-09-11, and paired with the
+    # boots scope in .github/green-criteria.yml, which already declares the
+    # same three prefixes out of scope for the same reason.
+    #
+    # The runs-on selector below sends those compositors to the `gpu` group for
+    # a real DRM render node. The account's vCPU limit for the g4dn bucket is
+    # 0, so EC2 rejects every fleet request and the job dies before its first
+    # step ever runs:
+    #   Failed to launch runner: failed to create fleet: VcpuLimitExceeded
+    #   ... vCPU limit of 0 ... AllowedInstanceTypes:["g4dn*"]
+    #
+    # Scheduling it anyway measures nothing -- no runner, no serial log, no
+    # screenshot, no compositor -- and costs the cell its image on top: Promote
+    # needs verify_boot to be success OR skipped, and a runner that never
+    # attaches is neither. That is why `builds` reads not-green for cosmic and
+    # niri on ten variants whose images built, pushed and passed every other
+    # gate (albacore 34573957352, yellowfin 34563335220, marlin 34505652376 --
+    # Gate is the only red job in each).
+    #
+    # This is NOT a claim that those cells boot, and it does not make them
+    # green: `boots` still reads ⬜ for every one of them, which is what "not
+    # measured" has meant here since #2123. It stops a runner shortage from
+    # being recorded as a build failure.
+    #
+    # Revert together with the green-criteria exclusion the moment g4dn
+    # capacity exists (tuna-os/tunaOS#2123). The three prefixes here, in the
+    # runs-on selector below, and in green-criteria.yml are pinned equal by
+    # tests/test_the_boots_scope_matches_the_gpu_routing.py, so they cannot
+    # drift apart -- and re-adding capacity without re-adding the gate fails
+    # that test rather than silently leaving the cells ungated.
     if: >-
       inputs.publish && github.event_name != 'pull_request' &&
       !startsWith(inputs.flavor, 'base') &&
+      !startsWith(inputs.flavor, 'cosmic') &&
+      !startsWith(inputs.flavor, 'niri') &&
+      !startsWith(inputs.flavor, 'xfwl4') &&
       contains(inputs.platforms, 'amd64')
     # Back on RunsOn (AWS credits restored) for the DRM-gated desktops only:
     # cosmic/niri/xfwl4 are Smithay compositors that hard-require a DRM render

--- a/README.md
+++ b/README.md
@@ -62,10 +62,9 @@ The `gnome-asahi` image is off until the tier adds aarch64
 ([tunaos-packages#673](https://github.com/tuna-os/tunaos-packages/issues/673)).
 Every GNOME image uses GNOME 50 or newer. The project does not promote older versions.
 
-Hummingbird is x86_64 only, including its base. Its aarch64 package snapshot
-does not yet carry `xfsprogs`, which the base stage requires and refuses to go
-without, so no hummingbird arm64 image can be built at all today — not a
-narrower desktop selection, an absent architecture. See
+Hummingbird is x86_64 only. This includes its base. The aarch64 package
+snapshot has no `xfsprogs`, and the base stage needs it. No hummingbird arm64
+image builds today. The architecture is absent, not thinner. See
 [docs/HUMMINGBIRD.md](docs/HUMMINGBIRD.md).
 
 Tags are `<desktop>[-hardware]` — e.g. `yellowfin:gnome-hwe`,

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ TunaOS builds **bootc-based desktop operating systems** with atomic updates and 
 | 🐟 **Albacore** | AlmaLinux 10 (RHEL 10) | `ghcr.io/tuna-os/albacore` | GNOME (x86_64 only, see note), KDE, COSMIC, Niri | x86_64, x86_64/v2, arm64 |
 | 🍣 **Skipjack** | CentOS Stream 10 | `ghcr.io/tuna-os/skipjack` | GNOME (x86_64 only, see note), KDE, COSMIC, Niri | x86_64, arm64 |
 | 🎣 **Bonito** | Fedora 44 | `ghcr.io/tuna-os/bonito` | GNOME, KDE, COSMIC, Niri | x86_64, arm64 |
-| 🐦 **Hummingbird** | Fedora Hummingbird (experimental) | `ghcr.io/tuna-os/hummingbird` | Base, GNOME, COSMIC | x86_64; arm64 (base only) |
+| 🐦 **Hummingbird** | Fedora Hummingbird (experimental) | `ghcr.io/tuna-os/hummingbird` | Base, GNOME, COSMIC | x86_64 (see note) |
 | 🎏 **Wahoo** | Fedora ELN — EL11 preview (experimental, no codecs) | `ghcr.io/tuna-os/wahoo` | Base, GNOME | x86_64, arm64 |
 | 🔒 **Redfin** | Red Hat Enterprise Linux 10 | *Local-Build Only* | GNOME, KDE, COSMIC, Niri, XFCE | x86_64, arm64 |
 | 🐟 **Grouper** | Ubuntu 26.04 | `ghcr.io/tuna-os/grouper` | GNOME, KDE, Niri, XFCE | x86_64 |
@@ -61,6 +61,12 @@ today, so the `gnome` and `gnome-hwe` images have only x86_64 support.
 The `gnome-asahi` image is off until the tier adds aarch64
 ([tunaos-packages#673](https://github.com/tuna-os/tunaos-packages/issues/673)).
 Every GNOME image uses GNOME 50 or newer. The project does not promote older versions.
+
+Hummingbird is x86_64 only, including its base. Its aarch64 package snapshot
+does not yet carry `xfsprogs`, which the base stage requires and refuses to go
+without, so no hummingbird arm64 image can be built at all today — not a
+narrower desktop selection, an absent architecture. See
+[docs/HUMMINGBIRD.md](docs/HUMMINGBIRD.md).
 
 Tags are `<desktop>[-hardware]` — e.g. `yellowfin:gnome-hwe`,
 `albacore:kde-nvidia`. Full tag reference: [docs/IMAGE-TAGS.md](docs/IMAGE-TAGS.md).

--- a/build_scripts/desktop/dms-qml-payload.sh
+++ b/build_scripts/desktop/dms-qml-payload.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Ensure the DMS (DankMaterialShell) QML payload is on the image whenever
+# greetd is going to launch dms-greeter.
+#
+# Why this exists as a post_install hook and not as a call inside niri.sh.
+# niri.sh is the LEGACY per-desktop installer. Every variant that ships niri
+# today takes the manifest path instead (manifests/desktops/niri.yaml →
+# install-desktop.sh), and that path never sources niri.sh — so the fallback
+# niri.sh calls has never once run on a variant that needed it. The result was
+# measured on 2026-09-11, identically on albacore, skipjack and yellowfin:
+#
+#   FAIL: greetd launches dms-greeter but
+#         /usr/share/quickshell/dms-greeter/DMSGreeter.qml is missing
+#   FAIL: no wallpaper daemon (swaybg/swww/wpaperd) and no dms
+#   TUNAOS_BRANDING_NIRI_FAIL failures=2
+#
+# — two failures, one cause, and the niri image build died after three
+# attempts on all three variants (runs 34573957352, 34483960197, 34563335220).
+# Both assertions in verify-branding-niri.sh read the same directory, which the
+# AvengeMedia EL10 dms-greeter 1.6 RPM does not populate: it is a runtime-sync
+# launcher that ships no QML, and an image build cannot rely on a first-boot
+# download.
+#
+# Sourced, not executed, by install-desktop.sh — so this file must never
+# `exit`. The real installer runs in its own shell for exactly that reason.
+#
+# Conditioned on the state that is broken rather than on a distro list: if a
+# repository ever ships an RPM that owns DMSGreeter.qml, the file is already
+# there and this is a no-op (tunaOS#2359). Variants with no DMS at all (Arch's
+# marlin, openSUSE's sailfin) have no dms-greeter binary and are skipped —
+# their greeters are cosmic-greeter and gtkgreet, and hardcoding DMS paths onto
+# them is what reddened marlin:niri before.
+if command -v dms-greeter >/dev/null 2>&1 &&
+	[[ ! -f /usr/share/quickshell/dms-greeter/DMSGreeter.qml ]]; then
+	echo "dms-qml-payload: dms-greeter is installed but ships no QML; installing the pinned payload"
+	bash "${_TD_CTX:-/run/context}/build_scripts/install-dms-qml-fallback.sh"
+else
+	echo "dms-qml-payload: nothing to do (no dms-greeter, or its QML is already present)"
+fi

--- a/docs/HUMMINGBIRD.md
+++ b/docs/HUMMINGBIRD.md
@@ -44,30 +44,30 @@ it leads directly to expecting Fedora 43's package set to be present. It is not.
 tunaOS builds `hummingbird:{base,gnome,cosmic}` (see
 `.github/build-config.yml`), **amd64 only — every flavor, base included**.
 
-That is narrower than it used to read here, and the reason moved down a layer.
-It was GNOME alone that was amd64-only, because its utah-packages source is not
-multi-arch; COSMIC's own package set converged on aarch64 on 2026-09-06. But the
-*base* cannot build on arm64 at all, so a desktop whose packages resolve has
-nothing to layer onto. `build_scripts/10-base-packages.sh` requires `xfsprogs`
-and exits rather than ship an image `bootc install to-disk` cannot format a root
-for, and no enabled repository carries it for aarch64. Measured against the live
-indexes on 2026-09-11 (`repo.tunaos.org/hummingbird/20251124-$basearch/repodata`,
-`primary.xml`) rather than inferred:
+That is narrower than this page said before, and the cause moved down a layer.
+GNOME alone was amd64-only, because its utah-packages source is x86_64. COSMIC's
+own package set converged on aarch64 on 2026-09-06. But the *base* does not build
+on arm64. A desktop whose packages resolve has nothing to layer onto.
+
+`build_scripts/10-base-packages.sh` needs `xfsprogs`. It exits when no repository
+has it, because `bootc install to-disk` cannot format a root without it. No
+aarch64 repository has it. These counts come from the live indexes on 2026-09-11
+(`repo.tunaos.org/hummingbird/20251124-$basearch/repodata`, `primary.xml`):
 
 | arch | packages | `xfsprogs` | `malcontent` |
 |---|---:|---:|---:|
 | x86_64 | 13442 | 1 | 2 |
 | aarch64 | 7177 | **0** | **0** |
 
-The aarch64 rebuild wave is roughly half-published, and the same gap is why
-`flatpak` is *broken* rather than merely missing there: nothing provides
+The aarch64 rebuild wave is about half-published. The same gap explains
+`flatpak`: on that arch it is *broken*, not absent. Nothing supplies
 `libmalcontent-0.so.0` for `flatpak-1.17.3-1.bfin1.aarch64`.
 
-Restoring arm64 needs two things measured, not one: `xfsprogs` present in the
-aarch64 snapshot (the curl above is the whole check), **and** an aarch64 build of
-whatever package source the variant is on by then. As hummingbird takes more of
-its set from utah-packages that second condition gets harder, not easier — that
-repository is a single-manifest x86_64 OCI image with no manifest list at all.
+To restore arm64, satisfy two conditions, not one. First, `xfsprogs` must appear
+in the aarch64 snapshot; the curl above is the whole check. Second, the
+variant's package source must build for aarch64. This condition gets harder as
+hummingbird takes more of its set from utah-packages. The utah repository is one
+OCI image for x86_64, with no manifest list.
 
 Everything except `base` asks a distribution that
 **deliberately ships no desktop environment** to host a full desktop, layered

--- a/docs/HUMMINGBIRD.md
+++ b/docs/HUMMINGBIRD.md
@@ -42,9 +42,34 @@ it leads directly to expecting Fedora 43's package set to be present. It is not.
 ## What this means for tunaOS
 
 tunaOS builds `hummingbird:{base,gnome,cosmic}` (see
-`.github/build-config.yml`). Base and COSMIC build for amd64 and arm64; GNOME
-remains amd64-only because its utah-packages source is not multi-arch. Everything
-except `base` asks a distribution that
+`.github/build-config.yml`), **amd64 only — every flavor, base included**.
+
+That is narrower than it used to read here, and the reason moved down a layer.
+It was GNOME alone that was amd64-only, because its utah-packages source is not
+multi-arch; COSMIC's own package set converged on aarch64 on 2026-09-06. But the
+*base* cannot build on arm64 at all, so a desktop whose packages resolve has
+nothing to layer onto. `build_scripts/10-base-packages.sh` requires `xfsprogs`
+and exits rather than ship an image `bootc install to-disk` cannot format a root
+for, and no enabled repository carries it for aarch64. Measured against the live
+indexes on 2026-09-11 (`repo.tunaos.org/hummingbird/20251124-$basearch/repodata`,
+`primary.xml`) rather than inferred:
+
+| arch | packages | `xfsprogs` | `malcontent` |
+|---|---:|---:|---:|
+| x86_64 | 13442 | 1 | 2 |
+| aarch64 | 7177 | **0** | **0** |
+
+The aarch64 rebuild wave is roughly half-published, and the same gap is why
+`flatpak` is *broken* rather than merely missing there: nothing provides
+`libmalcontent-0.so.0` for `flatpak-1.17.3-1.bfin1.aarch64`.
+
+Restoring arm64 needs two things measured, not one: `xfsprogs` present in the
+aarch64 snapshot (the curl above is the whole check), **and** an aarch64 build of
+whatever package source the variant is on by then. As hummingbird takes more of
+its set from utah-packages that second condition gets harder, not easier — that
+repository is a single-manifest x86_64 OCI image with no manifest list at all.
+
+Everything except `base` asks a distribution that
 **deliberately ships no desktop environment** to host a full desktop, layered
 from tunaOS's own package snapshot.
 

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -109,9 +109,32 @@ downloads:
   # AvengeMedia's EL10 dms-greeter 1.6 RPM is a runtime-sync launcher and
   # carries no QML. Keep the same source payload and checksum as the pending
   # tunaos-packages dms/dms-greeter recipes for the offline-build fallback.
+  #
+  # The checksum here was wrong from the day it landed and could not be
+  # noticed, because the only caller of install-dms-qml-fallback.sh was
+  # build_scripts/desktop/niri.sh -- the legacy installer, which the manifest
+  # build path never sources. The first build that actually ran the fallback
+  # died on it (yellowfin:niri arm64, run 34602178178):
+  #
+  #   sha256sum: WARNING: 1 computed checksum did NOT match
+  #   /tmp/tmp.5NcpUhiidJ/dms-qml.tar.gz: FAILED
+  #
+  # Upstream publishes its own checksum next to the asset, so this one is
+  # copied from the source of truth rather than computed from a download and
+  # trusted on its own:
+  #
+  #   curl -sSL https://github.com/AvengeMedia/DankMaterialShell/releases/\
+  #     download/v1.6.1/dms-qml.tar.gz.sha256
+  #   904ad2709a2075f10dbb089b42a9f4eb39d8f06cb2634fd4c95fa739ef9c4a2d  dms-qml.tar.gz
+  #
+  # That value matches the asset on two separate fetches, and the archive
+  # holds what the fallback asserts: DMSGreeter.qml, and a
+  # Modules/Greetd/assets/dms-greeter that is a shell script, so one payload
+  # serves every architecture. Re-derive from the .sha256 asset, never from a
+  # local sha256sum of whatever arrived, whenever this version moves.
   # renovate: datasource=github-releases depName=AvengeMedia/DankMaterialShell
   dms_qml: "v1.6.1"
-  dms_qml_sha256: "aef0e90ad39bf85f676743da7bbe4c32758059d49342d82741d93ec414b88888"
+  dms_qml_sha256: "904ad2709a2075f10dbb089b42a9f4eb39d8f06cb2634fd4c95fa739ef9c4a2d"
 
   # Zirconium's mkosi.extra payload, fetched as a source tarball by
   # build_scripts/install-zirconium.sh (niri stages only). Pinned to a commit

--- a/manifests/desktops/niri.yaml
+++ b/manifests/desktops/niri.yaml
@@ -286,6 +286,11 @@ post_install:
   # dms-greeter); on openSUSE it is the difference between a login screen and
   # greetd's stock text prompt into a bare shell.
   - greetd-gtkgreet.sh
+  # The DMS QML payload, for the variants whose dms-greeter RPM ships only the
+  # runtime-sync launcher. Must run AFTER the COPR transaction above installs
+  # dms-greeter and BEFORE verify-branding-niri.sh reads the directory. No-op
+  # where there is no dms-greeter, or where its QML is already present.
+  - dms-qml-payload.sh
   # Curated Flatpak set (store + browser) + preinstall service — see the
   # script header; asserts live in verify-desktop-experience.sh.
   - flatpak-preinstall.sh

--- a/scripts/check-download-checksums.py
+++ b/scripts/check-download-checksums.py
@@ -53,6 +53,11 @@ class Pin:
     # {version} is the tag (v1.2.3); {num} is the tag without the leading v.
     checksums_url: str
     asset: str
+    # Which architectures this download is pinned per. Most ship one asset per
+    # arch; a payload that is the same bytes everywhere (QML, scripts) has a
+    # single checksum and uses ("noarch",) so the loop below runs once and the
+    # regexes need no {arch}.
+    arches: tuple = ARCHES
     versions: dict = field(default_factory=dict)
 
 
@@ -74,6 +79,30 @@ PINS = [
         checksum_re=r'^\s+{arch}:\s*"([0-9a-f]{{64}})"',
         checksums_url="https://github.com/twpayne/chezmoi/releases/download/{version}/chezmoi_{num}_checksums.txt",
         asset="chezmoi_{num}_linux_{arch}.deb",
+    ),
+    # The DMS QML payload, consumed by build_scripts/install-dms-qml-fallback.sh
+    # on every EL10 niri image. Added after its pinned checksum turned out to
+    # have never matched the asset: the only caller was the legacy niri.sh,
+    # which the manifest build path does not source, so nothing downloaded the
+    # tarball and nothing compared the hash. The first build that ran the
+    # fallback failed closed on it (yellowfin:niri, run 34602178178).
+    #
+    # A checksum no build verifies and no checker covers is not a pin, it is a
+    # comment. This entry is the half that would have caught it without waiting
+    # for a build: the schedule re-checks it nightly, so a release re-published
+    # under the same tag is caught the same way it is for remora and chezmoi.
+    #
+    # One asset for every architecture -- the payload is QML plus a shell
+    # script -- hence arches=("noarch",) and no {arch} in the patterns below.
+    Pin(
+        name="dms-qml",
+        version_file="image-versions.yaml",
+        version_re=r'^\s+dms_qml:\s*"(v[^"]+)"',
+        checksum_file="image-versions.yaml",
+        checksum_re=r'^\s+dms_qml_sha256:\s*"([0-9a-f]{{64}})"',
+        checksums_url="https://github.com/AvengeMedia/DankMaterialShell/releases/download/{version}/dms-qml.tar.gz.sha256",
+        asset="dms-qml.tar.gz",
+        arches=("noarch",),
     ),
 ]
 
@@ -140,7 +169,7 @@ def main() -> int:
         version = find_version(pin)
         published = fetch_published(pin, version)
 
-        for arch in ARCHES:
+        for arch in pin.arches:
             pattern, pinned = find_checksum(pin, arch)
             asset = pin.asset.format(arch=arch, num=version.lstrip("v"))
             want = published.get(asset)

--- a/tests/bats/test_niri_dms_payload.bats
+++ b/tests/bats/test_niri_dms_payload.bats
@@ -55,6 +55,33 @@ _code() { grep -v '^[[:space:]]*#' "$1"; }
   grep -qE '^[[:space:]]+dms_qml_sha256: "[0-9a-f]{64}"' "$versions"
 }
 
+@test "the path that actually builds niri reaches the QML fallback" {
+  # The test above pins niri.sh, which is the LEGACY installer. Every variant
+  # that ships niri takes the manifest path instead, and it never sources
+  # niri.sh — so that assertion held while the fallback ran on nothing. Three
+  # EL10 variants failed their niri build on the missing payload the same day
+  # (albacore/skipjack/yellowfin, 2026-09-11) with the pin above green.
+  #
+  # install-desktop.sh sources post_install entries from build_scripts/desktop/
+  # by bare name, so the hook has to live there and be named in the manifest.
+  local manifest="${REPO_ROOT}/manifests/desktops/niri.yaml"
+  local hook="${REPO_ROOT}/build_scripts/desktop/dms-qml-payload.sh"
+
+  [ -f "$hook" ]
+  _code "$manifest" | grep -qE '^[[:space:]]*-[[:space:]]*dms-qml-payload\.sh[[:space:]]*$'
+  _code "$hook" | grep -qF 'install-dms-qml-fallback.sh'
+
+  # Sourced, not executed: an `exit` here would abandon the rest of the
+  # desktop install (branding checks included) and still report success.
+  ! _code "$hook" | grep -qE '^[[:space:]]*exit[[:space:]]'
+}
+
+@test "the QML payload hook passes shellcheck" {
+  if ! command -v shellcheck &>/dev/null; then skip "shellcheck not installed"; fi
+  run shellcheck --severity=error --exclude=SC1091 "${REPO_ROOT}/build_scripts/desktop/dms-qml-payload.sh"
+  [ "$status" -eq 0 ]
+}
+
 @test "DMS QML fallback passes shellcheck" {
   if ! command -v shellcheck &>/dev/null; then skip "shellcheck not installed"; fi
   run shellcheck --severity=error --exclude=SC1091 "${REPO_ROOT}/build_scripts/install-dms-qml-fallback.sh"

--- a/tests/test_hummingbird_arm64_honesty.py
+++ b/tests/test_hummingbird_arm64_honesty.py
@@ -34,17 +34,41 @@ def test_desktop_flavors_without_aarch64_package_sources_are_amd64_only():
                 f"from PINNED_AMD64_ONLY in the same change")
 
 
-def test_cosmic_uses_both_converged_package_repositories():
+def test_cosmic_does_not_pin_an_arch_the_variant_does_not_offer():
+    """COSMIC's own package set converged on aarch64 (2026-09-06) and the
+    flavor still declares no platforms of its own, so it inherits whatever the
+    variant offers. That is the honest shape: the reason arm64 is unavailable
+    today is one layer below COSMIC, in the base, and this flavor should follow
+    the variant back to arm64 automatically when the base can build there."""
     hb = _hummingbird()
     cosmic = next(f for f in hb["flavors"] if f["id"] == "cosmic")
-    assert cosmic.get("platforms", hb["platforms"]) == [
-        "linux/amd64", "linux/arm64"]
+    assert cosmic.get("platforms") is None, (
+        "hummingbird:cosmic should inherit the variant's platforms — its own "
+        "package set resolves on aarch64, so it must not carry an independent "
+        "pin that would outlive the base's arm64 gap")
 
 
-def test_base_keeps_both_arches():
-    """base needs no rebuild repo and promotes on both arches — the pin is
-    about desktop package coverage, not the variant."""
+def test_the_variant_drops_arm64_while_its_base_cannot_resolve_xfsprogs():
+    """The base stage's xfsprogs guard is mandatory and unsatisfiable on arm64.
+
+    Measured against the live indexes on 2026-09-11 rather than inferred
+    (repo.tunaos.org/hummingbird/20251124-$basearch/repodata, primary.xml):
+
+        x86_64   13442 packages   xfsprogs: 1   malcontent: 2
+        aarch64   7177 packages   xfsprogs: 0   malcontent: 0
+
+    build_scripts/10-base-packages.sh exits 1 when xfsprogs is absent, by
+    design (`bootc install to-disk` cannot format the root without it), so
+    every hummingbird arm64 build died in the base stage — run 34545625709,
+    both `base / linux-arm64` and `cosmic / linux-arm64`, after three attempts.
+
+    Re-add "linux/arm64" here in the same change that measures xfsprogs present
+    in the aarch64 snapshot. Removing this assertion without that measurement
+    puts the nightly back to failing every arm64 leg.
+    """
     hb = _hummingbird()
+    assert hb["platforms"] == ["linux/amd64"]
     base = next(f for f in hb["flavors"] if f["id"] == "base")
-    assert base.get("platforms", hb["platforms"]) == [
-        "linux/amd64", "linux/arm64"]
+    assert base.get("platforms") is None, (
+        "base should inherit the variant's platforms, so that restoring arm64 "
+        "is a single edit in one reviewable place")

--- a/tests/test_the_boots_scope_matches_the_gpu_routing.py
+++ b/tests/test_the_boots_scope_matches_the_gpu_routing.py
@@ -69,6 +69,56 @@ def test_the_scope_excludes_exactly_the_gpu_routed_compositors():
     )
 
 
+def _skipped_prefixes() -> set[str]:
+    """The flavors verify_boot's `if:` refuses to schedule.
+
+    Read out of the `if:` expression only. That expression also negates 'base',
+    which is excluded for an unrelated and permanent reason (base is a parent
+    layer, not a user-facing artifact), so 'base' is dropped here rather than
+    counted as a GPU-gated compositor.
+    """
+    text = WORKFLOW.read_text()
+    start = text.index("  verify_boot:")
+    end = text.index("\n    runs-on:", start)
+    job = text[start:end]
+    cond_start = job.index("    if: >-")
+    condition = job[cond_start:]
+    return {
+        p for p in re.findall(
+            r"!startsWith\(inputs\.flavor,\s*'([^']+)'\)", condition)
+        if p != "base"
+    }
+
+
+def test_the_gate_does_not_schedule_what_it_cannot_launch():
+    """The `if:` guard and the runs-on routing must name the same compositors.
+
+    Two lists in the same job, and the whole point of the guard is that it
+    covers exactly the flavors the routing sends to a group with no capacity
+    (maintainer decision 2026-09-11). Drift either way is a silent bug:
+
+      routed but not skipped  → the job is scheduled onto a runner that never
+                                attaches, Promote is skipped, and the cell
+                                loses its image for a gate that measured
+                                nothing — the state this guard exists to end.
+      skipped but not routed  → a flavor that CAN reach a hosted runner stops
+                                being boot-gated at all, and a real boot
+                                regression could no longer fail it.
+
+    So when g4dn capacity returns, deleting the three negations here is part of
+    the same change that removes the GPU routing — not a later cleanup.
+    """
+    routed = _routed_prefixes()
+    skipped = _skipped_prefixes()
+    assert skipped == routed, (
+        "verify_boot's `if:` guard and its GPU routing disagree.\n"
+        f"  routed to a GPU runner: {sorted(routed)}\n"
+        f"  never scheduled:        {sorted(skipped)}\n"
+        "A flavor routed to a runner CI cannot launch must not be scheduled; a "
+        "flavor that can reach a runner must still be gated."
+    )
+
+
 def test_the_exclusion_is_scoped_to_boots_and_nothing_else():
     """The gate cannot run — that says nothing about the desktop contract,
     which is measured from the published image with no runner involved."""


### PR DESCRIPTION
## Summary

Every variant's build workflow was red on `main`. I read the **Promote** job of each variant's newest conclusive nightly (Promote is what `gen-matrix-status.py` scores the `builds` axis from) and sorted the causes. Five are fixed here, each verified by a dispatched build on this branch; three are reported rather than worked around.

> Two findings below were made *by* the verification builds, after the first version of this PR: the rawhide fix was initially wrong, and the niri fix uncovered a second bug underneath it. Both are described where they happened rather than folded away.

### 1. Base image digests garbage-collected upstream

The pull fails before a single build step runs, so the variant's whole tree goes with it — base, every desktop layered on it, and every ISO built from those (bonito's nightly showed 13 `ISO …` jobs failing with `Artifact not found`, all downstream of this one line):

```
Error: creating build container: unable to copy from source docker://<ref>:
  reading manifest sha256:<pin> in <repo>: manifest unknown
```

| variant | image | pinned | fix |
|---|---|---|---|
| bonito | `quay.io/fedora/fedora-bootc:44` | `9c8fae9f…` → 404 | repinned `2c38c5f7…` |
| sailfin | `registry.opensuse.org/opensuse/tumbleweed:latest` | `1691585b…` → 404 | repinned `349094be…` |
| bonito-rawhide | `quay.io/fedora/fedora-bootc:rawhide` | `6c04d260…` → 404 | **unpinned — see below** |

Both repins were confirmed to be multi-arch indexes carrying amd64 and arm64 before they went in, so no variant quietly loses an architecture. Every other pin in `build-config.yml` was re-checked in the same pass and resolves.

**bonito-rawhide needed a different fix, and the build that tested the repin is what showed it.** The freshly-resolved digest was already gone 41 minutes later:

```
12:55  :rawhide -> sha256:0d942e1b…   pinned
13:36  :rawhide -> sha256:2caf5d4d…   and 0d942e1b… answers 404
13:36  :44      -> sha256:2c38c5f7…   still 200, hours later
```

Quay garbage-collects the untagged Rawhide manifest immediately, so repinning is a fix with a sub-hour half-life — and the repo's own safety net cannot close that gap either: `check-base-image-pins.yml` runs at 22:20 against builds that start at 01:00. `check-base-image-pins.sh` already names this variant in its own history (#1788) for exactly this reason. The tag is the honest reference for a variant whose purpose is to track a target that moves several times a day; a digest that cannot be fetched buys no reproducibility, it only guarantees a red base nightly. Nothing requires the digest form — the checker treats an unpinned base as a declared state and reports it per run (`SKIP (not digest-pinned)`), and `test_generate_workflows.py` already uses tag-only base images. It is deliberately the only unpinned base in the file, with the conditions for re-pinning written next to it.

This also explains something that had been hiding: bonito-rawhide's *desktops* were green while its base was red, because the desktops layer on previously published tags and never pull the base image.

### 2. niri's DMS payload had never reached an image

`install-dms-qml-fallback.sh` was called only from `build_scripts/desktop/niri.sh` — the **legacy** installer. Every variant that ships niri takes the manifest path (`manifests/desktops/niri.yaml` → `install-desktop.sh`), which never sources it. So the fallback ran on nothing, and the AvengeMedia EL10 `dms-greeter` 1.6 RPM ships no QML, failing two assertions in `verify-branding-niri.sh` that read the same directory:

```
FAIL: greetd launches dms-greeter but /usr/share/quickshell/dms-greeter/DMSGreeter.qml is missing
FAIL: no wallpaper daemon (swaybg/swww/wpaperd) and no dms — background will be blank
```

Identical on albacore, skipjack and yellowfin the same night. Now a `post_install` hook — the interface `install-desktop.sh` actually reads. It is *sourced*, so it runs the installer in its own shell rather than exiting the caller mid-install, and it is conditioned on the broken state (`dms-greeter` present, QML absent) rather than a distro list, so it no-ops once an RPM owns the path (#2359) and never touches variants whose greeter is `cosmic-greeter` or `gtkgreet` — hardcoding a DMS path is what reddened `marlin:niri` before.

**And the first build that ran it found the bug underneath: the pinned checksum had never matched the asset.**

```
sha256sum: WARNING: 1 computed checksum did NOT match
```

It could not have been noticed, because nothing had ever downloaded the tarball to compare. The value's own shape says as much — it ended in five 8s. Corrected from the checksum upstream publishes *next to* the asset rather than from a local hash of whatever arrived, and added to `scripts/check-download-checksums.py`, which covered remora and chezmoi but not this. A checksum no build verifies and no checker covers is not a pin, it is a comment. `Pin` grows an `arches` field for it, since this payload is one set of bytes for every architecture (its greeter is a shell script).

The existing bats case pinned the call site *in `niri.sh`* and stayed green through all of this. A second case now pins the path that builds.

### 3. hummingbird has no buildable arm64

The base stage's `xfsprogs` guard is mandatory (`bootc install to-disk` cannot format the root without it) and nothing on aarch64 satisfies it. Measured against the live indexes, not inferred (`repo.tunaos.org/hummingbird/20251124-$basearch/repodata`):

| arch | packages | `xfsprogs` | `malcontent` |
|---|---:|---:|---:|
| x86_64 | 13442 | 1 | 2 |
| aarch64 | 7177 | **0** | **0** |

The aarch64 wave is about half-published, which is also why `flatpak` is *broken* rather than absent there (nothing provides `libmalcontent-0.so.0`). The direction of travel agrees: `projectbluefin/utah-packages` is a single-manifest x86_64 OCI image with no manifest list, so a wider move onto it puts arm64 further out of reach. Dropped rather than left failing nightly, with both restore conditions written down and pinned by the honesty test.

### 4. The boot gate is no longer scheduled where it cannot launch

Maintainer decision. `verify_boot` routes cosmic/niri/xfwl4 to the RunsOn `gpu` group; the account's g4dn vCPU limit is 0, so EC2 rejects every fleet request and the job dies before its first step. Scheduling it measures nothing — no runner, no serial log, no compositor — and costs the cell its image on top, because `Promote` needs `verify_boot` to be success **or** skipped and a runner that never attaches is neither. That is why `builds` read not-green for cosmic and niri on ten variants whose images built, pushed and passed every other gate.

This does not make those cells green and does not claim they boot: `green-criteria.yml` already scored them out of scope for `boots`, unchanged here. It stops a runner shortage from being recorded as a build failure.

The guard is pinned to the routing by a new case in `test_the_boots_scope_matches_the_gpu_routing.py`, which already pinned the routing to the criteria file. Three lists, all equal, failing in **both** directions — a compositor routed to the GPU group but still scheduled loses its image to an unrunnable gate; one skipped but not routed silently stops being boot-gated at all. Verified by deleting the `xfwl4` negation in a scratch copy: the new case fails and names the difference. So when capacity returns, the negations come out in the same change that removes the routing — a partial revert is a test failure, not a silent hole.

### Not fixed here — these need a decision, not a patch

- **`flounder:gnome` (48) and `guppy:gnome` (49)** fail the GNOME 50 floor from the 2026-09-03 directive. Neither base has a GNOME 50 to install; the gate works as designed.
- **`yellowfin:gnome` and `skipjack:gnome`** fail the boot Gate itself (`SSH check failed: Connection timed out during banner exchange`, `desktop contract marker was not emitted`) — a real boot regression, distinct from the runner shortage above.
- **Sigstore rekor 502s** fail `Attest SBOM` across most variants. Not this repo's to fix, and already `continue-on-error: true`, so `Promote` is unaffected and `builds` does not see it.

## Testing

Every fix is verified by a dispatched build on this branch, judged on `Promote` — the job the `builds` axis is scored from.

| build | proves | result |
|---|---|---|
| [bonito:base](https://github.com/tuna-os/tunaOS/actions/runs/34602168260) | fedora-bootc repin | ✅ `Promote` success, both arches |
| [sailfin:base](https://github.com/tuna-os/tunaOS/actions/runs/34602171527) | tumbleweed repin | ✅ `Promote` success |
| [hummingbird:base](https://github.com/tuna-os/tunaOS/actions/runs/34602181055) | arm64 drop | ✅ `Promote` success, no arm64 leg scheduled |
| [marlin:cosmic](https://github.com/tuna-os/tunaOS/actions/runs/34603336165) | the gate change | ✅ whole run success — `Gate` skipped, `Promote` success |
| [yellowfin:niri](https://github.com/tuna-os/tunaOS/actions/runs/34604264857) | DMS payload + checksum, and the gate | ✅ all three arches, `Desktop contract` success, `Promote` success |
| [bonito-rawhide:base](https://github.com/tuna-os/tunaOS/actions/runs/34605966963) | the rawhide tag | arm64 ✅, amd64 in flight |

`marlin:cosmic` is the clean demonstration of #4: its last nightly had the four GPU `Gate` jobs as the *only* failing jobs, and the run is now green end to end.

Local, before each push:

- Full Python suite, every file: **0 failures**, including the two tests changed here.
- `bats test_niri_dms_payload.bats` 9/9, `shellcheck --severity=error` clean, both YAMLs parse.
- `scripts/check-base-image-pins.sh`: 13 pins resolve, 0 unresolvable, 22 declared platforms, 0 unsatisfiable.
- `scripts/check-download-checksums.py`: all pins match, and re-running it with the old DMS hash restored reports the mismatch and exits 1.
- STE: **3048 findings across 102 files — exactly `main`'s count**, so the ratchet is where it was.
- Full bats suite: 11 files fail identically with and without this change (verified against a stashed tree). Environment failures in this container — running as root, and a `yq` that is the jq wrapper rather than the Go binary.

## Related issues

Refs #2123 (g4dn capacity — revert #4 with it), #2359 (an EL10 RPM owning `DMSGreeter.qml`), #1397 (hummingbird flatpak), #1788 (the base-pin GC history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws