### PR TITLE
fix(ci): run the tests on the files the tests read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,18 +2,54 @@ name: Test
 on:
   pull_request:
     paths:
+      # Every path the suite asserts on, so that a change to one of them
+      # re-runs the tests that read it. tests/
+      # test_the_test_filter_covers_what_the_tests_read.py holds this list to
+      # that rule, because the gap is invisible from a pull request: a PR that
+      # matched nothing here showed every applicable check green and ran no
+      # Unit Tests at all, which reads exactly like a PR that was tested.
+      #
+      # That is measured, not theoretical. tunaOS#2475 changed one file,
+      # manifests/desktops/gnome.yaml, and merged on 13 green checks with Unit
+      # Tests absent -- while ten test files read manifests/. One of them,
+      # tests/bats/test_niri_dms_payload.bats, exists because a niri image once
+      # shipped, booted and published with its entire shell missing
+      # (tunaOS#1009, #637); a manifest edit that broke that guard would have
+      # gone green here and failed on a nightly instead.
+      #
+      # Reference counts across tests/**/*.py and tests/**/*.bats:
+      #   build_scripts 262   scripts 139   .github 101   live-iso 35
+      #   Containerfile* ~36  manifests 23  .github/build-config.yml 20
+      #   just 14  image-versions.yaml 11  system_files 11
+      #   registry-map.yaml 4  files 2
       - 'scripts/**'
       - 'tests/**'
       - 'build_scripts/**'
-      - '.github/scripts/**'
-      - '.github/changelogs.py'
-      # The CI contract (tests/test_ci_contract.py) proves every green gate
-      # exists and runs; it has to re-run when the gates themselves move.
-      - '.github/workflows/**'
-      - '.github/green-criteria.yml'
-      - 'docs/CI_SPEC.md'
+      # One entry rather than six. .github/scripts/**, changelogs.py,
+      # workflows/**, green-criteria.yml, runs-on.yml and actions/** were all
+      # listed while .github/build-config.yml -- the matrix itself, what
+      # variants exist and what flavors each declares -- was not, and twenty
+      # test files read it. A partially covered directory is the shape of this
+      # bug, so this covers it wholesale. It also keeps the CI contract
+      # (tests/test_ci_contract.py) re-running when the gates it proves move.
+      - '.github/**'
+      # Build inputs.
+      - 'manifests/**'
+      - 'live-iso/**'
+      - 'system_files/**'
+      - 'system_files_overrides/**'
+      - 'custom/**'
+      - 'files/**'
+      - 'Containerfile*'
+      - 'image-versions.yaml'
+      - 'registry-map.yaml'
+      - 'renovate.json'
       - 'Justfile'
       - 'just/**'
+      # Read as a spec by the CI contract test, not as prose. The rest of
+      # docs/ is prose and generated content, gated by `ste` and `regenerate`;
+      # see the test named above for why docs/** is deliberately absent.
+      - 'docs/CI_SPEC.md'
   push:
     branches: [main]
   workflow_dispatch:

--- a/tests/test_ci_contract.py
+++ b/tests/test_ci_contract.py
@@ -28,6 +28,7 @@ not the same as a test being run."
 
 from __future__ import annotations
 
+import fnmatch
 import importlib.util
 from pathlib import Path
 
@@ -210,11 +211,37 @@ def test_a_dispatch_only_workflow_is_not_active():
     assert contract.cadence_days("x.yml", {"x.yml": doc}) is None
 
 
+def _filter_matches(path: str, patterns: list[str]) -> bool:
+    """Would a change to `path` match any entry in a paths filter?
+
+    Compares coverage, not spelling. The assertion below used to require the
+    literal strings ".github/workflows/**" and ".github/green-criteria.yml",
+    which failed when the filter was widened to ".github/**" -- a change that
+    covers strictly more, including .github/build-config.yml, which twenty
+    test files read and no entry had matched. A literal check cannot tell
+    "broader" from "gone", so it reads a safer filter as a broken one.
+    """
+    return any(fnmatch.fnmatch(path, pat.replace("/**", "/*"))
+               or path.startswith(pat.removesuffix("**"))
+               for pat in patterns)
+
+
 def test_the_contract_test_runs_on_workflow_changes():
     """A contract that only runs when tests/ change cannot catch a workflow
-    edit that breaks a gate. test.yml's pull_request paths must include the
+    edit that breaks a gate. test.yml's pull_request paths must cover the
     workflows and the criteria file."""
     doc = yaml.safe_load((ROOT / ".github/workflows/test.yml").read_text())
     paths = contract.triggers(doc)["pull_request"]["paths"]
-    assert ".github/workflows/**" in paths, paths
-    assert ".github/green-criteria.yml" in paths, paths
+    for needed in (".github/workflows/reusable-build-image.yml",
+                   ".github/green-criteria.yml"):
+        assert _filter_matches(needed, paths), (
+            f"a change to {needed} would not re-run Unit Tests; "
+            f"paths filter is {paths}")
+
+
+def test_the_filter_match_helper_can_say_no():
+    """Guard the helper: one that returned True for everything would make the
+    assertion above vacuously true (tunaOS#1730)."""
+    assert not _filter_matches(".github/workflows/x.yml", ["scripts/**"])
+    assert _filter_matches(".github/workflows/x.yml", [".github/**"])
+    assert _filter_matches(".github/workflows/x.yml", [".github/workflows/**"])

--- a/tests/test_the_test_filter_covers_what_the_tests_read.py
+++ b/tests/test_the_test_filter_covers_what_the_tests_read.py
@@ -1,0 +1,142 @@
+"""The Test workflow must run on the files the tests actually read.
+
+`test.yml` is path-filtered, so a pull request touching nothing in the filter
+gets no Unit Tests at all -- and a PR with every applicable check green reads
+exactly like a PR that was tested.
+
+That is not theoretical. tunaOS#2475 changed one file,
+manifests/desktops/gnome.yaml, and merged on 13 green checks with Unit Tests
+absent, because `manifests/**` was not in the filter. Ten test files read
+manifests/. One of them, tests/bats/test_niri_dms_payload.bats, exists because
+a niri image once shipped, booted and published with its entire shell missing
+(tunaOS#1009, #637) -- a manifest edit that broke that guard would have gone
+green here and failed on a nightly instead.
+
+The property: every repository path the suite asserts on is a path that
+re-runs the suite. A test that cannot run on a change to the thing it tests is
+the same class of dead gate as a karg on the wrong install path (tunaOS#2472)
+-- present, passing, and measuring nothing.
+
+Deliberately NOT required here, with reasons, because coverage comes from
+elsewhere:
+
+  README.md, ROADMAP.md, AGENTS.md   Prose. The `ste` workflow (Simplified
+  CLAUDE.md                          Technical English) runs without a path
+                                     filter, so an edit is still gated -- by a
+                                     different check.
+
+  docs/**                            Prose and generated content. The two docs
+                                     files the suite reads more than once are
+                                     MATRIX-STATUS.md, which the `regenerate`
+                                     check owns end to end, and LUKS-TPM.md,
+                                     which is prose under `ste`. Adding
+                                     docs/** would run the whole suite on
+                                     every typo fix for no coverage the repo
+                                     does not already have. docs/CI_SPEC.md is
+                                     in the filter on its own, because the CI
+                                     contract test reads it as a spec rather
+                                     than as prose.
+"""
+from __future__ import annotations
+
+import collections
+import pathlib
+import re
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "test.yml"
+
+# A path must be referenced at least this many times before it counts. A single
+# mention is often an example in a docstring or a one-off fixture; a path the
+# suite genuinely depends on is read repeatedly.
+MIN_REFS = 2
+
+GATED_ELSEWHERE = {
+    # Prose, gated by the `ste` workflow, which has no path filter.
+    "README.md", "ROADMAP.md", "AGENTS.md", "CLAUDE.md",
+    # Prose and generated content -- see the module docstring. CI_SPEC.md is
+    # listed in the filter separately and is not excluded here.
+    "docs",
+}
+
+
+def _filter_paths() -> list[str]:
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    # PyYAML parses the bare key `on:` as the boolean True.
+    triggers = doc[True] if True in doc else doc["on"]
+    return triggers["pull_request"]["paths"]
+
+
+def _paths_the_suite_reads() -> dict[str, int]:
+    """Top-level repo paths referenced from test files, with a count.
+
+    Read out of the tests themselves rather than hardcoded, so a new test that
+    reaches into a new directory shows up here instead of being silently
+    untested.
+    """
+    refs: collections.Counter[str] = collections.Counter()
+    for f in sorted(ROOT.joinpath("tests").rglob("*")):
+        if f.suffix not in {".py", ".bats"}:
+            continue
+        text = f.read_text(encoding="utf-8", errors="replace")
+        # Only the FIRST segment. `ROOT / ".github" / "workflows"` is a
+        # two-segment reference, but the filter's entries for .github are
+        # file- and directory-specific, so comparing first segments alone
+        # would call .github covered while .github/build-config.yml was not --
+        # which is exactly the gap that existed. _is_covered handles that by
+        # requiring a filter entry to cover the segment wholesale.
+        for m in re.finditer(r'ROOT\s*/\s*"([A-Za-z0-9_.\-]+)"', text):
+            refs[m.group(1)] += 1
+        for m in re.finditer(r"\$\{REPO_ROOT\}/([A-Za-z0-9_.\-]+)", text):
+            refs[m.group(1)] += 1
+    return {k: v for k, v in refs.items() if v >= MIN_REFS}
+
+
+def _is_covered(name: str, patterns: list[str]) -> bool:
+    """Is every change under `name` guaranteed to run the suite?
+
+    Deliberately strict for a directory: `.github/scripts/**` does NOT make
+    `.github` covered, because a change to `.github/anything-else` would still
+    run nothing. Only a wholesale entry counts. That strictness is the point --
+    a partially-covered directory reads as covered otherwise, which is how
+    `.github/build-config.yml` went twenty test files deep with no trigger.
+    """
+    for pat in patterns:
+        if pat == name or pat == f"{name}/**":
+            return True
+        # A glob like Containerfile* covers Containerfile.el10.
+        if pat.endswith("*") and not pat.endswith("/**"):
+            if name.startswith(pat[:-1]):
+                return True
+    return False
+
+
+def test_the_selectors_find_something():
+    """Guard both sides: either matching nothing would make the assertion
+    below vacuously true (tunaOS#1730)."""
+    patterns = _filter_paths()
+    assert patterns, "test.yml has no pull_request paths filter any more"
+    reads = _paths_the_suite_reads()
+    assert reads, "no repo paths parsed out of the test files"
+    for known in ("build_scripts", "scripts", "manifests"):
+        assert known in reads, (
+            f"expected the suite to read {known}; parsed {sorted(reads)}")
+
+
+@pytest.mark.parametrize(
+    "name", sorted(n for n in _paths_the_suite_reads()
+                   if n not in GATED_ELSEWHERE))
+def test_a_path_the_suite_reads_also_triggers_the_suite(name: str):
+    patterns = _filter_paths()
+    assert _is_covered(name, patterns), (
+        f"the test suite reads {name!r}, but test.yml's paths filter does not "
+        f"match it, so a pull request changing only {name!r} runs no Unit "
+        f"Tests and still shows every applicable check green.\n"
+        f"Add it to the filter, or -- if a different workflow gates it "
+        f"without a path filter, as `ste` does for prose -- add it to "
+        f"GATED_ELSEWHERE with that reason."
+    )


### PR DESCRIPTION
## Summary

`test.yml` is path-filtered, so a pull request matching nothing in the filter runs **no Unit Tests** — and shows every applicable check green, which reads exactly like a PR that was tested.

Measured this morning, not hypothesised: **#2475 changed one file, `manifests/desktops/gnome.yaml`, and merged on 13 green checks with `Unit Tests` absent** — while ten test files read `manifests/`. One of them, `tests/bats/test_niri_dms_payload.bats`, exists because a niri image once shipped, booted and published with its entire shell missing (#1009, #637). A manifest edit that broke that guard would have gone green here and failed on a nightly instead.

I ran the suite locally on #2475, so nothing shipped broken — but nothing in CI would have stopped it.

Reference counts across `tests/**/*.py` and `tests/**/*.bats`, which is how the additions were chosen rather than by guessing:

```
build_scripts 262   scripts 139   .github 101   live-iso 35
Containerfile* ~36  manifests 23  .github/build-config.yml 20
just 14  image-versions.yaml 11  system_files 11
registry-map.yaml 4  files 2
```

### The `.github` entry is the one worth reading twice

Six specific entries were listed — `scripts/**`, `changelogs.py`, `workflows/**`, `green-criteria.yml` — while **`.github/build-config.yml` was not**. That file *is* the matrix: what variants exist, what flavors each declares, which arches they build. Twenty test files read it, and a change to it alone ran none of them.

A partially covered directory is the exact shape of this bug, so those entries collapse into `.github/**`, which covers strictly more.

### What stays out, and why

`docs/**` is deliberately absent. The two docs files the suite reads more than once are `MATRIX-STATUS.md`, which the `regenerate` check owns end to end, and `LUKS-TPM.md`, which is prose under `ste`. Neither gains coverage, and `docs/**` would run the whole suite on every typo fix. `docs/CI_SPEC.md` keeps its own entry — the contract test reads it as a spec, not as prose.

### One existing test changed, and not to weaken it

`test_ci_contract.py::test_the_contract_test_runs_on_workflow_changes` required the **literal strings** `".github/workflows/**"` and `".github/green-criteria.yml"`, so widening the filter to `".github/**"` — which covers both, *plus* `build-config.yml` — failed it. A literal check cannot tell "broader" from "gone", so it reads a safer filter as a broken one.

It now asserts that a change to those paths **would match** the filter, which is strictly stronger than string equality, and ships with a guard proving the matcher can still say no.

## Testing

```
$ pytest tests/ -q      (minus four slow files, run separately — see note)
1440 passed, 16 skipped in 110.45s
```

Negative controls, so this isn't just "the check stopped firing":

```
manifests/** removed          → FAILED …test_a_path_the_suite_reads_also_triggers_the_suite[manifests]
.github/** → partial entries  → FAILED …test_a_path_the_suite_reads_also_triggers_the_suite[.github]

_filter_matches('.github/build-config.yml', ['.github/workflows/**'])  → False
_filter_matches('.github/build-config.yml', ['.github/**'])            → True
```

STE findings 3048, unchanged from main.

The four excluded files (`test_the_welcome_keywords_match_what_kde_says.py`, `test_installer_walkthrough.py`, `test_sign_step_retries_cosign.py`, `test_the_progress_screen_keywords_were_measured.py`) are merely slow, not failing — they take 8–10 minutes each locally and are unaffected by this diff.

## Related issues

Same class of defect as #2472: a guard that exists, passes, and does not run where it is needed.

Note this PR increases CI spend — `.github/**` and the build-input paths mean more PRs run the suite. That is the intended trade, but it is a real cost and your call if you'd rather narrow it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws

---
_Generated by [Claude Code](https://claude.ai/code/session_01L59jmWZu8kiH2G9Jx7tcws)_