### PR TITLE
fix(flounder): lightdm needs an X server, so xfce-debian has to name one

### DIFF
--- a/build_scripts/checks/verify-desktop-experience.sh
+++ b/build_scripts/checks/verify-desktop-experience.sh
@@ -149,6 +149,50 @@ require_any_user_unit() {
 # LUKS gate read green — xfce.sh's own comment documents the blindness.
 # So assert the greeter statically, on exactly the branch xfce.sh's enable
 # logic takes: greetd is this image's DM if and only if lightdm did not land.
+# An X11 display manager with no X server is a crash loop, not a login screen.
+#
+# lightdm spawns an X server for its greeter. It only RECOMMENDS one, and
+# every apt install here runs --no-install-recommends, so on Debian/Ubuntu the
+# server arrives only if a manifest names it. When it does not, lightdm exits
+# 1 and display-manager.service restarts it until systemd gives up:
+#
+#   × lightdm.service - Light Display Manager
+#       Process: ExecStart=/usr/sbin/lightdm (code=exited, status=1/FAILURE)
+#      lightdm.service: Start request repeated too quickly.
+#
+# Nothing else in this file sees that. require_any_unit asks whether the DM
+# unit EXISTS, which it does; the boot gate reports a desktop contract
+# timeout; and lightdm writes the actual reason -- "Seat seat0: Can't create
+# display server for greeter" -- to /var/log/lightdm/lightdm.log and nowhere
+# a CI artifact looks. So the image publishes, the gate fails opaquely, and
+# the cause is one absent package.
+#
+# Paid for twice before this check existed: gurnard:pantheon (LUKS run
+# 31215923156, bisected) and then flounder:xfce + flounder-sid:xfce (run
+# 34541165610), because the fix for the first was a comment in one manifest
+# and the second manifest never read it.
+#
+# Asserted here rather than only over the manifests because this runs INSIDE
+# the image, so it holds however the packages got there -- apt, a base image
+# that already carried lightdm, or a distro whose packaging differs.
+# Deliberately silent when lightdm is absent: greetd/gtkgreet and
+# cosmic-greeter are Wayland and need no X server.
+x11_display_manager_has_a_server() {
+	command -v lightdm >/dev/null 2>&1 || return 0
+	# Xorg is /usr/bin/Xorg on some families and /usr/lib/xorg/Xorg on
+	# Debian/Ubuntu, where it is not always on PATH.
+	command -v Xorg >/dev/null 2>&1 && return 0
+	local root="${TUNAOS_VERIFY_ROOT:-}"
+	compgen -G "${root}/usr/lib/xorg/Xorg" >/dev/null && return 0
+	compgen -G "${root}/usr/libexec/Xorg" >/dev/null && return 0
+	echo "lightdm is installed but no X server is (Xorg, /usr/lib/xorg/Xorg, /usr/libexec/Xorg) — lightdm cannot create a display server for its greeter, exits 1, and display-manager.service crash-loops; the reason is logged only to /var/log/lightdm/lightdm.log" >&2
+	if [[ "${IS_HUMMINGBIRD:-false}" == "true" ]]; then
+		waive
+		return 0
+	fi
+	exit 1
+}
+
 xfce_greetd_greeter_contract() {
 	command -v lightdm >/dev/null 2>&1 && return 0
 	command -v greetd >/dev/null 2>&1 || return 0
@@ -491,6 +535,12 @@ pantheon)
 	;;
 *) exit 0 ;;
 esac
+
+# Outside the case on purpose: lightdm is not one desktop's concern. xfce uses
+# it on Debian, pantheon uses it on Ubuntu, and the two paid for the same
+# missing package separately. Whichever desktop is being verified, if the image
+# ended up with lightdm it needs an X server.
+x11_display_manager_has_a_server
 
 if [[ "$mode" == --runtime ]]; then
 	# Each check is individually gated so a single failure doesn't

--- a/manifests/desktops/xfce-debian.yaml
+++ b/manifests/desktops/xfce-debian.yaml
@@ -13,6 +13,34 @@ packages:
     - xfce4-goodies
     - lightdm
     - lightdm-gtk-greeter
+    # The X server lightdm's seat spawns. Debian's XFCE session is X11 and
+    # lightdm only RECOMMENDS an X server, so under the installer's
+    # --no-install-recommends (build_scripts/lib.sh) nothing on this list
+    # pulls one in. Without it lightdm cannot create a display server for the
+    # greeter, exits 1, and display-manager.service crash-loops:
+    #
+    #   × lightdm.service - Light Display Manager
+    #       Process: 810 ExecStart=/usr/sbin/lightdm (code=exited, status=1/FAILURE)
+    #      lightdm.service: Scheduled restart job, restart counter is at 5.
+    #
+    # and the boot gate then times out waiting for a desktop contract marker
+    # that cannot arrive (flounder:xfce and flounder-sid:xfce, run
+    # 34541165610). The daemon writes the actual reason -- "Seat seat0: Can't
+    # create display server for greeter" -- only to /var/log/lightdm/
+    # lightdm.log; the journal shows the bare exit 1 above, which is why this
+    # reads as a mystery rather than a missing package.
+    #
+    # This is the same bug pantheon.yaml carries a note about, in the same
+    # shape: measured on gurnard:pantheon by LUKS run 31215923156, bisected
+    # there with this package set minus/plus these two. XFCE on Debian is the
+    # other apt manifest that declares lightdm, and it never got the fix.
+    # tests/test_an_apt_lightdm_manifest_ships_an_x_server.py pins both.
+    - xserver-xorg
+    # Queried by every lightdm greeter for the user list; also a lightdm
+    # Recommends, so it never arrives implicitly either. Absent, each greeter
+    # start first warns "Error getting user list from
+    # org.freedesktop.Accounts".
+    - accountsservice
     - xdg-desktop-portal-gtk
     - thunar
     - mousepad

--- a/tests/test_an_apt_lightdm_manifest_ships_an_x_server.py
+++ b/tests/test_an_apt_lightdm_manifest_ships_an_x_server.py
@@ -1,0 +1,120 @@
+"""An apt manifest that uses lightdm must list an X server explicitly.
+
+lightdm only RECOMMENDS an X server and accountsservice. Every apt install in
+this tree runs with --no-install-recommends (build_scripts/lib.sh), so neither
+arrives unless a manifest names it. Without an X server lightdm cannot create a
+display server for its greeter and exits 1, and display-manager.service
+crash-loops.
+
+What makes this worth a test rather than a comment is where the evidence goes.
+lightdm writes the real reason -- "Seat seat0: Can't create display server for
+greeter" -- to /var/log/lightdm/lightdm.log and nowhere else. systemd records a
+bare `status=1/FAILURE`, so the boot gate reports a desktop contract timeout and
+the cause is invisible in every artifact CI collects.
+
+It has now been paid for twice, in the same shape:
+
+  gurnard:pantheon   LUKS run 31215923156. Diagnosed and bisected; pantheon.yaml
+                     gained xserver-xorg and accountsservice, with a note.
+  flounder:xfce      run 34541165610, and flounder-sid:xfce alongside it.
+                     xfce-debian.yaml is the other apt manifest that declares
+                     lightdm, and the fix was never carried across.
+
+The note on the first one did not stop the second, because a note only helps a
+reader who already opened that file. This asserts it over every manifest, so a
+third lightdm desktop fails here instead of in a boot gate three hours later.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MANIFESTS = ROOT / "manifests" / "desktops"
+
+# Debian/Ubuntu ship the server under several names; any one of them seats a
+# greeter. xserver-xorg is the metapackage, -core the server itself, and the
+# Xephyr/Xvfb nested servers are deliberately NOT here -- they are not display
+# servers lightdm can seat on real hardware.
+X_SERVERS = {"xserver-xorg", "xserver-xorg-core", "xwayland-run"}
+# lightdm's other Recommends that every greeter queries for the user list.
+USER_LIST = "accountsservice"
+
+
+def _apt_packages(section) -> list:
+    """The package names in a `packages.apt` section, whichever shape it has.
+
+    Two are in use. xfce-debian.yaml writes a plain list; pantheon.yaml writes
+    a mapping because it also needs a `ppa:` entry, and puts the names under
+    `packages:`. Reading only the list shape made this test assert that
+    pantheon -- the manifest that HAS the fix -- was missing it, which is the
+    failure mode worth avoiding: a checker whose parser silently disagrees with
+    the file reports the wrong manifests and gets muted.
+    """
+    if isinstance(section, dict):
+        return list(section.get("packages") or [])
+    return list(section or [])
+
+
+def _apt_manifests_using_lightdm() -> list[tuple[str, list]]:
+    """(name, apt package list) for every manifest whose apt path is lightdm.
+
+    Scoped to the apt path on purpose: zypper and emerge resolve recommends
+    differently, so xfce.yaml's zypper section naming lightdm is not in scope.
+    """
+    found = []
+    for path in sorted(MANIFESTS.glob("*.yaml")):
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        apt = _apt_packages((doc.get("packages") or {}).get("apt"))
+        if not apt:
+            continue
+        if (doc.get("display_manager") or "").strip() != "lightdm":
+            continue
+        found.append((path.name, apt))
+    return found
+
+
+def test_the_scan_finds_the_manifests_it_is_meant_to_cover():
+    """Absence of evidence is not evidence of absence (#1730): a selector that
+    silently matches nothing would make every assertion below vacuously true."""
+    names = {name for name, _ in _apt_manifests_using_lightdm()}
+    assert "xfce-debian.yaml" in names, (
+        "xfce-debian.yaml no longer reads as an apt+lightdm manifest; if its "
+        "display manager changed, this test's premise needs revisiting"
+    )
+    assert "pantheon.yaml" in names
+
+
+@pytest.mark.parametrize(
+    "name,apt",
+    _apt_manifests_using_lightdm(),
+    ids=[n for n, _ in _apt_manifests_using_lightdm()],
+)
+def test_an_apt_lightdm_manifest_lists_an_x_server(name: str, apt: list):
+    packages = {str(p).strip() for p in apt}
+    assert packages & X_SERVERS, (
+        f"{name} installs lightdm through apt but lists no X server "
+        f"({' / '.join(sorted(X_SERVERS))}). lightdm only Recommends one and "
+        "every apt install here uses --no-install-recommends, so lightdm will "
+        "exit 1 with 'Can't create display server for greeter' -- written only "
+        "to /var/log/lightdm/lightdm.log, never the journal. The boot gate will "
+        "report a desktop contract timeout and name nothing."
+    )
+
+
+@pytest.mark.parametrize(
+    "name,apt",
+    _apt_manifests_using_lightdm(),
+    ids=[n for n, _ in _apt_manifests_using_lightdm()],
+)
+def test_an_apt_lightdm_manifest_lists_accountsservice(name: str, apt: list):
+    packages = {str(p).strip() for p in apt}
+    assert USER_LIST in packages, (
+        f"{name} installs lightdm through apt but not {USER_LIST}. It is "
+        "another lightdm Recommends, so --no-install-recommends drops it, and "
+        "every greeter then starts by warning 'Error getting user list from "
+        "org.freedesktop.Accounts'."
+    )


### PR DESCRIPTION
## Summary

`flounder:xfce` and `flounder-sid:xfce` fail their boot gate. lightdm exits 1, five times, and `display-manager.service` crash-loops:

```
× lightdm.service - Light Display Manager
    Process: 810 ExecStart=/usr/sbin/lightdm (code=exited, status=1/FAILURE)
   lightdm.service: Scheduled restart job, restart counter is at 5.
   lightdm.service: Start request repeated too quickly.
```

so the gate waits its full 900s for a desktop contract marker that cannot arrive (run [34541165610](https://github.com/tuna-os/tunaOS/actions/runs/34541165610)).

**The cause is a package the manifest does not name.** lightdm only *Recommends* an X server; every apt install here runs with `--no-install-recommends` (`build_scripts/lib.sh:364`); and neither `xfce-debian.yaml` nor the `xfce.yaml` it replaces lists one. So nothing pulls one in, and lightdm has no display server to seat its greeter. `accountsservice` is the same shape — another lightdm Recommends, absent, so every greeter start warns `Error getting user list from org.freedesktop.Accounts`.

### This diagnosis already exists in the tree

`pantheon.yaml` carries a written-out note about the identical failure, measured and bisected on `gurnard:pantheon` by LUKS run 31215923156, and gained exactly these two packages as a result. **XFCE on Debian is the other apt manifest that declares lightdm, and it never got the fix.**

### Why it stayed hidden

lightdm writes the real reason — `Seat seat0: Can't create display server for greeter` — to `/var/log/lightdm/lightdm.log` and nowhere else. systemd records a bare `status=1/FAILURE`. So every artifact CI collects shows a contract timeout and names nothing, on both variants, indefinitely.

That is also why the note on `pantheon.yaml` did not prevent this: **a note only reaches a reader who already opened that file.** So the invariant is now asserted over every manifest instead — a third lightdm desktop fails in unit tests rather than in a boot gate three hours later.

## Testing

- `tests/test_an_apt_lightdm_manifest_ships_an_x_server.py` — 5 passed. Parametrised over every apt manifest that declares `display_manager: lightdm` (finds `pantheon.yaml` and `xfce-debian.yaml`), with a guard case asserting the scan is non-empty so a selector that silently matches nothing cannot make the rest vacuously true (#1730).
- **Proved it catches the bug**: stripped both packages back out in a scratch copy → the two `xfce-debian` cases fail and name the missing package; `pantheon` stays green.
- The test parses **both** shapes `packages.apt` is written in — a plain list (`xfce-debian`) and a mapping with a sibling `ppa:` key (`pantheon`). My first draft read only the list shape and duly reported `pantheon` — the manifest that *has* the fix — as missing it. A checker whose parser disagrees with the file gets muted rather than believed, so that is called out in the helper's docstring.
- Manifest parses; resulting apt list inspected directly.
- STE: 3048 findings, equal to `main`.

**Not verified by a build.** The runner pool is currently saturated by ten variant builds and flounder's gate is hours out. This rests on the package-level evidence above and the `gurnard:pantheon` precedent, not on a green gate — I would rather say so than imply coverage I do not have. The next flounder nightly will settle it, and with #2465 merged its `serial.log` will now carry lightdm's own journal either way.

## Related issues

Same failure class as the `gurnard:pantheon` fix noted in `manifests/desktops/pantheon.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws

---
_Generated by [Claude Code](https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws)_