### PR TITLE
fix(ci): forward the journal on the disk the boot Gate actually boots

### DIFF
--- a/just/qcow2-build.just
+++ b/just/qcow2-build.just
@@ -179,6 +179,29 @@ qcow2 variant flavor='gnome' repo='local' tag='':
     # screenshot) while the captured serial.log held nothing but kernel printk —
     # an emergency-mode boot with no recorded reason. ttyS0 last puts the boot
     # log the Gate captures where it is actually useful.
+    #
+    # systemd.journald.forward_to_console=1 for the same reason, one layer up.
+    # The console carries systemd's status lines, but a unit's own stderr goes
+    # to the journal, so a failure reads:
+    #
+    #   [FAILED] Failed to start dbus-broker.service - D-Bus System Message Bus.
+    #   See 'systemctl status dbus-broker.service' for details.
+    #
+    # pointing at a command nobody can run, because the guest is unreachable
+    # for exactly the reason being diagnosed: dbus-broker fails, so
+    # systemd-logind fails, so sshd cannot open a PAM session, and
+    # collect_disk_boot_diagnostics records the one line it can —
+    # "guest SSH unavailable; could not collect boot diagnostics".
+    #
+    # Measured on three variants the same day (2026-09-11): yellowfin:gnome,
+    # skipjack:gnome and wahoo:gnome all died this way, nine cells between them
+    # once the -hwe and -nvidia flavors are counted, while kde on the same
+    # images booted clean. Nothing in the evidence says WHY dbus-broker failed.
+    #
+    # scripts/iso-e2e.sh bakes this karg on its own `bootc install to-disk`
+    # (tunaOS#2465). The Gate does not take that path — it builds the disk
+    # here, with `just qcow2`, and boots the result — so the karg has to be on
+    # both or the gate that actually scores `boots` stays undiagnosable.
     echo "==> Running bootc install to-disk (this takes a few minutes)..."
     sudo podman run \
         --rm \
@@ -196,6 +219,7 @@ qcow2 variant flavor='gnome' repo='local' tag='':
             --generic-image \
             "${COMPOSEFS_ARGS[@]}" \
             --karg console=tty0 --karg console=ttyS0 \
+            --karg systemd.journald.forward_to_console=1 \
             --karg systemd.unit=graphical.target \
             "${SSH_KEY_ARGS[@]}" \
             --source-imgref "containers-storage:${IMG_REF}" \

--- a/tests/test_every_disk_boot_path_forwards_the_journal.py
+++ b/tests/test_every_disk_boot_path_forwards_the_journal.py
@@ -1,0 +1,104 @@
+"""A disk built to be watched over serial must send unit stderr there too.
+
+`boots` is scored by a QEMU boot whose only surviving channel is the serial
+console: the gate reaches the guest over SSH for diagnostics, and the failures
+worth diagnosing are the ones that stop SSH from working. dbus-broker fails, so
+systemd-logind fails, so sshd cannot open a PAM session, and the collector
+records one line:
+
+    WARNING: guest SSH unavailable; could not collect boot diagnostics
+
+leaving systemd's terse status line as the whole evidence base:
+
+    [FAILED] Failed to start dbus-broker.service - D-Bus System Message Bus.
+    See 'systemctl status dbus-broker.service' for details.
+
+-- a command nobody can run, on a guest nobody can reach. Measured 2026-09-11 on
+yellowfin:gnome, skipjack:gnome and wahoo:gnome, nine cells between them once
+the -hwe and -nvidia flavors are counted, with kde green on the same images.
+
+systemd.journald.forward_to_console=1 is the fix, and tunaOS#2465 adding it to
+scripts/iso-e2e.sh was not enough: the Gate does not install through that
+script. It builds the disk with `just qcow2` and boots the result, so the karg
+was absent exactly where `boots` is decided.
+
+So the property here is not "the karg is in one file" -- #2465 already
+satisfied that while the gate stayed blind. It is: any install that bakes a
+serial console in order to be WATCHED over it must also put the journal there,
+because the status lines the console carries by default name a failure without
+naming its cause.
+
+Scoped by `console=ttyS0` on purpose, rather than by every `bootc install
+to-disk` in the tree. A disk nobody watches over serial (scripts/build-qcow2.sh,
+which bakes no console kargs at all -- local builds and the weekly screenshot
+job) has no serial log for the karg to improve, and sweeping it in would make
+this file an unrelated style rule instead of a gate on evidence.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+KARG = "systemd.journald.forward_to_console=1"
+SEARCH_ROOTS = ("scripts", "just", "build_scripts", ".github")
+
+
+def _strip_comments(text: str) -> str:
+    """Drop whole-line comments.
+
+    This repo's prose quotes the very kargs these tests search for, so an
+    un-stripped match passes with the flag deleted from the command.
+    """
+    return "\n".join(
+        line for line in text.splitlines()
+        if not line.lstrip().startswith("#"))
+
+
+def _serial_watched_installers() -> list[pathlib.Path]:
+    """Files that install a disk AND bake a serial console to watch it on."""
+    hits = []
+    for root in SEARCH_ROOTS:
+        base = ROOT / root
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*")):
+            if not path.is_file():
+                continue
+            try:
+                code = _strip_comments(path.read_text(encoding="utf-8"))
+            except (UnicodeDecodeError, OSError):
+                continue
+            if re.search(r"bootc install to-disk", code) and "console=ttyS0" in code:
+                hits.append(path)
+    return hits
+
+
+def test_the_search_finds_the_paths_we_know_about():
+    """Guard the selector: a discovery that matched nothing would make the
+    real assertion below vacuously true (tunaOS#1730)."""
+    found = {p.relative_to(ROOT).as_posix() for p in _serial_watched_installers()}
+    for known in ("scripts/iso-e2e.sh", "just/qcow2-build.just"):
+        assert known in found, (
+            f"{known} installs a disk and bakes console=ttyS0, but the "
+            f"discovery missed it -- found {sorted(found)}. Fix the search "
+            "before trusting the assertion below."
+        )
+
+
+@pytest.mark.parametrize(
+    "path", _serial_watched_installers(), ids=lambda p: p.name)
+def test_a_serial_watched_disk_also_forwards_its_journal(path: pathlib.Path):
+    code = _strip_comments(path.read_text(encoding="utf-8"))
+    assert KARG in code, (
+        f"{path.relative_to(ROOT)} bakes console=ttyS0 so a boot can be "
+        f"watched over serial, but does not pass --karg {KARG}.\n"
+        "The console carries systemd's status lines; a unit's own stderr goes "
+        "to the journal, and the journal is unreachable once sshd is "
+        "downstream of whatever broke. Without this the serial log names the "
+        "failed unit and never its cause. Add the karg alongside the console= "
+        "ones."
+    )


### PR DESCRIPTION
## Summary

#2465 added `systemd.journald.forward_to_console=1` to `scripts/iso-e2e.sh` so a failed boot would say *why*. It didn't work, and the reason is worth stating plainly: **the Gate does not install through that script.** It builds the disk with `just qcow2` and boots the result. The karg was absent exactly where `boots` is scored, so the gate stayed blind while the change read as done.

This adds it to `just/qcow2-build.just`, alongside the `console=` kargs already there for the same reason.

### Why it matters right now

Three variants died the same way on 2026-09-11 — `yellowfin:gnome`, `skipjack:gnome`, `wahoo:gnome` — **nine cells between them** once `-hwe` and `-nvidia` are counted. Same signature on all three, with `kde` green on the same images:

```
A valid context for root could not be obtained.
[FAILED] Failed to start dbus-broker.service - D-Bus System Message Bus.
See 'systemctl status dbus-broker.service' for details.
WARNING: guest SSH unavailable; could not collect boot diagnostics
```

Then the cascade: `systemd-logind`, `polkit`, `upower`, `NetworkManager`, and finally `Dependency failed for gdm.service`.

That is the entire evidence base — a command nobody can run, on a guest nobody can reach. And it's unreachable *for the reason being diagnosed*: dbus-broker fails, so systemd-logind fails, so sshd cannot open a PAM session, so the SSH-based diagnostics collector gets nothing. The serial console is the one channel that needs no service inside the guest.

**This diagnoses; it does not fix.** What makes dbus-broker fail on gnome is still unknown. The `A valid context for root could not be obtained` line appears only on the failing images and looks like an SELinux lookup failure, but I'm not going to assert a cause the evidence doesn't carry — the next Gate run is what will say.

### The test

It pins the *property*, not the file, because "the karg is in one file" is precisely what #2465 satisfied while the gate stayed blind. The rule: any install that bakes `console=ttyS0` **in order to be watched over serial** must also put the journal there.

Scoped by that rather than by every `bootc install to-disk` in the tree — `scripts/build-qcow2.sh` bakes no console kargs at all (local builds and the weekly screenshot job), so it has no serial log for this to improve, and sweeping it in would make the file an unrelated style rule instead of a gate on evidence. A discovery guard fails if the search stops matching the two paths we know about, so the parametrized assertion can't go vacuously green.

## Testing

```
$ pytest tests/test_every_disk_boot_path_forwards_the_journal.py -q
3 passed

# negative control — karg deleted from qcow2-build.just:
FAILED …::test_a_serial_watched_disk_also_forwards_its_journal[qcow2-build.just]

$ pytest tests/test_just_modules_resolve_repo_paths.py -q
11 passed
```

`bats tests/bats/test_iso_e2e.bats` — 93 ok, 4 not ok. I checked those four against a clean `main` with the change stashed and they fail identically there, so they're a local environment gap, not this diff.

STE findings 3048, unchanged from main.

## Related issues

Follows up #2465, which made this change on the ISO/E2E install path only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws

---
_Generated by [Claude Code](https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws)_