### PR TITLE
fix(wahoo): record fastfetch as an ELN absence, not a strict install

### DIFF
--- a/build_scripts/10-base-packages.sh
+++ b/build_scripts/10-base-packages.sh
@@ -296,8 +296,8 @@ elif [[ ${IS_ELN:-false} == true ]]; then
 	# Base set, strict. Every name here was verified present in
 	# eln-{baseos,appstream,crb,extras} on 2026-08-25; a miss is a real ELN
 	# regression worth failing the build on, which is the whole point of an
-	# early-warning lane. The four names the EL/Fedora lists carry that ELN
-	# does NOT ship are deliberately absent rather than silently skipped:
+	# early-warning lane. The names the EL/Fedora lists carry that ELN does
+	# NOT ship are deliberately absent rather than silently skipped:
 	#
 	#   systemd-oomd  — `dnf repoquery --whatprovides systemd-oomd` returns
 	#                   nothing (EL drops the subpackage); systemd-oomd-defaults
@@ -306,6 +306,22 @@ elif [[ ${IS_ELN:-false} == true ]]; then
 	#   tailscale     — pkgs.tailscale.com/stable/centos/11/tailscale.repo
 	#                   is a 404 (measured); 20-packages.sh's own guard
 	#                   already declines to fetch it.
+	#   fastfetch     — retired from ELN between 2026-09-11 23:24 and
+	#                   2026-09-12 08:53 UTC. The lane caught it exactly as
+	#                   designed: run 34657968072 installed
+	#                   fastfetch-0:2.68.1-1.eln159 and run 34684438275, on
+	#                   the same eln159 build tags, got
+	#
+	#                       No match for argument: fastfetch
+	#
+	#                   which killed base on both arches and took all four
+	#                   wahoo cells with it. Queried against the live repos
+	#                   the same day (dl.fedoraproject.org/pub/eln/1,
+	#                   AppStream+BaseOS+CRB+Extras, 12996 packages): absent,
+	#                   while glow, gum and distrobox — its neighbours in
+	#                   this very transaction — all still resolve, which is
+	#                   what rules out a broken compose. Move it back up the
+	#                   moment ELN ships it again.
 	#
 	# glow, gum, tuned-ppd, system-reinstall-bootc, fpaste and the libcamera
 	# set are EPEL packages on the EL10 family but are IN ELN (eln-appstream
@@ -322,7 +338,6 @@ elif [[ ${IS_ELN:-false} == true ]]; then
 		systemd-container \
 		flatpak \
 		distrobox \
-		fastfetch \
 		fwupd \
 		dbus-daemon \
 		fuse-overlayfs \

--- a/tests/test_the_eln_absences_match_the_eln_transaction.py
+++ b/tests/test_the_eln_absences_match_the_eln_transaction.py
@@ -1,0 +1,121 @@
+"""The ELN lane's prose and its dnf transaction must name the same absences.
+
+wahoo is an early-warning lane: its base package set is installed strictly, so
+a package ELN stops shipping fails the build instead of vanishing from the
+image. `10-base-packages.sh` says so in as many words -- "a miss is a real ELN
+regression worth failing the build on" -- and keeps a block naming each package
+the EL/Fedora lists carry that ELN does not, with the measurement that
+established it.
+
+Two lists, one meaning, and nothing kept them in step. The failure mode is
+quiet in both directions:
+
+  listed absent, still installed  → the build dies on a package the file
+                                    already documents as unavailable, and the
+                                    next reader trusts the prose over the code.
+  removed, not documented         → a package leaves the lane with no record
+                                    of why, which is the "silently skipped"
+                                    outcome the whole strict transaction
+                                    exists to prevent.
+
+Measured instance, 2026-09-12: ELN retired fastfetch between two wahoo runs ten
+hours apart (34657968072 installed fastfetch-0:2.68.1-1.eln159; 34684438275, on
+the same build tags, got "No match for argument: fastfetch"). That killed base
+on both arches and took all four wahoo cells with it. Dropping the name without
+recording the measurement would have left the next person to rediscover it.
+
+So when ELN ships one of these again, moving the name back into the
+transaction and deleting its entry here are the same edit -- this test fails
+on either half alone.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "build_scripts" / "10-base-packages.sh"
+
+MARKER = "NOT ship are deliberately absent rather than silently skipped:"
+
+
+def _eln_branch() -> str:
+    """The IS_ELN branch only. The Fedora and EL10 lists are separate
+    transactions against separate bases, and they legitimately carry names ELN
+    does not -- reading the whole file would compare across bases."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    start = text.index("elif [[ ${IS_ELN:-false} == true ]]; then")
+    end = text.index("\nelif ", start + 1)
+    return text[start:end]
+
+
+def _documented_absences() -> list[str]:
+    """Package names from the `... does NOT ship ...` block.
+
+    Each entry looks like `#   name  — reason`, and the block ends at the first
+    comment line that is not one (the glow/gum paragraph that follows).
+    """
+    branch = _eln_branch()
+    block = branch[branch.index(MARKER):]
+    names = []
+    for line in block.splitlines()[1:]:
+        stripped = line.strip()
+        if not stripped.startswith("#"):
+            break
+        m = re.match(r"#\s{2,}([a-z0-9][a-z0-9._+-]*)\s+[-—]\s+\S", stripped)
+        if m:
+            names.append(m.group(1))
+        elif stripped == "#" or re.match(r"#\s{18,}\S", stripped):
+            continue          # blank spacer, or a wrapped continuation line
+        else:
+            break
+    return names
+
+
+def _strictly_installed() -> set[str]:
+    """Package names in the ELN branch's strict `dnf -y install` transactions.
+
+    Tolerant paths are excluded by construction: they carry
+    --skip-unavailable, or go through install_available.
+    """
+    pkgs: set[str] = set()
+    branch = _eln_branch()
+    for m in re.finditer(r"^\tdnf -y install \\\n((?:\t\t\S.*\n)+)", branch, re.M):
+        body = m.group(1)
+        if "--skip-unavailable" in body:
+            continue
+        for line in body.splitlines():
+            name = line.strip().rstrip("\\").strip()
+            if name and not name.startswith("-"):
+                pkgs.add(name)
+    return pkgs
+
+
+def test_the_absence_block_still_parses():
+    """Guard both selectors: either matching nothing would make the real
+    assertion vacuously true (tunaOS#1730)."""
+    documented = _documented_absences()
+    assert documented, (
+        f"no names parsed out of the '{MARKER}' block -- its shape changed, "
+        "so the assertion below is measuring nothing")
+    for known in ("systemd-oomd", "just", "tailscale"):
+        assert known in documented, (
+            f"{known} should be a documented ELN absence; parsed {documented}")
+    installed = _strictly_installed()
+    assert {"podman", "flatpak"} <= installed, (
+        f"the strict ELN transaction did not parse; got {sorted(installed)}")
+
+
+@pytest.mark.parametrize("pkg", _documented_absences())
+def test_a_documented_absence_is_not_strictly_installed(pkg: str):
+    assert pkg not in _strictly_installed(), (
+        f"10-base-packages.sh documents {pkg!r} as a package ELN does not "
+        f"ship, but still installs it in the strict ELN transaction. The "
+        f"build will fail on it every time.\n"
+        f"If ELN now ships {pkg}, delete its entry from the absence block in "
+        f"the same change that adds it back to the transaction -- the two "
+        f"lists are one statement, and this test is what keeps them saying "
+        f"the same thing."
+    )


### PR DESCRIPTION
## Summary

ELN retired `fastfetch` between two wahoo runs ten hours apart, and the early-warning lane caught it exactly as designed:

```
run 34657968072 (2026-09-11 23:24) — Installing fastfetch-0:2.68.1-1.eln159
run 34684438275 (2026-09-12 08:53) — No match for argument: fastfetch
```

Same `eln159` build tags on both. The strict transaction failed on both arches, base never published, and **all four wahoo cells went with it** — including `wahoo:cosmic`, which #2471 had just unblocked.

I confirmed this is a retirement and not a broken compose, by querying the live repos (`dl.fedoraproject.org/pub/eln/1`, AppStream+BaseOS+CRB+Extras, 12996 packages):

```
PRESENT podman, systemd, flatpak, upower    ← sanity check on the probe itself
absent  fastfetch
PRESENT glow, gum, distrobox                ← its neighbours in this very transaction
```

`fastfetch`'s list-neighbours still resolving is what rules out a compose outage. (Two earlier probe attempts of mine returned "absent" for *everything* including `kernel`; the sanity line is what caught them, which is why it's in there.)

So this moves the name into the block that already records `systemd-oomd`, `just` and `tailscale`, with the measurement attached.

It deliberately does **not** add `--skip-unavailable`. The same comment block says that is how #1555 shipped ten nightlies silently missing tailscale, and an early-warning lane that skips what it cannot find isn't one.

The Fedora and EL10 lists still install `fastfetch` — separate transactions against separate bases, and it resolves on both.

### The test

The absence block and the transaction are one statement, and nothing kept them in step. Both directions fail quietly:

- **listed absent, still installed** → the build dies every time on a package the file already documents as unavailable, and the next reader trusts the prose over the code.
- **removed, not documented** → a package leaves the lane with no record of why, which is the "silently skipped" outcome the strict list exists to prevent.

This PR is itself a two-place edit, which is the gap. Now, when ELN ships `fastfetch` again, moving the name back and deleting its entry become the same change — either half alone fails the test.

## Testing

```
$ pytest tests/test_the_eln_absences_match_the_eln_transaction.py -q
5 passed

# negative control — fastfetch put back in the transaction:
FAILED …::test_a_documented_absence_is_not_strictly_installed[fastfetch]

$ shellcheck --severity=error --exclude=SC1091 build_scripts/10-base-packages.sh
(clean)

$ bash -n build_scripts/10-base-packages.sh
$ bats tests/bats/test_10_base_packages.bats     # 26 tests, 0 failures
```

STE findings 3048, unchanged from main.

Parsed values, to show the selectors aren't matching nothing: documented absences `['systemd-oomd', 'just', 'tailscale', 'fastfetch']`, strict ELN transaction 37 packages.

## Related issues

Unblocks the verification of #2471 — `wahoo:cosmic`'s promotion is still untested, because the desktop flavors never got scheduled once base failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws

---
_Generated by [Claude Code](https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws)_