### PR TITLE
fix(ci): pass IS_ELN to the desktop contract, so wahoo's codec gap can be waived

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -1673,10 +1673,36 @@ jobs:
 
           is_hb=false
           [[ "${IMAGE_VARIANT}" == hummingbird* ]] && is_hb=true
+          # IS_ELN matters here for the same reason IS_HUMMINGBIRD does: the
+          # contract reads it to decide whether a finding is a packaging
+          # mistake or a measured property of the upstream compose.
+          #
+          # At build time install-desktop.sh sources lib.sh, which derives
+          # IS_ELN from BASE_IMAGE, so the script's ELN branch fires and wahoo
+          # builds. This job runs the SAME script standalone in a container and
+          # passed only IS_HUMMINGBIRD, so IS_ELN defaulted to false, the
+          # branch could not fire, and the script exited 1 on a gap it is
+          # written to name and allow:
+          #
+          #   ffmpeg cannot decode h264 — a free/crippled libavcodec is installed
+          #
+          # That is wahoo's documented ELN codec gap (README calls the variant
+          # "no codecs"; tests/bats/test_eln_codec_gap.bats pins the exemption
+          # as ELN-only and loud). It cost wahoo its gnome, cosmic and kde
+          # cells: Desktop contract failed, so Promote was skipped, so `builds`
+          # read not-green for three images that built and pushed (run
+          # 34609709028). Nothing was wrong with the images.
+          #
+          # Derived from the variant id the same way is_hb is, rather than
+          # re-deriving from BASE_IMAGE, so the two stay one line apart and
+          # neither can drift from the other.
+          is_eln=false
+          [[ "${IMAGE_VARIANT}" == wahoo* ]] && is_eln=true
 
           sudo podman run --rm \
             -v "$PWD/build_scripts/checks/verify-desktop-experience.sh:/vde.sh:z" \
             -e IS_HUMMINGBIRD="$is_hb" \
+            -e IS_ELN="$is_eln" \
             --entrypoint /bin/bash "${TEST_IMAGE}" /vde.sh "${DESKTOP}"
 
       - name: Verify package wishlist

--- a/tests/test_the_desktop_contract_gets_the_variant_flags_it_reads.py
+++ b/tests/test_the_desktop_contract_gets_the_variant_flags_it_reads.py
@@ -1,0 +1,116 @@
+"""Every variant flag the desktop contract reads must reach it in CI.
+
+verify-desktop-experience.sh runs in two places with different plumbing:
+
+  build time   install-desktop.sh sources build_scripts/lib.sh, which derives
+               IS_ELN / IS_HUMMINGBIRD from BASE_IMAGE. Both are set.
+  Desktop      reusable-build-image.yml runs the same script standalone in a
+  contract     container, so nothing sources lib.sh and every flag has to be
+               passed with an explicit `-e`.
+
+The script uses those flags to tell a packaging mistake apart from a measured
+property of an upstream compose. A flag that does not arrive silently reads as
+false, so an exemption the script is written to apply cannot fire, and a
+correctly-built image fails a check that was never meant to fail it.
+
+Measured, 2026-09-11: the job passed IS_HUMMINGBIRD and not IS_ELN, so wahoo's
+ELN codec gap -- documented in the README ("no codecs"), implemented in the
+script, and pinned by tests/bats/test_eln_codec_gap.bats as ELN-only and loud --
+could not fire in that job. wahoo:gnome, :cosmic and :kde all failed Desktop
+contract on
+
+    ffmpeg cannot decode h264 - a free/crippled libavcodec is installed
+
+which skipped their Promote and read as three not-green `builds` cells for
+images that had built and pushed (run 34609709028).
+
+So the invariant is the join, not either side: whatever flags the script reads,
+the job that runs it must pass. Adding a third flag to the script without
+plumbing it fails here rather than on a variant's nightly.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "build_scripts" / "checks" / "verify-desktop-experience.sh"
+WORKFLOW = ROOT / ".github" / "workflows" / "reusable-build-image.yml"
+
+# Flags the script reads that the job is NOT expected to pass, each with the
+# reason. Anything else the script starts branching on has to be plumbed, which
+# is the point of this file.
+#
+# IS_FEDORA is deliberately here rather than fixed alongside IS_ELN, because
+# passing it would change nothing today. Its one use is
+#
+#   if [[ "${PKG_MGR:-}" == "dnf" && "${IS_FEDORA:-false}" != true && ... ]]
+#
+# and PKG_MGR is unset in this job for a deeper reason: the script's
+# `source /run/context/build_scripts/lib.sh` is a no-op here, because the
+# container mounts only the script itself, so `detected_os` never runs and the
+# whole OS-detection layer is absent. The first clause is therefore already
+# false and IS_FEDORA cannot affect the branch either way.
+#
+# That deeper gap has its own consequence -- with PKG_MGR unset the el10 family
+# takes the `else` and REQUIRES cosmic-files, which tunaOS#916 says is
+# best-effort there -- but fixing it means mounting lib.sh and letting
+# detection run, which is a change to how this job works rather than a missing
+# `-e`. Kept as a named exclusion so it stays visible instead of passing
+# silently.
+INERT_IN_THIS_JOB = {"IS_FEDORA"}
+
+# Not per-variant switches at all: a test-harness path override and an
+# allowlist path used by a different script.
+NOT_VARIANT_FLAGS = {"TUNAOS_VERIFY_ROOT", "TUNAOS_WISHLIST_ALLOWLIST"}
+
+
+def _flags_the_script_reads() -> set[str]:
+    """IS_* variables the contract branches on, read from the script itself."""
+    text = CONTRACT.read_text(encoding="utf-8")
+    # Matches ${IS_ELN:-false} and "${IS_HUMMINGBIRD:-false}" alike.
+    return {
+        name
+        for name in re.findall(r"\$\{(IS_[A-Z0-9_]+)(?::-[^}]*)?\}", text)
+        if name not in NOT_VARIANT_FLAGS and name not in INERT_IN_THIS_JOB
+    }
+
+
+def _desktop_contract_step() -> str:
+    """The run: body of the step that executes verify-desktop-experience.sh."""
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    for job in doc["jobs"].values():
+        for step in job.get("steps") or []:
+            body = step.get("run") or ""
+            if "verify-desktop-experience.sh" in body:
+                return body
+    raise AssertionError(
+        "no step in reusable-build-image.yml runs "
+        "verify-desktop-experience.sh - this test's premise moved"
+    )
+
+
+def test_the_script_actually_branches_on_variant_flags():
+    """Guard the selector: a regex that matches nothing would make the real
+    assertion below vacuously true (#1730)."""
+    flags = _flags_the_script_reads()
+    assert flags, "no IS_* flags found in the contract - the regex stopped matching"
+    assert "IS_ELN" in flags and "IS_HUMMINGBIRD" in flags, (
+        f"expected the two known variant flags among {sorted(flags)}"
+    )
+
+
+@pytest.mark.parametrize("flag", sorted(_flags_the_script_reads()))
+def test_the_desktop_contract_step_passes_every_flag_the_script_reads(flag: str):
+    body = _desktop_contract_step()
+    assert re.search(rf"-e\s+{flag}=", body), (
+        f"verify-desktop-experience.sh branches on {flag}, but the Desktop "
+        f"contract step in reusable-build-image.yml does not pass it. Nothing "
+        f"sources build_scripts/lib.sh in that container, so {flag} reads as "
+        f"false and any exemption guarded by it cannot fire - the image fails a "
+        f"check it was never meant to fail, and its Promote is skipped."
+    )


### PR DESCRIPTION
## Summary

`wahoo:gnome`, `:cosmic` and `:kde` all failed Desktop contract on

```
ffmpeg cannot decode h264 — a free/crippled libavcodec is installed
```

which skipped their `Promote` and read as **three not-green `builds` cells for images that had built and pushed** (run [34609709028](https://github.com/tuna-os/tunaOS/actions/runs/34609709028)). Nothing was wrong with the images.

That gap is wahoo's **documented** ELN codec gap, and the contract is already written to allow it: `verify-desktop-experience.sh` names it, marks it `TUNAOS_CODEC_GAP: ELN`, and lets it through; `tests/bats/test_eln_codec_gap.bats` pins the exemption as ELN-only and loud; the README calls the variant "no codecs".

**The exemption could not fire.** It is guarded on `IS_ELN`, and the two places the script runs are plumbed differently:

| | how it runs | `IS_ELN` |
|---|---|---|
| build time | `install-desktop.sh` sources `build_scripts/lib.sh`, which derives it from `BASE_IMAGE` | set — wahoo builds fine |
| Desktop contract | the same script, standalone in a container, with only `-e IS_HUMMINGBIRD` | **defaulted to false** |

So the script exited 1 on the one base where that finding is a measured property of the upstream compose rather than a packaging mistake this repo can fix.

`is_eln` is derived from the variant id one line below `is_hb`, rather than re-derived from `BASE_IMAGE`, so the two cannot drift apart.

## The general invariant

This is the second time a flag the contract needs did not reach it, so it is now asserted rather than noted: `tests/test_the_desktop_contract_gets_the_variant_flags_it_reads.py` requires every `IS_*` flag the script branches on to be passed by the job that runs it. A third exemption flag added to the script fails there instead of on a variant's nightly.

### One honest exclusion

`IS_FEDORA` is excluded **by name, with the reason in the test**. Passing it would change nothing today: its only use also tests `PKG_MGR`, and `PKG_MGR` is unset in this job because the script's `source /run/context/build_scripts/lib.sh` is a no-op there — the container mounts only the script, so `detected_os` never runs and the whole OS-detection layer is absent.

That deeper gap has its own consequence worth flagging: with `PKG_MGR` unset, the el10 family takes the `else` branch and **requires `cosmic-files`**, which tunaOS#916 calls best-effort there. Closing it means mounting `lib.sh` and letting detection run — a change to how the job works, not a missing `-e` — so I have not widened this PR into it. It is left visible as a named exclusion rather than fixed silently or dropped.

## Testing

- `tests/test_the_desktop_contract_gets_the_variant_flags_it_reads.py` — 3 passed, including a guard case asserting the flag scan is non-empty so a regex that stops matching cannot make the rest vacuously true (#1730).
- **Proved it catches the bug**: deleted the new `-e IS_ELN=` line in a scratch copy → the `IS_ELN` case fails and names the consequence.
- Workflow parses; the edited step verified to pass both flags and derive `is_eln` from the variant id.
- `test_ci_contract.py` 35 passed, `test_workflow_conditions_name_real_inputs.py` 9 passed, `test_generate_workflows.py` 17 passed, `test_the_boots_scope_matches_the_gpu_routing.py` 3 passed.

## Related issues

Refs tunaOS#916 (`cosmic-files` best-effort on el10, the `PKG_MGR` gap above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws

---
_Generated by [Claude Code](https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws)_