### PR TITLE
fix(iso-e2e): make a failed boot diagnosable, instead of only a successful one

### DIFF
--- a/docs/ci-troubleshooting.md
+++ b/docs/ci-troubleshooting.md
@@ -517,10 +517,31 @@ grep -n "Stopped\|Started\|gdm\|contract\|poweroff\\|shutdown\|TUNAOS" /tmp/gate
 eog /tmp/gate-artifact/10-ready.ppm  # or similar viewer
 ```
 
+### serial.log carries the journal, not only the console
+
+`iso-e2e.sh` boots the installed system with
+`systemd.journald.forward_to_console=1`, so `serial.log` holds each unit's own
+stderr as well as systemd's status lines. Read it first for any unit that
+failed: the reason is usually there in full.
+
+This exists because `boot-diagnostics.txt` fails you on the worst boots. The
+gate collects that file over SSH. The failures you most want to read are the
+ones that break SSH: `dbus-broker` fails, so `systemd-logind` fails, so sshd
+cannot open a PAM session. `NetworkManager` is a dbus dependent, so it takes
+the TCP transport too. The file then holds one line:
+
+```
+WARNING: guest SSH unavailable; could not collect boot diagnostics
+```
+
+The serial console needs no service inside the guest, so it survives that.
+When SSH *does* work, `boot-diagnostics.txt` is still richer — read both.
+
 ### What to look for in serial.log
 
 | Pattern | Means | Action |
 |---------|-------|--------|
+| `Failed to start dbus-broker.service` | Everything that needs the bus fails after it: logind, NetworkManager, upower, the display manager. Nothing downstream is a separate bug | Find dbus-broker's own journal lines in `serial.log`; the cascade below it is noise |
 | `Started gdm.service` then `localhost login:` | Display server crashed, fell back to text getty | Check GDM journal, check NVIDIA/virtio-gpu driver |
 | `Starting tunaos-desktop-contract.service` with no `Started`/`Finished` | Service hung — likely `systemctl is-active` blocking on dbus | Add `TimeoutStartSec=30` |
 | `TUNAOS_DESKTOP_CONTRACT_FAIL reason=*` | Individual check failed | Use the reason field to identify which check |

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -2324,6 +2324,26 @@ run_install_generic() {
 	# /dev and the store bind-mounted. The kargs the passphrase-gate path
 	# appends post-install are baked here instead — bootc owns the BLS
 	# entries it writes, and --karg is the supported way in.
+	#
+	# systemd.journald.forward_to_console=1 is what makes a FAILED boot
+	# diagnosable at all. collect_disk_boot_diagnostics reaches the guest over
+	# SSH, and the failures worth diagnosing are exactly the ones that stop SSH
+	# from working: dbus-broker fails, so systemd-logind fails, so sshd cannot
+	# open a PAM session, and NetworkManager never comes up either. The gate
+	# then records the one line it can:
+	#
+	#   WARNING: guest SSH unavailable; could not collect boot diagnostics
+	#
+	# and the evidence for a real boot failure is a screenshot and systemd's
+	# terse "[FAILED] Failed to start dbus-broker.service ... See 'systemctl
+	# status' for details" — pointing at a command nobody can run, on a guest
+	# nobody can reach (yellowfin:gnome and skipjack:gnome, 2026-09-11).
+	#
+	# The serial console is the one channel that survives, because it needs no
+	# service inside the guest. Forwarding the journal to it puts each unit's
+	# actual stderr into serial.log, which is already captured and uploaded as
+	# evidence whether or not the guest is reachable. SSH collection stays as
+	# it is: richer where it works, and this costs nothing when it does.
 	if ! timeout 1800 "${ssh_cmd[@]}" "sudo podman run --rm --privileged --pid=host \
 		-v /var/lib/containers:/var/lib/containers -v /dev:/dev \
 		${luks_cfg_mount} \
@@ -2331,6 +2351,7 @@ run_install_generic() {
 		${imgref} \
 		bootc install to-disk --wipe ${block_setup} \
 		--karg console=ttyS0,115200n8 --karg rd.plymouth=0 --karg plymouth.enable=0 \
+		--karg systemd.journald.forward_to_console=1 \
 		/dev/vda 2>&1" 2>&1 | tee -a "${SERIAL_LOG}"; then
 		echo "ERROR: bootc install to-disk failed or timed out" >&2
 		return 3
@@ -3518,17 +3539,54 @@ collect_disk_boot_diagnostics() {
 		systemctl --failed --no-pager --full || true
 		echo '=== dbus-broker status ==='
 		systemctl status dbus-broker.service dbus.socket --no-pager --full || true
-		echo '=== display manager status ==='
-		systemctl status display-manager.service --no-pager --full || true
+
+		# display-manager.service is an ALIAS -- a symlink to lightdm/gdm/sddm/
+		# greetd. `systemctl status` follows it, but `journalctl -u` matches on
+		# the literal unit name a message was logged under, which is always the
+		# concrete one. So the status block below showed lightdm exiting 1 five
+		# times on flounder:xfce while the journal section that would have said
+		# WHY came back with only the dbus.socket line (2026-09-11).
+		# Resolve the alias and ask for both names.
+		dm="$(systemctl show -P Id display-manager.service 2>/dev/null || true)"
+		[ -n "$dm" ] || dm=display-manager.service
+		echo "=== display manager status (${dm}) ==="
+		systemctl status "$dm" --no-pager --full || true
+
+		# Every failed unit, not a hardcoded list: the unit that matters is the
+		# FIRST one to fail, and which one that is differs per variant. The
+		# named units above stay because they are the usual suspects and are
+		# worth having even when they did not fail.
+		echo '=== journal for every failed unit (this boot) ==='
+		failed="$(systemctl --failed --no-legend --plain --no-pager 2>/dev/null | awk '{print $1}')"
+		for unit in $failed; do
+			echo "--- ${unit} ---"
+			journalctl -b --no-pager -o short-precise -u "$unit" | tail -n 60 || true
+		done
+
 		echo '=== dbus/display-manager journal (this boot) ==='
 		journalctl -b --no-pager -o short-precise \
-			-u dbus-broker.service -u dbus.socket -u display-manager.service || true
+			-u dbus-broker.service -u dbus.socket \
+			-u display-manager.service -u "$dm" || true
+
+		# Everything at error level, as a backstop: a unit that never reached
+		# "failed" (it restart-loops, or a dependency was cancelled first)
+		# leaves nothing in the loop above but does leave this.
+		echo '=== priority<=err, this boot ==='
+		journalctl -b --no-pager -o short-precise -p err | tail -n 80 || true
+
 		echo '=== recent coredumps ==='
-		coredumpctl --no-pager --no-legend list 2>&1 | tail -n 30 || true
-		for exe in dbus-broker dbus-broker-launch; do
-			echo "=== coredump info: ${exe} ==="
-			coredumpctl --no-pager info "$exe" 2>&1 | tail -n 160 || true
-		done
+		# Debian images ship no systemd-coredump, so this whole block used to
+		# emit three `sh: coredumpctl: not found` lines into the evidence and
+		# nothing else. Say which it is.
+		if command -v coredumpctl >/dev/null 2>&1; then
+			coredumpctl --no-pager --no-legend list 2>&1 | tail -n 30 || true
+			for exe in dbus-broker dbus-broker-launch; do
+				echo "=== coredump info: ${exe} ==="
+				coredumpctl --no-pager info "$exe" 2>&1 | tail -n 160 || true
+			done
+		else
+			echo '(coredumpctl not installed on this image; no coredump metadata)'
+		fi
 	DIAGEOF
 	cat "$out" >&2
 }

--- a/scripts/iso-e2e.sh
+++ b/scripts/iso-e2e.sh
@@ -1013,10 +1013,13 @@ _agent_debug_instructions() {
 	echo "  ${OUTPUT_DIR:-<unset>}"
 	echo
 	echo "Read these first, in this order:"
-	echo "  serial.log                     guest kernel + systemd console (the live boot)"
+	echo "  serial.log                     guest kernel + systemd console AND the"
+	echo "                                 forwarded journal (each unit's own stderr)"
 	echo "  installed-serial.log           the same for the post-install boot (LUKS/install modes)"
 	echo "  current-phase.txt              which phase was in flight when it died"
-	echo "  boot-diagnostics.txt           failed-unit status/journal/coredump, when collected"
+	echo "  boot-diagnostics.txt           failed-unit status/journal/coredump, when"
+	echo "                                 collected — needs SSH, which the worst"
+	echo "                                 failures break; serial.log always has it"
 	echo "  *.ppm / *.png                  framebuffer captures (00-boot, 10-ready, 30-installed)"
 	echo "  walkthrough/                   per-step installer frames + TAP (published mode)"
 	echo


### PR DESCRIPTION
## Summary

Four cells are red on the boot gate right now — `yellowfin:gnome`, `skipjack:gnome`, `flounder:xfce`, `flounder-sid:xfce` — and **none of them can be root-caused from the evidence the gate produces.** That is the blocker this removes. It does not itself turn a cell green.

Two independent blind spots, both found while reading those four failures.

### 1. SSH collection cannot reach the guests worth collecting from

`collect_disk_boot_diagnostics` (#2326) gathers everything over SSH — and the failures worth diagnosing are exactly the ones that stop SSH from working.

On `yellowfin:gnome` and `skipjack:gnome`, `dbus-broker` fails → `systemd-logind` fails → sshd cannot open a PAM session. `NetworkManager` is a dbus dependent, so it never comes up either, taking the TCP transport with it. Both transports are gone before the gate asks, and the entire evidence file reads:

```
WARNING: guest SSH unavailable; could not collect boot diagnostics
```

What remains is a screenshot and systemd's terse console line:

```
[FAILED] Failed to start dbus-broker.service - D-Bus System Message Bus.
See 'systemctl status dbus-broker.service' for details.
```

— pointing at a command nobody can run, on a guest nobody can reach.

The serial console is the one channel that needs no service inside the guest, and `serial.log` is already captured and uploaded as evidence whether or not the guest is reachable. The installed system is now booted with `systemd.journald.forward_to_console=1`, so each unit's actual stderr lands there. SSH collection is untouched — richer where it works, and this costs nothing when it does.

### 2. The journal was queried for an alias, so it matched nothing

`display-manager.service` is a symlink to `lightdm`/`gdm`/`sddm`/`greetd`. `systemctl status` follows it; `journalctl -u` matches the literal unit a message was logged under, which is always the concrete one.

On `flounder:xfce` the status block duly showed the failure:

```
× lightdm.service - Light Display Manager
    Process: 810 ExecStart=/usr/sbin/lightdm (code=exited, status=1/FAILURE)
   lightdm.service: Scheduled restart job, restart counter is at 5.
```

…and the journal section that would have said **why** came back holding a single unrelated `dbus.socket` line. The alias is now resolved via `systemctl show -P Id` and both names are queried.

Two more, since a hardcoded unit list cannot know which unit fails first on a given variant:

- **Every failed unit gets its own journal**, derived from `systemctl --failed` rather than named in advance.
- **A `-p err` tail backstops it**, for the unit that never reaches `failed` because it restart-loops or its dependency was cancelled first.
- `coredumpctl` is probed rather than assumed — Debian images ship no `systemd-coredump`, so that block previously contributed three `sh: coredumpctl: not found` lines and nothing else.

### Documentation

`docs/ci-troubleshooting.md`'s "Serial Log Deep Diagnosis" section now states what `serial.log` contains and when `boot-diagnostics.txt` cannot be trusted, and its failure table gains a `dbus-broker` row — that cascade (logind, upower, NetworkManager, the display manager) reads as five bugs and is one. `_agent_debug_instructions` in the script is the other surface that described the evidence layout, and it is updated to match.

## What this is expected to reveal

Not a fix for the four cells, and deliberately not a guess at one. For the record, the packages point somewhere specific and the next run should confirm or kill it — the two **rolling** EL10 bases fail while the **stable** one passes:

| package | albacore (**passes**) | yellowfin (fails) | skipjack (fails) |
|---|---|---|---|
| `dbus` | 1.14.10-5.el10 | 1.14.10-**5** | 1.14.10-**6** |
| `dbus-daemon` | 1.14.10-5.el10 | 1.14.10-**6** | 1.14.10-**6** |
| `dbus-common` | 1.14.10-5.el10 | 1.14.10-**6** | 1.14.10-**6** |
| `dbus-libs` | 1.14.10-5.el10 | 1.14.10-**6** | 1.14.10-**6** |
| `systemd` | 257-23.el10_2.2 | 257-33.el10.alma.1 | 257-33.el10 |

Note `yellowfin` carries a **split** dbus stack — `dbus` at `-5` with its subpackages at `-6`. Whether that is the cause or a coincidence is exactly what the forwarded journal will say, and I would rather land the instrument than the hypothesis.

## Testing

- Guest-side script run against stubbed `systemctl`/`journalctl`: the alias resolves to `lightdm.service`, both failed units get their own journal, the combined query carries the concrete unit, and the coredump block reports its absence in one line.
- `shellcheck --severity=error` clean; `bash -n` clean; the heredoc body separately parses as the `sh` it is executed with (`sh -n`).
- **Python suite, every file, run to completion and checked on pytest's own exit status** — no failures. Four files are slow enough that a short per-file timeout silently kills them, so the times are recorded here rather than left as "0 failures":

  | file | result |
  |---|---|
  | `test_the_welcome_keywords_match_what_kde_says.py` | 19 passed, 491.50s |
  | `test_installer_walkthrough.py` | 12 passed, 294.85s |
  | `test_sign_step_retries_cosign.py` | 16 passed, 192.59s |
  | `test_the_progress_screen_keywords_were_measured.py` | 5 passed, 98.26s |
  | `test_desktop_verify.py` | 1 skipped |
  | all others | passed |

- `tests/bats/test_iso_e2e.bats` and `test_iso_e2e_poweroff.bats` fail identically with and without this change (4 and 3, verified against a stashed tree) — pre-existing container-environment failures, not regressions.
- STE: 3048 findings across 102 files, equal to `main`. The first draft of the docs was 3052; it was rewritten rather than the budget raised.

## Related issues

Refs #2326 (the SSH-based collector this extends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws