### PR TITLE
fix(wahoo): name gnome-keyring on ELN instead of inheriting it

### DIFF
--- a/manifests/desktops/gnome.yaml
+++ b/manifests/desktops/gnome.yaml
@@ -171,6 +171,28 @@ packages:
   # GNOME version on this base: 51~beta (gnome-shell 51~beta-3.eln158,
   # gdm 51~beta-1.eln158, mutter 51~beta-1.eln158), on BOTH x86_64 and
   # aarch64 — so no per-arch flavor pin is needed, unlike hummingbird.
+  # gnome-keyring is named here rather than left to whatever gdm or
+  # gnome-shell happen to Require. ELN used to pull it in transitively and
+  # stopped: wahoo:gnome built clean on 2026-09-11 23:24 (run 34657968072) and
+  # failed on 2026-09-12 09:5x (run 34686896701) with
+  #
+  #     GNOME 51 meets the floor of 50
+  #     missing required path: none of [/usr/bin/gnome-keyring-daemon] exist
+  #
+  # from verify-desktop-experience.sh, in the same compose churn that retired
+  # fastfetch the same morning. Both names resolve on ELN, measured against the
+  # live repos (dl.fedoraproject.org/pub/eln/1, AppStream+BaseOS+CRB+Extras).
+  #
+  # -pam alongside it for the reason the apt and zypper sections give: without
+  # the PAM module the keyring is not unlocked by the login password, so saved
+  # credentials and the SSH/GPG agents prompt separately on first use. apt lists
+  # gnome-keyring + libpam-gnome-keyring and zypper lists gnome-keyring +
+  # gnome-keyring-pam; this makes ELN say the same thing.
+  #
+  # The other dnf sections (fedora, el10, hummingbird) still get it
+  # transitively and are deliberately untouched -- their contract checks pass,
+  # and changing a list on a measurement taken against a different base is how
+  # a guess ships.
   eln:
     packages:
       - ModemManager
@@ -190,6 +212,8 @@ packages:
       - gnome-control-center
       - gnome-disk-utility
       - gnome-initial-setup
+      - gnome-keyring
+      - gnome-keyring-pam
       - gnome-remote-desktop
       - gnome-session-wayland-session
       - gnome-settings-daemon


### PR DESCRIPTION
## Summary

The desktop contract now fails `wahoo:gnome` at build time:

```
GNOME 51 meets the floor of 50
missing required path: none of [/usr/bin/gnome-keyring-daemon] exist
```

ELN used to pull `gnome-keyring` in transitively and stopped. The same image built clean at 23:24 on 2026-09-11 ([run 34657968072](https://github.com/tuna-os/tunaOS/actions/runs/34657968072), which got as far as its boot Gate) and failed all three attempts at 09:5x on 2026-09-12 ([run 34686896701](https://github.com/tuna-os/tunaOS/actions/runs/34686896701)) — GNOME went 50 → 51 between them, in the same compose churn that retired `fastfetch` the same morning (#2473).

So the gate is right: the manifest was relying on a `Requires` that no longer holds. This names the package instead.

Both names resolve on ELN, measured against the live repos (`dl.fedoraproject.org/pub/eln/1`, AppStream+BaseOS+CRB+Extras) rather than assumed — with a sanity check on `gdm`, `gnome-shell`, `nautilus` and `polkit` first, since two earlier probes of mine returned "absent" for everything.

`-pam` alongside it for the reason the other sections already give: without the PAM module the keyring isn't unlocked by the login password, so saved credentials and the SSH/GPG agents prompt separately on first use. `apt` lists `gnome-keyring` + `libpam-gnome-keyring`, `zypper` lists `gnome-keyring` + `gnome-keyring-pam`; this makes ELN say the same thing.

**`fedora`, `el10` and `hummingbird` are deliberately untouched.** They still get the package transitively and their contract checks pass. Changing a list on a measurement taken against a different base is how a guess ships — if the same `Requires` drops on those bases, their own contract check will catch it and the fix belongs in that change, with that measurement.

**No new test.** `verify-desktop-experience.sh`'s `require_any_glob '/usr/bin/gnome-keyring-daemon'` *is* the test, and it's what caught this. A unit test asserting the manifest names a package would only restate the manifest.

## Testing

```
$ pytest tests/ -k "manifest or desktop or wishlist or package"
207 passed, 5 skipped

$ pytest tests/ -k gnome
46 passed, 2 skipped
```

Confirmed the other package sections are byte-identical after the edit: `fedora` 52, `el10` 27, `hummingbird` 52 packages, none naming a keyring package; `apt` and `zypper` unchanged with theirs.

STE findings 3048, unchanged from main.

## Related issues

Third failure in one morning's ELN churn, after #2471 (ELN package gaps the wishlist gate found) and #2473 (`fastfetch` retired from ELN).

Context on what this does and doesn't unblock: `wahoo:base`, `:kde` and `:cosmic` all promote as of run 34686896701 — `:cosmic` is #2471 landing, verified. `:gnome` needs this to build at all, and then still has to clear its boot Gate, where `dbus-broker` fails for a reason #2472 should now record on the serial console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws

---
_Generated by [Claude Code](https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws)_