### PR TITLE
fix(wahoo): declare the ELN package gaps the wishlist gate found

### DIFF
--- a/build_scripts/checks/package-miss-allowlist.txt
+++ b/build_scripts/checks/package-miss-allowlist.txt
@@ -123,3 +123,41 @@ gum
 #    one. Remove this entry once rpmfusion-free-rawhide rebuilds ffmpeg
 #    against openapv 0.3 (liboapv.so.3), restoring ffmpeg on bonito-rawhide.
 ffmpeg
+
+# ── wahoo (Fedora ELN preview lane) — GNOME/COSMIC extras the ELN compose
+#    does not carry ──
+#
+# Measured 2026-09-11 by the probe itself, not inferred: install_available
+# asked for each of these against wahoo's own enabled repos and recorded the
+# miss, which is what a wishlist entry IS (run 34657968072, wahoo:gnome and
+# wahoo:cosmic Desktop contract).
+#
+# Every one is a nice-to-have by this file's own test: none is a display
+# manager, greeter, portal or session package, so none is load-bearing for a
+# usable desktop, and verify-desktop-experience.sh — which does assert those —
+# passes on both images. What is lost is VPN configuration dialogs, document
+# and video thumbnailers, iOS device mounting, Qt window decorations that match
+# Adwaita, and the stock wallpaper sets. An image without them is still
+# correct; it is plainer.
+#
+# Note the limitation this file's format imposes: these entries are GLOBAL, so
+# a Fedora variant that starts missing gnome-backgrounds now passes too. That
+# is the existing trade in every section above (xorg-x11-server-Xwayland is
+# listed for EL10 and thereby tolerated everywhere). Per-variant scoping would
+# fix it and is a change to the gate, not to this list.
+#
+# Remove each entry once it resolves on ELN — either upstream ships it or
+# tuna-os/tunaos-packages builds it for the preview lane. The gate only fires
+# on actual misses, so deleting a line is safe the moment the package exists.
+NetworkManager-openconnect-gnome
+NetworkManager-ssh-gnome
+NetworkManager-vpnc-gnome
+evince-previewer
+evince-thumbnailer
+gnome-backgrounds
+gnome-user-share
+gvfs-afc
+qadwaitadecorations-qt5
+totem-video-thumbnailer
+# wahoo:cosmic — the only miss on that image, and purely cosmetic.
+cosmic-wallpapers


### PR DESCRIPTION
## Summary

#2469 got `IS_ELN` to the Desktop contract and the codec exemption now fires as designed:

```
TUNAOS_CODEC_GAP: ELN publishes no functional H.264/H.265 decoder …
TUNAOS_DESKTOP_CONTRACT_WAIVED desktop=gnome missing=1
```

But the same job runs a second check, the package wishlist, and that one failed — so `wahoo:gnome` and `wahoo:cosmic` still skipped Promote and still read as not-green `builds` cells (run [34657968072](https://github.com/tuna-os/tunaOS/actions/runs/34657968072)):

```
TUNAOS_WISHLIST_FAIL misses=10   (gnome)
TUNAOS_WISHLIST_FAIL misses=1    (cosmic — cosmic-wallpapers)
```

This adds the eleven names to `package-miss-allowlist.txt` with the section comment the file's convention asks for.

These are **measured, not inferred**: `install_available` asked for each package against wahoo's own enabled repos and recorded the miss, which is what a wishlist entry *is*. The gate's own instruction is to package them, install them strictly, or declare them acceptable. The third is the honest option here — every name is a nice-to-have by this file's stated test. None is a display manager, greeter, portal or session package, and `verify-desktop-experience.sh`, which *does* assert those, passes on both images. What an ELN user actually loses: VPN configuration dialogs, document and video thumbnailers, iOS device mounting, Qt decorations matching Adwaita, and the stock wallpaper sets. The image is plainer, not broken.

**One limitation worth your call.** These entries are global — the file has no per-variant scoping — so a Fedora variant that starts missing `gnome-backgrounds` will now pass too. That is the existing trade in every section of the file (`xorg-x11-server-Xwayland` is listed for EL10 and thereby tolerated everywhere), so I followed the convention rather than redesigning the gate in a PR about wahoo. Adding scoped entries (`name @variant`) would fix it properly and is a change to `verify-package-wishlist.sh`; happy to do it separately if you want it.

**This does not turn `wahoo:gnome` green by itself.** That cell also fails its boot Gate, for an unrelated reason — see below.

## Testing

Ran the real gate against the real allowlist, including a negative control so this is not just "the check stopped firing":

```
$ TUNAOS_WISHLIST_DIR=… verify-package-wishlist.sh      # the 10 + gnome's two existing
TUNAOS_WISHLIST_OK misses=12 (all allowlisted)

$ TUNAOS_WISHLIST_DIR=… verify-package-wishlist.sh      # cosmic
TUNAOS_WISHLIST_OK misses=1 (all allowlisted)

$ TUNAOS_WISHLIST_DIR=… verify-package-wishlist.sh      # gnome-backgrounds + an unlisted gdm
TUNAOS_WISHLIST_FAIL misses=1
  gdm
```

STE findings 3048, unchanged from main.

## Related issues

Not filed — recording here instead, since both are findings rather than fixes.

**`wahoo:gnome` boot Gate.** `dbus-broker.service` fails to start, and everything downstream cascades: `systemd-logind`, `polkit`, `upower`, `NetworkManager`, `tuned`, and finally `gdm.service` — `Dependency failed for gdm.service - GNOME Display Manager`. The serial log shows the failure but not its cause (`See 'systemctl status dbus-broker.service' for details`), and the post-boot diagnostics can't reach it either:

```
WARNING: guest SSH unavailable; could not collect boot diagnostics
```

which is the honest limit of the diagnostics #2465 added — they collect over SSH, and SSH is downstream of the thing that failed. The gate boots through `corral`, so the fix that would make this self-diagnosing (the `systemd.journald.forward_to_console=1` karg #2465 added to `iso-e2e.sh`) has to go through corral's interface rather than a karg I can add here. Left for someone who can exercise that path.

**`Attest SBOM` is red fleet-wide** (every flavor of bonito and wahoo), and it is not ours: `rekor.sigstore.dev` returned 502 on every attempt, and the step's own retry logic correctly identified it — `SIGSTORE_OUTAGE: attest still failing after 10m of Sigstore unavailability; giving up`. No action needed; noting it so the red isn't re-diagnosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws

---
_Generated by [Claude Code](https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws)_